### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -258,12 +258,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "b0127d6fd2932bf1fdffe334ae59fdd6c8272029"
+                "reference": "081cbe36c64e4090f8d7b2858efa7d81c8eb3de3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/b0127d6fd2932bf1fdffe334ae59fdd6c8272029",
-                "reference": "b0127d6fd2932bf1fdffe334ae59fdd6c8272029",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/081cbe36c64e4090f8d7b2858efa7d81c8eb3de3",
+                "reference": "081cbe36c64e4090f8d7b2858efa7d81c8eb3de3",
                 "shasum": ""
             },
             "require": {
@@ -295,7 +295,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2024-08-14T08:51:54+00:00"
+            "time": "2024-09-06T00:40:00+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency