### PR TITLE
fix: respect mimetype aliases for file previews

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.spec.js
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.spec.js
@@ -348,6 +348,7 @@ describe('FilePreview.vue', () => {
 					availableHandlers: [{
 						mimes: ['image/png', 'image/jpeg'],
 					}],
+					mimetypes: ['image/png', 'image/jpeg'],
 				}
 
 				const wrapper = shallowMount(FilePreview, {
@@ -423,6 +424,7 @@ describe('FilePreview.vue', () => {
 						availableHandlers: [{
 							mimes: ['video/mp4', 'image/jpeg', 'image/png', 'image/gif'],
 						}],
+						mimetypes: ['video/mp4', 'image/jpeg', 'image/png', 'image/gif'],
 					}
 				})
 

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
@@ -375,18 +375,7 @@ export default {
 		},
 
 		isViewerAvailable() {
-			if (!OCA.Viewer) {
-				return false
-			}
-
-			const availableHandlers = OCA.Viewer.availableHandlers
-			for (let i = 0; i < availableHandlers.length; i++) {
-				if (availableHandlers[i]?.mimes?.includes && availableHandlers[i].mimes.includes(this.file.mimetype)) {
-					return true
-				}
-			}
-
-			return false
+			return OCA.Viewer?.mimetypes?.includes(this.file.mimetype)
 		},
 
 		isVoiceMessage() {


### PR DESCRIPTION
### ☑️ Resolves

* Fix FilePreview appearance
* Mimetypes from server are here: https://github.com/nextcloud/viewer/blob/41f169bbef37ce5e9c52ca9c3b632f9cb69bae99/src/models/videos.js



## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="487" alt="2024-10-09_19h02_50" src="https://github.com/user-attachments/assets/cc8e8587-31cb-48d3-9043-a52c0e323cc4"> | <img width="487" alt="2024-10-09_19h03_40" src="https://github.com/user-attachments/assets/05cee98c-0006-400e-8063-a2d87197d51e">

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required