### PR TITLE
feat(call): add option to enable blur background by default for all c…

### DIFF
--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -162,4 +162,4 @@
 * `download-call-participants` - Whether the endpoints for moderators to download the call participants is available
 * `config => call => start-without-media` (local) - Boolean, whether media should be disabled when starting or joining a conversation
 * `config => call => max-duration` - Integer, maximum call duration in seconds. Please note that this should only be used with system cron and with a reasonable high value, due to the expended duration until the background job ran.
-* `config => call => blur-background` (local) - Boolean, whether blur background is set by default when joining a conversation
+* `config => call => blur-virtual-background` (local) - Boolean, whether blur background is set by default when joining a conversation

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -162,3 +162,4 @@
 * `download-call-participants` - Whether the endpoints for moderators to download the call participants is available
 * `config => call => start-without-media` (local) - Boolean, whether media should be disabled when starting or joining a conversation
 * `config => call => max-duration` - Integer, maximum call duration in seconds. Please note that this should only be used with system cron and with a reasonable high value, due to the expended duration until the background job ran.
+* `config => call => blur-background` (local) - Boolean, whether blur background is set by default when joining a conversation

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -31,6 +31,7 @@ Instead, the server API `POST /ocs/v2.php/apps/provisioning_api/api/v1/config/us
 | `typing_privacy`            | `config => chat => typing-privacy`      | `0`                                                | One of the typing privacy constants from the [constants list](constants.md#participant-typing-privacy)   |
 | `play_sounds`               |                                         | `'yes'`                                            | `'yes'` and `'no'`                                                                                       |
 | `calls_start_without_media` | `config => call => start-without-media` | `''` falling back to app config with the same name | `'yes'` and `'no'`                                                                                       |
+| `blur_background`           | `config => call => blur-background`     | `'no'`                                             | `'yes'` and `'no'`                                                                                       |
 
 ## Set SIP settings
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -24,14 +24,14 @@
 **Note:** Settings from `calls_start_without_media` onwards can not be set via above API.
 Instead, the server API `POST /ocs/v2.php/apps/provisioning_api/api/v1/config/users/{appId}/{configKey}` needs to be used.
 
-| Key                         | Capability                              | Default                                            | Valid values                                                                                             |
-|-----------------------------|-----------------------------------------|----------------------------------------------------|----------------------------------------------------------------------------------------------------------|
-| `attachment_folder`         | `config => attachments => folder`       | Value of app config `default_attachment_folder`    | Path owned by the user to store uploads and received shares. It is created if it does not exist.         |
-| `read_status_privacy`       | `config => chat => read-privacy`        | `0`                                                | One of the read-status constants from the [constants list](constants.md#participant-read-status-privacy) |
-| `typing_privacy`            | `config => chat => typing-privacy`      | `0`                                                | One of the typing privacy constants from the [constants list](constants.md#participant-typing-privacy)   |
-| `play_sounds`               |                                         | `'yes'`                                            | `'yes'` and `'no'`                                                                                       |
-| `calls_start_without_media` | `config => call => start-without-media` | `''` falling back to app config with the same name | `'yes'` and `'no'`                                                                                       |
-| `blur_background`           | `config => call => blur-background`     | `'no'`                                             | `'yes'` and `'no'`                                                                                       |
+| Key                         | Capability                                  | Default                                            | Valid values                                                                                             |
+|-----------------------------|---------------------------------------------|----------------------------------------------------|----------------------------------------------------------------------------------------------------------|
+| `attachment_folder`         | `config => attachments => folder`           | Value of app config `default_attachment_folder`    | Path owned by the user to store uploads and received shares. It is created if it does not exist.         |
+| `read_status_privacy`       | `config => chat => read-privacy`            | `0`                                                | One of the read-status constants from the [constants list](constants.md#participant-read-status-privacy) |
+| `typing_privacy`            | `config => chat => typing-privacy`          | `0`                                                | One of the typing privacy constants from the [constants list](constants.md#participant-typing-privacy)   |
+| `play_sounds`               |                                             | `'yes'`                                            | `'yes'` and `'no'`                                                                                       |
+| `calls_start_without_media` | `config => call => start-without-media`     | `''` falling back to app config with the same name | `'yes'` and `'no'`                                                                                       |
+| `blur_virtual_background`   | `config => call => blur-virtual-background` | `'no'`                                             | `'yes'` and `'no'`                                                                                       |
 
 ## Set SIP settings
 

--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -202,7 +202,7 @@ class Capabilities implements IPublicCapability {
 					'can-enable-sip' => false,
 					'start-without-media' => $this->talkConfig->getCallsStartWithoutMedia($user?->getUID()),
 					'max-duration' => $this->appConfig->getAppValueInt('max_call_duration'),
-					'blur-virtual-background' => $this->talkConfig->getBlurBackground($user?->getUID()),
+					'blur-virtual-background' => $this->talkConfig->getBlurVirtualBackground($user?->getUID()),
 				],
 				'chat' => [
 					'max-length' => ChatManager::MAX_CHAT_LENGTH,
@@ -252,7 +252,7 @@ class Capabilities implements IPublicCapability {
 			$capabilities['config']['attachments']['folder'] = $this->talkConfig->getAttachmentFolder($user->getUID());
 			$capabilities['config']['chat']['read-privacy'] = $this->talkConfig->getUserReadPrivacy($user->getUID());
 			$capabilities['config']['chat']['typing-privacy'] = $this->talkConfig->getUserTypingPrivacy($user->getUID());
-			$capabilities['config']['call']['blur-virtual-background'] = $this->talkConfig->getBlurBackground($user->getUID());
+			$capabilities['config']['call']['blur-virtual-background'] = $this->talkConfig->getBlurVirtualBackground($user->getUID());
 		}
 
 		$pubKey = $this->talkConfig->getSignalingTokenPublicKey();

--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -130,7 +130,7 @@ class Capabilities implements IPublicCapability {
 			'predefined-backgrounds',
 			'can-upload-background',
 			'start-without-media',
-			'blur-background',
+			'blur-virtual-background',
 		],
 		'chat' => [
 			'read-privacy',
@@ -202,7 +202,7 @@ class Capabilities implements IPublicCapability {
 					'can-enable-sip' => false,
 					'start-without-media' => $this->talkConfig->getCallsStartWithoutMedia($user?->getUID()),
 					'max-duration' => $this->appConfig->getAppValueInt('max_call_duration'),
-					'blur-background' => $this->talkConfig->getBlurBackground($user?->getUID()),
+					'blur-virtual-background' => $this->talkConfig->getBlurBackground($user?->getUID()),
 				],
 				'chat' => [
 					'max-length' => ChatManager::MAX_CHAT_LENGTH,
@@ -252,7 +252,7 @@ class Capabilities implements IPublicCapability {
 			$capabilities['config']['attachments']['folder'] = $this->talkConfig->getAttachmentFolder($user->getUID());
 			$capabilities['config']['chat']['read-privacy'] = $this->talkConfig->getUserReadPrivacy($user->getUID());
 			$capabilities['config']['chat']['typing-privacy'] = $this->talkConfig->getUserTypingPrivacy($user->getUID());
-			$capabilities['config']['call']['blur-background'] = $this->talkConfig->getBlurBackground($user->getUID());
+			$capabilities['config']['call']['blur-virtual-background'] = $this->talkConfig->getBlurBackground($user->getUID());
 		}
 
 		$pubKey = $this->talkConfig->getSignalingTokenPublicKey();

--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -130,6 +130,7 @@ class Capabilities implements IPublicCapability {
 			'predefined-backgrounds',
 			'can-upload-background',
 			'start-without-media',
+			'blur-background',
 		],
 		'chat' => [
 			'read-privacy',
@@ -201,6 +202,7 @@ class Capabilities implements IPublicCapability {
 					'can-enable-sip' => false,
 					'start-without-media' => $this->talkConfig->getCallsStartWithoutMedia($user?->getUID()),
 					'max-duration' => $this->appConfig->getAppValueInt('max_call_duration'),
+					'blur-background' => $this->talkConfig->getBlurBackground($user?->getUID()),
 				],
 				'chat' => [
 					'max-length' => ChatManager::MAX_CHAT_LENGTH,
@@ -250,6 +252,7 @@ class Capabilities implements IPublicCapability {
 			$capabilities['config']['attachments']['folder'] = $this->talkConfig->getAttachmentFolder($user->getUID());
 			$capabilities['config']['chat']['read-privacy'] = $this->talkConfig->getUserReadPrivacy($user->getUID());
 			$capabilities['config']['chat']['typing-privacy'] = $this->talkConfig->getUserTypingPrivacy($user->getUID());
+			$capabilities['config']['call']['blur-background'] = $this->talkConfig->getBlurBackground($user->getUID());
 		}
 
 		$pubKey = $this->talkConfig->getSignalingTokenPublicKey();

--- a/lib/Config.php
+++ b/lib/Config.php
@@ -687,7 +687,7 @@ class Config {
 	 * @param ?string $userId
 	 * @return bool
 	 */
-	public function getBlurBackground(?string $userId): bool {
+	public function getBlurVirtualBackground(?string $userId): bool {
 		if ($userId !== null) {
 			$userSetting = $this->config->getUserValue($userId, 'spreed', UserPreference::BLUR_VIRTUAL_BACKGROUND);
 			return $userSetting === 'yes';

--- a/lib/Config.php
+++ b/lib/Config.php
@@ -689,7 +689,7 @@ class Config {
 	 */
 	public function getBlurBackground(?string $userId): bool {
 		if ($userId !== null) {
-			$userSetting = $this->config->getUserValue($userId, 'spreed', UserPreference::BLUR_BACKGROUND);
+			$userSetting = $this->config->getUserValue($userId, 'spreed', UserPreference::BLUR_VIRTUAL_BACKGROUND);
 			return $userSetting === 'yes';
 		}
 		return false;

--- a/lib/Config.php
+++ b/lib/Config.php
@@ -680,4 +680,18 @@ class Config {
 
 		return $this->appConfig->getAppValueBool('calls_start_without_media');
 	}
+
+	/**
+	 * User setting for blur background
+	 *
+	 * @param ?string $userId
+	 * @return bool
+	 */
+	public function getBlurBackground(?string $userId): bool {
+		if ($userId !== null) {
+			$userSetting = $this->config->getUserValue($userId, 'spreed', UserPreference::BLUR_BACKGROUND);
+			return $userSetting === 'yes';
+		}
+		return false;
+	}
 }

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -2458,8 +2458,8 @@ class RoomController extends AEnvironmentAwareController {
 			if (isset($data['config']['call']['start-without-media'])) {
 				$data['config']['call']['start-without-media'] = $this->talkConfig->getCallsStartWithoutMedia($this->userId);
 			}
-			if (isset($data['config']['call']['blur-background'])) {
-				$data['config']['call']['blur-background'] = $this->talkConfig->getBlurBackground($this->userId);
+			if (isset($data['config']['call']['blur-virtual-background'])) {
+				$data['config']['call']['blur-virtual-background'] = $this->talkConfig->getBlurBackground($this->userId);
 			}
 
 			if ($response->getHeaders()['X-Nextcloud-Talk-Hash']) {

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -2458,6 +2458,9 @@ class RoomController extends AEnvironmentAwareController {
 			if (isset($data['config']['call']['start-without-media'])) {
 				$data['config']['call']['start-without-media'] = $this->talkConfig->getCallsStartWithoutMedia($this->userId);
 			}
+			if (isset($data['config']['call']['blur-background'])) {
+				$data['config']['call']['blur-background'] = $this->talkConfig->getBlurBackground($this->userId);
+			}
 
 			if ($response->getHeaders()['X-Nextcloud-Talk-Hash']) {
 				$headers['X-Nextcloud-Talk-Proxy-Hash'] = $response->getHeaders()['X-Nextcloud-Talk-Hash'];

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -2459,7 +2459,7 @@ class RoomController extends AEnvironmentAwareController {
 				$data['config']['call']['start-without-media'] = $this->talkConfig->getCallsStartWithoutMedia($this->userId);
 			}
 			if (isset($data['config']['call']['blur-virtual-background'])) {
-				$data['config']['call']['blur-virtual-background'] = $this->talkConfig->getBlurBackground($this->userId);
+				$data['config']['call']['blur-virtual-background'] = $this->talkConfig->getBlurVirtualBackground($this->userId);
 			}
 
 			if ($response->getHeaders()['X-Nextcloud-Talk-Hash']) {

--- a/lib/Federation/Proxy/TalkV1/ProxyRequest.php
+++ b/lib/Federation/Proxy/TalkV1/ProxyRequest.php
@@ -42,6 +42,9 @@ class ProxyRequest {
 						'read-privacy',
 						'typing-privacy',
 					],
+					'call' => [
+						'blur-background',
+					]
 				],
 			]
 		]));

--- a/lib/Federation/Proxy/TalkV1/ProxyRequest.php
+++ b/lib/Federation/Proxy/TalkV1/ProxyRequest.php
@@ -43,7 +43,7 @@ class ProxyRequest {
 						'typing-privacy',
 					],
 					'call' => [
-						'blur-background',
+						'blur-virtual-background',
 					]
 				],
 			]

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -348,7 +348,7 @@ namespace OCA\Talk;
  *             can-enable-sip: bool,
  *             start-without-media: bool,
  *             max-duration: int,
- *             blur-background: bool,
+ *             blur-virtual-background: bool,
  *         },
  *         chat: array{
  *             max-length: int,

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -348,6 +348,7 @@ namespace OCA\Talk;
  *             can-enable-sip: bool,
  *             start-without-media: bool,
  *             max-duration: int,
+ *             blur-background: bool,
  *         },
  *         chat: array{
  *             max-length: int,

--- a/lib/Settings/BeforePreferenceSetEventListener.php
+++ b/lib/Settings/BeforePreferenceSetEventListener.php
@@ -60,7 +60,8 @@ class BeforePreferenceSetEventListener implements IEventListener {
 
 		// "boolean" yes/no
 		if ($key === UserPreference::CALLS_START_WITHOUT_MEDIA
-			|| $key === UserPreference::PLAY_SOUNDS) {
+			|| $key === UserPreference::PLAY_SOUNDS
+			|| $key === UserPreference::BLUR_BACKGROUND) {
 			return $value === 'yes' || $value === 'no';
 		}
 

--- a/lib/Settings/BeforePreferenceSetEventListener.php
+++ b/lib/Settings/BeforePreferenceSetEventListener.php
@@ -61,7 +61,7 @@ class BeforePreferenceSetEventListener implements IEventListener {
 		// "boolean" yes/no
 		if ($key === UserPreference::CALLS_START_WITHOUT_MEDIA
 			|| $key === UserPreference::PLAY_SOUNDS
-			|| $key === UserPreference::BLUR_BACKGROUND) {
+			|| $key === UserPreference::BLUR_VIRTUAL_BACKGROUND) {
 			return $value === 'yes' || $value === 'no';
 		}
 

--- a/lib/Settings/UserPreference.php
+++ b/lib/Settings/UserPreference.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace OCA\Talk\Settings;
 
 class UserPreference {
+	public const BLUR_BACKGROUND = 'blur_background';
 	public const CALLS_START_WITHOUT_MEDIA = 'calls_start_without_media';
 	public const PLAY_SOUNDS = 'play_sounds';
 	public const TYPING_PRIVACY = 'typing_privacy';

--- a/lib/Settings/UserPreference.php
+++ b/lib/Settings/UserPreference.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace OCA\Talk\Settings;
 
 class UserPreference {
-	public const BLUR_BACKGROUND = 'blur_background';
+	public const BLUR_VIRTUAL_BACKGROUND = 'blur_virtual_background';
 	public const CALLS_START_WITHOUT_MEDIA = 'calls_start_without_media';
 	public const PLAY_SOUNDS = 'play_sounds';
 	public const TYPING_PRIVACY = 'typing_privacy';

--- a/openapi-administration.json
+++ b/openapi-administration.json
@@ -149,7 +149,8 @@
                                     "sip-dialout-enabled",
                                     "can-enable-sip",
                                     "start-without-media",
-                                    "max-duration"
+                                    "max-duration",
+                                    "blur-background"
                                 ],
                                 "properties": {
                                     "enabled": {
@@ -195,6 +196,9 @@
                                     "max-duration": {
                                         "type": "integer",
                                         "format": "int64"
+                                    },
+                                    "blur-background": {
+                                        "type": "boolean"
                                     }
                                 }
                             },

--- a/openapi-administration.json
+++ b/openapi-administration.json
@@ -150,7 +150,7 @@
                                     "can-enable-sip",
                                     "start-without-media",
                                     "max-duration",
-                                    "blur-background"
+                                    "blur-virtual-background"
                                 ],
                                 "properties": {
                                     "enabled": {
@@ -197,7 +197,7 @@
                                         "type": "integer",
                                         "format": "int64"
                                     },
-                                    "blur-background": {
+                                    "blur-virtual-background": {
                                         "type": "boolean"
                                     }
                                 }

--- a/openapi-backend-recording.json
+++ b/openapi-backend-recording.json
@@ -83,7 +83,7 @@
                                     "can-enable-sip",
                                     "start-without-media",
                                     "max-duration",
-                                    "blur-background"
+                                    "blur-virtual-background"
                                 ],
                                 "properties": {
                                     "enabled": {
@@ -130,7 +130,7 @@
                                         "type": "integer",
                                         "format": "int64"
                                     },
-                                    "blur-background": {
+                                    "blur-virtual-background": {
                                         "type": "boolean"
                                     }
                                 }

--- a/openapi-backend-recording.json
+++ b/openapi-backend-recording.json
@@ -82,7 +82,8 @@
                                     "sip-dialout-enabled",
                                     "can-enable-sip",
                                     "start-without-media",
-                                    "max-duration"
+                                    "max-duration",
+                                    "blur-background"
                                 ],
                                 "properties": {
                                     "enabled": {
@@ -128,6 +129,9 @@
                                     "max-duration": {
                                         "type": "integer",
                                         "format": "int64"
+                                    },
+                                    "blur-background": {
+                                        "type": "boolean"
                                     }
                                 }
                             },

--- a/openapi-backend-signaling.json
+++ b/openapi-backend-signaling.json
@@ -83,7 +83,7 @@
                                     "can-enable-sip",
                                     "start-without-media",
                                     "max-duration",
-                                    "blur-background"
+                                    "blur-virtual-background"
                                 ],
                                 "properties": {
                                     "enabled": {
@@ -130,7 +130,7 @@
                                         "type": "integer",
                                         "format": "int64"
                                     },
-                                    "blur-background": {
+                                    "blur-virtual-background": {
                                         "type": "boolean"
                                     }
                                 }

--- a/openapi-backend-signaling.json
+++ b/openapi-backend-signaling.json
@@ -82,7 +82,8 @@
                                     "sip-dialout-enabled",
                                     "can-enable-sip",
                                     "start-without-media",
-                                    "max-duration"
+                                    "max-duration",
+                                    "blur-background"
                                 ],
                                 "properties": {
                                     "enabled": {
@@ -128,6 +129,9 @@
                                     "max-duration": {
                                         "type": "integer",
                                         "format": "int64"
+                                    },
+                                    "blur-background": {
+                                        "type": "boolean"
                                     }
                                 }
                             },

--- a/openapi-backend-sipbridge.json
+++ b/openapi-backend-sipbridge.json
@@ -125,7 +125,8 @@
                                     "sip-dialout-enabled",
                                     "can-enable-sip",
                                     "start-without-media",
-                                    "max-duration"
+                                    "max-duration",
+                                    "blur-background"
                                 ],
                                 "properties": {
                                     "enabled": {
@@ -171,6 +172,9 @@
                                     "max-duration": {
                                         "type": "integer",
                                         "format": "int64"
+                                    },
+                                    "blur-background": {
+                                        "type": "boolean"
                                     }
                                 }
                             },

--- a/openapi-backend-sipbridge.json
+++ b/openapi-backend-sipbridge.json
@@ -126,7 +126,7 @@
                                     "can-enable-sip",
                                     "start-without-media",
                                     "max-duration",
-                                    "blur-background"
+                                    "blur-virtual-background"
                                 ],
                                 "properties": {
                                     "enabled": {
@@ -173,7 +173,7 @@
                                         "type": "integer",
                                         "format": "int64"
                                     },
-                                    "blur-background": {
+                                    "blur-virtual-background": {
                                         "type": "boolean"
                                     }
                                 }

--- a/openapi-bots.json
+++ b/openapi-bots.json
@@ -83,7 +83,7 @@
                                     "can-enable-sip",
                                     "start-without-media",
                                     "max-duration",
-                                    "blur-background"
+                                    "blur-virtual-background"
                                 ],
                                 "properties": {
                                     "enabled": {
@@ -130,7 +130,7 @@
                                         "type": "integer",
                                         "format": "int64"
                                     },
-                                    "blur-background": {
+                                    "blur-virtual-background": {
                                         "type": "boolean"
                                     }
                                 }

--- a/openapi-bots.json
+++ b/openapi-bots.json
@@ -82,7 +82,8 @@
                                     "sip-dialout-enabled",
                                     "can-enable-sip",
                                     "start-without-media",
-                                    "max-duration"
+                                    "max-duration",
+                                    "blur-background"
                                 ],
                                 "properties": {
                                     "enabled": {
@@ -128,6 +129,9 @@
                                     "max-duration": {
                                         "type": "integer",
                                         "format": "int64"
+                                    },
+                                    "blur-background": {
+                                        "type": "boolean"
                                     }
                                 }
                             },

--- a/openapi-federation.json
+++ b/openapi-federation.json
@@ -125,7 +125,8 @@
                                     "sip-dialout-enabled",
                                     "can-enable-sip",
                                     "start-without-media",
-                                    "max-duration"
+                                    "max-duration",
+                                    "blur-background"
                                 ],
                                 "properties": {
                                     "enabled": {
@@ -171,6 +172,9 @@
                                     "max-duration": {
                                         "type": "integer",
                                         "format": "int64"
+                                    },
+                                    "blur-background": {
+                                        "type": "boolean"
                                     }
                                 }
                             },

--- a/openapi-federation.json
+++ b/openapi-federation.json
@@ -126,7 +126,7 @@
                                     "can-enable-sip",
                                     "start-without-media",
                                     "max-duration",
-                                    "blur-background"
+                                    "blur-virtual-background"
                                 ],
                                 "properties": {
                                     "enabled": {
@@ -173,7 +173,7 @@
                                         "type": "integer",
                                         "format": "int64"
                                     },
-                                    "blur-background": {
+                                    "blur-virtual-background": {
                                         "type": "boolean"
                                     }
                                 }

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -302,7 +302,7 @@
                                     "can-enable-sip",
                                     "start-without-media",
                                     "max-duration",
-                                    "blur-background"
+                                    "blur-virtual-background"
                                 ],
                                 "properties": {
                                     "enabled": {
@@ -349,7 +349,7 @@
                                         "type": "integer",
                                         "format": "int64"
                                     },
-                                    "blur-background": {
+                                    "blur-virtual-background": {
                                         "type": "boolean"
                                     }
                                 }
@@ -16372,8 +16372,7 @@
                                             "attachment_folder",
                                             "read_status_privacy",
                                             "typing_privacy",
-                                            "play_sounds",
-                                            "blur_background"
+                                            "play_sounds"
                                         ],
                                         "description": "Key to update"
                                     },

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -301,7 +301,8 @@
                                     "sip-dialout-enabled",
                                     "can-enable-sip",
                                     "start-without-media",
-                                    "max-duration"
+                                    "max-duration",
+                                    "blur-background"
                                 ],
                                 "properties": {
                                     "enabled": {
@@ -347,6 +348,9 @@
                                     "max-duration": {
                                         "type": "integer",
                                         "format": "int64"
+                                    },
+                                    "blur-background": {
+                                        "type": "boolean"
                                     }
                                 }
                             },
@@ -16368,7 +16372,8 @@
                                             "attachment_folder",
                                             "read_status_privacy",
                                             "typing_privacy",
-                                            "play_sounds"
+                                            "play_sounds",
+                                            "blur_background"
                                         ],
                                         "description": "Key to update"
                                     },

--- a/openapi.json
+++ b/openapi.json
@@ -243,7 +243,7 @@
                                     "can-enable-sip",
                                     "start-without-media",
                                     "max-duration",
-                                    "blur-background"
+                                    "blur-virtual-background"
                                 ],
                                 "properties": {
                                     "enabled": {
@@ -290,7 +290,7 @@
                                         "type": "integer",
                                         "format": "int64"
                                     },
-                                    "blur-background": {
+                                    "blur-virtual-background": {
                                         "type": "boolean"
                                     }
                                 }
@@ -16506,8 +16506,7 @@
                                             "attachment_folder",
                                             "read_status_privacy",
                                             "typing_privacy",
-                                            "play_sounds",
-                                            "blur_background"
+                                            "play_sounds"
                                         ],
                                         "description": "Key to update"
                                     },

--- a/openapi.json
+++ b/openapi.json
@@ -242,7 +242,8 @@
                                     "sip-dialout-enabled",
                                     "can-enable-sip",
                                     "start-without-media",
-                                    "max-duration"
+                                    "max-duration",
+                                    "blur-background"
                                 ],
                                 "properties": {
                                     "enabled": {
@@ -288,6 +289,9 @@
                                     "max-duration": {
                                         "type": "integer",
                                         "format": "int64"
+                                    },
+                                    "blur-background": {
+                                        "type": "boolean"
                                     }
                                 }
                             },
@@ -16502,7 +16506,8 @@
                                             "attachment_folder",
                                             "read_status_privacy",
                                             "typing_privacy",
-                                            "play_sounds"
+                                            "play_sounds",
+                                            "blur_background"
                                         ],
                                         "description": "Key to update"
                                     },

--- a/src/__mocks__/capabilities.ts
+++ b/src/__mocks__/capabilities.ts
@@ -117,6 +117,7 @@ export const mockedCapabilities: Capabilities = {
 				'can-enable-sip': true,
 				'start-without-media': false,
 				'max-duration': 0,
+				'blur-background': false,
 			},
 			chat: {
 				'max-length': 32000,
@@ -149,6 +150,7 @@ export const mockedCapabilities: Capabilities = {
 				'predefined-backgrounds',
 				'can-upload-background',
 				'start-without-media',
+				'blur-background',
 			],
 			chat: [
 				'read-privacy',

--- a/src/__mocks__/capabilities.ts
+++ b/src/__mocks__/capabilities.ts
@@ -117,7 +117,7 @@ export const mockedCapabilities: Capabilities = {
 				'can-enable-sip': true,
 				'start-without-media': false,
 				'max-duration': 0,
-				'blur-background': false,
+				'blur-virtual-background': false,
 			},
 			chat: {
 				'max-length': 32000,
@@ -150,7 +150,7 @@ export const mockedCapabilities: Capabilities = {
 				'predefined-backgrounds',
 				'can-upload-background',
 				'start-without-media',
-				'blur-background',
+				'blur-virtual-background',
 			],
 			chat: [
 				'read-privacy',

--- a/src/components/MediaSettings/MediaSettings.vue
+++ b/src/components/MediaSettings/MediaSettings.vue
@@ -352,6 +352,10 @@ export default {
 			return this.settingsStore.getShowMediaSettings(this.token)
 		},
 
+		blurBackgroundEnabled() {
+			return this.settingsStore.getBlurBackgroundEnabled
+		},
+
 		showVideo() {
 			return this.videoPreviewAvailable && this.videoOn
 		},
@@ -431,16 +435,21 @@ export default {
 				this.audioOn = !BrowserStorage.getItem('audioDisabled_' + this.token)
 				this.videoOn = !BrowserStorage.getItem('videoDisabled_' + this.token)
 				this.silentCall = !!BrowserStorage.getItem('silentCall_' + this.token)
-
-				// Set virtual background depending on BrowserStorage's settings
-				if (BrowserStorage.getItem('virtualBackgroundEnabled_' + this.token) === 'true') {
-					if (BrowserStorage.getItem('virtualBackgroundType_' + this.token) === VIRTUAL_BACKGROUND.BACKGROUND_TYPE.BLUR) {
-						this.blurVirtualBackground()
-					} else if (BrowserStorage.getItem('virtualBackgroundType_' + this.token) === VIRTUAL_BACKGROUND.BACKGROUND_TYPE.IMAGE) {
-						this.setVirtualBackgroundImage(BrowserStorage.getItem('virtualBackgroundUrl_' + this.token))
-					}
+				// Check main blur background setting
+				if (this.blurBackgroundEnabled) {
+					this.blurVirtualBackground()
+					this.blurBackground()
 				} else {
-					this.clearVirtualBackground()
+					// Set virtual background depending on BrowserStorage's settings
+					if (BrowserStorage.getItem('virtualBackgroundEnabled_' + this.token) === 'true') {
+						if (BrowserStorage.getItem('virtualBackgroundType_' + this.token) === VIRTUAL_BACKGROUND.BACKGROUND_TYPE.BLUR) {
+							this.blurVirtualBackground()
+						} else if (BrowserStorage.getItem('virtualBackgroundType_' + this.token) === VIRTUAL_BACKGROUND.BACKGROUND_TYPE.IMAGE) {
+							this.setVirtualBackgroundImage(BrowserStorage.getItem('virtualBackgroundUrl_' + this.token))
+						}
+					} else {
+						this.clearVirtualBackground()
+					}
 				}
 
 				this.initializeDevices()

--- a/src/components/MediaSettings/MediaSettings.vue
+++ b/src/components/MediaSettings/MediaSettings.vue
@@ -436,20 +436,19 @@ export default {
 				this.audioOn = !BrowserStorage.getItem('audioDisabled_' + this.token)
 				this.videoOn = !BrowserStorage.getItem('videoDisabled_' + this.token)
 				this.silentCall = !!BrowserStorage.getItem('silentCall_' + this.token)
-				// Check main blur background setting
-				if (this.blurBackgroundEnabled) {
+
+				// Set virtual background depending on BrowserStorage's settings
+				if (BrowserStorage.getItem('virtualBackgroundEnabled_' + this.token) === 'true') {
+					if (BrowserStorage.getItem('virtualBackgroundType_' + this.token) === VIRTUAL_BACKGROUND.BACKGROUND_TYPE.BLUR) {
+						this.blurVirtualBackground()
+					} else if (BrowserStorage.getItem('virtualBackgroundType_' + this.token) === VIRTUAL_BACKGROUND.BACKGROUND_TYPE.IMAGE) {
+						this.setVirtualBackgroundImage(BrowserStorage.getItem('virtualBackgroundUrl_' + this.token))
+					}
+				} else if (this.blurBackgroundEnabled) {
+					// Fall back to global blur background setting
 					this.blurVirtualBackground()
 				} else {
-					// Set virtual background depending on BrowserStorage's settings
-					if (BrowserStorage.getItem('virtualBackgroundEnabled_' + this.token) === 'true') {
-						if (BrowserStorage.getItem('virtualBackgroundType_' + this.token) === VIRTUAL_BACKGROUND.BACKGROUND_TYPE.BLUR) {
-							this.blurVirtualBackground()
-						} else if (BrowserStorage.getItem('virtualBackgroundType_' + this.token) === VIRTUAL_BACKGROUND.BACKGROUND_TYPE.IMAGE) {
-							this.setVirtualBackgroundImage(BrowserStorage.getItem('virtualBackgroundUrl_' + this.token))
-						}
-					} else {
-						this.clearVirtualBackground()
-					}
+					this.clearVirtualBackground()
 				}
 
 				this.initializeDevices()
@@ -476,8 +475,9 @@ export default {
 
 		isInCall(value) {
 			if (value) {
+				const virtualBackgroundEnabled = BrowserStorage.getItem('virtualBackgroundEnabled_' + this.token) === 'true'
 				// Apply global blur background setting
-				if (this.blurBackgroundEnabled && !this.skipBlurBackgroundEnabled) {
+				if (this.blurBackgroundEnabled && !this.skipBlurBackgroundEnabled && !virtualBackgroundEnabled) {
 					this.blurBackground(true)
 				}
 			}

--- a/src/components/MediaSettings/MediaSettings.vue
+++ b/src/components/MediaSettings/MediaSettings.vue
@@ -321,7 +321,7 @@ export default {
 			isRecordingFromStart: false,
 			isPublicShareAuthSidebar: false,
 			isMirrored: false,
-			skipBlurBackgroundEnabled: false,
+			skipBlurVirtualBackgroundEnabled: false,
 		}
 	},
 
@@ -353,8 +353,8 @@ export default {
 			return this.settingsStore.getShowMediaSettings(this.token)
 		},
 
-		blurBackgroundEnabled() {
-			return this.settingsStore.blurBackgroundEnabled
+		blurVirtualBackgroundEnabled() {
+			return this.settingsStore.blurVirtualBackgroundEnabled
 		},
 
 		showVideo() {
@@ -444,7 +444,7 @@ export default {
 					} else if (BrowserStorage.getItem('virtualBackgroundType_' + this.token) === VIRTUAL_BACKGROUND.BACKGROUND_TYPE.IMAGE) {
 						this.setVirtualBackgroundImage(BrowserStorage.getItem('virtualBackgroundUrl_' + this.token))
 					}
-				} else if (this.blurBackgroundEnabled) {
+				} else if (this.blurVirtualBackgroundEnabled) {
 					// Fall back to global blur background setting
 					this.blurVirtualBackground()
 				} else {
@@ -477,7 +477,7 @@ export default {
 			if (value) {
 				const virtualBackgroundEnabled = BrowserStorage.getItem('virtualBackgroundEnabled_' + this.token) === 'true'
 				// Apply global blur background setting
-				if (this.blurBackgroundEnabled && !this.skipBlurBackgroundEnabled && !virtualBackgroundEnabled) {
+				if (this.blurVirtualBackgroundEnabled && !this.skipBlurVirtualBackgroundEnabled && !virtualBackgroundEnabled) {
 					this.blurBackground(true)
 				}
 			}
@@ -573,14 +573,14 @@ export default {
 
 		handleUpdateBackground(background) {
 			// Default global blur background setting was changed by user
-			if (this.blurBackgroundEnabled && background !== 'blur') {
-				this.skipBlurBackgroundEnabled = true
+			if (this.blurVirtualBackgroundEnabled && background !== 'blur') {
+				this.skipBlurVirtualBackgroundEnabled = true
 			}
 			// Apply the new background
 			if (background === 'none') {
 				this.clearBackground()
 			} else if (background === 'blur') {
-				this.blurBackground(this.blurBackgroundEnabled)
+				this.blurBackground(this.blurVirtualBackgroundEnabled)
 			} else {
 				this.setBackgroundImage(background)
 			}
@@ -629,14 +629,14 @@ export default {
 		/**
 		 * Blurs the background of the participants in current or future call
 		 *
-		 * @param {boolean} globalBlurBackground - Whether the global blur background setting is enabled (in Talk settings)
+		 * @param {boolean} globalBlurVirtualBackground - Whether the global blur background setting is enabled (in Talk settings)
 		 */
-		blurBackground(globalBlurBackground = false) {
+		blurBackground(globalBlurVirtualBackground = false) {
 			if (this.isInCall) {
 				localMediaModel.enableVirtualBackground()
-				localMediaModel.setVirtualBackgroundBlur(VIRTUAL_BACKGROUND.BLUR_STRENGTH.DEFAULT, globalBlurBackground)
-			} else if (!globalBlurBackground) {
-				this.skipBlurBackgroundEnabled = true
+				localMediaModel.setVirtualBackgroundBlur(VIRTUAL_BACKGROUND.BLUR_STRENGTH.DEFAULT, globalBlurVirtualBackground)
+			} else if (!globalBlurVirtualBackground) {
+				this.skipBlurVirtualBackgroundEnabled = true
 				BrowserStorage.setItem('virtualBackgroundEnabled_' + this.token, 'true')
 				BrowserStorage.setItem('virtualBackgroundType_' + this.token, VIRTUAL_BACKGROUND.BACKGROUND_TYPE.BLUR)
 				BrowserStorage.setItem('virtualBackgroundBlurStrength_' + this.token, VIRTUAL_BACKGROUND.BLUR_STRENGTH.DEFAULT)

--- a/src/components/MediaSettings/VideoBackgroundEditor.vue
+++ b/src/components/MediaSettings/VideoBackgroundEditor.vue
@@ -118,6 +118,11 @@ export default {
 			type: String,
 			required: true,
 		},
+
+		skipBlurVirtualBackground: {
+			type: Boolean,
+			default: false,
+		},
 	},
 
 	emits: ['update-background'],
@@ -265,7 +270,7 @@ export default {
 				} else {
 					this.selectedBackground = 'none'
 				}
-			} else if (this.settingsStore.blurVirtualBackgroundEnabled) {
+			} else if (this.settingsStore.blurVirtualBackgroundEnabled && !this.skipBlurVirtualBackground) {
 				this.selectedBackground = 'blur'
 			} else {
 				this.selectedBackground = 'none'

--- a/src/components/MediaSettings/VideoBackgroundEditor.vue
+++ b/src/components/MediaSettings/VideoBackgroundEditor.vue
@@ -87,6 +87,7 @@ import { VIRTUAL_BACKGROUND } from '../../constants.js'
 import BrowserStorage from '../../services/BrowserStorage.js'
 import { getTalkConfig } from '../../services/CapabilitiesManager.ts'
 import { getDavClient } from '../../services/DavClient.js'
+import { useSettingsStore } from '../../stores/settings.js'
 import { findUniquePath } from '../../utils/fileUpload.js'
 
 const predefinedBackgroundLabels = {
@@ -125,6 +126,7 @@ export default {
 		return {
 			canUploadBackgrounds: getTalkConfig('local', 'call', 'can-upload-background'),
 			predefinedBackgrounds: getTalkConfig('local', 'call', 'predefined-backgrounds'),
+			settingsStore: useSettingsStore(),
 		}
 	},
 
@@ -254,6 +256,11 @@ export default {
 		},
 
 		loadBackground() {
+			// Set virtual background depending on main blur setting (in Talk settings)
+			if (this.settingsStore.blurBackgroundEnabled) {
+				this.selectedBackground = 'blur'
+				return
+			}
 			// Set virtual background depending on browser storage's settings
 			if (BrowserStorage.getItem('virtualBackgroundEnabled_' + this.token) === 'true') {
 				if (BrowserStorage.getItem('virtualBackgroundType_' + this.token) === VIRTUAL_BACKGROUND.BACKGROUND_TYPE.BLUR) {

--- a/src/components/MediaSettings/VideoBackgroundEditor.vue
+++ b/src/components/MediaSettings/VideoBackgroundEditor.vue
@@ -256,11 +256,6 @@ export default {
 		},
 
 		loadBackground() {
-			// Set virtual background depending on main blur setting (in Talk settings)
-			if (this.settingsStore.blurBackgroundEnabled) {
-				this.selectedBackground = 'blur'
-				return
-			}
 			// Set virtual background depending on browser storage's settings
 			if (BrowserStorage.getItem('virtualBackgroundEnabled_' + this.token) === 'true') {
 				if (BrowserStorage.getItem('virtualBackgroundType_' + this.token) === VIRTUAL_BACKGROUND.BACKGROUND_TYPE.BLUR) {
@@ -270,6 +265,8 @@ export default {
 				} else {
 					this.selectedBackground = 'none'
 				}
+			} else if (this.settingsStore.blurBackgroundEnabled) {
+				this.selectedBackground = 'blur'
 			} else {
 				this.selectedBackground = 'none'
 			}

--- a/src/components/MediaSettings/VideoBackgroundEditor.vue
+++ b/src/components/MediaSettings/VideoBackgroundEditor.vue
@@ -265,7 +265,7 @@ export default {
 				} else {
 					this.selectedBackground = 'none'
 				}
-			} else if (this.settingsStore.blurBackgroundEnabled) {
+			} else if (this.settingsStore.blurVirtualBackgroundEnabled) {
 				this.selectedBackground = 'blur'
 			} else {
 				this.selectedBackground = 'none'

--- a/src/components/SettingsDialog/MediaDevicesPreview.vue
+++ b/src/components/SettingsDialog/MediaDevicesPreview.vue
@@ -91,7 +91,7 @@ import { VIRTUAL_BACKGROUND } from '../../constants.js'
 import { getTalkConfig } from '../../services/CapabilitiesManager.ts'
 import { useSettingsStore } from '../../stores/settings.js'
 
-const supportDefaultBlurBackground = getTalkConfig('local', 'call', 'blur-background') !== undefined
+const supportDefaultBlurBackground = getTalkConfig('local', 'call', 'blur-virtual-background') !== undefined
 
 export default {
 

--- a/src/components/SettingsDialog/MediaDevicesPreview.vue
+++ b/src/components/SettingsDialog/MediaDevicesPreview.vue
@@ -63,6 +63,11 @@
 				disablePictureInPicture="true"
 				tabindex="-1" />
 		</div>
+		<NcCheckboxRadioSwitch type="switch"
+			:checked="blurBackgroundEnabled"
+			@update:checked="setBlurBackgroundEnabled">
+			{{ t('spreed', 'Enable blur background by default for all conversations.') }}
+		</NcCheckboxRadioSwitch>
 	</div>
 </template>
 
@@ -75,10 +80,14 @@ import VideoOff from 'vue-material-design-icons/VideoOff.vue'
 
 import { t } from '@nextcloud/l10n'
 
+import NcCheckboxRadioSwitch from '@nextcloud/vue/dist/Components/NcCheckboxRadioSwitch.js'
+
 import MediaDevicesSelector from '../MediaSettings/MediaDevicesSelector.vue'
 import VolumeIndicator from '../UIShared/VolumeIndicator.vue'
 
 import { useDevices } from '../../composables/useDevices.js'
+import { VIRTUAL_BACKGROUND } from '../../constants.js'
+import { useSettingsStore } from '../../stores/settings.js'
 
 export default {
 
@@ -88,6 +97,7 @@ export default {
 		AlertCircle,
 		MediaDevicesSelector,
 		MicrophoneOff,
+		NcCheckboxRadioSwitch,
 		VideoOff,
 		VolumeIndicator,
 	},
@@ -108,6 +118,7 @@ export default {
 			audioStreamError,
 			videoStream,
 			videoStreamError,
+			virtualBackground,
 		} = useDevices(video, true)
 
 		return {
@@ -125,6 +136,8 @@ export default {
 			audioStreamError,
 			videoStream,
 			videoStreamError,
+			virtualBackground,
+			settingsStore: useSettingsStore(),
 		}
 	},
 
@@ -180,6 +193,10 @@ export default {
 
 			return t('spreed', 'Error while accessing camera')
 		},
+
+		blurBackgroundEnabled() {
+			return this.settingsStore.getBlurBackgroundEnabled
+		},
 	},
 
 	methods: {
@@ -193,6 +210,19 @@ export default {
 		handleVideoInputIdChange(videoInputId) {
 			this.videoInputId = videoInputId
 			this.updatePreferences('videoinput')
+		},
+
+		setBlurBackgroundEnabled(value) {
+			this.settingsStore.setBlurBackgroundEnabled(value)
+			if (value) {
+				this.virtualBackground.setEnabled(true)
+				this.virtualBackground.setVirtualBackground({
+					backgroundType: VIRTUAL_BACKGROUND.BACKGROUND_TYPE.BLUR,
+					blurValue: VIRTUAL_BACKGROUND.BLUR_STRENGTH.DEFAULT,
+				})
+			} else {
+				this.virtualBackground.setEnabled(false)
+			}
 		},
 	},
 }

--- a/src/components/SettingsDialog/MediaDevicesPreview.vue
+++ b/src/components/SettingsDialog/MediaDevicesPreview.vue
@@ -63,10 +63,10 @@
 				disablePictureInPicture="true"
 				tabindex="-1" />
 		</div>
-		<NcCheckboxRadioSwitch v-if="supportDefaultBlurBackground"
+		<NcCheckboxRadioSwitch v-if="supportDefaultBlurVirtualBackground"
 			type="switch"
-			:checked="blurBackgroundEnabled"
-			@update:checked="setBlurBackgroundEnabled">
+			:checked="blurVirtualBackgroundEnabled"
+			@update:checked="setBlurVirtualBackgroundEnabled">
 			{{ t('spreed', 'Enable blur background by default for all conversation') }}
 		</NcCheckboxRadioSwitch>
 	</div>
@@ -91,7 +91,7 @@ import { VIRTUAL_BACKGROUND } from '../../constants.js'
 import { getTalkConfig } from '../../services/CapabilitiesManager.ts'
 import { useSettingsStore } from '../../stores/settings.js'
 
-const supportDefaultBlurBackground = getTalkConfig('local', 'call', 'blur-virtual-background') !== undefined
+const supportDefaultBlurVirtualBackground = getTalkConfig('local', 'call', 'blur-virtual-background') !== undefined
 
 export default {
 
@@ -142,7 +142,7 @@ export default {
 			videoStreamError,
 			settingsStore: useSettingsStore(),
 			virtualBackground,
-			supportDefaultBlurBackground,
+			supportDefaultBlurVirtualBackground,
 		}
 	},
 
@@ -199,13 +199,13 @@ export default {
 			return t('spreed', 'Error while accessing camera')
 		},
 
-		blurBackgroundEnabled() {
-			return this.settingsStore.blurBackgroundEnabled
+		blurVirtualBackgroundEnabled() {
+			return this.settingsStore.blurVirtualBackgroundEnabled
 		},
 	},
 
 	mounted() {
-		if (this.blurBackgroundEnabled) {
+		if (this.blurVirtualBackgroundEnabled) {
 			// wait for the virtual background to be ready
 			this.$nextTick(() => {
 				this.virtualBackground.setEnabled(true)
@@ -230,9 +230,9 @@ export default {
 			this.updatePreferences('videoinput')
 		},
 
-		async setBlurBackgroundEnabled(value) {
+		async setBlurVirtualBackgroundEnabled(value) {
 			try {
-				await this.settingsStore.setBlurBackgroundEnabled(value)
+				await this.settingsStore.setBlurVirtualBackgroundEnabled(value)
 				if (value) {
 					this.virtualBackground.setEnabled(true)
 					this.virtualBackground.setVirtualBackground({

--- a/src/composables/useDevices.js
+++ b/src/composables/useDevices.js
@@ -6,6 +6,8 @@
 import createHark from 'hark'
 import { computed, onBeforeUnmount, onMounted, reactive, ref, watch } from 'vue'
 
+import { VIRTUAL_BACKGROUND } from '../constants.js'
+import BrowserStorage from '../services/BrowserStorage.js'
 import attachMediaStream from '../utils/attachmediastream.js'
 import TrackToStream from '../utils/media/pipeline/TrackToStream.js'
 import VirtualBackground from '../utils/media/pipeline/VirtualBackground.js'
@@ -105,6 +107,15 @@ export function useDevices(video, initializeOnMounted) {
 		videoTrackToStream.value.addInputTrackSlot('video')
 
 		virtualBackground.value.connectTrackSink('default', videoTrackToStream.value, 'video')
+
+		const blurBackgroundEnabled = BrowserStorage.getItem('blurBackgroundEnabled')
+		if (blurBackgroundEnabled === 'true') {
+			virtualBackground.value.setEnabled(true)
+			virtualBackground.value.setVirtualBackground({
+				backgroundType: VIRTUAL_BACKGROUND.BACKGROUND_TYPE.BLUR,
+				blurValue: VIRTUAL_BACKGROUND.BLUR_STRENGTH.DEFAULT,
+			})
+		}
 
 		if (initializeOnMounted) {
 			initializeDevices()

--- a/src/composables/useDevices.js
+++ b/src/composables/useDevices.js
@@ -6,8 +6,6 @@
 import createHark from 'hark'
 import { computed, onBeforeUnmount, onMounted, reactive, ref, watch } from 'vue'
 
-import { VIRTUAL_BACKGROUND } from '../constants.js'
-import BrowserStorage from '../services/BrowserStorage.js'
 import attachMediaStream from '../utils/attachmediastream.js'
 import TrackToStream from '../utils/media/pipeline/TrackToStream.js'
 import VirtualBackground from '../utils/media/pipeline/VirtualBackground.js'
@@ -107,15 +105,6 @@ export function useDevices(video, initializeOnMounted) {
 		videoTrackToStream.value.addInputTrackSlot('video')
 
 		virtualBackground.value.connectTrackSink('default', videoTrackToStream.value, 'video')
-
-		const blurBackgroundEnabled = BrowserStorage.getItem('blurBackgroundEnabled')
-		if (blurBackgroundEnabled === 'true') {
-			virtualBackground.value.setEnabled(true)
-			virtualBackground.value.setVirtualBackground({
-				backgroundType: VIRTUAL_BACKGROUND.BACKGROUND_TYPE.BLUR,
-				blurValue: VIRTUAL_BACKGROUND.BLUR_STRENGTH.DEFAULT,
-			})
-		}
 
 		if (initializeOnMounted) {
 			initializeDevices()

--- a/src/services/settingsService.js
+++ b/src/services/settingsService.js
@@ -78,7 +78,7 @@ const setStartWithoutMedia = async function(value) {
 	await setUserConfig('spreed', 'calls_start_without_media', value ? 'yes' : 'no')
 }
 
-const setBlurBackground = async function(value) {
+const setBlurVirtualBackground = async function(value) {
 	await setUserConfig('spreed', 'blur_virtual_background', value ? 'yes' : 'no')
 }
 
@@ -97,7 +97,7 @@ const setUserConfig = async function(appId, configKey, configValue) {
 
 export {
 	setAttachmentFolder,
-	setBlurBackground,
+	setBlurVirtualBackground,
 	setReadStatusPrivacy,
 	setTypingStatusPrivacy,
 	setSIPSettings,

--- a/src/services/settingsService.js
+++ b/src/services/settingsService.js
@@ -78,6 +78,10 @@ const setStartWithoutMedia = async function(value) {
 	await setUserConfig('spreed', 'calls_start_without_media', value ? 'yes' : 'no')
 }
 
+const setBlurBackground = async function(value) {
+	await setUserConfig('spreed', 'blur_background', value ? 'yes' : 'no')
+}
+
 /**
  * Set user config using provisioning API
  *

--- a/src/services/settingsService.js
+++ b/src/services/settingsService.js
@@ -79,7 +79,7 @@ const setStartWithoutMedia = async function(value) {
 }
 
 const setBlurBackground = async function(value) {
-	await setUserConfig('spreed', 'blur_background', value ? 'yes' : 'no')
+	await setUserConfig('spreed', 'blur_virtual_background', value ? 'yes' : 'no')
 }
 
 /**

--- a/src/services/settingsService.js
+++ b/src/services/settingsService.js
@@ -97,6 +97,7 @@ const setUserConfig = async function(appId, configKey, configValue) {
 
 export {
 	setAttachmentFolder,
+	setBlurBackground,
 	setReadStatusPrivacy,
 	setTypingStatusPrivacy,
 	setSIPSettings,

--- a/src/stores/__tests__/settings.spec.js
+++ b/src/stores/__tests__/settings.spec.js
@@ -71,8 +71,9 @@ describe('settingsStore', () => {
 			// Assert
 			expect(results).toEqual([true, false])
 			// It's always called at least once : BrowserStorage.getItem('cachedConversations')
-			// +1
-			expect(BrowserStorage.getItem).toHaveBeenCalledTimes(1)
+			// Whenever capabilitiesManager.ts is imported
+			// +2
+			expect(BrowserStorage.getItem).toHaveBeenCalledTimes(2)
 		})
 
 		it('shows correct values received from BrowserStorage', () => {
@@ -89,11 +90,11 @@ describe('settingsStore', () => {
 
 			// Assert
 			expect(results).toEqual([true, true, false])
-			// It's always called at least once : BrowserStorage.getItem('cachedConversations')
-			expect(BrowserStorage.getItem).toHaveBeenCalledTimes(4) // 1 + 3
-			expect(BrowserStorage.getItem).toHaveBeenNthCalledWith(2, 'showMediaSettings_token-1')
-			expect(BrowserStorage.getItem).toHaveBeenNthCalledWith(3, 'showMediaSettings_token-2')
-			expect(BrowserStorage.getItem).toHaveBeenNthCalledWith(4, 'showMediaSettings_token-3')
+			// It's always called at least once : BrowserStorage.getItem('cachedConversations') (+2)
+			expect(BrowserStorage.getItem).toHaveBeenCalledTimes(5) // 2 + 3
+			expect(BrowserStorage.getItem).toHaveBeenNthCalledWith(3, 'showMediaSettings_token-1')
+			expect(BrowserStorage.getItem).toHaveBeenNthCalledWith(4, 'showMediaSettings_token-2')
+			expect(BrowserStorage.getItem).toHaveBeenNthCalledWith(5, 'showMediaSettings_token-3')
 		})
 
 		it('updates values correctly', async () => {
@@ -109,8 +110,8 @@ describe('settingsStore', () => {
 
 			// Assert
 			expect(results).toEqual([false, true])
-			// It's always called at least once : BrowserStorage.getItem('cachedConversations')
-			expect(BrowserStorage.getItem).toHaveBeenCalledTimes(1)
+			// It's always called at least once : BrowserStorage.getItem('cachedConversations') (+2)
+			expect(BrowserStorage.getItem).toHaveBeenCalledTimes(2)
 			expect(BrowserStorage.setItem).toHaveBeenCalledTimes(2)
 			expect(BrowserStorage.setItem).toHaveBeenNthCalledWith(1, 'showMediaSettings_token-1', 'false')
 			expect(BrowserStorage.setItem).toHaveBeenNthCalledWith(2, 'showMediaSettings_token-2', 'true')

--- a/src/stores/settings.js
+++ b/src/stores/settings.js
@@ -14,7 +14,8 @@ import { getTalkConfig } from '../services/CapabilitiesManager.ts'
 import {
 	setReadStatusPrivacy,
 	setTypingStatusPrivacy,
-	setStartWithoutMedia
+	setStartWithoutMedia,
+	setBlurBackground,
 } from '../services/settingsService.js'
 
 /**
@@ -39,8 +40,8 @@ export const useSettingsStore = defineStore('settings', {
 		readStatusPrivacy: loadState('spreed', 'read_status_privacy', PRIVACY.PRIVATE),
 		typingStatusPrivacy: loadState('spreed', 'typing_privacy', PRIVACY.PRIVATE),
 		showMediaSettings: {},
-		startWithoutMedia: getTalkConfig('local', 'call', 'start-without-media'),,
-		blurBackgroundEnabled: undefined,
+		startWithoutMedia: getTalkConfig('local', 'call', 'start-without-media'),
+		blurBackgroundEnabled: getTalkConfig('local', 'call', 'blur-background'),
 	}),
 
 	getters: {
@@ -72,16 +73,6 @@ export const useSettingsStore = defineStore('settings', {
 			}
 			}
 		},
-
-		getBlurBackgroundEnabled: (state) => {
-			if (state.blurBackgroundEnabled !== undefined) {
-				return state.blurBackgroundEnabled
-			}
-
-			const storedValue = BrowserStorage.getItem('blurBackgroundEnabled')
-			state.blurBackgroundEnabled = storedValue === 'true'
-			return state.blurBackgroundEnabled
-		}
 	},
 
 	actions: {
@@ -114,12 +105,8 @@ export const useSettingsStore = defineStore('settings', {
 			Vue.set(this.showMediaSettings, token, value)
 		},
 
-		setBlurBackgroundEnabled(value) {
-			if (value) {
-				BrowserStorage.setItem('blurBackgroundEnabled', 'true')
-			} else {
-				BrowserStorage.removeItem('blurBackgroundEnabled')
-			}
+		async setBlurBackgroundEnabled(value) {
+			await setBlurBackground(value)
 			this.blurBackgroundEnabled = value
 		},
 

--- a/src/stores/settings.js
+++ b/src/stores/settings.js
@@ -15,7 +15,7 @@ import {
 	setReadStatusPrivacy,
 	setTypingStatusPrivacy,
 	setStartWithoutMedia,
-	setBlurBackground,
+	setBlurVirtualBackground,
 } from '../services/settingsService.js'
 
 /**
@@ -41,7 +41,7 @@ export const useSettingsStore = defineStore('settings', {
 		typingStatusPrivacy: loadState('spreed', 'typing_privacy', PRIVACY.PRIVATE),
 		showMediaSettings: {},
 		startWithoutMedia: getTalkConfig('local', 'call', 'start-without-media'),
-		blurBackgroundEnabled: getTalkConfig('local', 'call', 'blur-virtual-background'),
+		blurVirtualBackgroundEnabled: getTalkConfig('local', 'call', 'blur-virtual-background'),
 	}),
 
 	getters: {
@@ -105,9 +105,9 @@ export const useSettingsStore = defineStore('settings', {
 			Vue.set(this.showMediaSettings, token, value)
 		},
 
-		async setBlurBackgroundEnabled(value) {
-			await setBlurBackground(value)
-			this.blurBackgroundEnabled = value
+		async setBlurVirtualBackgroundEnabled(value) {
+			await setBlurVirtualBackground(value)
+			this.blurVirtualBackgroundEnabled = value
 		},
 
 		async setStartWithoutMedia(value) {

--- a/src/stores/settings.js
+++ b/src/stores/settings.js
@@ -41,7 +41,7 @@ export const useSettingsStore = defineStore('settings', {
 		typingStatusPrivacy: loadState('spreed', 'typing_privacy', PRIVACY.PRIVATE),
 		showMediaSettings: {},
 		startWithoutMedia: getTalkConfig('local', 'call', 'start-without-media'),
-		blurBackgroundEnabled: getTalkConfig('local', 'call', 'blur-background'),
+		blurBackgroundEnabled: getTalkConfig('local', 'call', 'blur-virtual-background'),
 	}),
 
 	getters: {

--- a/src/stores/settings.js
+++ b/src/stores/settings.js
@@ -39,7 +39,8 @@ export const useSettingsStore = defineStore('settings', {
 		readStatusPrivacy: loadState('spreed', 'read_status_privacy', PRIVACY.PRIVATE),
 		typingStatusPrivacy: loadState('spreed', 'typing_privacy', PRIVACY.PRIVATE),
 		showMediaSettings: {},
-		startWithoutMedia: getTalkConfig('local', 'call', 'start-without-media'),
+		startWithoutMedia: getTalkConfig('local', 'call', 'start-without-media'),,
+		blurBackgroundEnabled: undefined,
 	}),
 
 	getters: {
@@ -71,6 +72,16 @@ export const useSettingsStore = defineStore('settings', {
 			}
 			}
 		},
+
+		getBlurBackgroundEnabled: (state) => {
+			if (state.blurBackgroundEnabled !== undefined) {
+				return state.blurBackgroundEnabled
+			}
+
+			const storedValue = BrowserStorage.getItem('blurBackgroundEnabled')
+			state.blurBackgroundEnabled = storedValue === 'true'
+			return state.blurBackgroundEnabled
+		}
 	},
 
 	actions: {
@@ -101,6 +112,15 @@ export const useSettingsStore = defineStore('settings', {
 				BrowserStorage.setItem('showMediaSettings_' + token, 'false')
 			}
 			Vue.set(this.showMediaSettings, token, value)
+		},
+
+		setBlurBackgroundEnabled(value) {
+			if (value) {
+				BrowserStorage.setItem('blurBackgroundEnabled', 'true')
+			} else {
+				BrowserStorage.removeItem('blurBackgroundEnabled')
+			}
+			this.blurBackgroundEnabled = value
 		},
 
 		async setStartWithoutMedia(value) {

--- a/src/types/openapi/openapi-administration.ts
+++ b/src/types/openapi/openapi-administration.ts
@@ -231,6 +231,7 @@ export type components = {
                     "start-without-media": boolean;
                     /** Format: int64 */
                     "max-duration": number;
+                    "blur-background": boolean;
                 };
                 chat: {
                     /** Format: int64 */

--- a/src/types/openapi/openapi-administration.ts
+++ b/src/types/openapi/openapi-administration.ts
@@ -231,7 +231,7 @@ export type components = {
                     "start-without-media": boolean;
                     /** Format: int64 */
                     "max-duration": number;
-                    "blur-background": boolean;
+                    "blur-virtual-background": boolean;
                 };
                 chat: {
                     /** Format: int64 */

--- a/src/types/openapi/openapi-backend-recording.ts
+++ b/src/types/openapi/openapi-backend-recording.ts
@@ -65,6 +65,7 @@ export type components = {
                     "start-without-media": boolean;
                     /** Format: int64 */
                     "max-duration": number;
+                    "blur-background": boolean;
                 };
                 chat: {
                     /** Format: int64 */

--- a/src/types/openapi/openapi-backend-recording.ts
+++ b/src/types/openapi/openapi-backend-recording.ts
@@ -65,7 +65,7 @@ export type components = {
                     "start-without-media": boolean;
                     /** Format: int64 */
                     "max-duration": number;
-                    "blur-background": boolean;
+                    "blur-virtual-background": boolean;
                 };
                 chat: {
                     /** Format: int64 */

--- a/src/types/openapi/openapi-backend-signaling.ts
+++ b/src/types/openapi/openapi-backend-signaling.ts
@@ -51,7 +51,7 @@ export type components = {
                     "start-without-media": boolean;
                     /** Format: int64 */
                     "max-duration": number;
-                    "blur-background": boolean;
+                    "blur-virtual-background": boolean;
                 };
                 chat: {
                     /** Format: int64 */

--- a/src/types/openapi/openapi-backend-signaling.ts
+++ b/src/types/openapi/openapi-backend-signaling.ts
@@ -51,6 +51,7 @@ export type components = {
                     "start-without-media": boolean;
                     /** Format: int64 */
                     "max-duration": number;
+                    "blur-background": boolean;
                 };
                 chat: {
                     /** Format: int64 */

--- a/src/types/openapi/openapi-backend-sipbridge.ts
+++ b/src/types/openapi/openapi-backend-sipbridge.ts
@@ -146,7 +146,7 @@ export type components = {
                     "start-without-media": boolean;
                     /** Format: int64 */
                     "max-duration": number;
-                    "blur-background": boolean;
+                    "blur-virtual-background": boolean;
                 };
                 chat: {
                     /** Format: int64 */

--- a/src/types/openapi/openapi-backend-sipbridge.ts
+++ b/src/types/openapi/openapi-backend-sipbridge.ts
@@ -146,6 +146,7 @@ export type components = {
                     "start-without-media": boolean;
                     /** Format: int64 */
                     "max-duration": number;
+                    "blur-background": boolean;
                 };
                 chat: {
                     /** Format: int64 */

--- a/src/types/openapi/openapi-bots.ts
+++ b/src/types/openapi/openapi-bots.ts
@@ -69,7 +69,7 @@ export type components = {
                     "start-without-media": boolean;
                     /** Format: int64 */
                     "max-duration": number;
-                    "blur-background": boolean;
+                    "blur-virtual-background": boolean;
                 };
                 chat: {
                     /** Format: int64 */

--- a/src/types/openapi/openapi-bots.ts
+++ b/src/types/openapi/openapi-bots.ts
@@ -69,6 +69,7 @@ export type components = {
                     "start-without-media": boolean;
                     /** Format: int64 */
                     "max-duration": number;
+                    "blur-background": boolean;
                 };
                 chat: {
                     /** Format: int64 */

--- a/src/types/openapi/openapi-federation.ts
+++ b/src/types/openapi/openapi-federation.ts
@@ -177,7 +177,7 @@ export type components = {
                     "start-without-media": boolean;
                     /** Format: int64 */
                     "max-duration": number;
-                    "blur-background": boolean;
+                    "blur-virtual-background": boolean;
                 };
                 chat: {
                     /** Format: int64 */

--- a/src/types/openapi/openapi-federation.ts
+++ b/src/types/openapi/openapi-federation.ts
@@ -177,6 +177,7 @@ export type components = {
                     "start-without-media": boolean;
                     /** Format: int64 */
                     "max-duration": number;
+                    "blur-background": boolean;
                 };
                 chat: {
                     /** Format: int64 */

--- a/src/types/openapi/openapi-full.ts
+++ b/src/types/openapi/openapi-full.ts
@@ -1927,6 +1927,7 @@ export type components = {
                     "start-without-media": boolean;
                     /** Format: int64 */
                     "max-duration": number;
+                    "blur-background": boolean;
                 };
                 chat: {
                     /** Format: int64 */
@@ -8277,7 +8278,7 @@ export interface operations {
                      * @description Key to update
                      * @enum {string}
                      */
-                    key: "attachment_folder" | "read_status_privacy" | "typing_privacy" | "play_sounds";
+                    key: "attachment_folder" | "read_status_privacy" | "typing_privacy" | "play_sounds" | "blur_background";
                     /** @description New value for the key */
                     value?: (string | number) | null;
                 };

--- a/src/types/openapi/openapi-full.ts
+++ b/src/types/openapi/openapi-full.ts
@@ -1927,7 +1927,7 @@ export type components = {
                     "start-without-media": boolean;
                     /** Format: int64 */
                     "max-duration": number;
-                    "blur-background": boolean;
+                    "blur-virtual-background": boolean;
                 };
                 chat: {
                     /** Format: int64 */
@@ -8278,7 +8278,7 @@ export interface operations {
                      * @description Key to update
                      * @enum {string}
                      */
-                    key: "attachment_folder" | "read_status_privacy" | "typing_privacy" | "play_sounds" | "blur_background";
+                    key: "attachment_folder" | "read_status_privacy" | "typing_privacy" | "play_sounds";
                     /** @description New value for the key */
                     value?: (string | number) | null;
                 };

--- a/src/types/openapi/openapi.ts
+++ b/src/types/openapi/openapi.ts
@@ -1424,7 +1424,7 @@ export type components = {
                     "start-without-media": boolean;
                     /** Format: int64 */
                     "max-duration": number;
-                    "blur-background": boolean;
+                    "blur-virtual-background": boolean;
                 };
                 chat: {
                     /** Format: int64 */
@@ -7859,7 +7859,7 @@ export interface operations {
                      * @description Key to update
                      * @enum {string}
                      */
-                    key: "attachment_folder" | "read_status_privacy" | "typing_privacy" | "play_sounds" | "blur_background";
+                    key: "attachment_folder" | "read_status_privacy" | "typing_privacy" | "play_sounds";
                     /** @description New value for the key */
                     value?: (string | number) | null;
                 };

--- a/src/types/openapi/openapi.ts
+++ b/src/types/openapi/openapi.ts
@@ -1424,6 +1424,7 @@ export type components = {
                     "start-without-media": boolean;
                     /** Format: int64 */
                     "max-duration": number;
+                    "blur-background": boolean;
                 };
                 chat: {
                     /** Format: int64 */
@@ -7858,7 +7859,7 @@ export interface operations {
                      * @description Key to update
                      * @enum {string}
                      */
-                    key: "attachment_folder" | "read_status_privacy" | "typing_privacy" | "play_sounds";
+                    key: "attachment_folder" | "read_status_privacy" | "typing_privacy" | "play_sounds" | "blur_background";
                     /** @description New value for the key */
                     value?: (string | number) | null;
                 };

--- a/src/utils/webrtc/models/LocalMediaModel.js
+++ b/src/utils/webrtc/models/LocalMediaModel.js
@@ -387,7 +387,7 @@ LocalMediaModel.prototype = {
 		this._webRtc.enableVirtualBackground()
 	},
 
-	setVirtualBackgroundBlur(blurStrength) {
+	setVirtualBackgroundBlur(blurStrength, globalBlurBackground = false) {
 		if (!this._webRtc) {
 			throw new Error('WebRtc not initialized yet')
 		}
@@ -396,9 +396,11 @@ LocalMediaModel.prototype = {
 			blurStrength = VIRTUAL_BACKGROUND.BLUR_STRENGTH.DEFAULT
 		}
 
-		BrowserStorage.setItem('virtualBackgroundType_' + this.get('token'), VIRTUAL_BACKGROUND.BACKGROUND_TYPE.BLUR)
-		BrowserStorage.setItem('virtualBackgroundBlurStrength_' + this.get('token'), blurStrength)
-		BrowserStorage.removeItem('virtualBackgroundUrl_' + this.get('token'))
+		if (!globalBlurBackground) {
+			BrowserStorage.setItem('virtualBackgroundType_' + this.get('token'), VIRTUAL_BACKGROUND.BACKGROUND_TYPE.BLUR)
+			BrowserStorage.setItem('virtualBackgroundBlurStrength_' + this.get('token'), blurStrength)
+			BrowserStorage.removeItem('virtualBackgroundUrl_' + this.get('token'))
+		}
 
 		this._webRtc.setVirtualBackground({
 			backgroundType: VIRTUAL_BACKGROUND.BACKGROUND_TYPE.BLUR,

--- a/src/utils/webrtc/models/LocalMediaModel.js
+++ b/src/utils/webrtc/models/LocalMediaModel.js
@@ -387,7 +387,7 @@ LocalMediaModel.prototype = {
 		this._webRtc.enableVirtualBackground()
 	},
 
-	setVirtualBackgroundBlur(blurStrength, globalBlurBackground = false) {
+	setVirtualBackgroundBlur(blurStrength, globalBlurVirtualBackground = false) {
 		if (!this._webRtc) {
 			throw new Error('WebRtc not initialized yet')
 		}
@@ -396,7 +396,7 @@ LocalMediaModel.prototype = {
 			blurStrength = VIRTUAL_BACKGROUND.BLUR_STRENGTH.DEFAULT
 		}
 
-		if (!globalBlurBackground) {
+		if (!globalBlurVirtualBackground) {
 			BrowserStorage.setItem('virtualBackgroundType_' + this.get('token'), VIRTUAL_BACKGROUND.BACKGROUND_TYPE.BLUR)
 			BrowserStorage.setItem('virtualBackgroundBlurStrength_' + this.get('token'), blurStrength)
 			BrowserStorage.removeItem('virtualBackgroundUrl_' + this.get('token'))

--- a/tests/php/CapabilitiesTest.php
+++ b/tests/php/CapabilitiesTest.php
@@ -121,7 +121,7 @@ class CapabilitiesTest extends TestCase {
 						'can-enable-sip' => false,
 						'start-without-media' => false,
 						'max-duration' => 0,
-						'blur-background' => false,
+						'blur-virtual-background' => false,
 						'predefined-backgrounds' => [
 							'1_office.jpg',
 							'2_home.jpg',
@@ -257,7 +257,7 @@ class CapabilitiesTest extends TestCase {
 						'can-enable-sip' => false,
 						'start-without-media' => false,
 						'max-duration' => 0,
-						'blur-background' => false,
+						'blur-virtual-background' => false,
 						'predefined-backgrounds' => [
 							'1_office.jpg',
 							'2_home.jpg',

--- a/tests/php/CapabilitiesTest.php
+++ b/tests/php/CapabilitiesTest.php
@@ -121,6 +121,7 @@ class CapabilitiesTest extends TestCase {
 						'can-enable-sip' => false,
 						'start-without-media' => false,
 						'max-duration' => 0,
+						'blur-background' => false,
 						'predefined-backgrounds' => [
 							'1_office.jpg',
 							'2_home.jpg',
@@ -256,6 +257,7 @@ class CapabilitiesTest extends TestCase {
 						'can-enable-sip' => false,
 						'start-without-media' => false,
 						'max-duration' => 0,
+						'blur-background' => false,
 						'predefined-backgrounds' => [
 							'1_office.jpg',
 							'2_home.jpg',


### PR DESCRIPTION
…onversations


### ☑️ Resolves

It's default settings, meaning that if this config is on, the blur effect will apply automatically and it's up to user to change it before joining the call. 

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

Talk Settings | Media Settings
-- | --
![blur-settings](https://github.com/user-attachments/assets/d4ada281-66d1-4370-a5c9-9ca5f42404ab) | ![blur-media-settings](https://github.com/user-attachments/assets/8559c44c-18b6-4a41-99ef-7eeff4101fed)


<!-- ☀️ Light theme | 🌑 Dark Theme -->

### 🚧 Tasks

- [x] Clean previous browserStorage usage

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
