### PR TITLE
feat(calls): Add appconfig and user preference for default setting of…

### DIFF
--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -158,3 +158,4 @@
 
 ## 20.1
 * `archived-conversations` (local) - Conversations can be marked as archived which will hide them from the conversation list by default
+* `config => call => start-without-media` (local) - Boolean, whether media should be disabled when starting or joining a conversation

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -21,11 +21,16 @@
 
 ## User settings
 
-| Key                   | Capability                         | Default                                         | Valid values                                                                                             |
-|-----------------------|------------------------------------|-------------------------------------------------|----------------------------------------------------------------------------------------------------------|
-| `attachment_folder`   | `config => attachments => folder`  | Value of app config `default_attachment_folder` | Path owned by the user to store uploads and received shares. It is created if it does not exist.         |
-| `read_status_privacy` | `config => chat => read-privacy`   | `0`                                             | One of the read-status constants from the [constants list](constants.md#participant-read-status-privacy) |
-| `typing_privacy`      | `config => chat => typing-privacy` | `0`                                             | One of the typing privacy constants from the [constants list](constants.md#participant-typing-privacy)   |
+**Note:** Settings from `calls_start_without_media` onwards can not be set via above API.
+Instead, the server API `POST /ocs/v2.php/apps/provisioning_api/api/v1/config/users/{appId}/{configKey}` needs to be used.
+
+| Key                         | Capability                              | Default                                            | Valid values                                                                                             |
+|-----------------------------|-----------------------------------------|----------------------------------------------------|----------------------------------------------------------------------------------------------------------|
+| `attachment_folder`         | `config => attachments => folder`       | Value of app config `default_attachment_folder`    | Path owned by the user to store uploads and received shares. It is created if it does not exist.         |
+| `read_status_privacy`       | `config => chat => read-privacy`        | `0`                                                | One of the read-status constants from the [constants list](constants.md#participant-read-status-privacy) |
+| `typing_privacy`            | `config => chat => typing-privacy`      | `0`                                                | One of the typing privacy constants from the [constants list](constants.md#participant-typing-privacy)   |
+| `play_sounds`               |                                         | `'yes'`                                            | `'yes'` and `'no'`                                                                                       |
+| `calls_start_without_media` | `config => call => start-without-media` | `''` falling back to app config with the same name | `'yes'` and `'no'`                                                                                       |
 
 ## Set SIP settings
 
@@ -94,6 +99,7 @@ Legend:
 | `changelog`                          | string<br>`yes` or `no`                                          | `yes`      | No   |        | Whether the changelog conversation is updated with new features on major releases                                                                                                                                                                                                |
 | `has_reference_id`                   | string<br>`yes` or `no`                                          | `no`       | Yes  |        | Indicator whether the clients can use the reference value to identify their message, will be automatically set to `yes` when the repair steps are executed                                                                                                                       |
 | `hide_signaling_warning`             | string<br>`yes` or `no`                                          | `no`       | No   | 🖌️    | Flag that allows to suppress the warning that an HPB should be configured                                                                                                                                                                                                        |
+| `calls_start_without_media`          | string<br>`yes` or `no`                                          | `no`       | Yes  |        | Whether participants start with enabled or disabled audio and video by default                                                                                                                                                                                                   |
 | `breakout_rooms`                     | string<br>`yes` or `no`                                          | `yes`      | Yes  |        | Whether or not breakout rooms are allowed (Will only prevent creating new breakout rooms. Existing conversations are not modified.)                                                                                                                                              |
 | `call_recording`                     | string<br>`yes` or `no`                                          | `yes`      | Yes  |        | Enable call recording                                                                                                                                                                                                                                                            |
 | `call_recording_transcription`       | string<br>`yes` or `no`                                          | `no`       | No   |        | Whether call recordings should automatically be transcripted when a transcription provider is enabled.                                                                                                                                                                           |

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -106,6 +106,7 @@ use OCA\Talk\Search\CurrentMessageSearch;
 use OCA\Talk\Search\MessageSearch;
 use OCA\Talk\Search\UnifiedSearchCSSLoader;
 use OCA\Talk\Search\UnifiedSearchFilterPlugin;
+use OCA\Talk\Settings\BeforePreferenceSetEventListener;
 use OCA\Talk\Settings\Personal;
 use OCA\Talk\SetupCheck\BackgroundBlurLoading;
 use OCA\Talk\SetupCheck\FederationLockCache;
@@ -124,6 +125,7 @@ use OCP\AppFramework\Bootstrap\IRegistrationContext;
 use OCP\Collaboration\AutoComplete\AutoCompleteFilterEvent;
 use OCP\Collaboration\Resources\IProviderManager;
 use OCP\Collaboration\Resources\LoadAdditionalScriptsEvent;
+use OCP\Config\BeforePreferenceSetEvent;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Federation\ICloudFederationProvider;
 use OCP\Federation\ICloudFederationProviderManager;
@@ -177,6 +179,7 @@ class Application extends App implements IBootstrap {
 		$context->registerEventListener(BeforeTemplateRenderedEvent::class, PublicShareTemplateLoader::class);
 		$context->registerEventListener(BeforeTemplateRenderedEvent::class, PublicShareAuthTemplateLoader::class);
 		$context->registerEventListener(LoadSidebar::class, FilesTemplateLoader::class);
+		$context->registerEventListener(BeforePreferenceSetEvent::class, BeforePreferenceSetEventListener::class);
 
 		// Activity listeners
 		$context->registerEventListener(AttendeesAddedEvent::class, ActivityListener::class);

--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -127,6 +127,7 @@ class Capabilities implements IPublicCapability {
 		'call' => [
 			'predefined-backgrounds',
 			'can-upload-background',
+			'start-without-media',
 		],
 		'chat' => [
 			'read-privacy',
@@ -196,6 +197,7 @@ class Capabilities implements IPublicCapability {
 					'sip-enabled' => $this->talkConfig->isSIPConfigured(),
 					'sip-dialout-enabled' => $this->talkConfig->isSIPDialOutEnabled(),
 					'can-enable-sip' => false,
+					'start-without-media' => $this->talkConfig->getCallsStartWithoutMedia($user?->getUID()),
 				],
 				'chat' => [
 					'max-length' => ChatManager::MAX_CHAT_LENGTH,

--- a/lib/Config.php
+++ b/lib/Config.php
@@ -12,6 +12,7 @@ use OCA\Talk\Events\BeforeTurnServersGetEvent;
 use OCA\Talk\Federation\Authenticator;
 use OCA\Talk\Model\Attendee;
 use OCA\Talk\Service\RecordingService;
+use OCA\Talk\Settings\UserPreference;
 use OCA\Talk\Vendor\Firebase\JWT\JWT;
 use OCP\AppFramework\Services\IAppConfig;
 use OCP\AppFramework\Utility\ITimeFactory;
@@ -661,5 +662,22 @@ class Config {
 
 	public function getGridVideosLimitEnforced(): bool {
 		return $this->config->getAppValue('spreed', 'grid_videos_limit_enforced', 'no') === 'yes';
+	}
+
+	/**
+	 * User setting falling back to admin defined app config
+	 *
+	 * @param ?string $userId
+	 * @return bool
+	 */
+	public function getCallsStartWithoutMedia(?string $userId): bool {
+		if ($userId !== null) {
+			$userSetting = $this->config->getUserValue($userId, 'spreed', UserPreference::CALLS_START_WITHOUT_MEDIA);
+			if ($userSetting === 'yes' || $userSetting === 'no') {
+				return $userSetting === 'yes';
+			}
+		}
+
+		return $this->appConfig->getAppValueBool('calls_start_without_media');
 	}
 }

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -2436,6 +2436,9 @@ class RoomController extends AEnvironmentAwareController {
 			if (isset($data['config']['chat']['typing-privacy'])) {
 				$data['config']['chat']['typing-privacy'] = Participant::PRIVACY_PRIVATE;
 			}
+			if (isset($data['config']['call']['start-without-media'])) {
+				$data['config']['call']['start-without-media'] = $this->talkConfig->getCallsStartWithoutMedia($this->userId);
+			}
 
 			if ($response->getHeaders()['X-Nextcloud-Talk-Hash']) {
 				$headers['X-Nextcloud-Talk-Proxy-Hash'] = $response->getHeaders()['X-Nextcloud-Talk-Hash'];

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -339,6 +339,7 @@ namespace OCA\Talk;
  *             sip-enabled: bool,
  *             sip-dialout-enabled: bool,
  *             can-enable-sip: bool,
+ *             start-without-media: bool,
  *         },
  *         chat: array{
  *             max-length: int,

--- a/lib/Settings/BeforePreferenceSetEventListener.php
+++ b/lib/Settings/BeforePreferenceSetEventListener.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Talk\Settings;
+
+use OCA\Files_Sharing\SharedStorage;
+use OCA\Talk\AppInfo\Application;
+use OCA\Talk\Model\Attendee;
+use OCA\Talk\Participant;
+use OCA\Talk\Service\ParticipantService;
+use OCP\Config\BeforePreferenceSetEvent;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\Files\Folder;
+use OCP\Files\IRootFolder;
+use OCP\Files\NotFoundException;
+use OCP\Files\NotPermittedException;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @template-implements IEventListener<Event>
+ */
+class BeforePreferenceSetEventListener implements IEventListener {
+	public function __construct(
+		protected IRootFolder $rootFolder,
+		protected ParticipantService $participantService,
+		protected LoggerInterface $logger,
+	) {
+	}
+
+	public function handle(Event $event): void {
+		if (!($event instanceof BeforePreferenceSetEvent)) {
+			// Unrelated
+			return;
+		}
+
+		if ($event->getAppId() !== Application::APP_ID) {
+			return;
+		}
+
+		$event->setValid($this->validatePreference(
+			$event->getUserId(),
+			$event->getConfigKey(),
+			$event->getConfigValue(),
+		));
+	}
+
+	/**
+	 * @internal Make private/protected once SettingsController route was removed
+	 */
+	public function validatePreference(string $userId, string $key, string $value): bool {
+		if ($key === 'attachment_folder') {
+			return $this->validateAttachmentFolder($userId, $value);
+		}
+
+		// "boolean" yes/no
+		if ($key === UserPreference::CALLS_START_WITHOUT_MEDIA
+			|| $key === UserPreference::PLAY_SOUNDS) {
+			return $value === 'yes' || $value === 'no';
+		}
+
+		// "privacy" 0/1
+		if ($key === UserPreference::TYPING_PRIVACY
+			|| $key === UserPreference::READ_STATUS_PRIVACY) {
+			$valid = $value === (string)Participant::PRIVACY_PRIVATE || $value === (string)Participant::PRIVACY_PUBLIC;
+
+			if ($valid && $key === 'read_status_privacy') {
+				$this->participantService->updateReadPrivacyForActor(Attendee::ACTOR_USERS, $userId, (int)$value);
+			}
+			return $valid;
+		}
+
+		return false;
+	}
+
+	protected function validateAttachmentFolder(string $userId, string $value): bool {
+		try {
+			$userFolder = $this->rootFolder->getUserFolder($userId);
+			$node = $userFolder->get($value);
+			if (!$node instanceof Folder) {
+				throw new NotPermittedException('Node is not a directory');
+			}
+			if ($node->isShared()) {
+				throw new NotPermittedException('Folder is shared');
+			}
+			return !$node->getStorage()->instanceOfStorage(SharedStorage::class);
+		} catch (NotFoundException) {
+			$userFolder->newFolder($value);
+			return true;
+		} catch (NotPermittedException) {
+		} catch (\Exception $e) {
+			$this->logger->error($e->getMessage(), ['exception' => $e]);
+		}
+		return false;
+	}
+}

--- a/lib/Settings/UserPreference.php
+++ b/lib/Settings/UserPreference.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Talk\Settings;
+
+class UserPreference {
+	public const CALLS_START_WITHOUT_MEDIA = 'calls_start_without_media';
+	public const PLAY_SOUNDS = 'play_sounds';
+	public const TYPING_PRIVACY = 'typing_privacy';
+	public const READ_STATUS_PRIVACY = 'read_status_privacy';
+}

--- a/openapi-administration.json
+++ b/openapi-administration.json
@@ -147,7 +147,8 @@
                                     "can-upload-background",
                                     "sip-enabled",
                                     "sip-dialout-enabled",
-                                    "can-enable-sip"
+                                    "can-enable-sip",
+                                    "start-without-media"
                                 ],
                                 "properties": {
                                     "enabled": {
@@ -185,6 +186,9 @@
                                         "type": "boolean"
                                     },
                                     "can-enable-sip": {
+                                        "type": "boolean"
+                                    },
+                                    "start-without-media": {
                                         "type": "boolean"
                                     }
                                 }

--- a/openapi-backend-recording.json
+++ b/openapi-backend-recording.json
@@ -80,7 +80,8 @@
                                     "can-upload-background",
                                     "sip-enabled",
                                     "sip-dialout-enabled",
-                                    "can-enable-sip"
+                                    "can-enable-sip",
+                                    "start-without-media"
                                 ],
                                 "properties": {
                                     "enabled": {
@@ -118,6 +119,9 @@
                                         "type": "boolean"
                                     },
                                     "can-enable-sip": {
+                                        "type": "boolean"
+                                    },
+                                    "start-without-media": {
                                         "type": "boolean"
                                     }
                                 }

--- a/openapi-backend-signaling.json
+++ b/openapi-backend-signaling.json
@@ -80,7 +80,8 @@
                                     "can-upload-background",
                                     "sip-enabled",
                                     "sip-dialout-enabled",
-                                    "can-enable-sip"
+                                    "can-enable-sip",
+                                    "start-without-media"
                                 ],
                                 "properties": {
                                     "enabled": {
@@ -118,6 +119,9 @@
                                         "type": "boolean"
                                     },
                                     "can-enable-sip": {
+                                        "type": "boolean"
+                                    },
+                                    "start-without-media": {
                                         "type": "boolean"
                                     }
                                 }

--- a/openapi-backend-sipbridge.json
+++ b/openapi-backend-sipbridge.json
@@ -123,7 +123,8 @@
                                     "can-upload-background",
                                     "sip-enabled",
                                     "sip-dialout-enabled",
-                                    "can-enable-sip"
+                                    "can-enable-sip",
+                                    "start-without-media"
                                 ],
                                 "properties": {
                                     "enabled": {
@@ -161,6 +162,9 @@
                                         "type": "boolean"
                                     },
                                     "can-enable-sip": {
+                                        "type": "boolean"
+                                    },
+                                    "start-without-media": {
                                         "type": "boolean"
                                     }
                                 }

--- a/openapi-bots.json
+++ b/openapi-bots.json
@@ -80,7 +80,8 @@
                                     "can-upload-background",
                                     "sip-enabled",
                                     "sip-dialout-enabled",
-                                    "can-enable-sip"
+                                    "can-enable-sip",
+                                    "start-without-media"
                                 ],
                                 "properties": {
                                     "enabled": {
@@ -118,6 +119,9 @@
                                         "type": "boolean"
                                     },
                                     "can-enable-sip": {
+                                        "type": "boolean"
+                                    },
+                                    "start-without-media": {
                                         "type": "boolean"
                                     }
                                 }

--- a/openapi-federation.json
+++ b/openapi-federation.json
@@ -123,7 +123,8 @@
                                     "can-upload-background",
                                     "sip-enabled",
                                     "sip-dialout-enabled",
-                                    "can-enable-sip"
+                                    "can-enable-sip",
+                                    "start-without-media"
                                 ],
                                 "properties": {
                                     "enabled": {
@@ -161,6 +162,9 @@
                                         "type": "boolean"
                                     },
                                     "can-enable-sip": {
+                                        "type": "boolean"
+                                    },
+                                    "start-without-media": {
                                         "type": "boolean"
                                     }
                                 }

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -285,7 +285,8 @@
                                     "can-upload-background",
                                     "sip-enabled",
                                     "sip-dialout-enabled",
-                                    "can-enable-sip"
+                                    "can-enable-sip",
+                                    "start-without-media"
                                 ],
                                 "properties": {
                                     "enabled": {
@@ -323,6 +324,9 @@
                                         "type": "boolean"
                                     },
                                     "can-enable-sip": {
+                                        "type": "boolean"
+                                    },
+                                    "start-without-media": {
                                         "type": "boolean"
                                     }
                                 }

--- a/openapi.json
+++ b/openapi.json
@@ -226,7 +226,8 @@
                                     "can-upload-background",
                                     "sip-enabled",
                                     "sip-dialout-enabled",
-                                    "can-enable-sip"
+                                    "can-enable-sip",
+                                    "start-without-media"
                                 ],
                                 "properties": {
                                     "enabled": {
@@ -264,6 +265,9 @@
                                         "type": "boolean"
                                     },
                                     "can-enable-sip": {
+                                        "type": "boolean"
+                                    },
+                                    "start-without-media": {
                                         "type": "boolean"
                                     }
                                 }

--- a/src/__mocks__/capabilities.ts
+++ b/src/__mocks__/capabilities.ts
@@ -112,6 +112,7 @@ export const mockedCapabilities: Capabilities = {
 				'sip-enabled': true,
 				'sip-dialout-enabled': true,
 				'can-enable-sip': true,
+				'start-without-media': false,
 			},
 			chat: {
 				'max-length': 32000,
@@ -143,6 +144,7 @@ export const mockedCapabilities: Capabilities = {
 			call: [
 				'predefined-backgrounds',
 				'can-upload-background',
+				'start-without-media',
 			],
 			chat: [
 				'read-privacy',

--- a/src/types/openapi/openapi-administration.ts
+++ b/src/types/openapi/openapi-administration.ts
@@ -228,6 +228,7 @@ export type components = {
                     "sip-enabled": boolean;
                     "sip-dialout-enabled": boolean;
                     "can-enable-sip": boolean;
+                    "start-without-media": boolean;
                 };
                 chat: {
                     /** Format: int64 */

--- a/src/types/openapi/openapi-backend-recording.ts
+++ b/src/types/openapi/openapi-backend-recording.ts
@@ -62,6 +62,7 @@ export type components = {
                     "sip-enabled": boolean;
                     "sip-dialout-enabled": boolean;
                     "can-enable-sip": boolean;
+                    "start-without-media": boolean;
                 };
                 chat: {
                     /** Format: int64 */

--- a/src/types/openapi/openapi-backend-signaling.ts
+++ b/src/types/openapi/openapi-backend-signaling.ts
@@ -48,6 +48,7 @@ export type components = {
                     "sip-enabled": boolean;
                     "sip-dialout-enabled": boolean;
                     "can-enable-sip": boolean;
+                    "start-without-media": boolean;
                 };
                 chat: {
                     /** Format: int64 */

--- a/src/types/openapi/openapi-backend-sipbridge.ts
+++ b/src/types/openapi/openapi-backend-sipbridge.ts
@@ -143,6 +143,7 @@ export type components = {
                     "sip-enabled": boolean;
                     "sip-dialout-enabled": boolean;
                     "can-enable-sip": boolean;
+                    "start-without-media": boolean;
                 };
                 chat: {
                     /** Format: int64 */

--- a/src/types/openapi/openapi-bots.ts
+++ b/src/types/openapi/openapi-bots.ts
@@ -66,6 +66,7 @@ export type components = {
                     "sip-enabled": boolean;
                     "sip-dialout-enabled": boolean;
                     "can-enable-sip": boolean;
+                    "start-without-media": boolean;
                 };
                 chat: {
                     /** Format: int64 */

--- a/src/types/openapi/openapi-federation.ts
+++ b/src/types/openapi/openapi-federation.ts
@@ -174,6 +174,7 @@ export type components = {
                     "sip-enabled": boolean;
                     "sip-dialout-enabled": boolean;
                     "can-enable-sip": boolean;
+                    "start-without-media": boolean;
                 };
                 chat: {
                     /** Format: int64 */

--- a/src/types/openapi/openapi-full.ts
+++ b/src/types/openapi/openapi-full.ts
@@ -1882,6 +1882,7 @@ export type components = {
                     "sip-enabled": boolean;
                     "sip-dialout-enabled": boolean;
                     "can-enable-sip": boolean;
+                    "start-without-media": boolean;
                 };
                 chat: {
                     /** Format: int64 */

--- a/src/types/openapi/openapi.ts
+++ b/src/types/openapi/openapi.ts
@@ -1379,6 +1379,7 @@ export type components = {
                     "sip-enabled": boolean;
                     "sip-dialout-enabled": boolean;
                     "can-enable-sip": boolean;
+                    "start-without-media": boolean;
                 };
                 chat: {
                     /** Format: int64 */

--- a/tests/php/CapabilitiesTest.php
+++ b/tests/php/CapabilitiesTest.php
@@ -119,6 +119,7 @@ class CapabilitiesTest extends TestCase {
 						'sip-enabled' => false,
 						'sip-dialout-enabled' => false,
 						'can-enable-sip' => false,
+						'start-without-media' => false,
 						'predefined-backgrounds' => [
 							'1_office.jpg',
 							'2_home.jpg',
@@ -252,6 +253,7 @@ class CapabilitiesTest extends TestCase {
 						'sip-enabled' => false,
 						'sip-dialout-enabled' => false,
 						'can-enable-sip' => false,
+						'start-without-media' => false,
 						'predefined-backgrounds' => [
 							'1_office.jpg',
 							'2_home.jpg',


### PR DESCRIPTION
… media


### ☑️ Resolves

* Fix API side of #13446 

## 🛠️ API Checklist

### ⚙️ Settings API

The endpoint for actually setting it is in the provisioning API:
if you have ocs_api_viewer installed: `/index.php/apps/ocs_api_viewer/view/provisioning_api#/operations/preferences-set-preference`
![grafik](https://github.com/user-attachments/assets/51f8cdb5-3a44-4cae-bfd6-2a8d851f99f6)


Sample:
```
POST /ocs/v2.php/apps/provisioning_api/api/v1/config/users/{appId}/{configKey}
{"configValue":"yes|no"}

POST /ocs/v2.php/apps/provisioning_api/api/v1/config/users/spreed/play_sounds
{"configValue":"no"}
```

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
