### PR TITLE
Fix some translation calls

### DIFF
--- a/src/components/ConversationSettings/ConversationAvatarEditor.vue
+++ b/src/components/ConversationSettings/ConversationAvatarEditor.vue
@@ -48,15 +48,15 @@
 					</template>
 
 					<!-- Set picture as avatar -->
-					<NcButton :title="t('settings', 'Upload conversation picture')"
-						:aria-label="t('settings', 'Upload conversation picture')"
+					<NcButton :title="t('spreed', 'Upload conversation picture')"
+						:aria-label="t('spreed', 'Upload conversation picture')"
 						@click="activateLocalFilePicker">
 						<template #icon>
 							<Upload :size="20" />
 						</template>
 					</NcButton>
-					<NcButton :title="t('settings', 'Choose conversation picture from files')"
-						:aria-label="t('settings', 'Choose conversation picture from files')"
+					<NcButton :title="t('spreed', 'Choose conversation picture from files')"
+						:aria-label="t('spreed', 'Choose conversation picture from files')"
 						@click="showFilePicker = true">
 						<template #icon>
 							<Folder :size="20" />
@@ -65,8 +65,8 @@
 
 					<!-- Remove existing avatar -->
 					<NcButton v-if="hasAvatar"
-						:title="t('settings', 'Remove conversation picture')"
-						:aria-label="t('settings', 'Remove conversation picture')"
+						:title="t('spreed', 'Remove conversation picture')"
+						:aria-label="t('spreed', 'Remove conversation picture')"
 						@click="removeAvatar">
 						<template #icon>
 							<Delete :size="20" />


### PR DESCRIPTION
### ☑️ Resolves

* 'settings' translations are not loaded in 'spreed' page


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/user-attachments/assets/f3ecd5f7-b893-4d30-b224-d24ada32f3d1) | Screenshot after

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
