### PR TITLE
Improve and reverse wording of microphone toggle button (participants)

### DIFF
--- a/src/components/CallView/shared/VideoBottomBar.vue
+++ b/src/components/CallView/shared/VideoBottomBar.vue
@@ -212,7 +212,7 @@ export default {
 		},
 		audioButtonTooltip() {
 			return this.model.attributes.audioAvailable
-				? t('spreed', 'Unmute')
+				? t('spreed', 'Muted')
 				: t('spreed', 'Mute')
 		},
 

--- a/src/components/CallView/shared/VideoBottomBar.vue
+++ b/src/components/CallView/shared/VideoBottomBar.vue
@@ -212,8 +212,8 @@ export default {
 		},
 		audioButtonTooltip() {
 			return this.model.attributes.audioAvailable
-				? t('spreed', 'Mute')
-				: t('spreed', 'Muted')
+				? t('spreed', 'Unmute')
+				: t('spreed', 'Mute')
 		},
 
 		// Video indicator


### PR DESCRIPTION
## I need reviewers to test it.

Go to the grid participants' view and check the microphone icon at the bottom right corner of the participant. 
- If microphone is ON, tooltip should be "Mute".
- If microphone is OFF, tooltip should be "Unmute".

### The main goal of this PR is to make sure that the tooltips' wordings indicate an action but not a state.


### ☑️ Resolves

* Fix #…

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
Screenshot before | Screenshot after

<!-- ☀️ Light theme | 🌑 Dark Theme -->

### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required

---

<!--
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
░░░███████░░░█████████░░█████░
░░███░░░███░░░███░░░███░░███░░
░░█████████░░░████████░░░███░░
░░███░░░███░░░███░░░░░░░░███░░
░█████░█████░█████░░░░░░█████░
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching frontend/UI code
-->

## 🛠️ API Checklist

### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not possible
- [ ] 📘 API documentation in `docs/` has been updated or is not required
- [ ] 🔖 Capability is added or not needed 
