### PR TITLE
fix(federation): Sync room properties on join

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -34,6 +34,17 @@ See the general [Nextcloud Developers - Events](https://docs.nextcloud.com/serve
 * After event: `OCA\Talk\Events\LobbyModifiedEvent`
 * Since: 18.0.0
 
+### Federated conversation synced
+
+When multiple properties of a federated conversation are synced, the individual
+"Conversation modified" and "Lobby modified" events are still triggered, but a
+listener could decide to not follow up individual but only after all properties
+where modified.
+
+* Before event: `OCA\Talk\Events\BeforeRoomSyncedEvent`
+* After event: `OCA\Talk\Events\RoomSyncedEvent`
+* Since: 20.0.0
+
 ### Call started
 
 * Before event: `OCA\Talk\Events\BeforeCallStartedEvent`

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -41,6 +41,7 @@ use OCA\Talk\Events\BeforeGuestJoinedRoomEvent;
 use OCA\Talk\Events\BeforeParticipantModifiedEvent;
 use OCA\Talk\Events\BeforeRoomDeletedEvent;
 use OCA\Talk\Events\BeforeRoomsFetchEvent;
+use OCA\Talk\Events\BeforeRoomSyncedEvent;
 use OCA\Talk\Events\BeforeSessionLeftRoomEvent;
 use OCA\Talk\Events\BeforeUserJoinedRoomEvent;
 use OCA\Talk\Events\BotDisabledEvent;
@@ -61,6 +62,7 @@ use OCA\Talk\Events\ParticipantModifiedEvent;
 use OCA\Talk\Events\RoomCreatedEvent;
 use OCA\Talk\Events\RoomDeletedEvent;
 use OCA\Talk\Events\RoomModifiedEvent;
+use OCA\Talk\Events\RoomSyncedEvent;
 use OCA\Talk\Events\SessionLeftRoomEvent;
 use OCA\Talk\Events\SystemMessageSentEvent;
 use OCA\Talk\Events\SystemMessagesMultipleSentEvent;
@@ -286,6 +288,8 @@ class Application extends App implements IBootstrap {
 		$context->registerEventListener(CallEndedForEveryoneEvent::class, SignalingListener::class);
 		$context->registerEventListener(GuestsCleanedUpEvent::class, SignalingListener::class);
 		$context->registerEventListener(LobbyModifiedEvent::class, SignalingListener::class);
+		$context->registerEventListener(BeforeRoomSyncedEvent::class, SignalingListener::class);
+		$context->registerEventListener(RoomSyncedEvent::class, SignalingListener::class);
 
 		$context->registerEventListener(ChatMessageSentEvent::class, SignalingListener::class);
 		$context->registerEventListener(SystemMessageSentEvent::class, SignalingListener::class);

--- a/lib/Events/ARoomModifiedEvent.php
+++ b/lib/Events/ARoomModifiedEvent.php
@@ -24,13 +24,13 @@ abstract class ARoomModifiedEvent extends ARoomEvent {
 	public const PROPERTY_LISTABLE = 'listable';
 	public const PROPERTY_LOBBY = 'lobby';
 	public const PROPERTY_MESSAGE_EXPIRATION = 'messageExpiration';
+	public const PROPERTY_MENTION_PERMISSIONS = 'mentionPermissions';
 	public const PROPERTY_NAME = 'name';
 	public const PROPERTY_PASSWORD = 'password';
 	public const PROPERTY_READ_ONLY = 'readOnly';
 	public const PROPERTY_RECORDING_CONSENT = 'recordingConsent';
 	public const PROPERTY_SIP_ENABLED = 'sipEnabled';
 	public const PROPERTY_TYPE = 'type';
-	public const PROPERTY_MENTION_PERMISSIONS = 'mentionPermissions';
 
 	/**
 	 * @param self::PROPERTY_* $property

--- a/lib/Events/ARoomSyncedEvent.php
+++ b/lib/Events/ARoomSyncedEvent.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Talk\Events;
+
+abstract class ARoomSyncedEvent extends ARoomEvent {
+	public const PROPERTY_LAST_ACTIVITY = 'lastActivity';
+}

--- a/lib/Events/BeforeRoomSyncedEvent.php
+++ b/lib/Events/BeforeRoomSyncedEvent.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Talk\Events;
+
+class BeforeRoomSyncedEvent extends ARoomSyncedEvent {
+}

--- a/lib/Events/RoomSyncedEvent.php
+++ b/lib/Events/RoomSyncedEvent.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Talk\Events;
+
+use OCA\Talk\Room;
+
+class RoomSyncedEvent extends ARoomSyncedEvent {
+	/**
+	 * @param array<array-key, ARoomModifiedEvent::PROPERTY_*|ARoomSyncedEvent::PROPERTY_*> $properties
+	 */
+	public function __construct(
+		Room $room,
+		protected array $properties,
+	) {
+		parent::__construct($room);
+	}
+
+	/**
+	 * @return array<array-key, ARoomModifiedEvent::PROPERTY_*|ARoomSyncedEvent::PROPERTY_*>
+	 */
+	public function getProperties(): array {
+		return $this->properties;
+	}
+}

--- a/lib/Federation/CloudFederationProviderTalk.php
+++ b/lib/Federation/CloudFederationProviderTalk.php
@@ -322,6 +322,8 @@ class CloudFederationProviderTalk implements ICloudFederationProvider {
 			}
 		} elseif ($notification['changedProperty'] === ARoomModifiedEvent::PROPERTY_AVATAR) {
 			$this->roomService->setAvatar($room, $notification['newValue']);
+		} elseif ($notification['changedProperty'] === ARoomModifiedEvent::PROPERTY_CALL_RECORDING) {
+			$this->roomService->setCallRecording($room, $notification['newValue']);
 		} elseif ($notification['changedProperty'] === ARoomModifiedEvent::PROPERTY_DESCRIPTION) {
 			$this->roomService->setDescription($room, $notification['newValue']);
 		} elseif ($notification['changedProperty'] === ARoomModifiedEvent::PROPERTY_IN_CALL) {
@@ -329,6 +331,10 @@ class CloudFederationProviderTalk implements ICloudFederationProvider {
 		} elseif ($notification['changedProperty'] === ARoomModifiedEvent::PROPERTY_LOBBY) {
 			$dateTime = !empty($notification['dateTime']) ? \DateTime::createFromFormat('U', $notification['dateTime']) : null;
 			$this->roomService->setLobby($room, $notification['newValue'], $dateTime, $notification['timerReached'] ?? false);
+		} elseif ($notification['changedProperty'] === ARoomModifiedEvent::PROPERTY_MENTION_PERMISSIONS) {
+			$this->roomService->setMentionPermissions($room, $notification['newValue']);
+		} elseif ($notification['changedProperty'] === ARoomModifiedEvent::PROPERTY_MESSAGE_EXPIRATION) {
+			$this->roomService->setMessageExpiration($room, $notification['newValue']);
 		} elseif ($notification['changedProperty'] === ARoomModifiedEvent::PROPERTY_NAME) {
 			$this->roomService->setName($room, $notification['newValue'], $notification['oldValue']);
 		} elseif ($notification['changedProperty'] === ARoomModifiedEvent::PROPERTY_READ_ONLY) {
@@ -336,6 +342,8 @@ class CloudFederationProviderTalk implements ICloudFederationProvider {
 		} elseif ($notification['changedProperty'] === ARoomModifiedEvent::PROPERTY_RECORDING_CONSENT) {
 			/** @psalm-suppress InvalidArgument */
 			$this->roomService->setRecordingConsent($room, $notification['newValue']);
+		} elseif ($notification['changedProperty'] === ARoomModifiedEvent::PROPERTY_SIP_ENABLED) {
+			$this->roomService->setSIPEnabled($room, $notification['newValue']);
 		} elseif ($notification['changedProperty'] === ARoomModifiedEvent::PROPERTY_TYPE) {
 			$this->roomService->setType($room, $notification['newValue']);
 		} else {

--- a/lib/Federation/Proxy/TalkV1/Controller/RoomController.php
+++ b/lib/Federation/Proxy/TalkV1/Controller/RoomController.php
@@ -91,7 +91,12 @@ class RoomController {
 
 		$headers = ['X-Nextcloud-Talk-Proxy-Hash' => $this->proxy->overwrittenRemoteTalkHash($proxy->getHeader('X-Nextcloud-Talk-Hash'))];
 
-		return new DataResponse([], $statusCode, $headers);
+		/** @var TalkRoom[] $data */
+		$data = $this->proxy->getOCSData($proxy);
+
+		$data = $this->userConverter->convertAttendee($room, $data, 'actorType', 'actorId', 'displayName');
+
+		return new DataResponse($data, $statusCode, $headers);
 	}
 
 	/**

--- a/lib/Federation/Proxy/TalkV1/Notifier/RoomModifiedListener.php
+++ b/lib/Federation/Proxy/TalkV1/Notifier/RoomModifiedListener.php
@@ -49,14 +49,22 @@ class RoomModifiedListener implements IEventListener {
 		if (!in_array($event->getProperty(), [
 			ARoomModifiedEvent::PROPERTY_ACTIVE_SINCE,
 			ARoomModifiedEvent::PROPERTY_AVATAR,
+			ARoomModifiedEvent::PROPERTY_CALL_RECORDING,
 			ARoomModifiedEvent::PROPERTY_DESCRIPTION,
 			ARoomModifiedEvent::PROPERTY_IN_CALL,
 			ARoomModifiedEvent::PROPERTY_LOBBY,
+			ARoomModifiedEvent::PROPERTY_MENTION_PERMISSIONS,
+			ARoomModifiedEvent::PROPERTY_MESSAGE_EXPIRATION,
 			ARoomModifiedEvent::PROPERTY_NAME,
 			ARoomModifiedEvent::PROPERTY_READ_ONLY,
 			ARoomModifiedEvent::PROPERTY_RECORDING_CONSENT,
+			ARoomModifiedEvent::PROPERTY_SIP_ENABLED,
 			ARoomModifiedEvent::PROPERTY_TYPE,
 		], true)) {
+			return;
+		}
+
+		if ($event->getRoom()->isFederatedConversation()) {
 			return;
 		}
 

--- a/lib/Recording/Listener.php
+++ b/lib/Recording/Listener.php
@@ -11,6 +11,7 @@ namespace OCA\Talk\Recording;
 
 use OCA\Talk\AppInfo\Application;
 use OCA\Talk\Events\ACallEndedEvent;
+use OCA\Talk\Events\ARoomEvent;
 use OCA\Talk\Events\CallEndedEvent;
 use OCA\Talk\Events\CallEndedForEveryoneEvent;
 use OCA\Talk\Events\RoomDeletedEvent;
@@ -39,6 +40,10 @@ class Listener implements IEventListener {
 	public function handle(Event $event): void {
 		if ($event instanceof AbstractTranscriptionEvent) {
 			$this->handleTranscriptionEvents($event);
+			return;
+		}
+
+		if ($event instanceof ARoomEvent && $event->getRoom()->isFederatedConversation()) {
 			return;
 		}
 

--- a/openapi-federation.json
+++ b/openapi-federation.json
@@ -1635,17 +1635,15 @@
                     }
                 ],
                 "requestBody": {
-                    "required": true,
+                    "required": false,
                     "content": {
                         "application/json": {
                             "schema": {
                                 "type": "object",
-                                "required": [
-                                    "sessionId"
-                                ],
                                 "properties": {
                                     "sessionId": {
                                         "type": "string",
+                                        "nullable": true,
                                         "description": "Federated session id to join with"
                                     }
                                 }
@@ -1715,7 +1713,9 @@
                                                 "meta": {
                                                     "$ref": "#/components/schemas/OCSMeta"
                                                 },
-                                                "data": {}
+                                                "data": {
+                                                    "$ref": "#/components/schemas/Room"
+                                                }
                                             }
                                         }
                                     }

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -17314,17 +17314,15 @@
                     }
                 ],
                 "requestBody": {
-                    "required": true,
+                    "required": false,
                     "content": {
                         "application/json": {
                             "schema": {
                                 "type": "object",
-                                "required": [
-                                    "sessionId"
-                                ],
                                 "properties": {
                                     "sessionId": {
                                         "type": "string",
+                                        "nullable": true,
                                         "description": "Federated session id to join with"
                                     }
                                 }
@@ -17394,7 +17392,9 @@
                                                 "meta": {
                                                     "$ref": "#/components/schemas/OCSMeta"
                                                 },
-                                                "data": {}
+                                                "data": {
+                                                    "$ref": "#/components/schemas/Room"
+                                                }
                                             }
                                         }
                                     }

--- a/src/types/openapi/openapi-federation.ts
+++ b/src/types/openapi/openapi-federation.ts
@@ -704,11 +704,11 @@ export interface operations {
             };
             cookie?: never;
         };
-        requestBody: {
+        requestBody?: {
             content: {
                 "application/json": {
                     /** @description Federated session id to join with */
-                    sessionId: string;
+                    sessionId?: string | null;
                 };
             };
         };
@@ -723,7 +723,7 @@ export interface operations {
                     "application/json": {
                         ocs: {
                             meta: components["schemas"]["OCSMeta"];
-                            data: unknown;
+                            data: components["schemas"]["Room"];
                         };
                     };
                 };

--- a/src/types/openapi/openapi-full.ts
+++ b/src/types/openapi/openapi-full.ts
@@ -8632,11 +8632,11 @@ export interface operations {
             };
             cookie?: never;
         };
-        requestBody: {
+        requestBody?: {
             content: {
                 "application/json": {
                     /** @description Federated session id to join with */
-                    sessionId: string;
+                    sessionId?: string | null;
                 };
             };
         };
@@ -8651,7 +8651,7 @@ export interface operations {
                     "application/json": {
                         ocs: {
                             meta: components["schemas"]["OCSMeta"];
-                            data: unknown;
+                            data: components["schemas"]["Room"];
                         };
                     };
                 };

--- a/tests/php/Service/RoomServiceTest.php
+++ b/tests/php/Service/RoomServiceTest.php
@@ -45,6 +45,7 @@ class RoomServiceTest extends TestCase {
 	protected IHasher&MockObject $hasher;
 	protected IEventDispatcher&MockObject $dispatcher;
 	protected IJobList&MockObject $jobList;
+	protected LoggerInterface&MockObject $logger;
 	protected ?RoomService $service = null;
 
 	public function setUp(): void {
@@ -58,6 +59,7 @@ class RoomServiceTest extends TestCase {
 		$this->hasher = $this->createMock(IHasher::class);
 		$this->dispatcher = $this->createMock(IEventDispatcher::class);
 		$this->jobList = $this->createMock(IJobList::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->service = new RoomService(
 			$this->manager,
 			$this->participantService,
@@ -67,7 +69,8 @@ class RoomServiceTest extends TestCase {
 			$this->config,
 			$this->hasher,
 			$this->dispatcher,
-			$this->jobList
+			$this->jobList,
+			$this->logger,
 		);
 	}
 
@@ -327,7 +330,8 @@ class RoomServiceTest extends TestCase {
 			$this->config,
 			$this->hasher,
 			$dispatcher,
-			$this->jobList
+			$this->jobList,
+			$this->logger,
 		);
 
 		$room = new Room(

--- a/tests/php/Signaling/ListenerTest.php
+++ b/tests/php/Signaling/ListenerTest.php
@@ -117,6 +117,8 @@ class ListenerTest extends TestCase {
 
 	public function testRecordingStatusChanged(): void {
 		$room = $this->createMock(Room::class);
+		$room->method('getCallRecording')
+			->willReturn(Room::RECORDING_VIDEO);
 
 		$event = new RoomModifiedEvent(
 			$room,
@@ -131,7 +133,7 @@ class ListenerTest extends TestCase {
 			->with($room, [
 				'type' => 'recording',
 				'recording' => [
-					'status' => $event->getNewValue(),
+					'status' => Room::RECORDING_VIDEO,
 				],
 			]);
 		$this->listener->handle($event);


### PR DESCRIPTION
### ☑️ Resolves

* Fix #13045
* Fix #13060
* Ref #12953 (fixes room permissions, but individual participant permissions still need manual syncing like attempted in #12979 )

### Follow-up ideas
- Track a "property-version" so that recipients know if the just now received data is newer or older https://github.com/nextcloud/spreed/issues/13079
- Always send the full room object when the room was modified, so the sync can heal other properties as well https://github.com/nextcloud/spreed/issues/13079

## 🛠️ API Checklist

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
