### PR TITLE
fix(FilePreview): set fixed size to image container

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.spec.js
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.spec.js
@@ -23,7 +23,6 @@ describe('FilePreview.vue', () => {
 	let localVue
 	let testStoreConfig
 	let propsData
-	let imageMock
 	let getUserIdMock
 	let oldPixelRatio
 
@@ -38,16 +37,6 @@ describe('FilePreview.vue', () => {
 		getUserIdMock = jest.fn().mockReturnValue('current-user-id')
 		testStoreConfig.modules.actorStore.getters.getUserId = () => getUserIdMock
 		store = new Vuex.Store(testStoreConfig)
-
-		imageMock = {
-			onload: jest.fn(),
-			onerror: jest.fn(),
-			src: null,
-		}
-		jest.spyOn(global, 'Image')
-			.mockImplementation(() => {
-				return imageMock
-			})
 
 		propsData = {
 			token: 'TOKEN',
@@ -84,7 +73,7 @@ describe('FilePreview.vue', () => {
 				propsData,
 			})
 
-			await imageMock.onload()
+			await wrapper.find('img').trigger('load')
 
 			expect(wrapper.element.tagName).toBe('A')
 			const imageUrl = parseRelativeUrl(wrapper.find('img').attributes('src'))
@@ -107,7 +96,7 @@ describe('FilePreview.vue', () => {
 				propsData,
 			})
 
-			await imageMock.onload()
+			await wrapper.find('img').trigger('load')
 
 			expect(wrapper.element.tagName).toBe('A')
 			const imageUrl = parseRelativeUrl(wrapper.find('img').attributes('src'))
@@ -129,7 +118,7 @@ describe('FilePreview.vue', () => {
 				propsData,
 			})
 
-			await imageMock.onload()
+			await wrapper.find('img').trigger('load')
 
 			expect(wrapper.element.tagName).toBe('A')
 			const imageUrl = parseRelativeUrl(wrapper.find('img').attributes('src'))
@@ -145,7 +134,7 @@ describe('FilePreview.vue', () => {
 				propsData,
 			})
 
-			await imageMock.onload()
+			await wrapper.find('img').trigger('load')
 
 			expect(wrapper.element.tagName).toBe('A')
 			const imageUrl = parseRelativeUrl(wrapper.find('img').attributes('src'))
@@ -185,7 +174,7 @@ describe('FilePreview.vue', () => {
 					propsData,
 				})
 
-				await imageMock.onload()
+				await wrapper.find('img').trigger('load')
 
 				expect(wrapper.element.tagName).toBe('DIV')
 				expect(wrapper.find('img').attributes('src')).toBe('blob:XYZ')
@@ -206,8 +195,8 @@ describe('FilePreview.vue', () => {
 			})
 
 			expect(wrapper.element.tagName).toBe('A')
-			expect(wrapper.find('img').exists()).toBe(false)
-			expect(wrapper.find('.loading').exists()).toBe(true)
+			const spinner = wrapper.findComponent({ name: 'NcLoadingIcon' })
+			expect(spinner.exists()).toBe(true)
 		})
 
 		test('renders default mime icon on load error', async () => {
@@ -218,7 +207,7 @@ describe('FilePreview.vue', () => {
 				propsData,
 			})
 
-			await imageMock.onerror()
+			await wrapper.find('img').trigger('error')
 
 			expect(wrapper.element.tagName).toBe('A')
 			const imageUrl = wrapper.find('img').attributes('src')
@@ -235,7 +224,7 @@ describe('FilePreview.vue', () => {
 				propsData,
 			})
 
-			await imageMock.onload()
+			await wrapper.find('img').trigger('load')
 
 			expect(wrapper.element.tagName).toBe('A')
 			const imageUrl = wrapper.find('img').attributes('src')
@@ -259,7 +248,7 @@ describe('FilePreview.vue', () => {
 					propsData,
 				})
 
-				await imageMock.onload()
+				await wrapper.find('img').trigger('load')
 
 				expect(wrapper.element.tagName).toBe('A')
 				expect(wrapper.find('img').attributes('src'))
@@ -276,7 +265,7 @@ describe('FilePreview.vue', () => {
 					propsData,
 				})
 
-				await imageMock.onload()
+				await wrapper.find('img').trigger('load')
 
 				expect(wrapper.element.tagName).toBe('A')
 				expect(wrapper.find('img').attributes('src'))
@@ -294,7 +283,7 @@ describe('FilePreview.vue', () => {
 					propsData,
 				})
 
-				await imageMock.onload()
+				await wrapper.find('img').trigger('load')
 
 				expect(wrapper.element.tagName).toBe('A')
 				expect(wrapper.find('img').attributes('src'))
@@ -311,7 +300,7 @@ describe('FilePreview.vue', () => {
 					propsData,
 				})
 
-				await imageMock.onload()
+				await wrapper.find('img').trigger('load')
 
 				expect(wrapper.element.tagName).toBe('A')
 				const imageUrl = parseRelativeUrl(wrapper.find('img').attributes('src'))
@@ -370,7 +359,7 @@ describe('FilePreview.vue', () => {
 					propsData,
 				})
 
-				await imageMock.onload()
+				await wrapper.find('img').trigger('load')
 
 				await wrapper.find('a').trigger('click')
 
@@ -404,7 +393,7 @@ describe('FilePreview.vue', () => {
 					propsData,
 				})
 
-				await imageMock.onload()
+				await wrapper.find('img').trigger('load')
 
 				await wrapper.find('a').trigger('click')
 
@@ -419,7 +408,7 @@ describe('FilePreview.vue', () => {
 					propsData,
 				})
 
-				await imageMock.onload()
+				await wrapper.find('img').trigger('load')
 
 				// no error
 				await wrapper.find('a').trigger('click')
@@ -450,7 +439,7 @@ describe('FilePreview.vue', () => {
 						propsData,
 					})
 
-					await imageMock.onload()
+					await wrapper.find('img').trigger('load')
 
 					const buttonEl = wrapper.findComponent(PlayCircleOutline)
 					expect(buttonEl.exists()).toBe(visible)
@@ -491,7 +480,7 @@ describe('FilePreview.vue', () => {
 						propsData,
 					})
 
-					await imageMock.onerror()
+					await wrapper.find('img').trigger('error')
 
 					const buttonEl = wrapper.findComponent(PlayCircleOutline)
 					expect(buttonEl.exists()).toBe(false)
@@ -524,7 +513,7 @@ describe('FilePreview.vue', () => {
 				propsData,
 			})
 
-			await imageMock.onload()
+			await wrapper.find('img').trigger('load')
 
 			expect(wrapper.element.tagName).toBe('DIV')
 			await wrapper.findComponent(NcButton).trigger('click')

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
@@ -15,40 +15,39 @@
 		v-bind="filePreviewBinding"
 		@click.exact="handleClick"
 		@keydown.enter="handleClick">
-		<span v-if="!isLoading || fallbackLocalUrl"
+		<span v-tooltip="previewTooltip"
 			class="image-container"
-			:class="{'playable': isPlayable}">
-			<span v-if="isPlayable && !smallPreview" class="play-video-button">
-				<PlayCircleOutline :size="48"
-					fill-color="#ffffff" />
-			</span>
-			<img v-if="!failed"
-				v-tooltip="previewTooltip"
-				:class="previewImageClass"
-				class="file-preview__image"
-				alt=""
-				:src="previewUrl">
-			<img v-else
-				:class="previewImageClass"
-				alt=""
-				:src="defaultIconUrl">
-			<NcProgressBar v-if="showUploadProgress"
-				class="file-preview__progress"
-				type="circular"
-				:value="uploadProgress" />
+			:class="{'playable': isPlayable}"
+			:style="imageContainerStyle">
+			<template v-if="!isLoading || fallbackLocalUrl">
+				<span v-if="isPlayable && !smallPreview" class="play-video-button">
+					<PlayCircleOutline :size="48"
+						fill-color="#ffffff" />
+				</span>
+				<img v-if="!failed"
+					:class="previewImageClass"
+					class="file-preview__image"
+					:alt="file.name"
+					:src="previewUrl">
+				<img v-else
+					:class="previewImageClass"
+					:alt="file.name"
+					:src="defaultIconUrl">
+				<NcProgressBar v-if="showUploadProgress"
+					class="file-preview__progress"
+					type="circular"
+					:value="uploadProgress" />
+			</template>
+			<template v-else-if="isLoading">
+				<canvas v-if="file.blurhash"
+					ref="blurCanvas"
+					width="32"
+					height="32"
+					class="preview preview-loading" />
+				<span v-else class="preview loading" />
+			</template>
 		</span>
-		<template v-else-if="isLoading">
-			<canvas v-if="file.blurhash"
-				ref="blurCanvas"
-				width="32"
-				height="32"
-				class="preview"
-				:style="imageContainerStyle" />
-			<span v-else
-				v-tooltip="previewTooltip"
-				class="preview loading"
-				:style="imageContainerStyle" />
-		</template>
+
 		<NcButton v-if="isUploadEditor"
 			class="remove-file"
 			tabindex="1"
@@ -590,31 +589,38 @@ export default {
 	}
 
 	.preview {
-		display: inline-block;
 		border-radius: var(--border-radius);
 		max-width: 100%;
 		max-height: 384px;
 	}
 
 	.preview-medium {
-		display: inline-block;
 		border-radius: var(--border-radius);
 		max-width: 100%;
 		max-height: 192px;
 	}
 
 	.preview-small {
-		display: inline-block;
 		border-radius: var(--border-radius);
 		max-width: 100%;
 		max-height: 32px;
 	}
 
-	.image-container {
-		position: relative;
-		display: inline-block;
+	.preview-loading {
+		border-radius: var(--border-radius);
 		width: 100%;
 		height: 100%;
+		background-color: var(--color-background-dark);
+	}
+
+	.image-container {
+		position: relative;
+		display: inline-flex;
+		width: 100%;
+		height: 100%;
+		max-width: 100%;
+		max-height: 100%;
+		border-radius: var(--border-radius);
 
 		&.playable {
 			.preview {

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
@@ -44,7 +44,7 @@
 					width="32"
 					height="32"
 					class="preview preview-loading" />
-				<span v-else class="preview loading" />
+				<NcLoadingIcon v-else class="preview preview-loading" />
 			</template>
 		</span>
 
@@ -76,6 +76,7 @@ import { generateUrl, imagePath, generateRemoteUrl } from '@nextcloud/router'
 import { getUploader } from '@nextcloud/upload'
 
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
+import NcLoadingIcon from '@nextcloud/vue/dist/Components/NcLoadingIcon.js'
 import NcProgressBar from '@nextcloud/vue/dist/Components/NcProgressBar.js'
 import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip.js'
 
@@ -97,10 +98,12 @@ export default {
 	name: 'FilePreview',
 
 	components: {
+		NcButton,
+		NcLoadingIcon,
 		NcProgressBar,
+		// Icons
 		Close,
 		PlayCircleOutline,
-		NcButton,
 	},
 
 	directives: {
@@ -182,6 +185,7 @@ export default {
 			uploadManager: null,
 		}
 	},
+
 	computed: {
 		shouldShowFileDetail() {
 			if (this.isSharedItems && !this.rowLayout) {
@@ -571,12 +575,6 @@ export default {
 		top: 50%;
 		right: 0;
 		transform: translate(100%, -50%);
-	}
-
-	.loading {
-		display: inline-block;
-		min-width: 32px;
-		background-color: var(--color-background-dark);
 	}
 
 	.mimeicon {


### PR DESCRIPTION
### ☑️ Resolves

- Minor UX changes to FilePreview
  - fix container size to single source (prevents jumping to 0 and back when image is loaded)
  - use NcLoadingIcon
  - don't load virtual image in mounted hook
  - add fade transition from blurhash/loader to image


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before

https://github.com/user-attachments/assets/b07a6464-2810-4892-9440-d9249b9ea946

🏡 After

https://github.com/user-attachments/assets/92102d54-0e13-47a9-8ff4-dd29214386e8

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [x] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required