### PR TITLE
fix(call): temporary disable a call button if ended by moderator

### DIFF
--- a/src/components/TopBar/CallButton.vue
+++ b/src/components/TopBar/CallButton.vue
@@ -253,6 +253,7 @@ export default {
 
 		startCallButtonDisabled() {
 			return this.disabled
+				|| this.$store.getters.callHasJustEnded
 				|| (!this.conversation.canStartCall && !this.hasCall)
 				|| this.isInLobby
 				|| this.conversation.readOnly
@@ -288,6 +289,10 @@ export default {
 		startCallToolTip() {
 			if (this.isNextcloudTalkHashDirty) {
 				return t('spreed', 'Nextcloud Talk was updated, you need to reload the page before you can start or join a call.')
+			}
+
+			if (this.$store.getters.callHasJustEnded) {
+				return t('spreed', 'This call has just ended')
 			}
 
 			if (this.callButtonTooltipText) {
@@ -350,6 +355,12 @@ export default {
 		isInLobby() {
 			return this.$store.getters.isInLobby
 		},
+	},
+
+	watch: {
+		token() {
+			this.$store.dispatch('resetCallHasJustEnded')
+		}
 	},
 
 	mounted() {

--- a/src/components/TopBar/CallButton.vue
+++ b/src/components/TopBar/CallButton.vue
@@ -253,7 +253,7 @@ export default {
 
 		startCallButtonDisabled() {
 			return this.disabled
-				|| this.$store.getters.callHasJustEnded
+				|| (this.$store.getters.callHasJustEnded && !this.hasCall)
 				|| (!this.conversation.canStartCall && !this.hasCall)
 				|| this.isInLobby
 				|| this.conversation.readOnly

--- a/src/store/callViewStore.js
+++ b/src/store/callViewStore.js
@@ -23,6 +23,7 @@ const state = {
 	qualityWarningTooltipDismissed: false,
 	participantRaisedHands: {},
 	backgroundImageAverageColorCache: {},
+	callHasJustEnded: false,
 }
 
 const getters = {
@@ -34,6 +35,7 @@ const getters = {
 	lastIsGrid: (state) => state.lastIsGrid,
 	lastIsStripeOpen: (state) => state.lastIsStripeOpen,
 	presentationStarted: (state) => state.presentationStarted,
+	callHasJustEnded: (state) => state.callHasJustEnded,
 	selectedVideoPeerId: (state) => {
 		return state.selectedVideoPeerId
 	},
@@ -106,6 +108,9 @@ const mutations = {
 	},
 	clearBackgroundImageAverageColorCache(state) {
 		state.backgroundImageAverageColorCache = {}
+	},
+	setCallHasJustEnded(state, value) {
+		state.callHasJustEnded = value
 	},
 }
 
@@ -240,6 +245,23 @@ const actions = {
 	isEmptyCallView(context, value) {
 		context.commit('isEmptyCallView', value)
 	},
+
+	setCallHasJustEnded(context, timestamp) {
+		// Check the time difference between the current time and the call end time.
+		// Then, disable the CallButton for the remaining time until 10 seconds after the call ends.
+		const timeDiff = Math.abs(Date.now() / 1000 - timestamp)
+		if (10000 - timeDiff < 0) {
+			return
+		}
+		context.commit('setCallHasJustEnded', true)
+		setTimeout(() => {
+			context.dispatch('resetCallHasJustEnded')
+		}, Math.max(0, 10000 - timeDiff))
+	},
+
+	resetCallHasJustEnded(context) {
+		context.commit('setCallHasJustEnded', false)
+	}
 }
 
 export default { state, mutations, getters, actions }

--- a/src/store/callViewStore.js
+++ b/src/store/callViewStore.js
@@ -23,7 +23,7 @@ const state = {
 	qualityWarningTooltipDismissed: false,
 	participantRaisedHands: {},
 	backgroundImageAverageColorCache: {},
-	callHasJustEnded: false,
+	callHasJustEnded: null,
 }
 
 const getters = {
@@ -35,7 +35,7 @@ const getters = {
 	lastIsGrid: (state) => state.lastIsGrid,
 	lastIsStripeOpen: (state) => state.lastIsStripeOpen,
 	presentationStarted: (state) => state.presentationStarted,
-	callHasJustEnded: (state) => state.callHasJustEnded,
+	callHasJustEnded: (state) => !!state.callHasJustEnded,
 	selectedVideoPeerId: (state) => {
 		return state.selectedVideoPeerId
 	},
@@ -253,14 +253,16 @@ const actions = {
 		if (10000 - timeDiff < 0) {
 			return
 		}
-		context.commit('setCallHasJustEnded', true)
-		setTimeout(() => {
+		clearTimeout(context.state.callHasJustEnded)
+		const timeoutId = setTimeout(() => {
 			context.dispatch('resetCallHasJustEnded')
 		}, Math.max(0, 10000 - timeDiff))
+		context.commit('setCallHasJustEnded', timeoutId)
 	},
 
 	resetCallHasJustEnded(context) {
-		context.commit('setCallHasJustEnded', false)
+		clearTimeout(context.state.callHasJustEnded)
+		context.commit('setCallHasJustEnded', null)
 	}
 }
 

--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -1181,8 +1181,9 @@ const actions = {
 					})
 				}
 				if (message.systemMessage === 'call_ended_everyone'
+					&& conversation.type !== CONVERSATION.TYPE.ONE_TO_ONE
 					&& !(message.actorId === context.getters.getActorId()
-					&& message.actorType === context.getters.getActorType())) {
+						&& message.actorType === context.getters.getActorType())) {
 					context.dispatch('setCallHasJustEnded', message.timestamp)
 				}
 			}

--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -1180,6 +1180,11 @@ const actions = {
 						lastActivity: message.timestamp,
 					})
 				}
+				if (message.systemMessage === 'call_ended_everyone'
+					&& !(message.actorId === context.getters.getActorId()
+					&& message.actorType === context.getters.getActorType())) {
+					context.dispatch('setCallHasJustEnded', message.timestamp)
+				}
 			}
 
 			// in case we encounter an already read message, reset the counter


### PR DESCRIPTION
### ☑️ Resolves

* Fix #8148
* DIsable CallButton for `10` seconds, when `call_ended_everyone` system message is received
	* Longer time picked for longer disconnection period

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

| 🏡 After
| --
| <img width="149" alt="image" src="https://github.com/user-attachments/assets/72cb137f-d437-43dc-b865-f038fb5565c1">


### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required