### PR TITLE
fix: warning from `false` SearchBox's aria-describedby value

### DIFF
--- a/src/components/RightSidebar/Participants/ParticipantsTab.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsTab.vue
@@ -12,7 +12,7 @@
 				:value.sync="searchText"
 				:is-focused.sync="isFocused"
 				:placeholder-text="searchBoxPlaceholder"
-				:aria-describedby="showSearchBoxDescription && searchBoxDescriptionId"
+				:aria-describedby="showSearchBoxDescription ? searchBoxDescriptionId : undefined"
 				@input="handleInput"
 				@keydown.enter="addParticipants(participantPhoneItem)"
 				@abort-search="abortSearch" />


### PR DESCRIPTION
### ☑️ Resolves

* Removes warning
  ![image](https://github.com/user-attachments/assets/e89b44f3-2a43-4934-9c80-6f7587d6638b)

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
Screenshot before | Screenshot after

<!-- ☀️ Light theme | 🌑 Dark Theme -->

### 🚧 Tasks

- [ ] Explicitly pass `undefined` when no value needed

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [x] Talk Desktop
  - [ ] Not risky to browser differences / client
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
