### PR TITLE
fix: correct userGroups intersection check for federation access

### DIFF
--- a/lib/Config.php
+++ b/lib/Config.php
@@ -108,7 +108,7 @@ class Config {
 		}
 
 		$userGroups = $this->groupManager->getUserGroupIds($user);
-		return empty(array_intersect($allowedGroups, $userGroups));
+		return !empty(array_intersect($allowedGroups, $userGroups));
 	}
 
 	public function isBreakoutRoomsEnabled(): bool {


### PR DESCRIPTION
Fixed `isFederatedEnabledForUser`, which was returning true when the intersection of `allowedGroups` and `userGroups` was empty. Now it correctly returns true when the intersection is not empty.


### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
