### PR TITLE
Get call peers by federated users

### DIFF
--- a/docs/call.md
+++ b/docs/call.md
@@ -12,6 +12,7 @@
 
 ## Get list of connected participants
 
+* Federation capability: `federation-v2`
 * Method: `GET`
 * Endpoint: `/call/{token}`
 
@@ -36,6 +37,7 @@
 
 ## Join a call
 
+* Federation capability: `federation-v2`
 * Method: `POST`
 * Endpoint: `/call/{token}`
 * Data:
@@ -102,6 +104,7 @@
 
 ## Update call flags
 
+* Federation capability: `federation-v2`
 * Method: `PUT`
 * Endpoint: `/call/{token}`
 * Data:
@@ -122,6 +125,7 @@
 
 ## Leave a call (but staying in the conversation for future calls and chat)
 
+* Federation capability: `federation-v2`
 * Method: `DELETE`
 * Endpoint: `/call/{token}`
 * Data:

--- a/lib/Controller/CallController.php
+++ b/lib/Controller/CallController.php
@@ -66,12 +66,19 @@ class CallController extends AEnvironmentAwareController {
 	 *
 	 * 200: List of peers in the call returned
 	 */
+	#[FederationSupported]
 	#[PublicPage]
 	#[RequireCallEnabled]
 	#[RequireModeratorOrNoLobby]
 	#[RequireParticipant]
 	#[RequireReadWriteConversation]
 	public function getPeersForCall(): DataResponse {
+		if ($this->room->isFederatedConversation()) {
+			/** @var \OCA\Talk\Federation\Proxy\TalkV1\Controller\CallController $proxy */
+			$proxy = \OCP\Server::get(\OCA\Talk\Federation\Proxy\TalkV1\Controller\CallController::class);
+			return $proxy->getPeersForCall($this->room, $this->participant);
+		}
+
 		$timeout = $this->timeFactory->getTime() - Session::SESSION_TIMEOUT;
 		$result = [];
 		$participants = $this->participantService->getParticipantsInCall($this->room, $timeout);

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -1672,6 +1672,11 @@ class RoomController extends AEnvironmentAwareController {
 				$participant = $this->participantService->joinRoomAsFederatedUser($room, Attendee::ACTOR_FEDERATED_USERS, $this->federationAuthenticator->getCloudId(), $sessionId);
 			}
 
+			$session = $participant->getSession();
+			if ($session instanceof Session) {
+				$this->sessionService->updateLastPing($session, $this->timeFactory->getTime());
+			}
+
 			// Let the clients know if they need to reload capabilities
 			$capabilities = $this->capabilities->getCapabilities();
 			return new DataResponse([], Http::STATUS_OK, [

--- a/src/components/CallView/shared/VideoVue.vue
+++ b/src/components/CallView/shared/VideoVue.vue
@@ -390,7 +390,8 @@ export default {
 			}
 
 			// Fallback to CallController::getPeers() endpoint
-			if (this.peerData.actorType === ATTENDEE.ACTOR_TYPE.USERS) {
+			if (this.peerData.actorType === ATTENDEE.ACTOR_TYPE.USERS
+				|| this.peerData.actorType === ATTENDEE.ACTOR_TYPE.FEDERATED_USERS) {
 				return this.peerData.actorId
 			}
 

--- a/tests/integration/features/federation/call.feature
+++ b/tests/integration/features/federation/call.feature
@@ -45,6 +45,7 @@ Feature: federation/call
       | actorType       | actorId                    | inCall |
       | users           | participant1               | 3      |
       | federated_users | participant2@{$REMOTE_URL} | 7      |
+    And user "participant1" sees 2 peers in call "room" with 200 (v4)
     And using server "REMOTE"
     And user "participant2" is participant of room "LOCAL::room" (v4)
       | callFlag |
@@ -53,6 +54,7 @@ Feature: federation/call
       | actorType       | actorId                   | inCall |
       | federated_users | participant1@{$LOCAL_URL} | 3      |
       | users           | participant2              | 7      |
+    And user "participant2" sees 2 peers in call "LOCAL::room" with 200 (v4)
 
   Scenario: update call flags
     Given user "participant1" creates room "room" (v4)
@@ -88,6 +90,7 @@ Feature: federation/call
       | actorType       | actorId                    | inCall |
       | users           | participant1               | 0      |
       | federated_users | participant2@{$REMOTE_URL} | 1      |
+    And user "participant1" sees 1 peers in call "room" with 200 (v4)
     And using server "REMOTE"
     And user "participant2" is participant of room "LOCAL::room" (v4)
       | callFlag |
@@ -96,6 +99,7 @@ Feature: federation/call
       | actorType       | actorId                   | inCall |
       | federated_users | participant1@{$LOCAL_URL} | 0      |
       | users           | participant2              | 1      |
+    And user "participant2" sees 1 peers in call "LOCAL::room" with 200 (v4)
 
   Scenario: leave call
     Given user "participant1" creates room "room" (v4)
@@ -131,6 +135,7 @@ Feature: federation/call
       | actorType       | actorId                    | inCall |
       | users           | participant1               | 0      |
       | federated_users | participant2@{$REMOTE_URL} | 0      |
+    And user "participant1" sees 0 peers in call "room" with 200 (v4)
     And using server "REMOTE"
     And user "participant2" is participant of room "LOCAL::room" (v4)
       | callFlag |
@@ -139,6 +144,7 @@ Feature: federation/call
       | actorType       | actorId                   | inCall |
       | federated_users | participant1@{$LOCAL_URL} | 0      |
       | users           | participant2              | 0      |
+    And user "participant2" sees 0 peers in call "LOCAL::room" with 200 (v4)
 
   Scenario: Host ends call for everyone
     Given user "participant1" creates room "room" (v4)
@@ -173,6 +179,7 @@ Feature: federation/call
       | actorType       | actorId                    | inCall |
       | users           | participant1               | 0      |
       | federated_users | participant2@{$REMOTE_URL} | 0      |
+    And user "participant1" sees 0 peers in call "room" with 200 (v4)
     And using server "REMOTE"
     And user "participant2" is participant of room "LOCAL::room" (v4)
       | callFlag |
@@ -181,6 +188,7 @@ Feature: federation/call
       | actorType       | actorId                   | inCall |
       | federated_users | participant1@{$LOCAL_URL} | 0      |
       | users           | participant2              | 0      |
+    And user "participant2" sees 0 peers in call "LOCAL::room" with 200 (v4)
 
   Scenario: normal call notification for federated user
     Given user "participant1" creates room "room" (v4)

--- a/tests/integration/features/federation/join-leave.feature
+++ b/tests/integration/features/federation/join-leave.feature
@@ -61,13 +61,13 @@ Feature: federation/join-leave
     And user "participant1" sees the following attendees in room "room" with 200 (v4)
       | actorType       | actorId                    | participantType | sessionIds                            |
       | users           | participant1               | 1               | [SESSION,]                            |
-      | federated_users | participant2@{$REMOTE_URL} | 3               | [SESSION#participant2@{$REMOTE_URL},] |
+      | federated_users | participant2@{$REMOTE_URL} | 3               | [SESSION#participant2@{$REMOTE_URL},SESSION#participant2@{$REMOTE_URL},] |
     And using server "REMOTE"
     And user "participant2" is participant of room "LOCAL::room" (v4)
     And user "participant2" sees the following attendees in room "LOCAL::room" with 200 (v4)
       | actorType       | actorId                   | participantType | sessionIds                            |
       | federated_users | participant1@{$LOCAL_URL} | 1               | [SESSION,]                            |
-      | users           | participant2              | 3               | [SESSION#participant2@{$REMOTE_URL},] |
+      | users           | participant2              | 3               | [SESSION#participant2@{$REMOTE_URL},SESSION#participant2@{$REMOTE_URL},] |
 
   Scenario: leave a group room
     Given user "participant1" creates room "room" (v4)


### PR DESCRIPTION
Fixes #12936

Additionally:
- it updates the ping of federated users when they join the host room for consistency with the behaviour for the rest of the participants (which is unrelated to https://github.com/nextcloud/spreed/issues/12917; there the problem is that the ping is not updated in the federated server) and because it is needed for the integration tests that depend on the ping and do not have a real external signaling server (in a real environment the external signaling server updated the ping of federated users in the host server)
- it takes into account federated users when getting the actor id from the call peers in the WebUI, which is used to set the correct avatar and background (in case the actor id was not provided by signaling messages, which it should be).
  - Note that it requires #12961, as otherwise the peer data is not found due to using the wrong index
