### PR TITLE
feat: Add "New in Talk 20" messages

### DIFF
--- a/lib/Chat/Changelog/Manager.php
+++ b/lib/Chat/Changelog/Manager.php
@@ -108,8 +108,8 @@ class Manager {
 			$this->l->t('## New in Talk %s', ['16']),
 			$this->l->t('- Emojis can now be autocompleted by typing a ":"'),
 			$this->l->t('- Link various items using the new smart-picker by typing a "/"'),
-			$this->l->t('- Moderators can now create breakout rooms (requires the external signaling server)'),
-			$this->l->t('- Calls can now be recorded (requires the external signaling server)'),
+			$this->l->t('- Moderators can now create breakout rooms (requires the High-performance backend)'),
+			$this->l->t('- Calls can now be recorded (requires the High-performance backend)'),
 			$this->l->t('## New in Talk %s', ['17']) . "\n"
 			. $this->l->t('- Conversations can now have an avatar or emoji as icon') . "\n"
 			. $this->l->t('- Virtual backgrounds are now available in addition to the blurred background in video calls') . "\n"
@@ -128,8 +128,12 @@ class Manager {
 			. $this->l->t('- Video of the speaker is now visible while sharing the screen and call reactions are animated'),
 			$this->l->t('## New in Talk %s', ['19']) . "\n"
 			. $this->l->t('- Messages can now be edited by logged-in authors and moderators for 6 hours') . "\n"
-			. $this->l->t('- Unsent message drafts are now saved in your browser ') . "\n"
+			. $this->l->t('- Unsent message drafts are now saved in your browser') . "\n"
 			. $this->l->t('- *Preview:* Text chatting can now be done in a federated way with other Talk servers'),
+			$this->l->t('## New in Talk %s', ['20']) . "\n"
+			. $this->l->t('- Moderators can now ban accounts and guests to prevent them from rejoining a conversation') . "\n"
+			. $this->l->t('- Upcoming calls from linked calendar events and out-of-office replacements are now shown in conversations') . "\n"
+			. $this->l->t('- *Preview:* Calls can now be done in a federated way with other Talk servers (requires the High-performance backend)'),
 		];
 	}
 }


### PR DESCRIPTION
## New in Talk 20
- Moderators can now ban accounts and guests to prevent them from rejoining a conversation
- Upcoming calls from linked calendar events and out-of-office replacements are shown now in conversations
- *Preview:* Calls can now be done in a federated way with other Talk servers (requires the High-performance backend)
