### PR TITLE
fix(fileUpload): don't duplicate file templates in store

### DIFF
--- a/src/components/NewMessage/NewMessageAttachments.vue
+++ b/src/components/NewMessage/NewMessageAttachments.vue
@@ -135,7 +135,7 @@ export default {
 
 	computed: {
 		fileTemplateOptions() {
-			return this.$store.getters.getFileTemplates()
+			return this.$store.getters.fileTemplates
 		},
 
 		shareFromNextcloudLabel() {

--- a/src/components/NewMessage/NewMessageNewFileDialog.vue
+++ b/src/components/NewMessage/NewMessageNewFileDialog.vue
@@ -110,7 +110,7 @@ export default {
 
 	computed: {
 		fileTemplateOptions() {
-			return this.$store.getters.getFileTemplates()
+			return this.$store.getters.fileTemplates
 		},
 
 		fileTemplate() {

--- a/src/store/fileUploadStore.js
+++ b/src/store/fileUploadStore.js
@@ -204,7 +204,7 @@ const mutations = {
 		state.fileTemplatesInitialised = true
 	},
 
-	markFileTemplatesInitialisedForGuests(state) {
+	markFileTemplatesInitialised(state) {
 		state.fileTemplatesInitialised = true
 	},
 }
@@ -547,9 +547,15 @@ const actions = {
 	},
 
 	async getFileTemplates({ commit, getters }) {
+		if (getters.fileTemplates.length) {
+			console.debug('Skip file templates setup as already done')
+			commit('markFileTemplatesInitialised')
+			return
+		}
+
 		if (getters.getUserId() === null) {
 			console.debug('Skip file templates setup for participants that are not logged in')
-			commit('markFileTemplatesInitialisedForGuests')
+			commit('markFileTemplatesInitialised')
 			return
 		}
 

--- a/src/store/fileUploadStore.js
+++ b/src/store/fileUploadStore.js
@@ -102,7 +102,7 @@ const getters = {
 		return state.fileTemplatesInitialised
 	},
 
-	getFileTemplates: (state) => () => {
+	fileTemplates: (state) => {
 		return state.fileTemplates
 	},
 }
@@ -199,8 +199,8 @@ const mutations = {
 		Vue.delete(state.uploads, uploadId)
 	},
 
-	storeFilesTemplates(state, { template }) {
-		state.fileTemplates.push(template)
+	storeFilesTemplates(state, templates) {
+		Vue.set(state, 'fileTemplates', templates)
 		state.fileTemplatesInitialised = true
 	},
 
@@ -555,10 +555,7 @@ const actions = {
 
 		try {
 			const response = await getFileTemplates()
-
-			response.data.ocs.data.forEach(template => {
-				commit('storeFilesTemplates', { template })
-			})
+			commit('storeFilesTemplates', response.data.ocs.data)
 		} catch (error) {
 			console.error('An error happened when trying to load the templates', error)
 		}


### PR DESCRIPTION
### ☑️ Resolves

* Fix duplicating of templates


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/user-attachments/assets/5e9a4b2a-9013-41be-b85f-d90387a7ef0d) | ![Screenshot from 2024-08-23 18-29-30](https://github.com/user-attachments/assets/9937b3d5-b5bc-4df2-a97c-603cecb7ece0)

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [x] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required