### PR TITLE
fix(TopBar): show "now" instead of start time when it is in the past

### DIFF
--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -285,7 +285,16 @@ export default {
 		},
 
 		eventInfo() {
-			return this.nextEvent ? moment(this.nextEvent.start * 1000).calendar() : null
+			if (!this.nextEvent) {
+				return null
+			}
+
+			// If timestamp is in the past, show "now"
+			if (this.nextEvent.start <= moment().unix()) {
+				return t('spreed', 'Now')
+			}
+
+			return moment(this.nextEvent.start * 1000).calendar()
 		},
 
 		showUpcomingEvent() {


### PR DESCRIPTION
### ☑️ Resolves

* Fix #13047

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/user-attachments/assets/c37671d3-328a-4627-b8c2-092d679a4bd2) | ![image](https://github.com/user-attachments/assets/e8150083-f19e-4e2a-8cd0-df8880e73175)

<!-- ☀️ Light theme | 🌑 Dark Theme -->

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required