### PR TITLE
feat(polls): Import/Export pre-filled poll form to JSON 📊

### DIFF
--- a/src/components/NewMessage/NewMessagePollEditor.vue
+++ b/src/components/NewMessage/NewMessagePollEditor.vue
@@ -94,6 +94,12 @@
 					</template>
 					{{ t('spreed', 'Save as draft') }}
 				</NcActionButton>
+				<NcActionLink :href="exportPollURI" :download="exportPollFileName">
+					<template #icon>
+						<IconFileDownload :size="20" />
+					</template>
+					{{ t('spreed', 'Export draft to file') }}
+				</NcActionLink>
 			</NcActions>
 			<NcButton type="primary" :disabled="!isFilled" @click="createPoll">
 				{{ t('spreed', 'Create poll') }}
@@ -107,6 +113,7 @@ import { computed, nextTick, reactive, ref } from 'vue'
 
 import IconArrowLeft from 'vue-material-design-icons/ArrowLeft.vue'
 import Close from 'vue-material-design-icons/Close.vue'
+import IconFileDownload from 'vue-material-design-icons/FileDownload.vue'
 import IconFileEdit from 'vue-material-design-icons/FileEdit.vue'
 import IconFileUpload from 'vue-material-design-icons/FileUpload.vue'
 import Plus from 'vue-material-design-icons/Plus.vue'
@@ -115,6 +122,7 @@ import { showError } from '@nextcloud/dialogs'
 import { t } from '@nextcloud/l10n'
 
 import NcActionButton from '@nextcloud/vue/dist/Components/NcActionButton.js'
+import NcActionLink from '@nextcloud/vue/dist/Components/NcActionLink.js'
 import NcActions from '@nextcloud/vue/dist/Components/NcActions.js'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import NcCheckboxRadioSwitch from '@nextcloud/vue/dist/Components/NcCheckboxRadioSwitch.js'
@@ -127,6 +135,7 @@ import { hasTalkFeature } from '../../services/CapabilitiesManager.ts'
 import { EventBus } from '../../services/EventBus.js'
 import { usePollsStore } from '../../stores/polls.ts'
 import type { createPollParams } from '../../types/index.ts'
+import { convertToJSONDataURI } from '../../utils/fileDownload.ts'
 import { validatePollForm } from '../../utils/validatePollForm.ts'
 
 const props = defineProps<{
@@ -176,6 +185,10 @@ const isMultipleAnswer = computed({
 })
 
 const isModerator = computed(() => (store.getters as unknown).isModerator)
+
+const exportPollURI = computed(() => convertToJSONDataURI(pollForm))
+const exportPollFileName = `Talk Poll ${new Date().toISOString().slice(0, 10)}`
+
 /**
  * Remove a previously added option
  * @param index option index

--- a/src/utils/fileDownload.ts
+++ b/src/utils/fileDownload.ts
@@ -1,0 +1,30 @@
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * Converts given payload to Data URI scheme
+ * data:[<mediatype>][;base64],<data>
+ *
+ * @param payload data to convert
+ * @param mediatype a MIME type string
+ * @param base64Token an optional base64 token if non-textual data is given
+ */
+const convertToDataURI = function(payload: string, mediatype: string = 'text/plain;charset=US-ASCII', base64Token: string = ''): string {
+	return 'data:' + mediatype + base64Token + ',' + encodeURIComponent(payload)
+}
+
+/**
+ * Converts given JS object to Data URI scheme
+ *
+ * @param payload JS object to convert
+ */
+const convertToJSONDataURI = function(payload: object): string {
+	return convertToDataURI(JSON.stringify(payload, null, 2), 'application/json;charset=utf-8')
+}
+
+export {
+	convertToDataURI,
+	convertToJSONDataURI,
+}

--- a/src/utils/validatePollForm.ts
+++ b/src/utils/validatePollForm.ts
@@ -1,0 +1,46 @@
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { createPollParams } from '../types/index.ts'
+
+type requiredPollParams = Omit<createPollParams, 'draft'>
+const pollFormExample = {
+	question: '',
+	options: ['', ''],
+	resultMode: 0,
+	maxVotes: 0,
+}
+const REQUIRED_KEYS: Array<keyof requiredPollParams> = Object.keys(pollFormExample) as Array<keyof requiredPollParams>
+
+/**
+ * Parses a given JSON object and validates with required poll form object.
+ * Throws an error if parsed object doesn't match
+ * @param jsonObject The object to validate
+ */
+function validatePollForm(jsonObject: requiredPollParams): requiredPollParams {
+	if (typeof jsonObject !== 'object') {
+		throw new Error('Invalid parsed object')
+	}
+
+	for (const key of REQUIRED_KEYS) {
+		if (jsonObject[key] === undefined) {
+			throw new Error('Missing required key')
+		}
+
+		if (typeof pollFormExample[key] !== typeof jsonObject[key]) {
+			throw new Error('Invalid parsed value')
+		}
+
+		if (key === 'options' && jsonObject[key]?.some((opt: unknown) => typeof opt !== 'string')) {
+			throw new Error('Invalid parsed option values')
+		}
+	}
+
+	return jsonObject
+}
+
+export {
+	validatePollForm,
+}


### PR DESCRIPTION
### ☑️ Resolves

* Ref #13439
  * [x] Handles import/export from/to JSON file (native browser functionality)
  * [x] Handles only fields defined in client code
  * [x] Skips missing and extraneous fields
  * [x] Type/value validation? (if someone would manually create/modify JSON files for import)

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

<img width="377" alt="image" src="https://github.com/user-attachments/assets/557d1432-59c6-4e84-8b6f-627cc54248fc">
<img width="359" alt="image" src="https://github.com/user-attachments/assets/ed0d3b1b-93e5-43c9-b9a5-9be97e1ae9b8">

### 🏁 Checklist


- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [x] Firefox
  - [ ] Safari
  - [x] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
