### PR TITLE
fix(VideoBackgroundEditor): change the container of file picker

### DIFF
--- a/src/components/MediaSettings/VideoBackgroundEditor.vue
+++ b/src/components/MediaSettings/VideoBackgroundEditor.vue
@@ -62,9 +62,9 @@
 			@change="handleFileInput">
 
 		<FilePickerVue v-if="showFilePicker"
-			:name="t('spreed', 'File to share')"
+			:name="t('spreed', 'Select a file')"
 			:path="relativeBackgroundsFolderPath"
-			container=".background-editor"
+			container=".media-settings"
 			:buttons="filePickerButtons"
 			:multiselect="false"
 			@close="showFilePicker = false" />
@@ -154,7 +154,7 @@ export default {
 
 		filePickerButtons() {
 			return [{
-				label: t('spreed', 'Choose'),
+				label: t('spreed', 'Confirm'),
 				callback: (nodes) => this.handleFileChoose(nodes),
 				type: 'primary'
 			}]


### PR DESCRIPTION
### ☑️ Resolves

* Fix #13312

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/user-attachments/assets/6b7df3be-75d4-4502-8584-b75c46fccc77) | ![image](https://github.com/user-attachments/assets/878a225b-2eea-4ea4-8fdc-a531556934cb)

<!-- ☀️ Light theme | 🌑 Dark Theme -->

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
