### PR TITLE
feat(audioPlayer): Auto play voice messages which are grouped together

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -276,6 +276,8 @@ export default {
 						component: FilePreview,
 						props: {
 							token: this.message.token,
+							messageId: this.message.id,
+							nextMessageId: this.nextMessageId,
 							itemType,
 							referenceId: this.message.referenceId,
 							file: this.message.messageParameters[p],

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
@@ -115,6 +115,16 @@ export default {
 			required: true,
 		},
 
+		messageId: {
+			type: [String, Number],
+			default: 0,
+		},
+
+		nextMessageId: {
+			type: [String, Number],
+			default: 0,
+		},
+
 		/**
 		 * File object
 		 */
@@ -245,6 +255,8 @@ export default {
 					name: this.file.name,
 					path: this.file.path,
 					link: this.file.link,
+					messageId: Number(this.messageId),
+					nextMessageId: Number(this.nextMessageId),
 				}
 			}
 			return {


### PR DESCRIPTION
### ☑️ Resolves

* Fix #13199 


**Note:**  In Whatsapp (whose example is given in the issue), the voice messages auto-play only when they are grouped together. Therefore I tried to replicate that only. If there's a message between two voice messages, it will not be auto-played.
That being said, its very easy to change this behaviour. We just need to remove this `since` check over [here](https://github.com/nextcloud/spreed/pull/13360/files#diff-8a7e5104736c054cb13539ee9b0721cbb5ad4bfa747633f51e9794f08d6a1ce6R94).

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

Before 

https://github.com/user-attachments/assets/5b899ae6-1e0e-4563-9097-e3282b8a0c28

After

https://github.com/user-attachments/assets/968525ea-9758-4b0f-bb63-a9b447c4557e

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required