### PR TITLE
fix(TopBar): re-enable upcoming event to all conversations apart from…

### DIFF
--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -302,7 +302,7 @@ export default {
 
 		showUpcomingEvent() {
 			return this.nextEvent && !this.isInCall && !this.isSidebar && !this.isMobile
-				&& this.conversation.type === CONVERSATION.TYPE.NOTE_TO_SELF
+				&& this.conversation.type !== CONVERSATION.TYPE.NOTE_TO_SELF
 		},
 	},
 


### PR DESCRIPTION
… note to self


### ☑️ Resolves

* Fix upcoming events, it was broken after #13122

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->


### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required

