### PR TITLE
Release 19.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,40 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 19.0.10 – 2024-10-10
+### Changed
+- Update translations
+- Update dependencies
+
+### Fixed
+- fix(performance): Fade out local blur-filter option for Nextcloud wide setting
+  [#13100](https://github.com/nextcloud/spreed/issues/13100)
+- fix(avatar): Fix missing translations
+  [#13410](https://github.com/nextcloud/spreed/issues/13410)
+- fix(chat): Expire message cache when deleting the last message
+  [#13392](https://github.com/nextcloud/spreed/issues/13392)
+- fix(call): Correctly ignore media offers from users without permissions when internal signaling is used
+  [#13494](https://github.com/nextcloud/spreed/issues/13494)
+- fix(call): Fix missing call sounds in Safari when tab is moved to the background
+  [#13352](https://github.com/nextcloud/spreed/issues/13352)
+
+## 18.0.12 – 2024-10-10
+### Changed
+- Update translations
+- Update dependencies
+
+### Fixed
+- fix(avatar): Fix missing translations
+  [#13411](https://github.com/nextcloud/spreed/issues/13411)
+- fix(chat): Expire message cache when deleting the last message
+  [#13391](https://github.com/nextcloud/spreed/issues/13391)
+- fix(call): Correctly ignore media offers from users without permissions when internal signaling is used
+  [#13493](https://github.com/nextcloud/spreed/issues/13493)
+- fix(call): Fix missing call sounds in Safari when tab is moved to the background
+  [#13351](https://github.com/nextcloud/spreed/issues/13351)
+- fix(avatar): Don't overwrite user avatar when selecting a square for a conversation
+  [#13287](https://github.com/nextcloud/spreed/issues/13287)
+
 ## 19.0.9 – 2024-09-12
 ### Fixed
 - fix(federation): Fix federation invites accepting from the notification

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -14,7 +14,7 @@
 * 🌉 **Sync with other chat solutions** With [Matterbridge](https://github.com/42wim/matterbridge/) being integrated in Talk, you can easily sync a lot of other chat solutions to Nextcloud Talk and vice-versa.
 ]]></description>
 
-	<version>19.0.9</version>
+	<version>19.0.10</version>
 	<licence>agpl</licence>
 
 	<author>Daniel Calviño Sánchez</author>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "talk",
-  "version": "19.0.9",
+  "version": "19.0.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "talk",
-      "version": "19.0.9",
+      "version": "19.0.10",
       "license": "agpl",
       "dependencies": {
         "@linusborg/vue-simple-portal": "^0.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "talk",
-  "version": "19.0.9",
+  "version": "19.0.10",
   "private": true,
   "description": "",
   "author": "Joas Schilling <coding@schilljs.com>",


### PR DESCRIPTION
## 19.0.10 – 2024-10-10
### Changed
- Update translations
- Update dependencies

### Fixed
- fix(performance): Fade out local blur-filter option for Nextcloud wide setting [#13100](https://github.com/nextcloud/spreed/issues/13100)
- fix(avatar): Fix missing translations [#13410](https://github.com/nextcloud/spreed/issues/13410)
- fix(chat): Expire message cache when deleting the last message [#13392](https://github.com/nextcloud/spreed/issues/13392)
- fix(call): Correctly ignore media offers from users without permissions when internal signaling is used [#13494](https://github.com/nextcloud/spreed/issues/13494)
- fix(call): Fix missing call sounds in Safari when tab is moved to the background [#13352](https://github.com/nextcloud/spreed/issues/13352)