### PR TITLE
fix(CallView): remove shadow of avatars

### DIFF
--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -839,10 +839,6 @@ export default {
 	vertical-align: top; /* fix white line below video */
 }
 
-#videos :deep(.avatardiv) {
-	box-shadow: 0 0 15px var(--color-box-shadow);
-}
-
 #videos :deep(video) {
 	padding: 0;
 }


### PR DESCRIPTION
### ☑️ Resolves

* Shadows are used only for elements on top of other elements, like menus/autocomplete

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/user-attachments/assets/4b117560-30bd-4177-85a3-79b02fa7cd85) | ![image](https://github.com/user-attachments/assets/bd6ff043-5aae-4a42-a8ab-aa0014eac9b6)

<!-- ☀️ Light theme | 🌑 Dark Theme -->


### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
