### PR TITLE
fix(info.xml): add discussion URL

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -45,6 +45,7 @@
 	<category>workflow</category>
 
 	<website>https://github.com/nextcloud/spreed</website>
+	<discussion>https://help.nextcloud.com/c/support/spreed/52</discussion>
 	<bugs>https://github.com/nextcloud/spreed/issues</bugs>
 	<repository>https://github.com/nextcloud/spreed.git</repository>
 


### PR DESCRIPTION
Update and explicitly specify the discussion URL as the link in the [app store page](https://apps.nextcloud.com/apps/spreed) is outdated anyway.

Related PR: https://github.com/nextcloud/appstore/pull/1496