### PR TITLE
fix(signaling): Avoid conflict potential of user and federated user

### DIFF
--- a/lib/Controller/SignalingController.php
+++ b/lib/Controller/SignalingController.php
@@ -195,14 +195,15 @@ class SignalingController extends OCSController {
 		$signalingMode = $this->talkConfig->getSignalingMode();
 		$signaling = $this->signalingManager->getSignalingServerLinkForConversation($room);
 
-		$helloAuthParams20UserId = $isTalkFederation ? $this->federationAuthenticator->getCloudId() : $this->userId;
+		$helloAuthParams20UserId = $isTalkFederation ? null : $this->userId;
+		$helloAuthParams20CloudId = $isTalkFederation ? $this->federationAuthenticator->getCloudId() : null;
 		$helloAuthParams = [
 			'1.0' => [
 				'userid' => $this->userId,
 				'ticket' => $this->talkConfig->getSignalingTicket(Config::SIGNALING_TICKET_V1, $this->userId),
 			],
 			'2.0' => [
-				'token' => $this->talkConfig->getSignalingTicket(Config::SIGNALING_TICKET_V2, $helloAuthParams20UserId),
+				'token' => $this->talkConfig->getSignalingTicket(Config::SIGNALING_TICKET_V2, $helloAuthParams20UserId, $helloAuthParams20CloudId),
 			],
 		];
 		$data = [

--- a/tests/php/ConfigTest.php
+++ b/tests/php/ConfigTest.php
@@ -15,7 +15,6 @@ use OCA\Talk\Vendor\Firebase\JWT\Key;
 use OCP\AppFramework\Services\IAppConfig;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\EventDispatcher\IEventDispatcher;
-use OCP\Federation\ICloudIdManager;
 use OCP\IConfig;
 use OCP\IGroupManager;
 use OCP\IURLGenerator;
@@ -37,14 +36,12 @@ class ConfigTest extends TestCase {
 		$groupManager = $this->createMock(IGroupManager::class);
 		/** @var MockObject|IUserManager $userManager */
 		$userManager = $this->createMock(IUserManager::class);
-		/** @var MockObject|ICloudIdManager $cloudIdManager */
-		$cloudIdManager = $this->createMock(ICloudIdManager::class);
 		/** @var MockObject|IURLGenerator $urlGenerator */
 		$urlGenerator = $this->createMock(IURLGenerator::class);
 		/** @var MockObject|IEventDispatcher $dispatcher */
 		$dispatcher = $this->createMock(IEventDispatcher::class);
 
-		$helper = new Config($config, $appConfig, $secureRandom, $groupManager, $userManager, $cloudIdManager, $urlGenerator, $timeFactory, $dispatcher);
+		$helper = new Config($config, $appConfig, $secureRandom, $groupManager, $userManager, $urlGenerator, $timeFactory, $dispatcher);
 		return $helper;
 	}
 
@@ -148,8 +145,6 @@ class ConfigTest extends TestCase {
 		$groupManager = $this->createMock(IGroupManager::class);
 		/** @var MockObject|IUserManager $userManager */
 		$userManager = $this->createMock(IUserManager::class);
-		/** @var MockObject|ICloudIdManager $cloudIdManager */
-		$cloudIdManager = $this->createMock(ICloudIdManager::class);
 		/** @var MockObject|IURLGenerator $urlGenerator */
 		$urlGenerator = $this->createMock(IURLGenerator::class);
 		/** @var MockObject|IEventDispatcher $dispatcher */
@@ -162,7 +157,7 @@ class ConfigTest extends TestCase {
 			->method('generate')
 			->with(16)
 			->willReturn('abcdefghijklmnop');
-		$helper = new Config($config, $appConfig, $secureRandom, $groupManager, $userManager, $cloudIdManager, $urlGenerator, $timeFactory, $dispatcher);
+		$helper = new Config($config, $appConfig, $secureRandom, $groupManager, $userManager, $urlGenerator, $timeFactory, $dispatcher);
 
 		//
 		$settings = $helper->getTurnSettings();
@@ -226,9 +221,6 @@ class ConfigTest extends TestCase {
 		/** @var MockObject|IUserManager $userManager */
 		$userManager = $this->createMock(IUserManager::class);
 
-		/** @var MockObject|ICloudIdManager $cloudIdManager */
-		$cloudIdManager = $this->createMock(ICloudIdManager::class);
-
 		/** @var MockObject|IURLGenerator $urlGenerator */
 		$urlGenerator = $this->createMock(IURLGenerator::class);
 
@@ -257,7 +249,7 @@ class ConfigTest extends TestCase {
 
 		$dispatcher->addServiceListener(BeforeTurnServersGetEvent::class, GetTurnServerListener::class);
 
-		$helper = new Config($config, $appConfig, $secureRandom, $groupManager, $userManager, $cloudIdManager, $urlGenerator, $timeFactory, $dispatcher);
+		$helper = new Config($config, $appConfig, $secureRandom, $groupManager, $userManager, $urlGenerator, $timeFactory, $dispatcher);
 
 		$settings = $helper->getTurnSettings();
 		$this->assertSame($servers, $settings);
@@ -362,8 +354,6 @@ class ConfigTest extends TestCase {
 		$groupManager = $this->createMock(IGroupManager::class);
 		/** @var MockObject|IUserManager $userManager */
 		$userManager = $this->createMock(IUserManager::class);
-		/** @var MockObject|ICloudIdManager $cloudIdManager */
-		$cloudIdManager = $this->createMock(ICloudIdManager::class);
 		/** @var MockObject|IURLGenerator $urlGenerator */
 		$urlGenerator = $this->createMock(IURLGenerator::class);
 		/** @var MockObject|IEventDispatcher $dispatcher */
@@ -395,7 +385,7 @@ class ConfigTest extends TestCase {
 			->method('getDisplayName')
 			->willReturn('Jane Doe');
 
-		$helper = new Config($config, $appConfig, $secureRandom, $groupManager, $userManager, $cloudIdManager, $urlGenerator, $timeFactory, $dispatcher);
+		$helper = new Config($config, $appConfig, $secureRandom, $groupManager, $userManager, $urlGenerator, $timeFactory, $dispatcher);
 
 		$config->setAppValue('spreed', 'signaling_token_alg', $algo);
 		// Make sure new keys are generated.
@@ -429,8 +419,6 @@ class ConfigTest extends TestCase {
 		$groupManager = $this->createMock(IGroupManager::class);
 		/** @var MockObject|IUserManager $userManager */
 		$userManager = $this->createMock(IUserManager::class);
-		/** @var MockObject|ICloudIdManager $cloudIdManager */
-		$cloudIdManager = $this->createMock(ICloudIdManager::class);
 		/** @var MockObject|IURLGenerator $urlGenerator */
 		$urlGenerator = $this->createMock(IURLGenerator::class);
 		/** @var MockObject|IEventDispatcher $dispatcher */
@@ -447,7 +435,7 @@ class ConfigTest extends TestCase {
 			->with('')
 			->willReturn('https://domain.invalid/nextcloud');
 
-		$helper = new Config($config, $appConfig, $secureRandom, $groupManager, $userManager, $cloudIdManager, $urlGenerator, $timeFactory, $dispatcher);
+		$helper = new Config($config, $appConfig, $secureRandom, $groupManager, $userManager, $urlGenerator, $timeFactory, $dispatcher);
 
 		$config->setAppValue('spreed', 'signaling_token_alg', $algo);
 		// Make sure new keys are generated.

--- a/tests/php/Controller/SignalingControllerTest.php
+++ b/tests/php/Controller/SignalingControllerTest.php
@@ -30,7 +30,6 @@ use OCP\App\IAppManager;
 use OCP\AppFramework\Services\IAppConfig;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\EventDispatcher\IEventDispatcher;
-use OCP\Federation\ICloudIdManager;
 use OCP\Http\Client\IClientService;
 use OCP\IConfig;
 use OCP\IDBConnection;
@@ -71,7 +70,6 @@ class SignalingControllerTest extends TestCase {
 	protected SessionService&MockObject $sessionService;
 	protected Messages&MockObject $messages;
 	protected IUserManager&MockObject $userManager;
-	protected ICloudIdManager&MockObject $cloudIdManager;
 	protected ITimeFactory&MockObject $timeFactory;
 	protected IClientService&MockObject $clientService;
 	protected IThrottler&MockObject $throttler;
@@ -103,10 +101,9 @@ class SignalingControllerTest extends TestCase {
 		$this->serverConfig->setAppValue('spreed', 'signaling_ticket_secret', 'the-app-ticket-secret');
 		$this->serverConfig->setUserValue($this->userId, 'spreed', 'signaling_ticket_secret', 'the-user-ticket-secret');
 		$this->userManager = $this->createMock(IUserManager::class);
-		$this->cloudIdManager = $this->createMock(ICloudIdManager::class);
 		$this->dispatcher = \OCP\Server::get(IEventDispatcher::class);
 		$urlGenerator = $this->createMock(IURLGenerator::class);
-		$this->config = new Config($this->serverConfig, $appConfig, $this->secureRandom, $groupManager, $this->userManager, $this->cloudIdManager, $urlGenerator, $timeFactory, $this->dispatcher);
+		$this->config = new Config($this->serverConfig, $appConfig, $this->secureRandom, $groupManager, $this->userManager, $urlGenerator, $timeFactory, $this->dispatcher);
 		$this->session = $this->createMock(TalkSession::class);
 		$this->dbConnection = \OCP\Server::get(IDBConnection::class);
 		$this->signalingManager = $this->createMock(\OCA\Talk\Signaling\Manager::class);

--- a/tests/php/Listener/RestrictStartingCallsTest.php
+++ b/tests/php/Listener/RestrictStartingCallsTest.php
@@ -18,6 +18,9 @@ use OCP\IConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
+/**
+ * @group DB
+ */
 class RestrictStartingCallsTest extends TestCase {
 	protected IConfig&MockObject $serverConfig;
 	protected ParticipantService&MockObject $participantService;

--- a/tests/php/Recording/BackendNotifierTest.php
+++ b/tests/php/Recording/BackendNotifierTest.php
@@ -23,7 +23,6 @@ use OCP\App\IAppManager;
 use OCP\AppFramework\Services\IAppConfig;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\EventDispatcher\IEventDispatcher;
-use OCP\Federation\ICloudIdManager;
 use OCP\Http\Client\IClientService;
 use OCP\IConfig;
 use OCP\IDBConnection;
@@ -91,11 +90,10 @@ class BackendNotifierTest extends TestCase {
 		$appConfig = $this->createMock(IAppConfig::class);
 		$groupManager = $this->createMock(IGroupManager::class);
 		$userManager = $this->createMock(IUserManager::class);
-		$cloudIdManager = $this->createMock(ICloudIdManager::class);
 		$timeFactory = $this->createMock(ITimeFactory::class);
 		$dispatcher = \OCP\Server::get(IEventDispatcher::class);
 
-		$this->config = new Config($config, $appConfig, $this->secureRandom, $groupManager, $userManager, $cloudIdManager, $this->urlGenerator, $timeFactory, $dispatcher);
+		$this->config = new Config($config, $appConfig, $this->secureRandom, $groupManager, $userManager, $this->urlGenerator, $timeFactory, $dispatcher);
 
 		$this->recreateBackendNotifier();
 


### PR DESCRIPTION
### ☑️ Resolves

* we knew the difference already
* Saves a query for federated users

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
