### PR TITLE
fix(changelog): Don't check the user changelog twice

### DIFF
--- a/lib/Chat/Changelog/Listener.php
+++ b/lib/Chat/Changelog/Listener.php
@@ -32,10 +32,6 @@ class Listener implements IEventListener {
 			return;
 		}
 
-		if (!$this->manager->userHasNewChangelog($event->getUserId())) {
-			return;
-		}
-
 		$this->manager->updateChangelog($event->getUserId());
 	}
 }

--- a/lib/Chat/Changelog/Manager.php
+++ b/lib/Chat/Changelog/Manager.php
@@ -130,11 +130,11 @@ class Manager {
 			$this->l->t('## New in Talk %s', ['19']) . "\n"
 			. $this->l->t('- Messages can now be edited by logged-in authors and moderators for 6 hours') . "\n"
 			. $this->l->t('- Unsent message drafts are now saved in your browser') . "\n"
-			. $this->l->t('- *Preview:* Text chatting can now be done in a federated way with other Talk servers'),
+			. $this->l->t('- Text chatting can now be done in a federated way with other Talk servers'),
 			$this->l->t('## New in Talk %s', ['20']) . "\n"
 			. $this->l->t('- Moderators can now ban accounts and guests to prevent them from rejoining a conversation') . "\n"
 			. $this->l->t('- Upcoming calls from linked calendar events and out-of-office replacements are now shown in conversations') . "\n"
-			. $this->l->t('- *Preview:* Calls can now be done in a federated way with other Talk servers (requires the High-performance backend)'),
+			. $this->l->t('- Calls can now be done in a federated way with other Talk servers (requires the High-performance backend)'),
 		];
 	}
 }


### PR DESCRIPTION
### ☑️ Resolves

* Related
![grafik](https://github.com/user-attachments/assets/c370ef5b-720e-448e-bb69-f804af8136af)

### Explanation

There was a simple race condition previously with 2 requests R1 and R2:

- R1: handle()
- R1: userHasNewChangelog() compares X0 with count()
- R2: handle()
- R2: userHasNewChangelog() compares X0 with count()
- R1: updateChangelog()
- R1: getChangelogForUser() reads X0
- R1: setUserValue() sets X1 with precondition X0
- R2: updateChangelog()
- R2: getChangelogForUser() reads X1 :boom: 
- R2: setUserValue() sets X1 with precondition X1

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
