### PR TITLE
fix: do not show two promoted videos

### DIFF
--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -21,7 +21,7 @@
 					:class="{'full-page': showFullPage}">
 					<!-- Selected video override mode -->
 					<VideoVue v-if="showSelectedVideo && selectedCallParticipantModel"
-						:key="selectedVideoPeerId"
+						:key="`promoted-${selectedVideoPeerId}`"
 						:token="token"
 						:model="selectedCallParticipantModel"
 						:shared-data="sharedDatas[selectedVideoPeerId]"
@@ -58,18 +58,9 @@
 						:call-participant-model="shownRemoteScreenCallParticipantModel"
 						:shared-data="sharedDatas[shownRemoteScreenPeerId]"
 						is-big />
-					<!-- presenter overlay -->
-					<PresenterOverlay v-if="shouldShowPresenterOverlay"
-						:token="token"
-						:model="presenterModel"
-						:shared-data="presenterSharedData"
-						:is-local-presenter="showLocalScreen"
-						:local-media-model="localMediaModel"
-						:is-collapsed="!showPresenterOverlay"
-						@click="toggleShowPresenterOverlay" />
 					<!-- Promoted "autopilot" mode -->
 					<VideoVue v-else-if="promotedParticipantModel"
-						:key="promotedParticipantModel.attributes.peerId"
+						:key="`autopilot-${promotedParticipantModel.attributes.peerId}`"
 						:token="token"
 						:model="promotedParticipantModel"
 						:shared-data="sharedDatas[promotedParticipantModel.attributes.peerId]"
@@ -80,6 +71,15 @@
 						:is-one-to-one="isOneToOne"
 						:is-sidebar="isSidebar"
 						@force-promote-video="forcePromotedModel = $event" />
+					<!-- presenter overlay -->
+					<PresenterOverlay v-if="shouldShowPresenterOverlay"
+						:token="token"
+						:model="presenterModel"
+						:shared-data="presenterSharedData"
+						:is-local-presenter="showLocalScreen"
+						:local-media-model="localMediaModel"
+						:is-collapsed="!showPresenterOverlay"
+						@click="toggleShowPresenterOverlay" />
 
 					<div v-else-if="devMode && !isGrid"
 						class="dev-mode-video--promoted">


### PR DESCRIPTION
### ☑️ Resolves

- PresenterOverlay broke `v-else-if` chain in previous place
- also add distinct keys to prevent rendering issues

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="219" alt="image" src="https://github.com/user-attachments/assets/03e544f8-dbdc-4d59-9964-6cb92a26d6dd"> | <img width="164" alt="image" src="https://github.com/user-attachments/assets/30e2950a-6626-4152-8db8-719d1e426c40">

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Not risky to browser differences / client