### PR TITLE
fix(Participant): hide ban option for federated users

### DIFF
--- a/src/components/RightSidebar/Participants/Participant.spec.js
+++ b/src/components/RightSidebar/Participants/Participant.spec.js
@@ -709,11 +709,11 @@ describe('Participant.vue', () => {
 				await testCanBan()
 			})
 
-			test('allows a moderator to ban a federated user', async () => {
+			test('doesn not allow a moderator to ban a federated user', async () => {
 				conversation.participantType = PARTICIPANT.TYPE.MODERATOR
 				participant.actorType = ATTENDEE.ACTOR_TYPE.FEDERATED_USERS
 				participant.participantType = PARTICIPANT.TYPE.USER
-				await testCanBan()
+				await testCannotBan()
 			})
 
 			test('allows a moderator to ban a guest', async () => {

--- a/src/components/RightSidebar/Participants/Participant.vue
+++ b/src/components/RightSidebar/Participants/Participant.vue
@@ -290,7 +290,7 @@
 				:name="removeParticipantLabel"
 				:container="container">
 				<p> {{ removeDialogMessage }} </p>
-				<template v-if="supportBanV1 && showPermissionsOptions">
+				<template v-if="showBanOption">
 					<NcCheckboxRadioSwitch :checked.sync="isBanParticipant">
 						{{ t('spreed', 'Also ban from this conversation') }}
 					</NcCheckboxRadioSwitch>
@@ -740,6 +740,12 @@ export default {
 
 		isModerator() {
 			return this.participantTypeIsModerator(this.participantType)
+		},
+
+		showBanOption() {
+			return this.supportBanV1
+				&& this.participant.actorType !== ATTENDEE.ACTOR_TYPE.FEDERATED_USERS
+				&& this.showPermissionsOptions
 		},
 
 		showPermissionsOptions() {


### PR DESCRIPTION
### ☑️ Resolves

* Fix #12955

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

Alice is a federated user

🏚️ After | 🏡 Before
-- | --
![image](https://github.com/user-attachments/assets/4361e731-1c3d-4767-b644-176d600d3050) | ![image](https://github.com/user-attachments/assets/267160ac-bc3c-485e-9cbd-7a2909628d61)

<!-- ☀️ Light theme | 🌑 Dark Theme -->


### 🏁 Checklist

- [ ] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
