### PR TITLE
feat(NoteToSelf): allow to edit old messages on frontend

### DIFF
--- a/src/__mocks__/capabilities.ts
+++ b/src/__mocks__/capabilities.ts
@@ -83,6 +83,7 @@ export const mockedCapabilities: Capabilities = {
 			'ban-v1',
 			'chat-reference-id',
 			'mention-permissions',
+			'edit-messages-note-to-self',
 		],
 		'features-local': [
 			'favorites',

--- a/src/composables/__tests__/useMessageInfo.spec.js
+++ b/src/composables/__tests__/useMessageInfo.spec.js
@@ -15,7 +15,7 @@ import { useStore } from '../useStore.js'
 jest.mock('@nextcloud/capabilities', () => ({
 	getCapabilities: jest.fn(() => ({
 		spreed: {
-			features: ['edit-messages'],
+			features: ['edit-messages', 'edit-messages-note-to-self'],
 			'features-local': [],
 		},
 	}))
@@ -163,6 +163,17 @@ describe('message actions', () => {
 		// the conversation is modifiable (not read-only and user is not a guest or guest moderator)
 		// the message is not a object share (e.g. poll)
 
+		// Act
+		const result = useMessageInfo(message)
+		// Assert
+		expect(result.isCurrentUserOwnMessage.value).toBe(true)
+		expect(result.isEditable.value).toBe(true)
+	})
+
+	test('can edit own message in note to self', () => {
+		// Arrange
+		message.value.timestamp = new Date('2024-04-28 7:20:00').getTime() / 1000
+		conversationProps.type = CONVERSATION.TYPE.NOTE_TO_SELF
 		// Act
 		const result = useMessageInfo(message)
 		// Assert

--- a/src/composables/useMessageInfo.js
+++ b/src/composables/useMessageInfo.js
@@ -10,7 +10,7 @@ import moment from '@nextcloud/moment'
 
 import { useConversationInfo } from './useConversationInfo.js'
 import { useStore } from './useStore.js'
-import { ATTENDEE } from '../constants.js'
+import { ATTENDEE, CONVERSATION } from '../constants.js'
 import { hasTalkFeature } from '../services/CapabilitiesManager.ts'
 import { useGuestNameStore } from '../stores/guestName.js'
 
@@ -57,6 +57,10 @@ export function useMessageInfo(message = ref({})) {
 		if (!hasTalkFeature(message.value.token, 'edit-messages') || !isConversationModifiable.value || isObjectShare.value || message.value.systemMessage
 			|| ((!store.getters.isModerator || isOneToOneConversation.value) && !isCurrentUserOwnMessage.value)) {
 			return false
+		}
+
+		if (hasTalkFeature(message.value.token, 'edit-messages-note-to-self') && conversation.value.type === CONVERSATION.TYPE.NOTE_TO_SELF) {
+			return true
 		}
 
 		return (moment(message.value.timestamp * 1000).add(1, 'd')) > moment()


### PR DESCRIPTION
### ☑️ Resolves

* Ref #13033

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

![image](https://github.com/user-attachments/assets/9fe47ac6-52e4-49c4-901b-a8cb84d34cf6)

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Not risky to browser differences / client
- [x] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
