### PR TITLE
fix(Reactions): show all names if they are at most 4 reactions

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/Reactions.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/Reactions.vue
@@ -23,7 +23,10 @@
 
 			<div v-if="hasReactionsLoaded" class="reaction-details">
 				<span>{{ getReactionSummary(reaction) }}
-					<a v-if="reactionsCount(reaction) > 3"
+					<span v-if="reactionsCount(reaction) === 4">
+						{{ remainingReactionsLabel(reaction) }}
+					</span>
+					<a v-else-if="reactionsCount(reaction) > 4"
 						class="more-reactions-button"
 						role="button"
 						tabindex="0"
@@ -269,6 +272,10 @@ export default {
 		},
 
 		remainingReactionsLabel(reaction) {
+			const reactionsCount = this.reactionsCount(reaction)
+			if (reactionsCount === 4) {
+				return t('spreed', 'and {participant}', { participant: this.getDisplayNameForReaction(this.detailedReactions[reaction][3]) })
+			}
 			return n('spreed', 'and %n other participant', 'and %n other participants', this.reactionsCount(reaction) - 3)
 		},
 	}


### PR DESCRIPTION
### ☑️ Resolves

* Fix: instead of `"A, B, C, and 1 other participant"`, it is now `"A, B, C, and D"` , +1 `"A, B, C, and 2 other participants"` ....

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/user-attachments/assets/b6f48021-29d5-4a4b-bbcb-569d10ed3a6b) | ![image](https://github.com/user-attachments/assets/c1762c96-6c2a-4a7b-98da-1d02ec20a589)

<!-- ☀️ Light theme | 🌑 Dark Theme -->


### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required

