### PR TITLE
fix(MessagesList): update date separator overnight

### DIFF
--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -25,7 +25,7 @@
 			:data-date-timestamp="dateTimestamp"
 			class="scroller__content"
 			:class="{ 'has-sticky': dateTimestamp === stickyDate }">
-			<li class="messages-group__date">
+			<li :key="dateSeparatorLabels[dateTimestamp]" class="messages-group__date">
 				<span class="messages-group__date-text" role="heading" aria-level="3">
 					{{ dateSeparatorLabels[dateTimestamp] }}
 				</span>
@@ -390,7 +390,7 @@ export default {
 					}
 
 					if (!this.dateSeparatorLabels[dateTimestamp]) {
-						this.dateSeparatorLabels[dateTimestamp] = this.generateDateSeparator(dateTimestamp)
+						this.$set(this.dateSeparatorLabels, dateTimestamp, this.generateDateSeparator(dateTimestamp))
 					}
 
 					if (!groupsByDate[dateTimestamp]) {
@@ -1266,6 +1266,10 @@ export default {
 			// setTimeout is needed here for Safari to correctly remove the unread marker
 			setTimeout(() => {
 				this.refreshReadMarkerPosition()
+				// Regenerate relative date separators
+				Object.keys(this.dateSeparatorLabels).forEach(dateTimestamp => {
+					this.$set(this.dateSeparatorLabels, dateTimestamp, this.generateDateSeparator(dateTimestamp))
+				})
 			}, 2)
 		},
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix: when keeping the conversation open overnight, relative dates do not get updated. 

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
messages list showing two "today", one of them is supposed to be "yesterday" | only one correct "today"

<!-- ☀️ Light theme | 🌑 Dark Theme -->


### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required