### PR TITLE
Release 19.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 19.0.9 – 2024-09-12
+### Fixed
+- fix(federation): Fix federation invites accepting from the notification
+  [#13153](https://github.com/nextcloud/spreed/issues/13153)
+- fix(chat): Fix "You deleted the message" when performed by federated user with same ID
+  [#13250](https://github.com/nextcloud/spreed/issues/13250)
+- fix(files): Keep order of attachments when sharing multiple
+  [#13099](https://github.com/nextcloud/spreed/issues/13099)
+- fix(avatar): Don't overwrite user avatar when selecting a square for a conversation
+  [#13277](https://github.com/nextcloud/spreed/issues/13277)
+
 ## 19.0.8 – 2024-08-22
 ### Changed
 - Update several dependencies

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -14,7 +14,7 @@
 * 🌉 **Sync with other chat solutions** With [Matterbridge](https://github.com/42wim/matterbridge/) being integrated in Talk, you can easily sync a lot of other chat solutions to Nextcloud Talk and vice-versa.
 ]]></description>
 
-	<version>19.0.8</version>
+	<version>19.0.9</version>
 	<licence>agpl</licence>
 
 	<author>Daniel Calviño Sánchez</author>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "talk",
-  "version": "19.0.8",
+  "version": "19.0.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "talk",
-      "version": "19.0.8",
+      "version": "19.0.9",
       "license": "agpl",
       "dependencies": {
         "@linusborg/vue-simple-portal": "^0.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "talk",
-  "version": "19.0.8",
+  "version": "19.0.9",
   "private": true,
   "description": "",
   "author": "Joas Schilling <coding@schilljs.com>",


### PR DESCRIPTION
# 19.0.9 – 2024-09-12
## Fixed
- fix(federation): Fix federation invites accepting from the notification [#13153](https://github.com/nextcloud/spreed/issues/13153)
- fix(chat): Fix "You deleted the message" when performed by federated user with same ID [#13250](https://github.com/nextcloud/spreed/issues/13250)
- fix(files): Keep order of attachments when sharing multiple [#13099](https://github.com/nextcloud/spreed/issues/13099)
- fix(avatar): Don't overwrite user avatar when selecting a square for a conversation [#13277](https://github.com/nextcloud/spreed/issues/13277)
