### PR TITLE
fix(CallButton): replace video icon with phone

### DIFF
--- a/src/components/TopBar/CallButton.vue
+++ b/src/components/TopBar/CallButton.vue
@@ -19,9 +19,9 @@
 			:type="startCallButtonType"
 			@click="handleClick">
 			<template #icon>
-				<PhoneDial v-if="isPhoneRoom" :size="20" />
-				<PhoneOutline v-else-if="silentCall" :size="20" />
-				<PhoneIcon v-else :size="20" />
+				<IconPhoneDial v-if="isPhoneRoom" :size="20" />
+				<IconPhoneOutline v-else-if="silentCall" :size="20" />
+				<IconPhone v-else :size="20" />
 			</template>
 			<template v-if="showButtonText" #default>
 				{{ startCallLabel }}
@@ -34,7 +34,7 @@
 			:disabled="loading"
 			@click="leaveCall(true)">
 			<template #icon>
-				<PhoneHangup :size="20" /> <!-- here -->
+				<IconPhoneHangup :size="20" /> <!-- here -->
 			</template>
 			<template v-if="showButtonText" #default>
 				{{ endCallLabel }}
@@ -47,7 +47,7 @@
 			:disabled="loading"
 			@click="leaveCall(false)">
 			<template #icon>
-				<PhoneHangup :size="20" />
+				<IconPhoneHangup :size="20" />
 			</template>
 			<template v-if="showButtonText" #default>
 				{{ leaveCallLabel }}
@@ -61,25 +61,25 @@
 			:container="container"
 			:type="isScreensharing ? 'tertiary' : 'error'">
 			<template #icon>
-				<PhoneHangup v-if="!isBreakoutRoom" :size="20" />
-				<ArrowLeft v-else :size="20" />
+				<IconPhoneHangup v-if="!isBreakoutRoom" :size="20" />
+				<IconArrowLeft v-else :size="20" />
 			</template>
 			<NcActionButton v-if="isBreakoutRoom"
 				@click="switchToParentRoom">
 				<template #icon>
-					<ArrowLeft :size="20" />
+					<IconArrowLeft :size="20" />
 				</template>
 				{{ backToMainRoomLabel }}
 			</NcActionButton>
 			<NcActionButton @click="leaveCall(false)">
 				<template #icon>
-					<PhoneHangup :size="20" />
+					<IconPhoneHangup :size="20" />
 				</template>
 				{{ leaveCallLabel }}
 			</NcActionButton>
 			<NcActionButton v-if="canEndForAll" @click="leaveCall(true)">
 				<template #icon>
-					<PhoneOff :size="20" />
+					<IconPhoneOff :size="20" />
 				</template>
 				{{ t('spreed', 'End call for everyone') }}
 			</NcActionButton>
@@ -88,12 +88,12 @@
 </template>
 
 <script>
-import ArrowLeft from 'vue-material-design-icons/ArrowLeft.vue'
-import PhoneIcon from 'vue-material-design-icons/Phone.vue'
-import PhoneDial from 'vue-material-design-icons/PhoneDial.vue'
-import PhoneHangup from 'vue-material-design-icons/PhoneHangup.vue'
-import PhoneOff from 'vue-material-design-icons/PhoneOff.vue'
-import PhoneOutline from 'vue-material-design-icons/PhoneOutline.vue'
+import IconArrowLeft from 'vue-material-design-icons/ArrowLeft.vue'
+import IconPhone from 'vue-material-design-icons/Phone.vue'
+import IconPhoneDial from 'vue-material-design-icons/PhoneDial.vue'
+import IconPhoneHangup from 'vue-material-design-icons/PhoneHangup.vue'
+import IconPhoneOff from 'vue-material-design-icons/PhoneOff.vue'
+import IconPhoneOutline from 'vue-material-design-icons/PhoneOutline.vue'
 
 import { showError } from '@nextcloud/dialogs'
 import { emit } from '@nextcloud/event-bus'
@@ -128,12 +128,12 @@ export default {
 		NcActionButton,
 		NcButton,
 		// Icons
-		ArrowLeft,
-		PhoneDial,
-		PhoneHangup,
-		PhoneIcon,
-		PhoneOff,
-		PhoneOutline,
+		IconArrowLeft,
+		IconPhone,
+		IconPhoneDial,
+		IconPhoneHangup,
+		IconPhoneOff,
+		IconPhoneOutline,
 	},
 
 	props: {

--- a/src/components/TopBar/CallButton.vue
+++ b/src/components/TopBar/CallButton.vue
@@ -19,9 +19,9 @@
 			:type="startCallButtonType"
 			@click="handleClick">
 			<template #icon>
-				<PhoneIcon v-if="isPhoneRoom" :size="20" />
-				<VideoOutlineIcon v-else-if="silentCall" :size="20" />
-				<VideoIcon v-else :size="20" />
+				<PhoneDial v-if="isPhoneRoom" :size="20" />
+				<PhoneOutline v-else-if="silentCall" :size="20" />
+				<PhoneIcon v-else :size="20" />
 			</template>
 			<template v-if="showButtonText" #default>
 				{{ startCallLabel }}
@@ -34,7 +34,7 @@
 			:disabled="loading"
 			@click="leaveCall(true)">
 			<template #icon>
-				<PhoneHangup :size="20" />
+				<PhoneHangup :size="20" /> <!-- here -->
 			</template>
 			<template v-if="showButtonText" #default>
 				{{ endCallLabel }}
@@ -47,7 +47,7 @@
 			:disabled="loading"
 			@click="leaveCall(false)">
 			<template #icon>
-				<VideoOff :size="20" />
+				<PhoneHangup :size="20" />
 			</template>
 			<template v-if="showButtonText" #default>
 				{{ leaveCallLabel }}
@@ -61,7 +61,7 @@
 			:container="container"
 			:type="isScreensharing ? 'tertiary' : 'error'">
 			<template #icon>
-				<VideoOff v-if="!isBreakoutRoom" :size="20" />
+				<PhoneHangup v-if="!isBreakoutRoom" :size="20" />
 				<ArrowLeft v-else :size="20" />
 			</template>
 			<NcActionButton v-if="isBreakoutRoom"
@@ -73,13 +73,13 @@
 			</NcActionButton>
 			<NcActionButton @click="leaveCall(false)">
 				<template #icon>
-					<VideoOff :size="20" />
+					<PhoneHangup :size="20" />
 				</template>
 				{{ leaveCallLabel }}
 			</NcActionButton>
 			<NcActionButton v-if="canEndForAll" @click="leaveCall(true)">
 				<template #icon>
-					<VideoBoxOff :size="20" />
+					<PhoneOff :size="20" />
 				</template>
 				{{ t('spreed', 'End call for everyone') }}
 			</NcActionButton>
@@ -90,11 +90,10 @@
 <script>
 import ArrowLeft from 'vue-material-design-icons/ArrowLeft.vue'
 import PhoneIcon from 'vue-material-design-icons/Phone.vue'
+import PhoneDial from 'vue-material-design-icons/PhoneDial.vue'
 import PhoneHangup from 'vue-material-design-icons/PhoneHangup.vue'
-import VideoIcon from 'vue-material-design-icons/Video.vue'
-import VideoBoxOff from 'vue-material-design-icons/VideoBoxOff.vue'
-import VideoOff from 'vue-material-design-icons/VideoOff.vue'
-import VideoOutlineIcon from 'vue-material-design-icons/VideoOutline.vue'
+import PhoneOff from 'vue-material-design-icons/PhoneOff.vue'
+import PhoneOutline from 'vue-material-design-icons/PhoneOutline.vue'
 
 import { showError } from '@nextcloud/dialogs'
 import { emit } from '@nextcloud/event-bus'
@@ -130,12 +129,11 @@ export default {
 		NcButton,
 		// Icons
 		ArrowLeft,
+		PhoneDial,
 		PhoneHangup,
 		PhoneIcon,
-		VideoBoxOff,
-		VideoIcon,
-		VideoOff,
-		VideoOutlineIcon,
+		PhoneOff,
+		PhoneOutline,
 	},
 
 	props: {


### PR DESCRIPTION
### ☑️ Resolves

* Fix https://github.com/nextcloud/spreed/issues/12862
* End call icon is the same as the Webcam toggle button
  ![image](https://github.com/user-attachments/assets/5b8eaec3-42c7-4162-b44e-ba5310a9d731)
  ![image](https://github.com/user-attachments/assets/8f218449-3812-4856-9475-69ee3eb3b255)


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
Screenshot before | Screenshot after
![image](https://github.com/user-attachments/assets/61684d19-f9d7-44e1-96ab-e3bcb4077ecd) | ![image](https://github.com/user-attachments/assets/07dfb249-89a3-4489-b2d2-fa80c5bac828)
![image](https://github.com/user-attachments/assets/9cee227b-c175-4ddb-b0ce-1e7705308554) | ![image](https://github.com/user-attachments/assets/f0f2db12-ed87-452d-9f23-02f445b8d96d)
![image](https://github.com/user-attachments/assets/2c4532be-0b66-4d6d-b312-8bb84f0ba077) | ![image](https://github.com/user-attachments/assets/79b14fb3-5a33-49ae-ad12-285c9f4a2a82)
![image](https://github.com/user-attachments/assets/bf264607-547b-4ecc-a324-cf6310e44b76) | ![image](https://github.com/user-attachments/assets/a340292c-3926-4b96-aad2-f4d745d78a61)
![image](https://github.com/user-attachments/assets/0615b686-5032-4870-b4be-2025e464935a) | ![image](https://github.com/user-attachments/assets/be62d02e-96a5-4f10-a89e-7d3dbf7e2f82)


![image](https://github.com/user-attachments/assets/ba87acb8-310d-43ae-94ab-1553e51c3bf9)



### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
