### PR TITLE
fix(FilePreview): use original size for uploaded image files

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
@@ -282,6 +282,11 @@ export default {
 		},
 
 		imageContainerStyle() {
+			// Uploaded image in temporary message (use actual image size)
+			if (this.previewType === PREVIEW_TYPE.TEMPORARY && !this.isUploadEditor) {
+				return {}
+			}
+
 			// Fallback for loading mimeicons (preview for audio files is not provided)
 			if (this.file['preview-available'] !== 'yes' || this.file.mimetype.startsWith('audio/')) {
 				return {
@@ -293,12 +298,9 @@ export default {
 			const widthConstraint = this.smallPreview ? 32 : (this.mediumPreview ? 192 : 600)
 			const heightConstraint = this.smallPreview ? 32 : (this.mediumPreview ? 192 : 384)
 
-			// Fallback when no metadata available
+			// Actual size when no metadata available
 			if (!this.file.width || !this.file.height) {
-				return {
-					width: widthConstraint + 'px',
-					height: heightConstraint + 'px',
-				}
+				return {}
 			}
 
 			const sizeMultiplicator = Math.min(
@@ -587,8 +589,8 @@ export default {
 
 	.preview {
 		border-radius: var(--border-radius);
-		max-width: 100%;
-		max-height: 384px;
+		max-width: min(100%, 600px);
+		max-height: min(100%, 384px);
 	}
 
 	.preview-medium {

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
@@ -288,7 +288,7 @@ export default {
 			}
 
 			// Fallback for loading mimeicons (preview for audio files is not provided)
-			if (this.file['preview-available'] !== 'yes' || this.file.mimetype.startsWith('audio/')) {
+			if (this.file['preview-available'] !== 'yes' || this.file.mimetype.startsWith('audio/') || this.failed) {
 				return {
 					width: this.smallPreview ? '32px' : '128px',
 					height: this.smallPreview ? '32px' : '128px',


### PR DESCRIPTION
### ☑️ Resolves

* Fix regression from #13109

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/user-attachments/assets/81162709-06e7-4dab-bca6-ce318843e6f6) | ![image](https://github.com/user-attachments/assets/7f5eb0c3-8072-4e7d-9517-7215e7683098)
![image](https://github.com/user-attachments/assets/d665e106-268c-40d0-a78c-5ad165578ee3) | ![image](https://github.com/user-attachments/assets/659a7dca-b9ed-4c12-8802-67925dabbc21)

<!-- ☀️ Light theme | 🌑 Dark Theme -->

### 🚧 Tasks

- [ ] Other cases?

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
