### PR TITLE
fix: remove extra spinner

### DIFF
--- a/src/components/AvatarWrapper/AvatarWrapper.vue
+++ b/src/components/AvatarWrapper/AvatarWrapper.vue
@@ -40,7 +40,7 @@
 		</span>
 		<NcLoadingIcon v-if="loading"
 			:size="size"
-			class="loading" />
+			class="loading-avatar" />
 	</div>
 </template>
 
@@ -289,7 +289,7 @@ export default {
 	}
 }
 
-.loading {
+.loading-avatar {
 	position: absolute;
 	top: 0;
 }


### PR DESCRIPTION
### ☑️ Resolves

`'loading'` class is "reserved" class that has attached spinner.

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
Screenshot before | Screenshot after

<!-- ☀️ Light theme | 🌑 Dark Theme -->


### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
