### PR TITLE
fix: don't remove LeftSidebar in fullscreen mode, but hide it

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -6,7 +6,7 @@
 <template>
 	<NcContent :class="{ 'icon-loading': loading, 'in-call': isInCall }"
 		app-name="talk">
-		<LeftSidebar v-if="getUserId && !isFullscreen" ref="leftSidebar" />
+		<LeftSidebar v-if="getUserId" ref="leftSidebar" />
 		<NcAppContent>
 			<router-view />
 		</NcAppContent>
@@ -92,10 +92,6 @@ export default {
 	},
 
 	computed: {
-		isFullscreen() {
-			return this.$store.getters.isFullscreen()
-		},
-
 		getUserId() {
 			return this.$store.getters.getUserId()
 		},

--- a/src/components/TopBar/TopBarMenu.vue
+++ b/src/components/TopBar/TopBarMenu.vue
@@ -439,6 +439,7 @@ export default {
 				this.$store.dispatch('setIsFullscreen', false)
 			} else {
 				this.enableFullscreen()
+				emit('toggle-navigation', { open: false })
 				this.$store.dispatch('setIsFullscreen', true)
 			}
 		},


### PR DESCRIPTION
### ☑️ Resolves

* Fix disappearing sidebar in fullcreenmode
  * Initial commit to remove it was made before AppNavigation has a toggle button
  * Now it's possible to hide it, but keep available to open back => proceed that way

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/user-attachments/assets/116ed520-5e62-46c9-8eb1-4c2c6416fa86) | ![image](https://github.com/user-attachments/assets/196be3b0-5fa7-4f71-b93b-bdaba095517d)


### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team