### PR TITLE
fix(signaling): check only required features on Frontend

### DIFF
--- a/src/utils/signaling.js
+++ b/src/utils/signaling.js
@@ -17,6 +17,7 @@ import {
 
 import CancelableRequest from './cancelableRequest.js'
 import { PARTICIPANT } from '../constants.js'
+import { hasTalkFeature } from '../services/CapabilitiesManager.ts'
 import { EventBus } from '../services/EventBus.js'
 import { rejoinConversation } from '../services/participantsService.js'
 import { pullSignalingMessages } from '../services/signalingService.js'
@@ -1082,10 +1083,12 @@ Signaling.Standalone.prototype.helloResponseReceived = function(data) {
 	}
 
 	if (!this.settings.helloAuthParams.internal
-			&& (!this.hasFeature('audio-video-permissions')
-				|| !this.hasFeature('federation')
-				|| !this.hasFeature('incall-all')
-				|| !this.hasFeature('switchto'))) {
+		&& ((!this.hasFeature('audio-video-permissions') && hasTalkFeature('local', 'conversation-permissions')) // Talk v13
+			|| !this.hasFeature('incall-all') // Talk v15
+			|| (!this.hasFeature('switchto') && hasTalkFeature('local', 'breakout-rooms-v1')) // Talk v16
+			|| (!this.hasFeature('federation') && hasTalkFeature('local', 'federation-v2')) // Talk v20
+		)
+	) {
 		showError(
 			t('spreed', 'The configured signaling server needs to be updated to be compatible with this version of Talk. Please contact your administration.'),
 			{


### PR DESCRIPTION
### ☑️ Resolves

* Fix https://github.com/nextcloud/talk-desktop/issues/760

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

Tested with Talk 19 on Talk Desktop (20 frontend)

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/user-attachments/assets/62db6fef-6630-4d26-af89-e02e2398c779) | ![image](https://github.com/user-attachments/assets/87d439cd-0d0e-4f2b-ae71-35ed014fa089)

### 🚧 Tasks

- [x] Check a signaling server feature only if corresponding capability is available

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [x] Talk Desktop
  - [ ] Not risky to browser differences / client
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required