### PR TITLE
fix(LeftSidebar): Fix conversation click when filter and search are on

### DIFF
--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -13,7 +13,7 @@
 					<SearchBox ref="searchBox"
 						:value.sync="searchText"
 						:is-focused.sync="isFocused"
-						:list="list"
+						:list-ref="scroller"
 						@input="debounceFetchSearchResults"
 						@abort-search="abortSearch" />
 				</div>
@@ -402,7 +402,7 @@ export default {
 	setup() {
 		const leftSidebar = ref(null)
 		const searchBox = ref(null)
-		const list = ref(null)
+		const scroller = ref(null)
 
 		const federationStore = useFederationStore()
 		const talkHashStore = useTalkHashStore()
@@ -414,7 +414,7 @@ export default {
 			resetNavigation,
 			leftSidebar,
 			searchBox,
-			list,
+			scroller,
 			federationStore,
 			talkHashStore,
 			isMobile,

--- a/src/components/UIShared/SearchBox.vue
+++ b/src/components/UIShared/SearchBox.vue
@@ -58,8 +58,8 @@ export default {
 		/**
 		 * Conversations list reference for handling click trigger
 		 */
-		 list: {
-			type: HTMLElement,
+		listRef: {
+			type: Object,
 			default: null,
 		},
 	},
@@ -143,10 +143,12 @@ export default {
 				})
 				return
 			}
+
 			// Blur triggered by clicking on a conversation item
-			if (this.list?.contains(event.relatedTarget)) {
+			if (this.listRef && this.listRef.$el.contains(event.relatedTarget)) {
 				return
 			}
+
 			 // Blur in other cases
 			this.$emit('blur', event)
 			if (!this.isSearching) {


### PR DESCRIPTION
### ☑️ Resolves

* Issue: if filter is on, you click on search box (without typing), and then click on a conversation, the latter won't be clicked.

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![list-2](https://github.com/user-attachments/assets/09d45350-ec6f-4617-9472-8d9dcdb1da52) | ![list-1](https://github.com/user-attachments/assets/facf05f4-568a-4049-8f62-7c6d17db717a)


### 🏁 Checklist

- [ ] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
