### PR TITLE
Release 18.0.11 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 18.0.11 – 2024-08-22
+### Changed
+- Update several dependencies
+
+### Fixed
+- fix(settings): hide secrets in password fields
+  [#12843](https://github.com/nextcloud/spreed/issues/12843)
+- fix(conversation): Fix adding and removing permissions
+  [#13080](https://github.com/nextcloud/spreed/issues/13080)
+- fix(session): Fix generating session id again if duplicated
+  [#12744](https://github.com/nextcloud/spreed/issues/12744)
+
 ## 18.0.10 – 2024-07-11
 ### Fixed
 - fix(sharing): Fix share detection within object stores

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -16,7 +16,7 @@ And in the works for the [coming versions](https://github.com/nextcloud/spreed/m
 
 	]]></description>
 
-	<version>18.0.10</version>
+	<version>18.0.11</version>
 	<licence>agpl</licence>
 
 	<author>Daniel Calviño Sánchez</author>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "talk",
-  "version": "18.0.10",
+  "version": "18.0.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "talk",
-      "version": "18.0.10",
+      "version": "18.0.11",
       "license": "agpl",
       "dependencies": {
         "@linusborg/vue-simple-portal": "^0.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "talk",
-  "version": "18.0.10",
+  "version": "18.0.11",
   "private": true,
   "description": "",
   "author": "Joas Schilling <coding@schilljs.com>",


### PR DESCRIPTION
# 18.0.11 – 2024-08-22
## Changed
- Update several dependencies

## Fixed
- fix(settings): hide secrets in password fields [#12843](https://github.com/nextcloud/spreed/issues/12843)
- fix(conversation): Fix adding and removing permissions [#13080](https://github.com/nextcloud/spreed/issues/13080)
- fix(session): Fix generating session id again if duplicated [#12744](https://github.com/nextcloud/spreed/issues/12744)