### PR TITLE
fix(federation): matching current user is actor in delete message

### DIFF
--- a/lib/Chat/Parser/SystemMessage.php
+++ b/lib/Chat/Parser/SystemMessage.php
@@ -699,7 +699,8 @@ class SystemMessage implements IEventListener {
 		} elseif (!$participant->isGuest()) {
 			$currentUserIsActor = $parsedParameters['actor']['type'] === 'user' &&
 				$participant->getAttendee()->getActorType() === Attendee::ACTOR_USERS &&
-				$participant->getAttendee()->getActorId() === $parsedParameters['actor']['id'];
+				$participant->getAttendee()->getActorId() === $parsedParameters['actor']['id'] &&
+				empty($parsedParameters['actor']['server']);
 		} else {
 			$currentUserIsActor = $parsedParameters['actor']['type'] === 'guest' &&
 				$participant->getAttendee()->getActorType() === 'guest' &&


### PR DESCRIPTION
### ☑️ Resolves

<!--
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
░░░███████░░░█████████░░█████░
░░███░░░███░░░███░░░███░░███░░
░░█████████░░░████████░░░███░░
░░███░░░███░░░███░░░░░░░░███░░
░█████░█████░█████░░░░░░█████░
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching frontend/UI code
-->

Deleting message as user1 from federated server shows user1 from host server as actor

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
