### PR TITLE
feat: Added blurhash to image metadata

### DIFF
--- a/lib/Chat/Parser/SystemMessage.php
+++ b/lib/Chat/Parser/SystemMessage.php
@@ -812,7 +812,7 @@ class SystemMessage implements IEventListener {
 		// If a preview is available, check if we can get the dimensions of the file from the metadata API
 		if ($isPreviewAvailable && str_starts_with($node->getMimeType(), 'image/')) {
 			try {
-				$sizeMetadata = $this->metadataCache->getMetadataPhotosSizeForFileId($fileId);
+				$sizeMetadata = $this->metadataCache->getImageMetadataForFileId($fileId);
 				if (isset($sizeMetadata['width'], $sizeMetadata['height'])) {
 					$data['width'] = (string) $sizeMetadata['width'];
 					$data['height'] = (string) $sizeMetadata['height'];

--- a/lib/Chat/Parser/SystemMessage.php
+++ b/lib/Chat/Parser/SystemMessage.php
@@ -817,6 +817,10 @@ class SystemMessage implements IEventListener {
 					$data['width'] = (string) $sizeMetadata['width'];
 					$data['height'] = (string) $sizeMetadata['height'];
 				}
+
+				if (isset($sizeMetadata['blurhash'])) {
+					$data['blurhash'] = $sizeMetadata['blurhash'];
+				}
 			} catch (FilesMetadataNotFoundException) {
 			}
 		}

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -91,6 +91,7 @@ namespace OCA\Talk;
  *     permissions?: string,
  *     width?: string,
  *     height?: string,
+ *     blurhash?: string,
  * }
  *
  * @psalm-type TalkBaseMessage = array{

--- a/lib/Share/Helper/FilesMetadataCache.php
+++ b/lib/Share/Helper/FilesMetadataCache.php
@@ -15,7 +15,7 @@ use OCP\FilesMetadata\IFilesMetadataManager;
 use OCP\FilesMetadata\Model\IFilesMetadata;
 
 class FilesMetadataCache {
-	/** @var array<int, ?array{width: int, height: int}> */
+	/** @var array<int, ?array{width: int, height: int, blurhash?: string}> */
 	protected array $filesSizeData = [];
 
 	public function __construct(
@@ -41,7 +41,7 @@ class FilesMetadataCache {
 	/**
 	 * @param int $fileId
 	 * @return array
-	 * @psalm-return array{width: int, height: int}
+	 * @psalm-return array{width: int, height: int, blurhash?: string}
 	 * @throws FilesMetadataNotFoundException
 	 */
 	public function getMetadataPhotosSizeForFileId(int $fileId): array {
@@ -75,6 +75,12 @@ class FilesMetadataCache {
 					'width' => $sizeMetadata['width'],
 					'height' => $sizeMetadata['height'],
 				];
+
+				// Retrieve Blurhash from metadata (if present)
+				if ($metadata->hasKey('blurhash')) {
+					$dimensions['blurhash'] = $metadata->getString('blurhash');
+				}
+
 				$this->filesSizeData[$fileId] = $dimensions;
 			} else {
 				$this->filesSizeData[$fileId] = null;

--- a/lib/Share/Helper/FilesMetadataCache.php
+++ b/lib/Share/Helper/FilesMetadataCache.php
@@ -44,7 +44,7 @@ class FilesMetadataCache {
 	 * @psalm-return array{width: int, height: int, blurhash?: string}
 	 * @throws FilesMetadataNotFoundException
 	 */
-	public function getMetadataPhotosSizeForFileId(int $fileId): array {
+	public function getImageMetadataForFileId(int $fileId): array {
 		if (!array_key_exists($fileId, $this->filesSizeData)) {
 			try {
 				$this->cachePhotosSize($fileId, $this->filesMetadataManager->getMetadata($fileId, true));

--- a/openapi-backend-sipbridge.json
+++ b/openapi-backend-sipbridge.json
@@ -495,6 +495,9 @@
                     },
                     "height": {
                         "type": "string"
+                    },
+                    "blurhash": {
+                        "type": "string"
                     }
                 }
             },

--- a/openapi-federation.json
+++ b/openapi-federation.json
@@ -549,6 +549,9 @@
                     },
                     "height": {
                         "type": "string"
+                    },
+                    "blurhash": {
+                        "type": "string"
                     }
                 }
             },

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -1083,6 +1083,9 @@
                     },
                     "height": {
                         "type": "string"
+                    },
+                    "blurhash": {
+                        "type": "string"
                     }
                 }
             },

--- a/openapi.json
+++ b/openapi.json
@@ -970,6 +970,9 @@
                     },
                     "height": {
                         "type": "string"
+                    },
+                    "blurhash": {
+                        "type": "string"
                     }
                 }
             },

--- a/src/types/openapi/openapi-backend-sipbridge.ts
+++ b/src/types/openapi/openapi-backend-sipbridge.ts
@@ -242,6 +242,7 @@ export type components = {
             permissions?: string;
             width?: string;
             height?: string;
+            blurhash?: string;
         };
         Room: {
             actorId: string;

--- a/src/types/openapi/openapi-federation.ts
+++ b/src/types/openapi/openapi-federation.ts
@@ -289,6 +289,7 @@ export type components = {
             permissions?: string;
             width?: string;
             height?: string;
+            blurhash?: string;
         };
         Room: {
             actorId: string;

--- a/src/types/openapi/openapi-full.ts
+++ b/src/types/openapi/openapi-full.ts
@@ -2082,6 +2082,7 @@ export type components = {
             permissions?: string;
             width?: string;
             height?: string;
+            blurhash?: string;
         };
         Room: {
             actorId: string;

--- a/src/types/openapi/openapi.ts
+++ b/src/types/openapi/openapi.ts
@@ -1563,6 +1563,7 @@ export type components = {
             permissions?: string;
             width?: string;
             height?: string;
+            blurhash?: string;
         };
         Room: {
             actorId: string;

--- a/tests/php/Chat/Parser/SystemMessageTest.php
+++ b/tests/php/Chat/Parser/SystemMessageTest.php
@@ -635,7 +635,7 @@ class SystemMessageTest extends TestCase {
 			->willReturn(true);
 
 		$this->filesMetadataCache->expects($this->once())
-			->method('getMetadataPhotosSizeForFileId')
+			->method('getImageMetadataForFileId')
 			->with(54)
 			->willReturn(['width' => 1234, 'height' => 4567]);
 
@@ -706,7 +706,7 @@ class SystemMessageTest extends TestCase {
 			->willReturn(true);
 	
 		$this->filesMetadataCache->expects($this->once())
-			->method('getMetadataPhotosSizeForFileId')
+			->method('getImageMetadataForFileId')
 			->with(54)
 			->willReturn([
 				'width' => 1234,
@@ -786,7 +786,7 @@ class SystemMessageTest extends TestCase {
 			->willReturn('absolute-link-owner');
 
 		$this->filesMetadataCache->expects($this->never())
-			->method('getMetadataPhotosSizeForFileId');
+			->method('getImageMetadataForFileId');
 
 		$participant = $this->createMock(Participant::class);
 		$attendee = Attendee::fromRow([
@@ -873,7 +873,7 @@ class SystemMessageTest extends TestCase {
 			->willReturn(false);
 
 		$this->filesMetadataCache->expects($this->never())
-			->method('getMetadataPhotosSizeForFileId');
+			->method('getImageMetadataForFileId');
 
 		$this->url->expects($this->once())
 			->method('linkToRouteAbsolute')


### PR DESCRIPTION
### ☑️ Resolves

* Fix #12351 

## 🛠️ API Checklist

### 🚧 Tasks

- [x] Added blurhash to image metadata

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [ ] 📘 API documentation in `docs/` has been updated or is not required
- [ ] 🔖 Capability is added or not needed 
