### PR TITLE
fix(chatManager): Expire unread cache on message delete

### DIFF
--- a/lib/Chat/ChatManager.php
+++ b/lib/Chat/ChatManager.php
@@ -521,6 +521,8 @@ class ChatManager {
 
 		$this->referenceManager->invalidateCache($chat->getToken());
 
+		$this->unreadCountCache->clear($chat->getId() . '-');
+
 		return $this->addSystemMessage(
 			$chat,
 			$participant->getAttendee()->getActorType(),


### PR DESCRIPTION
### ☑️ Resolves

* Fix #13286 

## Demo -

Before

Just as with the screencast below, the difference is that the unread message doesn't disappear even after refreshing the page.

After

https://github.com/user-attachments/assets/390a6902-f6d7-4aa7-990c-bdab5d7e0995

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts


<!-- ☀️ Light theme | 🌑 Dark Theme -->

### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required

---

<!--
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
░░░███████░░░█████████░░█████░
░░███░░░███░░░███░░░███░░███░░
░░█████████░░░████████░░░███░░
░░███░░░███░░░███░░░░░░░░███░░
░█████░█████░█████░░░░░░█████░
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching frontend/UI code
-->

## 🛠️ API Checklist

### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [ ] 📘 API documentation in `docs/` has been updated or is not required
- [ ] 🔖 Capability is added or not needed 
