### PR TITLE
fix(ConversationSettingsDialog): hide unused settings sections in 1-1

### DIFF
--- a/src/components/ConversationSettings/ConversationSettingsDialog.vue
+++ b/src/components/ConversationSettings/ConversationSettingsDialog.vue
@@ -18,7 +18,7 @@
 
 		<template v-if="!isBreakoutRoom">
 			<!-- Notifications settings and devices preview screen -->
-			<NcAppSettingsSection v-if="!isNoteToSelf"
+			<NcAppSettingsSection v-if="!isNoteToSelf && !isOneToOneFormer"
 				id="notifications"
 				:name="t('spreed', 'Personal')">
 				<NcCheckboxRadioSwitch v-if="showMediaSettingsToggle"
@@ -36,11 +36,11 @@
 
 			<NcAppSettingsSection id="conversation-settings"
 				:name="selfIsOwnerOrModerator ? t('spreed', 'Moderation') : t('spreed', 'Setup overview')">
-				<ListableSettings v-if="!isNoteToSelf && !isGuest" :token="token" :can-moderate="canFullModerate" />
-				<MentionsSettings v-if="!isNoteToSelf" :token="token" :can-moderate="canFullModerate" />
+				<ListableSettings v-if="!isNoteToSelf && !isGuest && !isOneToOne" :token="token" :can-moderate="canFullModerate" />
+				<MentionsSettings v-if="!isNoteToSelf && !isOneToOne" :token="token" :can-moderate="canFullModerate" />
 				<LinkShareSettings v-if="!isNoteToSelf" :token="token" :can-moderate="canFullModerate" />
-				<RecordingConsentSettings v-if="!isNoteToSelf && recordingConsentAvailable" :token="token" :can-moderate="selfIsOwnerOrModerator" />
-				<ExpirationSettings :token="token" :can-moderate="selfIsOwnerOrModerator" />
+				<RecordingConsentSettings v-if="!isNoteToSelf && !isOneToOneFormer && recordingConsentAvailable" :token="token" :can-moderate="selfIsOwnerOrModerator" />
+				<ExpirationSettings v-if="!isOneToOneFormer" :token="token" :can-moderate="selfIsOwnerOrModerator" />
 				<BanSettings v-if="supportBanV1 && canFullModerate" :token="token" />
 			</NcAppSettingsSection>
 
@@ -171,6 +171,14 @@ export default {
 
 		isNoteToSelf() {
 			return this.conversation.type === CONVERSATION.TYPE.NOTE_TO_SELF
+		},
+
+		isOneToOne() {
+			return this.conversation.type === CONVERSATION.TYPE.ONE_TO_ONE || this.isOneToOneFormer
+		},
+
+		isOneToOneFormer() {
+			return this.conversation.type === CONVERSATION.TYPE.ONE_TO_ONE_FORMER
 		},
 
 		isGuest() {


### PR DESCRIPTION
… and former 1-1 conversations

### ☑️ Resolves

* Fix #12884


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Former 1-1 | 🏡 1-1 | 🏘️ Group
-- | -- | --
![image](https://github.com/user-attachments/assets/192b5da1-d80b-429f-833a-964bf7505a74) | ![image](https://github.com/user-attachments/assets/9fba1b77-d28f-466f-9b37-ca715aa1f5bb) | ![image](https://github.com/user-attachments/assets/c343a80e-9c67-4489-9168-b5e51a7cc976)




### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Not risky to browser differences / client
