### PR TITLE
fix: handle background blur in Talk if server doesn't support it

### DIFF
--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -4,7 +4,7 @@
 -->
 
 <template>
-	<div id="call-container">
+	<div id="call-container" :style="callContainerStyle">
 		<ViewerOverlayCallView v-if="isViewerOverlay"
 			:token="token"
 			:model="promotedParticipantModel"
@@ -137,6 +137,7 @@ import { provide, ref } from 'vue'
 
 import { showMessage } from '@nextcloud/dialogs'
 import { subscribe, unsubscribe } from '@nextcloud/event-bus'
+import { loadState } from '@nextcloud/initial-state'
 import { t } from '@nextcloud/l10n'
 
 import Grid from './Grid/Grid.vue'
@@ -151,6 +152,7 @@ import ViewerOverlayCallView from './shared/ViewerOverlayCallView.vue'
 
 import { placeholderImage, placeholderModel, placeholderName, placeholderSharedData } from './Grid/gridPlaceholders.ts'
 import { SIMULCAST } from '../../constants.js'
+import BrowserStorage from '../../services/BrowserStorage.js'
 import { fetchPeers } from '../../services/callsService.js'
 import { getTalkConfig } from '../../services/CapabilitiesManager.ts'
 import { EventBus } from '../../services/EventBus.js'
@@ -158,6 +160,9 @@ import { useCallViewStore } from '../../stores/callView.js'
 import { useSettingsStore } from '../../stores/settings.js'
 import { localMediaModel, localCallParticipantModel, callParticipantCollection } from '../../utils/webrtc/index.js'
 import RemoteVideoBlocker from '../../utils/webrtc/RemoteVideoBlocker.js'
+
+const serverVersion = loadState('core', 'config', {}).versionstring ?? '29.0.0'
+const serverSupportsBackgroundBlurred = '29.0.4'.localeCompare(serverVersion) < 1
 
 export default {
 	name: 'CallView',
@@ -204,12 +209,17 @@ export default {
 			localMediaModel.disableVideo()
 		}
 
+		const isBackgroundBlurred = ref(serverSupportsBackgroundBlurred
+			? null
+			: BrowserStorage.getItem('background-blurred') !== 'false')
+
 		return {
 			localMediaModel,
 			localCallParticipantModel,
 			callParticipantCollection,
 			devMode,
 			callViewStore: useCallViewStore(),
+			isBackgroundBlurred,
 		}
 	},
 
@@ -379,6 +389,19 @@ export default {
 		supportedReactions() {
 			return getTalkConfig(this.token, 'call', 'supported-reactions')
 		},
+
+		/**
+		 * Fallback style for versions before v29.0.4
+		 */
+		callContainerStyle() {
+			if (serverSupportsBackgroundBlurred) {
+				return
+			}
+
+			return {
+				'backdrop-filter': this.isBackgroundBlurred ? 'blur(25px)' : 'none',
+			}
+		}
 	},
 
 	watch: {
@@ -470,6 +493,7 @@ export default {
 		callParticipantCollection.on('remove', this._lowerHandWhenParticipantLeaves)
 
 		subscribe('switch-screen-to-id', this._switchScreenToId)
+		subscribe('set-background-blurred', this.setBackgroundBlurred)
 	},
 
 	beforeDestroy() {
@@ -480,6 +504,7 @@ export default {
 		callParticipantCollection.off('remove', this._lowerHandWhenParticipantLeaves)
 
 		unsubscribe('switch-screen-to-id', this._switchScreenToId)
+		unsubscribe('set-background-blurred', this.setBackgroundBlurred)
 	},
 
 	methods: {
@@ -748,6 +773,14 @@ export default {
 			}
 		},
 
+		/**
+		 * Fallback method for versions before v29.0.4
+		 * @param {boolean} value whether background should be blurred
+		 */
+		setBackgroundBlurred(value) {
+			this.isBackgroundBlurred = value
+		},
+
 		isModelWithVideo(callParticipantModel) {
 			if (!callParticipantModel) {
 				return false
@@ -776,6 +809,7 @@ export default {
 	width: 100%;
 	height: 100%;
 	background-color: $color-call-background;
+	// Default value has changed since v29.0.4: 'blur(25px)' => 'none'
 	backdrop-filter: var(--filter-background-blur);
 	--grid-gap: calc(var(--default-grid-baseline) * 2);
 }

--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -4,7 +4,7 @@
 -->
 
 <template>
-	<div id="call-container" :style="callContainerStyle">
+	<div id="call-container" :class="callContainerClass">
 		<ViewerOverlayCallView v-if="isViewerOverlay"
 			:token="token"
 			:model="promotedParticipantModel"
@@ -158,11 +158,12 @@ import { getTalkConfig } from '../../services/CapabilitiesManager.ts'
 import { EventBus } from '../../services/EventBus.js'
 import { useCallViewStore } from '../../stores/callView.js'
 import { useSettingsStore } from '../../stores/settings.js'
+import { satisfyVersion } from '../../utils/satisfyVersion.ts'
 import { localMediaModel, localCallParticipantModel, callParticipantCollection } from '../../utils/webrtc/index.js'
 import RemoteVideoBlocker from '../../utils/webrtc/RemoteVideoBlocker.js'
 
-const serverVersion = loadState('core', 'config', {}).versionstring ?? '29.0.0'
-const serverSupportsBackgroundBlurred = '29.0.4'.localeCompare(serverVersion) < 1
+const serverVersion = loadState('core', 'config', {}).version ?? '29.0.0.0'
+const serverSupportsBackgroundBlurred = satisfyVersion(serverVersion, '29.0.4.0')
 
 export default {
 	name: 'CallView',
@@ -209,9 +210,8 @@ export default {
 			localMediaModel.disableVideo()
 		}
 
-		const isBackgroundBlurred = ref(serverSupportsBackgroundBlurred
-			? null
-			: BrowserStorage.getItem('background-blurred') !== 'false')
+		// Fallback ref for versions before v29.0.4
+		const isBackgroundBlurred = ref(BrowserStorage.getItem('background-blurred') !== 'false')
 
 		return {
 			localMediaModel,
@@ -393,14 +393,12 @@ export default {
 		/**
 		 * Fallback style for versions before v29.0.4
 		 */
-		callContainerStyle() {
+		callContainerClass() {
 			if (serverSupportsBackgroundBlurred) {
 				return
 			}
 
-			return {
-				'backdrop-filter': this.isBackgroundBlurred ? 'blur(25px)' : 'none',
-			}
+			return this.isBackgroundBlurred ? 'call-container__blurred' : 'call-container__non-blurred'
 		}
 	},
 
@@ -812,6 +810,13 @@ export default {
 	// Default value has changed since v29.0.4: 'blur(25px)' => 'none'
 	backdrop-filter: var(--filter-background-blur);
 	--grid-gap: calc(var(--default-grid-baseline) * 2);
+
+	&.call-container__blurred {
+		backdrop-filter: blur(25px);
+	}
+	&.call-container__non-blurred {
+		backdrop-filter: none;
+	}
 }
 
 #videos {

--- a/src/components/SettingsDialog/SettingsDialog.vue
+++ b/src/components/SettingsDialog/SettingsDialog.vue
@@ -219,9 +219,10 @@ import { useCustomSettings } from '../../services/SettingsAPI.ts'
 import { setUserConfig } from '../../services/settingsService.js'
 import { useSettingsStore } from '../../stores/settings.js'
 import { useSoundsStore } from '../../stores/sounds.js'
+import { satisfyVersion } from '../../utils/satisfyVersion.ts'
 
-const serverVersion = loadState('core', 'config', {}).versionstring ?? '29.0.0'
-const serverSupportsBackgroundBlurred = '29.0.4'.localeCompare(serverVersion) < 1
+const serverVersion = loadState('core', 'config', {}).version ?? '29.0.0.0'
+const serverSupportsBackgroundBlurred = satisfyVersion(serverVersion, '29.0.4.0')
 
 const isBackgroundBlurredState = serverSupportsBackgroundBlurred
 	? loadState('spreed', 'force_enable_blur_filter', '') // 'yes', 'no', ''
@@ -326,11 +327,9 @@ export default {
 				await setUserConfig('theming', 'force_enable_blur_filter', 'no')
 			}
 			BrowserStorage.removeItem('background-blurred')
-		} else {
+		} else if (blurred === null) {
 			// Fallback to BrowserStorage
-			if (blurred === null) {
-				BrowserStorage.setItem('background-blurred', 'true')
-			}
+			BrowserStorage.setItem('background-blurred', 'true')
 		}
 	},
 
@@ -387,12 +386,13 @@ export default {
 			this.privacyLoading = false
 		},
 
+		/**
+		 * Fallback method for versions before v29.0.4
+		 * @param {boolean} value whether background should be blurred
+		 */
 		toggleBackgroundBlurred(value) {
-			if (serverSupportsBackgroundBlurred) {
-				return
-			}
-			this.isBackgroundBlurred = value ? 'true' : 'false'
-			BrowserStorage.setItem('background-blurred', value)
+			this.isBackgroundBlurred = value.toString()
+			BrowserStorage.setItem('background-blurred', this.isBackgroundBlurred)
 			emit('set-background-blurred', value)
 		},
 

--- a/src/utils/__tests__/satisfyVersion.spec.js
+++ b/src/utils/__tests__/satisfyVersion.spec.js
@@ -1,0 +1,39 @@
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import { satisfyVersion } from '../satisfyVersion.ts'
+
+describe('satisfyVersion', () => {
+	const testCases = [
+		// Before required
+		['29.1.4.3', '28.2.5.4', true],
+		['29.1.4.3', '29.0.15.3', true],
+		['29.1.4.3', '29.1.1.3', true],
+		['29.1.4.3', '29.1.4.0', true],
+		['29.1.4.3', '29.1.4', true],
+		['29.1.4.3', '29.1', true],
+		['29.1.4.3', '29', true],
+		['29.1.4', '29.1.3.9', true],
+		['29.1', '29.0.9.1', true],
+		['29', '28.1.5.6', true],
+		// Exact match
+		['29.1.4.3', '29.1.4.3', true],
+		['29', '29.0.0.0', true],
+		// After required
+		['29.1.4.3', '29.1.4.4', false],
+		['29.1.4.3', '29.1.5.0', false],
+		['29.1.4.3', '29.2.0.0', false],
+		['29.1.4.3', '30.0.0.0', false],
+		['29.1.4.3', '29.1.5', false],
+		['29.1.4.3', '29.2', false],
+		['29.1.4.3', '30', false],
+		['29.1.4', '29.1.4.3', false],
+		['29.1', '29.1.4.3', false],
+		['29', '29.1.4.3', false],
+	]
+
+	it.each(testCases)('check if %s should satisfy requirement %s returns %s', (a, b, c) => {
+		expect(satisfyVersion(a, b)).toBe(c)
+	})
+})

--- a/src/utils/satisfyVersion.ts
+++ b/src/utils/satisfyVersion.ts
@@ -1,0 +1,26 @@
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * Checks if given version satisfy requirements (newer than)
+ * Versions are expected to have format like '29.1.4.3'
+ * @param version given version
+ * @param requirement version to compare against
+ */
+function satisfyVersion(version: string, requirement: string): boolean {
+	const versionMap = version.split('.').map(Number)
+	const requirementMap = requirement.split('.').map(Number)
+
+	for (let i = 0; i < Math.max(versionMap.length, requirementMap.length); i++) {
+		if ((versionMap[i] ?? 0) !== (requirementMap[i] ?? 0)) {
+			return (versionMap[i] ?? 0) > (requirementMap[i] ?? 0)
+		}
+	}
+	return true
+}
+
+export {
+	satisfyVersion,
+}


### PR DESCRIPTION


### ☑️ Resolves

* Ref #12633
- partially reverts ed39a6bef13f7c1312459ebc610ba669d26501e0
- returns compatibility for Talk Desktop with versions below 29.0.4

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/nextcloud/spreed/assets/93392545/b95abccc-9d28-4667-9c9a-2da987aa077f) | ![image](https://github.com/nextcloud/spreed/assets/93392545/4b84c4c8-150c-4598-bbcd-06e0d7e5a7ad)

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [x] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required