### PR TITLE
fix(FilePreview): limit preview size to 384px at upload

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
@@ -590,7 +590,7 @@ export default {
 	.preview {
 		border-radius: var(--border-radius);
 		max-width: min(100%, 600px);
-		max-height: min(100%, 384px);
+		max-height: 384px;
 	}
 
 	.preview-medium {


### PR DESCRIPTION
### ☑️ Resolves

* Fix regression from #13147 
* max-height: 100% takes the height of parent, which is .image-container, which is not limited
* images larger than 384px shown at full-size (especiall if photos app is disabled)

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/user-attachments/assets/26ac2287-4da1-4806-a4f5-ecc72a91fab2) | ![image](https://github.com/user-attachments/assets/df044660-eeb4-4032-a8eb-cfbc4c1c9035)


### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required