### PR TITLE
fix(RightSidebar): hide sidebar button in lobby

### DIFF
--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -4,7 +4,7 @@
 -->
 
 <template>
-	<NcAppSidebar v-if="token"
+	<NcAppSidebar v-if="isSidebarAvailable"
 		:open="opened"
 		:name="conversation.displayName"
 		:title="conversation.displayName"
@@ -172,11 +172,14 @@ export default {
 	},
 
 	computed: {
+		isSidebarAvailable() {
+			return this.token && !this.isInLobby
+		},
 		show() {
 			return this.$store.getters.getSidebarStatus
 		},
 		opened() {
-			return !this.isInLobby && this.show
+			return this.isSidebarAvailable && this.show
 		},
 		token() {
 			return this.$store.getters.getToken()


### PR DESCRIPTION
### ☑️ Resolves

* In Lobby sidebar is not available (intentionally, I guess?) but there still was the toggle button

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/user-attachments/assets/29385f1f-40b1-43ae-8e90-3503fdea9e88) | ![image](https://github.com/user-attachments/assets/e6ecfd68-bb61-4549-9523-e109adde95c9)

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [x] Talk Desktop
  - [x] Not risky to browser differences / client
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required