### PR TITLE
chore(deps): bump nextcloud/vue from 8.16.0 to 8.17.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@nextcloud/paths": "^2.2.1",
         "@nextcloud/router": "^3.0.1",
         "@nextcloud/upload": "^1.4.3",
-        "@nextcloud/vue": "^8.16.0",
+        "@nextcloud/vue": "^8.17.0",
         "@vueuse/components": "^11.0.0",
         "crypto-js": "^4.2.0",
         "debounce": "^2.1.0",
@@ -3900,9 +3900,9 @@
       }
     },
     "node_modules/@nextcloud/vue": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.16.0.tgz",
-      "integrity": "sha512-xkoR2VeWk+WTTmXC01Z7hI0yztSf222XMPXhy9OkDNQBXmCl/idEjNnMWmxezJMyqALtFD/csouW+GS7JUVoFw==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.17.0.tgz",
+      "integrity": "sha512-BylZZlJcGiEfBO9k/TE8iuKEzzSfmxek1fFwU2fpo0xUDxH9qQurMdTli3ix/kgXaBJgwBD8H8hjzYirpAYbXg==",
       "dependencies": {
         "@floating-ui/dom": "^1.1.0",
         "@linusborg/vue-simple-portal": "^0.1.5",
@@ -3918,8 +3918,8 @@
         "@nextcloud/sharing": "^0.2.2",
         "@nextcloud/timezones": "^0.1.1",
         "@nextcloud/vue-select": "^3.25.0",
-        "@vueuse/components": "^10.9.0",
-        "@vueuse/core": "^10.9.0",
+        "@vueuse/components": "^11.0.0",
+        "@vueuse/core": "^11.0.0",
         "clone": "^2.1.2",
         "debounce": "2.1.0",
         "dompurify": "^3.0.5",
@@ -3986,17 +3986,65 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.0.tgz",
       "integrity": "sha512-MFETx3tbTjE7Uk6vvnWINA/1iJ7LuMdO4fcq8UfF0pRbj01aGLduVvQcRyswuACJdpnHgg8E3rQLhaRdNEJS0w=="
     },
-    "node_modules/@nextcloud/vue/node_modules/@vueuse/components": {
-      "version": "10.11.1",
-      "resolved": "https://registry.npmjs.org/@vueuse/components/-/components-10.11.1.tgz",
-      "integrity": "sha512-ThcreQCX/eq61sLkLKjigD4PQvs3Wy4zglICvQH9tP6xl87y5KsQEoizn6OI+R3hrOgwQHLJe7Y0wLLh3fBKcg==",
+    "node_modules/@nextcloud/vue/node_modules/@vueuse/core": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-11.0.1.tgz",
+      "integrity": "sha512-YTrekI18WwEyP3h168Fir94G/HNC27wvXJI21Alm0sPOwvhihfkrvHIe+5PNJq+MpgWdRcsjvE/38JaoKrgZhQ==",
       "dependencies": {
-        "@vueuse/core": "10.11.1",
-        "@vueuse/shared": "10.11.1",
-        "vue-demi": ">=0.14.8"
+        "@types/web-bluetooth": "^0.0.20",
+        "@vueuse/metadata": "11.0.1",
+        "@vueuse/shared": "11.0.1",
+        "vue-demi": ">=0.14.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
-    "node_modules/@nextcloud/vue/node_modules/@vueuse/components/node_modules/vue-demi": {
+    "node_modules/@nextcloud/vue/node_modules/@vueuse/core/node_modules/vue-demi": {
+      "version": "0.14.10",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
+      "hasInstallScript": true,
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nextcloud/vue/node_modules/@vueuse/metadata": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-11.0.1.tgz",
+      "integrity": "sha512-dTFvuHFAjLYOiSd+t9Sk7xUiuL6jbfay/eX+g+jaipXXlwKur2VCqBCZX+jfu+2vROUGcUsdn3fJR9KkpadIOg==",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@nextcloud/vue/node_modules/@vueuse/shared": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-11.0.1.tgz",
+      "integrity": "sha512-eAPf5CQB3HR0S76HqrhjBqFYstZfiHWZq8xF9EQmobGBkrhPfErJEhr8aMNQMqd6MkENIx2pblIEfJGlHpClug==",
+      "dependencies": {
+        "vue-demi": ">=0.14.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@nextcloud/vue/node_modules/@vueuse/shared/node_modules/vue-demi": {
       "version": "0.14.10",
       "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
       "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
@@ -23757,9 +23805,9 @@
       }
     },
     "@nextcloud/vue": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.16.0.tgz",
-      "integrity": "sha512-xkoR2VeWk+WTTmXC01Z7hI0yztSf222XMPXhy9OkDNQBXmCl/idEjNnMWmxezJMyqALtFD/csouW+GS7JUVoFw==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.17.0.tgz",
+      "integrity": "sha512-BylZZlJcGiEfBO9k/TE8iuKEzzSfmxek1fFwU2fpo0xUDxH9qQurMdTli3ix/kgXaBJgwBD8H8hjzYirpAYbXg==",
       "requires": {
         "@floating-ui/dom": "^1.1.0",
         "@linusborg/vue-simple-portal": "^0.1.5",
@@ -23775,8 +23823,8 @@
         "@nextcloud/sharing": "^0.2.2",
         "@nextcloud/timezones": "^0.1.1",
         "@nextcloud/vue-select": "^3.25.0",
-        "@vueuse/components": "^10.9.0",
-        "@vueuse/core": "^10.9.0",
+        "@vueuse/components": "^11.0.0",
+        "@vueuse/core": "^11.0.0",
         "clone": "^2.1.2",
         "debounce": "2.1.0",
         "dompurify": "^3.0.5",
@@ -23828,14 +23876,36 @@
           "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.0.tgz",
           "integrity": "sha512-MFETx3tbTjE7Uk6vvnWINA/1iJ7LuMdO4fcq8UfF0pRbj01aGLduVvQcRyswuACJdpnHgg8E3rQLhaRdNEJS0w=="
         },
-        "@vueuse/components": {
-          "version": "10.11.1",
-          "resolved": "https://registry.npmjs.org/@vueuse/components/-/components-10.11.1.tgz",
-          "integrity": "sha512-ThcreQCX/eq61sLkLKjigD4PQvs3Wy4zglICvQH9tP6xl87y5KsQEoizn6OI+R3hrOgwQHLJe7Y0wLLh3fBKcg==",
+        "@vueuse/core": {
+          "version": "11.0.1",
+          "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-11.0.1.tgz",
+          "integrity": "sha512-YTrekI18WwEyP3h168Fir94G/HNC27wvXJI21Alm0sPOwvhihfkrvHIe+5PNJq+MpgWdRcsjvE/38JaoKrgZhQ==",
           "requires": {
-            "@vueuse/core": "10.11.1",
-            "@vueuse/shared": "10.11.1",
-            "vue-demi": ">=0.14.8"
+            "@types/web-bluetooth": "^0.0.20",
+            "@vueuse/metadata": "11.0.1",
+            "@vueuse/shared": "11.0.1",
+            "vue-demi": ">=0.14.10"
+          },
+          "dependencies": {
+            "vue-demi": {
+              "version": "0.14.10",
+              "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+              "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
+              "requires": {}
+            }
+          }
+        },
+        "@vueuse/metadata": {
+          "version": "11.0.1",
+          "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-11.0.1.tgz",
+          "integrity": "sha512-dTFvuHFAjLYOiSd+t9Sk7xUiuL6jbfay/eX+g+jaipXXlwKur2VCqBCZX+jfu+2vROUGcUsdn3fJR9KkpadIOg=="
+        },
+        "@vueuse/shared": {
+          "version": "11.0.1",
+          "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-11.0.1.tgz",
+          "integrity": "sha512-eAPf5CQB3HR0S76HqrhjBqFYstZfiHWZq8xF9EQmobGBkrhPfErJEhr8aMNQMqd6MkENIx2pblIEfJGlHpClug==",
+          "requires": {
+            "vue-demi": ">=0.14.10"
           },
           "dependencies": {
             "vue-demi": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@nextcloud/paths": "^2.2.1",
     "@nextcloud/router": "^3.0.1",
     "@nextcloud/upload": "^1.4.3",
-    "@nextcloud/vue": "^8.16.0",
+    "@nextcloud/vue": "^8.17.0",
     "@vueuse/components": "^11.0.0",
     "crypto-js": "^4.2.0",
     "debounce": "^2.1.0",


### PR DESCRIPTION
### ☑️ Resolves

* Changelog: https://github.com/nextcloud-libraries/nextcloud-vue/releases/tag/v8.17.0


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
Screenshot before | Screenshot after

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [x] 🖌️ Design was reviewed, approved or inspired by the design team