### PR TITLE
fix(ban): do not try to remove a banned user (handled by backend)

### DIFF
--- a/src/store/participantsStore.js
+++ b/src/store/participantsStore.js
@@ -595,8 +595,9 @@ const actions = {
 				showError(t('spreed', 'Error while banning the participant'))
 				throw error
 			}
+		} else {
+			await removeAttendeeFromConversation(token, attendeeId)
 		}
-		await removeAttendeeFromConversation(token, attendeeId)
 		commit('deleteParticipant', { token, attendeeId })
 	},
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix #13334 
* Frontend wasn't aligned with backend, that `ban` also removes a user

## 🖌️ UI Checklist

No unexpected behavior

### 🚧 Tasks

- [ ] Test

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Not risky to browser differences / client
- [ ] ⛑️ Tests are included or not possible