### PR TITLE
style: decrease chat messages 'reading width'

### DIFF
--- a/src/assets/variables.scss
+++ b/src/assets/variables.scss
@@ -4,13 +4,13 @@
  */
 
 /** Messages list dimensions:
- * - text max width: 1050px (70em recommended by W3C standard)
+ * - text max width: ~750px (80 characters per line is recommended by W3C standard)
  * - avatar width: 32px (AVATAR.SIZE.SMALL) + 16px (paddings) = 48px
  * - info width: 8ch(~68px) (timestamp) + 40px (checkmark with paddings) = ~108px
  * - list max width: 48px (avatar width) + 1058px (text width with paddings) + ~108px (info width) = ~1214px
  * - input max width: ~1214px (list max width) - 100px (send button) = ~1114px
  */
-$messages-text-max-width: calc(70 * var(--default-font-size));
+$messages-text-max-width: calc(50 * var(--default-font-size));
 $messages-avatar-width: calc(32px + 4 * var(--default-grid-baseline));
 $messages-info-width: calc(8ch + var(--clickable-area-small, 24px) + 4 * var(--default-grid-baseline));
 $messages-list-max-width: calc($messages-avatar-width + $messages-text-max-width + 2 * var(--default-grid-baseline) + $messages-info-width);


### PR DESCRIPTION
### ☑️ Resolves

* Decrease max width of text message to 750px (50em)
* Most resources recommended from 60 to 80 characters per line, example: https://baymard.com/blog/line-length-readability
* I managed now to fit 113 characters with normal font (91 with dyslexic font)

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
75ch (article) | ![image](https://github.com/user-attachments/assets/f40115eb-ed0f-49a8-92f1-65284ec3eb15)
35em (article) | ![image](https://github.com/user-attachments/assets/1da84005-13a5-46f1-a4b8-2a8bd5774533)
600px (stable29) | ![image](https://github.com/user-attachments/assets/98038ae8-c420-4785-a1b5-6b3ae2197b7e)
⚠️ 50em (this PR) | ![image](https://github.com/user-attachments/assets/1a928aa0-c6a5-451d-9cdd-f46b73118ebb)
⚠️ 50em (this PR) | ![image](https://github.com/user-attachments/assets/508c1b4e-eef8-4fe1-bf80-9d3a6cfc8d27)
70em (stable30) | ![image](https://github.com/user-attachments/assets/168f5efe-e78d-442b-a063-b675fef91d9c)
this PR + diff | ![image](https://github.com/user-attachments/assets/b06695c2-1a8d-4a9c-84c4-6b3b2b920f0b)


### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
