### PR TITLE
fix(Participant): re-render component in VirtualScroller

### DIFF
--- a/src/components/RightSidebar/Participants/Participant.vue
+++ b/src/components/RightSidebar/Participants/Participant.vue
@@ -4,7 +4,8 @@
 -->
 
 <template>
-	<NcListItem :name="computedName"
+	<NcListItem :key="participantNavigationId"
+		:name="computedName"
 		:data-nav-id="participantNavigationId"
 		class="participant"
 		:class="{ 'participant--offline': isOffline }"


### PR DESCRIPTION
### ☑️ Resolves

* Ref #13390
* Stick NcActions to dedicated Participant in virtual list
* Virtual list reuses same components
* In theory, it shoouldn't be possible anymore to promote/delete random participant because of the wrong action


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
Screenshot before | Screenshot after


### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
