### PR TITLE
Fix using signaling session ID instead of Nextcloud session ID

### DIFF
--- a/src/components/CallView/shared/LocalVideo.vue
+++ b/src/components/CallView/shared/LocalVideo.vue
@@ -49,9 +49,6 @@
 </template>
 
 <script>
-import Hex from 'crypto-js/enc-hex.js'
-import SHA1 from 'crypto-js/sha1.js'
-
 import { showError, showInfo, TOAST_PERMANENT_TIMEOUT } from '@nextcloud/dialogs'
 import { t } from '@nextcloud/l10n'
 
@@ -62,7 +59,6 @@ import VideoBackground from './VideoBackground.vue'
 import AvatarWrapper from '../../AvatarWrapper/AvatarWrapper.vue'
 
 import { AVATAR } from '../../../constants.js'
-import { useGuestNameStore } from '../../../stores/guestName.js'
 import attachMediaStream from '../../../utils/attachmediastream.js'
 import { ConnectionState } from '../../../utils/webrtc/models/CallParticipantModel.js'
 
@@ -126,11 +122,6 @@ export default {
 
 	emits: ['click-video'],
 
-	setup() {
-		const guestNameStore = useGuestNameStore()
-		return { guestNameStore }
-	},
-
 	data() {
 		return {
 			notificationHandle: null,
@@ -185,17 +176,6 @@ export default {
 
 		displayName() {
 			return this.$store.getters.getDisplayName()
-		},
-
-		sessionHash() {
-			return Hex.stringify(SHA1(this.localCallParticipantModel.attributes.peerId))
-		},
-
-		guestName() {
-			return this.guestNameStore.getGuestName(
-				this.$store.getters.getToken(),
-				this.sessionHash,
-			)
 		},
 
 		avatarSize() {

--- a/src/components/CallView/shared/ReactionToaster.vue
+++ b/src/components/CallView/shared/ReactionToaster.vue
@@ -180,17 +180,17 @@ export default {
 		},
 
 		getParticipantName(model) {
-			const { name, peerId } = model.attributes
+			const { name, nextcloudSessionId } = model.attributes
 			if (name) {
 				return name
 			}
 
-			const participant = this.participants.find(participant => participant.sessionIds.includes(peerId))
+			const participant = this.participants.find(participant => participant.sessionIds.includes(nextcloudSessionId))
 			if (participant?.displayName) {
 				return participant.displayName
 			}
 
-			return this.guestNameStore.getGuestName(this.token, Hex.stringify(SHA1(peerId)))
+			return this.guestNameStore.getGuestName(this.token, Hex.stringify(SHA1(nextcloudSessionId)))
 		},
 
 		getReactionURL(emoji) {

--- a/src/components/CallView/shared/Screen.vue
+++ b/src/components/CallView/shared/Screen.vue
@@ -88,7 +88,7 @@ export default {
 				return null
 			}
 
-			return Hex.stringify(SHA1(this.callParticipantModel.attributes.peerId))
+			return Hex.stringify(SHA1(this.callParticipantModel.attributes.nextcloudSessionId))
 		},
 
 		remoteParticipantName() {

--- a/src/components/CallView/shared/VideoVue.vue
+++ b/src/components/CallView/shared/VideoVue.vue
@@ -330,11 +330,11 @@ export default {
 		},
 
 		sessionHash() {
-			return Hex.stringify(SHA1(this.peerId))
+			return Hex.stringify(SHA1(this.nextcloudSessionId))
 		},
 
 		peerData() {
-			let peerData = this.$store.getters.getPeer(this.$store.getters.getToken(), this.peerId, this.model.attributes.userId)
+			let peerData = this.$store.getters.getPeer(this.$store.getters.getToken(), this.nextcloudSessionId, this.model.attributes.userId)
 			if (!peerData.actorId) {
 				EventBus.emit('refresh-peer-list')
 				peerData = {
@@ -352,7 +352,7 @@ export default {
 			 * via the participant list
 			 */
 			return this.$store.getters.findParticipant(this.$store.getters.getToken(), {
-				sessionId: this.peerId,
+				sessionId: this.nextcloudSessionId,
 			}) || {}
 		},
 
@@ -513,6 +513,10 @@ export default {
 
 		peerId() {
 			return this.model.attributes.peerId
+		},
+
+		nextcloudSessionId() {
+			return this.model.attributes.nextcloudSessionId
 		},
 	},
 


### PR DESCRIPTION
CallParticipantModels provide the [signaling session ID](https://github.com/nextcloud/spreed/blob/32ba79dec837d3c2f33015ccb2522bc4b4534b46/src/utils/webrtc/models/CallParticipantModel.js#L30) and the [Nextcloud session ID](https://github.com/nextcloud/spreed/blob/32ba79dec837d3c2f33015ccb2522bc4b4534b46/src/utils/webrtc/models/CallParticipantModel.js#L31). When the internal signaling server is used both IDs are the same, but not with the external signaling server. The session ID in the [participant](https://github.com/nextcloud/spreed/blob/36871453829632d08f3287a8ccf33ad9d80007f3/lib/Controller/RoomController.php#L959) and [peer](https://github.com/nextcloud/spreed/blob/2a38a527d24b26a1c6bbcfc7a752061d54ab7276/lib/Controller/CallController.php#L100) data provided by the Nextcloud server is the Nextcloud session ID, so no participant or peer data was found in the CallView components when the external signaling server was used, as the data was looked for using the signaling session ID.

This does not seem to have been a problem, though, as generally the CallParticipantModels provide the needed data from the signaling messages, and the components only fall back to the participant or peer data when the data is not found in the models. This seems to be the case only with SIP participants, as [the fall back to the peer data was initially introduced](https://github.com/nextcloud/spreed/commit/18e6072a300dc5ffa8eb8667859052c8a6213bf9#diff-c4ac38248a8b5115279577755ec9fb03994c5104771a045c9f57961f4ee83b91R206) when SIP support was added, and then the [fall back to the participant data was introduced in a later fix](https://github.com/nextcloud/spreed/pull/4956/commits/396f06d040b37eeda6094eb9f74bcb7ab2a19a3b). However... given that even when it was introduced the peer data was already using [the signaling session ID](https://github.com/nextcloud/spreed/commit/18e6072a300dc5ffa8eb8667859052c8a6213bf9#diff-c4ac38248a8b5115279577755ec9fb03994c5104771a045c9f57961f4ee83b91R207) but indexed using [the Nextcloud session ID](https://github.com/nextcloud/spreed/blob/18e6072a300dc5ffa8eb8667859052c8a6213bf9/src/store/participantsStore.js#L131) the fallbacks may not have even worked :thinking: Anyway, I could not test with SIP participants, so this pull request just fixes the usage of the session ID, independently of whether it is actually needed or not :shrug:

Besides that, note that the guest name store can not be used by guest themselves, as [the guest display name is set from the participant data](https://github.com/nextcloud/spreed/blob/3a3e4a4e93401bfa815d0be649b078d96754f524/src/store/participantsStore.js#L706-L710), which [is not available to guest users](https://github.com/nextcloud/spreed/blob/36871453829632d08f3287a8ccf33ad9d80007f3/lib/Controller/RoomController.php#L867-L869). But again the display name is expected to be provided by the model, and got from other places only as a fallback. The `VideoVue` component falls back to both the guest store and the peer data, but the `Screen` and `ReactionToaster` only fall back to the guest store, so it would not work when the current participant is a guest and the UI shows the screen or reaction of other guests. However, if the fallback is needed only for SIP participants then it should not be a problem, as they can not share the screen nor send a reaction.

Independently of all that, [`guestName` in `LocalVideo` is unused since `NcAvatar` was replaced by `AvatarWrapper`](https://github.com/nextcloud/spreed/pull/10610/commits/973a735924e095ffbf7740299771b8075c97ee71), so the computed property and all the related code was removed.

## How to test

- Remove the code to get the participant name, actor type and user id from the model in [`VideoVue`](https://github.com/nextcloud/spreed/blob/32ba79dec837d3c2f33015ccb2522bc4b4534b46/src/components/CallView/shared/VideoVue.vue#L360-L430), [`Screen`](https://github.com/nextcloud/spreed/blob/e9b9cf49022521291fce0386c78f6df1e70fb731/src/components/CallView/shared/Screen.vue#L94-L112) and [`ReactionToaster`](https://github.com/nextcloud/spreed/blob/e9b9cf49022521291fce0386c78f6df1e70fb731/src/components/CallView/shared/ReactionToaster.vue#L182-L194) so only the fallbacks are used (and for a thorough testing, leave a single fallback when there are several in the same method; be careful, as [the peer data itself falls back to the participant data when a user ID is provided](https://github.com/nextcloud/spreed/blob/3a3e4a4e93401bfa815d0be649b078d96754f524/src/store/participantsStore.js#L237-L250), so you may get data even if you were not expecting it, which can be a bit puzzling)
- Create a public conversation
- Start a call
- In a private window, join the conversation as a guest and set a name
- Join the call
- Share the screen and send reactions

### Result with this pull request

The name and avatar of the guest user is properly shown in the original window for the video, screen and reactions (note that the name and avatar of the registered user may not be shown in the guest window if the data is not got from the model)

### Result without this pull request

The name and avatar of the guest user is not set or is a generic one
