### PR TITLE
feat: NoteToSelf messages are editable forever

### DIFF
--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -154,3 +154,4 @@
 * `ban-v1` - Whether the API to ban attendees is available
 * `mention-permissions` - Whether non-moderators are allowed to mention `@all`
 * `federation-v2` - Whether federated session ids are used and calls are possible with federation
+* `edit-messages-note-to-self` - Messages in note-to-self conversations can be edited indefinitely

--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -102,6 +102,7 @@ class Capabilities implements IPublicCapability {
 		'ban-v1',
 		'chat-reference-id',
 		'mention-permissions',
+		'edit-messages-note-to-self',
 	];
 
 	public const LOCAL_FEATURES = [

--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -845,13 +845,14 @@ class ChatController extends AEnvironmentAwareController {
 			return new DataResponse([], Http::STATUS_METHOD_NOT_ALLOWED);
 		}
 
-		$maxAge = $this->timeFactory->getDateTime();
-		$maxAge->sub(new \DateInterval('P1D'));
-		if ($comment->getCreationDateTime() < $maxAge) {
-			// Message is too old
-			return new DataResponse(['error' => 'age'], Http::STATUS_BAD_REQUEST);
+		if ($this->room->getType() !== Room::TYPE_NOTE_TO_SELF) {
+			$maxAge = $this->timeFactory->getDateTime();
+			$maxAge->sub(new \DateInterval('P1D'));
+			if ($comment->getCreationDateTime() < $maxAge) {
+				// Message is too old
+				return new DataResponse(['error' => 'age'], Http::STATUS_BAD_REQUEST);
+			}
 		}
-
 		try {
 			$systemMessageComment = $this->chatManager->editMessage(
 				$this->room,

--- a/tests/integration/features/chat-1/note-to-self.feature
+++ b/tests/integration/features/chat-1/note-to-self.feature
@@ -22,3 +22,19 @@ Feature: chat/note-to-self
     Then user "participant1" sees the following system messages in room "Note to self" with 200
       | room         | actorType | actorId | actorDisplayName | message                         | messageParameters                                              | systemMessage        |
       | Note to self | guests    | system  |                  | System created the conversation | {"actor":{"type":"guest","id":"guest\/system","name":"Guest"}} | conversation_created |
+
+  Scenario: Edit messages forever in note-to-self room
+    When user "participant1" creates note-to-self (v4)
+    And user "participant1" is participant of the following note-to-self rooms (v4)
+      | id                        | type | name         |
+      | participant1-note-to-self | 6    | Note to self |
+    Then user "participant1" sends message "Initial message" to room "participant1-note-to-self" with 201
+    And user "participant1" sees the following messages in room "participant1-note-to-self" with 200
+      | room                      | actorType | actorId      | actorDisplayName         | message          | messageParameters |
+      | participant1-note-to-self | users     | participant1 | participant1-displayname | Initial message  | []                |
+    When aging messages 24 hours in room "participant1-note-to-self"
+    And user "participant1" edits message "Initial message" in room "participant1-note-to-self" to "Edited after 24 hours" with 200
+    Then user "participant1" sees the following messages in room "participant1-note-to-self" with 200
+      | room                      | actorType | actorId      | actorDisplayName         | message                | messageParameters | lastEditActorType | lastEditActorId | lastEditActorDisplayName |
+      | participant1-note-to-self | users     | participant1 | participant1-displayname | Edited after 24 hours  | []                | users             | participant1    | participant1-displayname |
+      


### PR DESCRIPTION
### ☑️ Resolves

* Fix #13033 

## 🛠️ API Checklist

### 🚧 Tasks

- [x] NoteToSelf messages are now editable forever

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
