### PR TITLE
Release 18.0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,23 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 18.0.12 – 2024-10-10
+### Changed
+- Update translations
+- Update dependencies
+
+### Fixed
+- fix(avatar): Fix missing translations
+  [#13411](https://github.com/nextcloud/spreed/issues/13411)
+- fix(chat): Expire message cache when deleting the last message
+  [#13391](https://github.com/nextcloud/spreed/issues/13391)
+- fix(call): Correctly ignore media offers from users without permissions when internal signaling is used
+  [#13493](https://github.com/nextcloud/spreed/issues/13493)
+- fix(call): Fix missing call sounds in Safari when tab is moved to the background
+  [#13351](https://github.com/nextcloud/spreed/issues/13351)
+- fix(avatar): Don't overwrite user avatar when selecting a square for a conversation
+  [#13287](https://github.com/nextcloud/spreed/issues/13287)
+
 ## 18.0.11 – 2024-08-22
 ### Changed
 - Update several dependencies

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -16,7 +16,7 @@ And in the works for the [coming versions](https://github.com/nextcloud/spreed/m
 
 	]]></description>
 
-	<version>18.0.11</version>
+	<version>18.0.12</version>
 	<licence>agpl</licence>
 
 	<author>Daniel Calviño Sánchez</author>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "talk",
-  "version": "18.0.11",
+  "version": "18.0.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "talk",
-      "version": "18.0.11",
+      "version": "18.0.12",
       "license": "agpl",
       "dependencies": {
         "@linusborg/vue-simple-portal": "^0.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "talk",
-  "version": "18.0.11",
+  "version": "18.0.12",
   "private": true,
   "description": "",
   "author": "Joas Schilling <coding@schilljs.com>",


### PR DESCRIPTION
## 18.0.12 – 2024-10-10
### Changed
- Update translations
- Update dependencies

### Fixed
- fix(avatar): Fix missing translations [#13411](https://github.com/nextcloud/spreed/issues/13411)
- fix(chat): Expire message cache when deleting the last message [#13391](https://github.com/nextcloud/spreed/issues/13391)
- fix(call): Correctly ignore media offers from users without permissions when internal signaling is used [#13493](https://github.com/nextcloud/spreed/issues/13493)
- fix(call): Fix missing call sounds in Safari when tab is moved to the background [#13351](https://github.com/nextcloud/spreed/issues/13351)
- fix(avatar): Don't overwrite user avatar when selecting a square for a conversation [#13287](https://github.com/nextcloud/spreed/issues/13287)
