### PR TITLE
fix(TopBar): disable buttons if user has no media permissions

### DIFF
--- a/src/components/CallView/shared/LocalAudioControlButton.vue
+++ b/src/components/CallView/shared/LocalAudioControlButton.vue
@@ -7,7 +7,8 @@
 	<NcButton v-tooltip="audioButtonTooltip"
 		:type="type"
 		:aria-label="audioButtonAriaLabel"
-		:class="{ 'no-audio-available': !isAudioAllowed || !model.attributes.audioAvailable }"
+		:class="{ 'no-audio-available': !model.attributes.audioAvailable }"
+		:disabled="!isAudioAllowed"
 		@click.stop="toggleAudio">
 		<template #icon>
 			<VolumeIndicator :audio-preview-available="model.attributes.audioAvailable"

--- a/src/components/CallView/shared/LocalVideoControlButton.vue
+++ b/src/components/CallView/shared/LocalVideoControlButton.vue
@@ -7,7 +7,8 @@
 	<NcButton v-tooltip="videoButtonTooltip"
 		:type="type"
 		:aria-label="videoButtonAriaLabel"
-		:class="{ 'no-video-available': !isVideoAllowed || !model.attributes.videoAvailable }"
+		:class="{ 'no-video-available': !model.attributes.videoAvailable }"
+		:disabled="!isVideoAllowed"
 		@click.stop="toggleVideo">
 		<template #icon>
 			<VideoIcon v-if="showVideoOn" :size="20" />

--- a/src/components/TopBar/TopBarMediaControls.vue
+++ b/src/components/TopBar/TopBarMediaControls.vue
@@ -73,6 +73,7 @@
 			class="app-navigation-entry-utils-menu-button"
 			:boundaries-element="boundaryElement"
 			:container="container"
+			:disabled="!isScreensharingAllowed"
 			:open.sync="screenSharingMenuOpen">
 			<template #icon>
 				<MonitorOff :size="20" />
@@ -95,6 +96,7 @@
 			v-tooltip="screenSharingButtonTooltip"
 			type="tertiary"
 			:aria-label="screenSharingButtonAriaLabel"
+			:disabled="!isScreensharingAllowed"
 			@click.stop="toggleScreenSharingMenu">
 			<template #icon>
 				<MonitorShare :size="20" />


### PR DESCRIPTION
### ☑️ Resolves

* Fix false positively active buttons
  * audio/video buttons could opened MediaSettings before, but if you're not allowed to stream audio/video - nothing to change?


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before (cursor: pointer) | 🏡 After (cursor: default)
-- | --
![image](https://github.com/user-attachments/assets/2c6055ea-2d5c-428c-8946-14301ccebefe) | ![image](https://github.com/user-attachments/assets/8b8c3cc7-a8ed-4912-a56a-f918b1f37fef)


### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
