### PR TITLE
fix(Avatar): Return dark avatar URL if the user has a dark theme selected

### DIFF
--- a/lib/Service/AvatarService.php
+++ b/lib/Service/AvatarService.php
@@ -12,6 +12,7 @@ namespace OCA\Talk\Service;
 use InvalidArgumentException;
 use OC\Files\Filesystem;
 use OCA\Talk\Room;
+use OCA\Theming\Service\ThemesService;
 use OCP\Files\IAppData;
 use OCP\Files\NotFoundException;
 use OCP\Files\SimpleFS\InMemoryFile;
@@ -37,6 +38,7 @@ class AvatarService {
 		private RoomService $roomService,
 		private IAvatarManager $avatarManager,
 		private IEmojiHelper $emojiHelper,
+		private ThemesService $themesService,
 	) {
 	}
 
@@ -317,9 +319,18 @@ class AvatarService {
 	}
 
 	public function getAvatarUrl(Room $room): string {
+		$darkTheme = false;
+		foreach ($this->themesService->getEnabledThemes() as $theme) {
+			if (str_starts_with($theme, 'dark')) {
+				$darkTheme = true;
+				break;
+			}
+		}
+
 		$arguments = [
 			'token' => $room->getToken(),
 			'apiVersion' => 'v1',
+			'darkTheme' => $darkTheme,
 		];
 
 		$avatarVersion = $this->getAvatarVersion($room);

--- a/psalm.xml
+++ b/psalm.xml
@@ -92,6 +92,7 @@
 		<file name="tests/stubs/oca_circles.php" />
 		<file name="tests/stubs/oca_federation_trustedservers.php" />
 		<file name="tests/stubs/oca_files_events.php" />
+		<file name="tests/stubs/oca_theming_themesservice.php" />
 		<file name="tests/stubs/GuzzleHttp_Exception_ClientException.php" />
 		<file name="tests/stubs/GuzzleHttp_Exception_ConnectException.php" />
 		<file name="tests/stubs/GuzzleHttp_Exception_ServerException.php" />

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -2637,8 +2637,8 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 			$item['iconUrl'] = str_replace('{$BASE_URL}', $this->baseUrl, $item['iconUrl']);
 			$item['iconUrl'] = str_replace('{token}', $token, $item['iconUrl']);
 
-			Assert::assertMatchesRegularExpression('/\?v=\w{8}$/', $actualItems[$key]['iconUrl']);
-			preg_match('/(?<version>\?v=\w{8})$/', $actualItems[$key]['iconUrl'], $matches);
+			Assert::assertMatchesRegularExpression('/\?darkTheme=0&v=\w{8}$/', $actualItems[$key]['iconUrl']);
+			preg_match('/(?<version>\?darkTheme=0&v=\w{8})$/', $actualItems[$key]['iconUrl'], $matches);
 			$item['iconUrl'] = str_replace('{version}', $matches['version'], $item['iconUrl']);
 
 			Assert::assertEquals($item, $actualItems[$key], 'Wrong details for item #' . $key);

--- a/tests/stubs/oca_theming_themesservice.php
+++ b/tests/stubs/oca_theming_themesservice.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Theming\Service;
+
+class ThemesService {
+	public function getEnabledThemes(): array {
+		return [];
+	}
+}


### PR DESCRIPTION
In places like the Dashboard the light user avatar is always shown regardless of the user theme. This is quite a visual distraction to me. AFAICT this fix also affects other places where a room avatar is shown.

Unfortunately it is only possible to detect the dark theme if the user configured it explicitly. If the user only has the `default` aka system theme, then only the browser can now the final theme.

The only real fix would be to extend the places where an URL is required and provide one for light and one for dark theme separately, such that the frontend can decide which to pick (but that would need to be implemented both in the clients and every dashboard widget and so on and is probably not worth the effort).

## 🛠️ API Checklist

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed