### PR TITLE
fix(federation): Recover broken invites

### DIFF
--- a/lib/Federation/BackendNotifier.php
+++ b/lib/Federation/BackendNotifier.php
@@ -81,6 +81,9 @@ class BackendNotifier {
 		$roomOwner = $this->userManager->get($roomOwnerAttendee->getActorId());
 
 		$remote = $this->prepareRemoteUrl($invitedCloudId->getRemote());
+		if (str_starts_with($remote, 'https://')) {
+			$remote = substr($remote, 8);
+		}
 
 		$shareWithCloudId = $invitedCloudId->getUser() . '@' . $remote;
 		$share = $this->cloudFederationFactory->getCloudFederationShare(

--- a/lib/Federation/FederationManager.php
+++ b/lib/Federation/FederationManager.php
@@ -103,8 +103,14 @@ class FederationManager {
 
 		if ($couldHaveInviteWithOtherCasing) {
 			try {
-				$this->invitationMapper->getInvitationForUserByLocalRoom($room, $user->getUID(), true);
-				throw new ProviderCouldNotAddShareException('User already invited', '', Http::STATUS_BAD_REQUEST);
+				$invitation = $this->invitationMapper->getInvitationForUserByLocalRoom($room, $user->getUID(), true);
+				$invitation->setAccessToken($sharedSecret);
+				$invitation->setRemoteAttendeeId($remoteAttendeeId);
+				$invitation->setInviterCloudId($inviterCloudId);
+				$invitation->setInviterDisplayName($inviterDisplayName);
+				$this->invitationMapper->update($invitation);
+
+				return $invitation;
 			} catch (DoesNotExistException) {
 				// Not invited with any casing already, so all good.
 			}

--- a/tests/php/Federation/FederationTest.php
+++ b/tests/php/Federation/FederationTest.php
@@ -145,7 +145,7 @@ class FederationTest extends TestCase {
 
 		$providerId = '3';
 		$token = 'abcdefghijklmno';
-		$shareWith = 'test@https://remote.test.local';
+		$shareWith = 'test@remote.test.local';
 		$name = 'abcdefgh';
 		$owner = 'Owner\'s name';
 		$ownerId = 'owner';


### PR DESCRIPTION
## 🛠️ API Checklist

### 👣 Steps
1. Invite User2 from Remote2
2. Simulate a disconnect, by either:
   a. Disable Remote2 and then delete User2 on Remote1
   b. or directly remote User2 from attendees table on Remote1
3. Re-invite User2 from Remote2 to the same room

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
