### PR TITLE
fix(avatar): decrease size of loading spinner

### DIFF
--- a/src/components/AvatarWrapper/AvatarWrapper.vue
+++ b/src/components/AvatarWrapper/AvatarWrapper.vue
@@ -39,7 +39,7 @@
 			<WebIcon :size="14" />
 		</span>
 		<NcLoadingIcon v-if="loading"
-			:size="size"
+			:size="size / 2"
 			class="loading-avatar" />
 	</div>
 </template>
@@ -292,6 +292,9 @@ export default {
 .loading-avatar {
 	position: absolute;
 	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
 }
 
 </style>

--- a/src/components/CallView/shared/LocalVideo.vue
+++ b/src/components/CallView/shared/LocalVideo.vue
@@ -25,7 +25,7 @@
 				class="video"
 				@playing="updateVideoAspectRatio" />
 			<NcLoadingIcon v-if="isNotConnected"
-				:size="avatarSize"
+				:size="avatarSize / 2"
 				class="video-loading" />
 		</div>
 		<div v-if="!screenshotModeUrl && !localMediaModel.attributes.videoEnabled && !isSidebar" class="avatar-container">

--- a/src/components/CallView/shared/VideoVue.vue
+++ b/src/components/CallView/shared/VideoVue.vue
@@ -29,7 +29,7 @@
 					:size="32"
 					@click="$emit('click-presenter')" />
 				<NcLoadingIcon v-if="isLoading"
-					:size="avatarSize"
+					:size="avatarSize / 2"
 					class="video-loading" />
 			</div>
 		</TransitionWrapper>


### PR DESCRIPTION
### ☑️ Resolves

* Reduce spinner size to 1/2 of avatar


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/user-attachments/assets/b6cb859f-e68e-43d0-b62c-924ca970832e) | ![image](https://github.com/user-attachments/assets/09173afc-eeac-4f81-afbf-d30993ecbd63)
![image](https://github.com/user-attachments/assets/c7b20d41-eebc-4707-9f3f-4143fed77c28) | ![image](https://github.com/user-attachments/assets/2e761e8d-49bd-4daf-b23d-173deb48001d)

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
