### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -258,12 +258,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "e018917855dc3909394a2543e255ed2403e34d81"
+                "reference": "dfcf4583e63fea987ad58585bb5f11c65cc05e82"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/e018917855dc3909394a2543e255ed2403e34d81",
-                "reference": "e018917855dc3909394a2543e255ed2403e34d81",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/dfcf4583e63fea987ad58585bb5f11c65cc05e82",
+                "reference": "dfcf4583e63fea987ad58585bb5f11c65cc05e82",
                 "shasum": ""
             },
             "require": {
@@ -295,7 +295,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2024-09-29T00:47:24+00:00"
+            "time": "2024-10-05T00:42:05+00:00"
         },
         {
             "name": "psr/clock",
@@ -1232,8 +1232,8 @@
     },
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
+    "platform": {},
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.1"
     },


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency