### PR TITLE
fix(upload): show blob previews for .webp image uploads

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
@@ -450,7 +450,7 @@ export default {
 		},
 
 		hasTemporaryImageUrl() {
-			return this.file.mimetype.startsWith('image/') && this.file.localUrl
+			return SHARED_ITEM.MEDIA_ALLOWED_PREVIEW.includes(this.file.mimetype) && this.file.localUrl
 		},
 
 		wrapperTabIndex() {

--- a/src/constants.js
+++ b/src/constants.js
@@ -198,6 +198,13 @@ export const SHARED_ITEM = {
 		RECORDING: 'recording',
 		VOICE: 'voice',
 	},
+	MEDIA_ALLOWED_PREVIEW: [
+		'image/gif',
+		'image/jpeg',
+		'image/jpg',
+		'image/png',
+		'image/webp',
+	],
 }
 
 export const WEBINAR = {

--- a/src/store/fileUploadStore.js
+++ b/src/store/fileUploadStore.js
@@ -11,6 +11,7 @@ import { t } from '@nextcloud/l10n'
 import moment from '@nextcloud/moment'
 import { getUploader } from '@nextcloud/upload'
 
+import { SHARED_ITEM } from '../constants.js'
 import { getDavClient } from '../services/DavClient.js'
 import { EventBus } from '../services/EventBus.js'
 import {
@@ -239,7 +240,7 @@ const actions = {
 
 			// Get localurl for some image previews
 			let localUrl = ''
-			if (file.type === 'image/png' || file.type === 'image/gif' || file.type === 'image/jpeg') {
+			if (SHARED_ITEM.MEDIA_ALLOWED_PREVIEW.includes(file.type)) {
 				localUrl = URL.createObjectURL(file)
 			} else if (isVoiceMessage) {
 				localUrl = file.localUrl


### PR DESCRIPTION
### ☑️ Resolves

* Fix #12866


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

Before | 🏡 After
-- | --
<img width="423" alt="image" src="https://github.com/user-attachments/assets/a761934e-7347-4382-b49a-c5bc82eb3336"> | <img width="420" alt="image" src="https://github.com/user-attachments/assets/0cc08a8e-9798-4826-a678-9821da8b3335">
<img width="93" alt="image" src="https://github.com/user-attachments/assets/27916edf-ba7e-49b9-b511-2ea5df9f0c9e"> | <img width="126" alt="image" src="https://github.com/user-attachments/assets/ae27e607-41bd-488a-b6b9-ca6c0f8b962a">


<!-- ☀️ Light theme | 🌑 Dark Theme -->



### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required