### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -258,12 +258,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "081cbe36c64e4090f8d7b2858efa7d81c8eb3de3"
+                "reference": "56dae49d60120c34b5651d37da7668c971424665"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/081cbe36c64e4090f8d7b2858efa7d81c8eb3de3",
-                "reference": "081cbe36c64e4090f8d7b2858efa7d81c8eb3de3",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/56dae49d60120c34b5651d37da7668c971424665",
+                "reference": "56dae49d60120c34b5651d37da7668c971424665",
                 "shasum": ""
             },
             "require": {
@@ -295,7 +295,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2024-09-06T00:40:00+00:00"
+            "time": "2024-09-14T00:40:10+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency