### PR TITLE
feat(call): list participants grid/stripe with a mouse wheel

### DIFF
--- a/src/components/CallView/Grid/Grid.vue
+++ b/src/components/CallView/Grid/Grid.vue
@@ -1052,6 +1052,7 @@ export default {
 	grid-template-columns: 165px 75px;
 	align-items: center;
 	justify-content: flex-start;
+	z-index: 1;
 
 	& span {
 		text-overflow: ellipsis;

--- a/src/components/CallView/Grid/Grid.vue
+++ b/src/components/CallView/Grid/Grid.vue
@@ -37,6 +37,7 @@
 						:class="{stripe: isStripe}"
 						:style="gridStyle"
 						@mousemove="handleMovement"
+						@wheel="debounceHandleWheelEvent"
 						@keydown="handleMovement">
 						<template v-if="!devMode && (!isLessThanTwoVideos || !isStripe)">
 							<EmptyCallView v-if="videos.length === 0 && !isStripe" class="video" :is-grid="true" />
@@ -267,6 +268,7 @@ export default {
 			// Timer for the videos bottom bar
 			showVideoOverlayTimer: null,
 			debounceMakeGrid: () => {},
+			debounceHandleWheelEvent: () => {},
 			tempPromotedModels: [],
 			unpromoteSpeakerTimer: {},
 			promotedHistoryMask: [],
@@ -621,6 +623,7 @@ export default {
 	// bind event handlers to the `handleResize` method
 	mounted() {
 		this.debounceMakeGrid = debounce(this.makeGrid, 200)
+		this.debounceHandleWheelEvent = debounce(this.handleWheelEvent, 50)
 		window.addEventListener('resize', this.handleResize)
 		subscribe('navigation-toggled', this.handleResize)
 		this.makeGrid()
@@ -629,6 +632,7 @@ export default {
 	},
 	beforeDestroy() {
 		this.debounceMakeGrid.clear?.()
+		this.debounceHandleWheelEvent.clear?.()
 		window.OCA.Talk.gridDebugInformation = () => console.debug('Not in a call')
 
 		window.removeEventListener('resize', this.handleResize)
@@ -820,6 +824,18 @@ export default {
 		// // in `handleClickNext`
 		// this.shrinkGrid(this.displayedVideos.length)
 		// },
+
+		handleWheelEvent(event) {
+			if (this.gridWidth <= 0) {
+				return
+			}
+
+			if (event.deltaY < 0 && this.hasPreviousPage) {
+				this.handleClickPrevious()
+			} else if (event.deltaY > 0 && this.hasNextPage) {
+				this.handleClickNext()
+			}
+		},
 
 		handleClickNext() {
 			this.currentPage++


### PR DESCRIPTION
### ☑️ Resolves

* Allows to change pages in call grid with a mouse wheel scrolling

⚠️ Second commited is not to be backported!


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

![2024-09-06_17h26_46](https://github.com/user-attachments/assets/e58032d2-3b4a-4a99-af64-5d120d696d44)

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required

