### PR TITLE
feat: draft polls management 📊

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/Poll.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/Poll.vue
@@ -7,12 +7,22 @@
 	<!-- Poll card -->
 	<div v-if="draft" class="poll-card" @click="openDraft">
 		<span class="poll-card__header">
-			<PollIcon :size="20" />
+			<IconPoll :size="20" />
 			<span>{{ name }}</span>
 		</span>
 		<span class="poll-card__footer">
 			{{ pollFooterText }}
 		</span>
+
+		<NcButton class="poll-card__delete-draft"
+			type="tertiary"
+			:title="t('spreed', 'Delete poll draft')"
+			:aria-label="t('spreed', 'Delete poll draft')"
+			@click.stop="deleteDraft">
+			<template #icon>
+				<IconDelete :size="20" />
+			</template>
+		</NcButton>
 	</div>
 	<a v-else-if="!showAsButton"
 		v-intersection-observer="getPollData"
@@ -21,7 +31,7 @@
 		role="button"
 		@click="openPoll">
 		<span class="poll-card__header">
-			<PollIcon :size="20" />
+			<IconPoll :size="20" />
 			<span>{{ name }}</span>
 		</span>
 		<span class="poll-card__footer">
@@ -41,7 +51,8 @@
 <script>
 import { vIntersectionObserver as IntersectionObserver } from '@vueuse/components'
 
-import PollIcon from 'vue-material-design-icons/Poll.vue'
+import IconDelete from 'vue-material-design-icons/Delete.vue'
+import IconPoll from 'vue-material-design-icons/Poll.vue'
 
 import { t, n } from '@nextcloud/l10n'
 
@@ -55,7 +66,8 @@ export default {
 
 	components: {
 		NcButton,
-		PollIcon,
+		IconDelete,
+		IconPoll,
 	},
 
 	directives: {
@@ -135,6 +147,13 @@ export default {
 			this.$emit('click', this.id)
 		},
 
+		deleteDraft() {
+			this.pollsStore.deletePollDraft({
+				token: this.token,
+				pollId: this.id,
+			})
+		},
+
 		openPoll() {
 			this.pollsStore.setActivePoll({
 				token: this.token,
@@ -148,9 +167,10 @@ export default {
 
 <style lang="scss" scoped>
 .poll-card {
+	position: relative;
 	display: block;
 	max-width: 300px;
-	padding: 16px;
+	padding: calc(3 * var(--default-grid-baseline)) calc(2 * var(--default-grid-baseline));
 	border: 2px solid var(--color-border);
 	border-radius: var(--border-radius-large);
 	background: var(--color-main-background);
@@ -171,6 +191,7 @@ export default {
 		font-weight: bold;
 		white-space: normal;
 		word-wrap: anywhere;
+		margin-right: var(--default-clickable-area);
 
 		:deep(.material-design-icon) {
 			margin-bottom: auto;
@@ -180,6 +201,12 @@ export default {
 	&__footer {
 		color: var(--color-text-maxcontrast);
 		white-space: normal;
+	}
+
+	& &__delete-draft {
+		position: absolute;
+		top: var(--default-grid-baseline);
+		right: var(--default-grid-baseline);
 	}
 }
 

--- a/src/components/NewMessage/NewMessage.vue
+++ b/src/components/NewMessage/NewMessage.vue
@@ -151,6 +151,10 @@
 			:token="token"
 			@close="togglePollEditor" />
 
+		<PollDraftHandler v-if="canCreatePollDrafts && showPollDraftHandler"
+			:token="token"
+			@close="togglePollDraftHandler" />
+
 		<!-- New file creation dialog -->
 		<NewMessageNewFileDialog v-if="showNewFileDialog !== -1"
 			:token="token"
@@ -194,6 +198,7 @@ import NewMessageAudioRecorder from './NewMessageAudioRecorder.vue'
 import NewMessageNewFileDialog from './NewMessageNewFileDialog.vue'
 import NewMessagePollEditor from './NewMessagePollEditor.vue'
 import NewMessageTypingIndicator from './NewMessageTypingIndicator.vue'
+import PollDraftHandler from '../PollViewer/PollDraftHandler.vue'
 import Quote from '../Quote.vue'
 
 import { useIsDarkTheme } from '../../composables/useIsDarkTheme.ts'
@@ -226,6 +231,7 @@ export default {
 		NewMessageAudioRecorder,
 		NewMessageNewFileDialog,
 		NewMessagePollEditor,
+		PollDraftHandler,
 		NewMessageTypingIndicator,
 		Quote,
 		// Icons
@@ -301,6 +307,7 @@ export default {
 			// True when the audio recorder component is recording
 			isRecordingAudio: false,
 			showPollEditor: false,
+			showPollDraftHandler: false,
 			showNewFileDialog: -1,
 			showFilePicker: false,
 			// Check empty template by default
@@ -384,6 +391,10 @@ export default {
 		canCreatePoll() {
 			return !this.isOneToOne && !this.noChatPermission
 				&& this.conversation.type !== CONVERSATION.TYPE.NOTE_TO_SELF
+		},
+
+		canCreatePollDrafts() {
+			return hasTalkFeature(this.token, 'talk-polls-drafts') && this.$store.getters.isModerator
 		},
 
 		currentConversationIsJoined() {
@@ -538,6 +549,7 @@ export default {
 		EventBus.on('upload-discard', this.handleUploadSideEffects)
 		EventBus.on('retry-message', this.handleRetryMessage)
 		EventBus.on('smart-picker-open', this.handleOpenTributeMenu)
+		EventBus.on('poll-drafts-open', this.togglePollDraftHandler)
 
 		if (!this.$store.getters.areFileTemplatesInitialised) {
 			this.$store.dispatch('getFileTemplates')
@@ -550,6 +562,7 @@ export default {
 		EventBus.off('upload-discard', this.handleUploadSideEffects)
 		EventBus.off('retry-message', this.handleRetryMessage)
 		EventBus.off('smart-picker-open', this.handleOpenTributeMenu)
+		EventBus.off('poll-drafts-open', this.togglePollDraftHandler)
 	},
 
 	methods: {
@@ -890,6 +903,10 @@ export default {
 
 		togglePollEditor() {
 			this.showPollEditor = !this.showPollEditor
+		},
+
+		togglePollDraftHandler() {
+			this.showPollDraftHandler = !this.showPollDraftHandler
 		},
 
 		async autoComplete(search, callback) {

--- a/src/components/NewMessage/NewMessage.vue
+++ b/src/components/NewMessage/NewMessage.vue
@@ -148,11 +148,13 @@
 
 		<!-- Poll creation dialog -->
 		<NewMessagePollEditor v-if="showPollEditor"
+			ref="pollEditor"
 			:token="token"
 			@close="togglePollEditor" />
 
 		<PollDraftHandler v-if="canCreatePollDrafts && showPollDraftHandler"
 			:token="token"
+			:show-create-button="!showPollEditor"
 			@close="togglePollDraftHandler" />
 
 		<!-- New file creation dialog -->
@@ -549,6 +551,7 @@ export default {
 		EventBus.on('upload-discard', this.handleUploadSideEffects)
 		EventBus.on('retry-message', this.handleRetryMessage)
 		EventBus.on('smart-picker-open', this.handleOpenTributeMenu)
+		EventBus.on('poll-editor-open', this.fillPollEditorFromDraft)
 		EventBus.on('poll-drafts-open', this.togglePollDraftHandler)
 
 		if (!this.$store.getters.areFileTemplatesInitialised) {
@@ -562,6 +565,7 @@ export default {
 		EventBus.off('upload-discard', this.handleUploadSideEffects)
 		EventBus.off('retry-message', this.handleRetryMessage)
 		EventBus.off('smart-picker-open', this.handleOpenTributeMenu)
+		EventBus.off('poll-editor-open', this.fillPollEditorFromDraft)
 		EventBus.off('poll-drafts-open', this.togglePollDraftHandler)
 	},
 
@@ -903,6 +907,16 @@ export default {
 
 		togglePollEditor() {
 			this.showPollEditor = !this.showPollEditor
+		},
+
+		fillPollEditorFromDraft(id) {
+			const isPollEditorOpened = this.showPollEditor
+			this.showPollEditor = true
+			this.$nextTick(() => {
+				this.$refs.pollEditor?.fillPollEditorFromDraft(id, isPollEditorOpened)
+				// Wait for editor to be mounted and filled before unmounting drafts dialog
+				this.togglePollDraftHandler()
+			})
 		},
 
 		togglePollDraftHandler() {

--- a/src/components/NewMessage/NewMessagePollEditor.vue
+++ b/src/components/NewMessage/NewMessagePollEditor.vue
@@ -12,7 +12,17 @@
 		<p class="poll-editor__caption">
 			{{ t('spreed', 'Question') }}
 		</p>
-		<NcTextField :value.sync="pollForm.question" :label="t('spreed', 'Ask a question')" v-on="$listeners" />
+		<div class="poll-editor__wrapper">
+			<NcTextField :value.sync="pollForm.question" :label="t('spreed', 'Ask a question')" v-on="$listeners" />
+			<NcActions v-if="supportPollDrafts" force-menu>
+				<NcActionButton v-if="isModerator" close-after-click @click="openPollDraftHandler">
+					<template #icon>
+						<IconFileEdit :size="20" />
+					</template>
+					{{ t('spreed', 'Browse poll drafts') }}
+				</NcActionButton>
+			</NcActions>
+		</div>
 
 		<!-- Poll options -->
 		<p class="poll-editor__caption">
@@ -89,6 +99,7 @@ import NcTextField from '@nextcloud/vue/dist/Components/NcTextField.js'
 import { useStore } from '../../composables/useStore.js'
 import { POLL } from '../../constants.js'
 import { hasTalkFeature } from '../../services/CapabilitiesManager.ts'
+import { EventBus } from '../../services/EventBus.js'
 import { usePollsStore } from '../../stores/polls.ts'
 import type { createPollParams } from '../../types/index.ts'
 
@@ -174,10 +185,23 @@ async function createPollDraft() {
 		form: pollForm,
 	})
 }
+
+/**
+ * Open a PollDraftHandler dialog
+ */
+function openPollDraftHandler() {
+	EventBus.emit('poll-drafts-open')
+}
 </script>
 
 <style lang="scss" scoped>
 .poll-editor {
+	&__wrapper {
+		display: flex;
+		align-items: flex-end;
+		gap: var(--default-grid-baseline);
+	}
+
 	&__caption {
 		margin: calc(var(--default-grid-baseline) * 2) 0 var(--default-grid-baseline);
 		font-weight: bold;

--- a/src/components/PollViewer/PollDraftHandler.vue
+++ b/src/components/PollViewer/PollDraftHandler.vue
@@ -24,8 +24,14 @@
 				:key="item.id"
 				:token="token"
 				:name="item.question"
-				draft />
+				draft
+				@click="openPollEditor" />
 		</div>
+		<template v-if="props.showCreateButton" #actions>
+			<NcButton @click="openPollEditor(null)">
+				{{ t('spreed', 'Create new poll') }}
+			</NcButton>
+		</template>
 	</NcDialog>
 </template>
 
@@ -36,16 +42,19 @@ import IconPoll from 'vue-material-design-icons/Poll.vue'
 
 import { t } from '@nextcloud/l10n'
 
+import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import NcDialog from '@nextcloud/vue/dist/Components/NcDialog.js'
 
 import EmptyView from '../EmptyView.vue'
 import Poll from '../MessagesList/MessagesGroup/Message/MessagePart/Poll.vue'
 
 import { useStore } from '../../composables/useStore.js'
+import { EventBus } from '../../services/EventBus.js'
 import { usePollsStore } from '../../stores/polls.ts'
 
 const props = defineProps<{
 	token: string,
+	showCreateButton?: boolean,
 }>()
 const emit = defineEmits<{
 	(event: 'close'): void,
@@ -58,6 +67,14 @@ const pollsStore = usePollsStore()
  */
 pollsStore.getPollDrafts(props.token)
 const pollDrafts = computed(() => pollsStore.getDrafts(props.token))
+
+/**
+ * Opens poll editor pre-filled from the draft
+ * @param id poll draft ID
+ */
+function openPollEditor(id) {
+	EventBus.emit('poll-editor-open', id)
+}
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/PollViewer/PollDraftHandler.vue
+++ b/src/components/PollViewer/PollDraftHandler.vue
@@ -1,0 +1,79 @@
+<!--
+  - SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<NcDialog class="drafts"
+		:name="t('spreed', 'Poll drafts')"
+		size="normal"
+		close-on-click-outside
+		v-on="$listeners"
+		@update:open="emit('close')">
+		<EmptyView v-if="!pollDrafts.length"
+			class="drafts__empty"
+			:name="t('spreed', 'No poll drafts')"
+			:description="t('spreed', 'There is no poll drafts yet saved for this conversation')">
+			<template #icon>
+				<IconPoll />
+			</template>
+		</EmptyView>
+		<div v-else class="drafts__wrapper">
+			<Poll v-for="item in pollDrafts"
+				:id="item.id.toString()"
+				:key="item.id"
+				:token="token"
+				:name="item.question"
+				draft />
+		</div>
+	</NcDialog>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+import IconPoll from 'vue-material-design-icons/Poll.vue'
+
+import { t } from '@nextcloud/l10n'
+
+import NcDialog from '@nextcloud/vue/dist/Components/NcDialog.js'
+
+import EmptyView from '../EmptyView.vue'
+import Poll from '../MessagesList/MessagesGroup/Message/MessagePart/Poll.vue'
+
+import { useStore } from '../../composables/useStore.js'
+import { usePollsStore } from '../../stores/polls.ts'
+
+const props = defineProps<{
+	token: string,
+}>()
+const emit = defineEmits<{
+	(event: 'close'): void,
+}>()
+
+const store = useStore()
+const pollsStore = usePollsStore()
+/**
+ * Receive poll drafts for the current conversation as owner/moderator
+ */
+pollsStore.getPollDrafts(props.token)
+const pollDrafts = computed(() => pollsStore.getDrafts(props.token))
+</script>
+
+<style lang="scss" scoped>
+.drafts {
+	:deep(.dialog__content) {
+		min-height: 200px;
+	}
+
+	&__wrapper {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		grid-gap: var(--default-grid-baseline);
+	}
+
+	&__empty {
+		margin: 0 !important;
+	}
+}
+</style>

--- a/src/components/RightSidebar/SharedItems/SharedItemsTab.vue
+++ b/src/components/RightSidebar/SharedItems/SharedItemsTab.vue
@@ -8,6 +8,14 @@
 		<LoadingComponent v-if="loading" class="shared-items-tab__loading" />
 
 		<template v-else>
+			<NcButton v-if="canCreatePollDrafts"
+				wide
+				@click="openPollDraftHandler">
+				<template #icon>
+					<IconPoll :size="20" />
+				</template>
+				{{ t('spreed', 'Browse poll drafts') }}
+			</NcButton>
 			<!-- Shared items grouped by type -->
 			<template v-for="type in sharedItemsOrder">
 				<div v-if="sharedItems[type]" :key="type">
@@ -68,6 +76,7 @@
 <script>
 import DotsHorizontal from 'vue-material-design-icons/DotsHorizontal.vue'
 import FolderMultipleImage from 'vue-material-design-icons/FolderMultipleImage.vue'
+import IconPoll from 'vue-material-design-icons/Poll.vue'
 
 import { loadState } from '@nextcloud/initial-state'
 import { t } from '@nextcloud/l10n'
@@ -88,6 +97,8 @@ import {
 	sharedItemsWithPreviewLimit,
 	sharedItemTitle,
 } from './sharedItemsConstants.js'
+import { hasTalkFeature } from '../../../services/CapabilitiesManager.ts'
+import { EventBus } from '../../../services/EventBus.js'
 import { useSharedItemsStore } from '../../../stores/sharedItems.js'
 import { useSidebarStore } from '../../../stores/sidebar.js'
 
@@ -98,6 +109,7 @@ export default {
 	components: {
 		DotsHorizontal,
 		FolderMultipleImage,
+		IconPoll,
 		LoadingComponent,
 		NcAppNavigationCaption,
 		NcButton,
@@ -148,6 +160,10 @@ export default {
 			return this.$store.getters.conversation(this.token)
 		},
 
+		canCreatePollDrafts() {
+			return hasTalkFeature(this.token, 'talk-polls-drafts') && this.$store.getters.isModerator
+		},
+
 		loading() {
 			return !this.sharedItemsStore.overviewLoaded[this.token]
 		},
@@ -194,6 +210,10 @@ export default {
 		limit(type) {
 			return this.sharedItemsWithPreviewLimit.includes(type) ? 2 : 6
 		},
+
+		openPollDraftHandler() {
+			EventBus.emit('poll-drafts-open')
+		}
 	},
 }
 </script>

--- a/src/stores/polls.ts
+++ b/src/stores/polls.ts
@@ -6,7 +6,7 @@ import debounce from 'debounce'
 import { defineStore } from 'pinia'
 import Vue from 'vue'
 
-import { showError, showInfo, TOAST_PERMANENT_TIMEOUT } from '@nextcloud/dialogs'
+import { showError, showInfo, showSuccess, TOAST_PERMANENT_TIMEOUT } from '@nextcloud/dialogs'
 import { t } from '@nextcloud/l10n'
 
 import {
@@ -141,8 +141,11 @@ export const usePollsStore = defineStore('polls', {
 			try {
 				const response = await createPollDraft({ token, ...form })
 				this.addPollDraft({ token, draft: response.data.ocs.data })
+
+				showSuccess(t('spreed', 'Poll draft has been saved'))
 				return response.data.ocs.data
 			} catch (error) {
+				showError(t('spreed', 'An error occurred while saving the draft'))
 				console.error(error)
 			}
 		},


### PR DESCRIPTION
### ☑️ Resolves

* Follow-up to #13516


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

Creation | Open poll
-- | -- 
<img width="369" alt="image" src="https://github.com/user-attachments/assets/df24a2dd-7209-48ef-9bd0-1cfae56e7e3a"> | ![image](https://github.com/user-attachments/assets/8d3df75c-9b5d-4f97-98a7-7f90b8e1aed1) 
Closed poll | Shared Items
![image](https://github.com/user-attachments/assets/150fae9d-35d6-4918-b99d-75495d7a99ee) | ![image](https://github.com/user-attachments/assets/7fde1df1-38f7-43da-93e4-3d887d5fe0e5)
Filled, from Poll Editor | Empty, from Shared items
<img width="461" alt="image" src="https://github.com/user-attachments/assets/b22578c2-0d3d-41b6-8a32-355213bb09d8"> | <img width="461" alt="image" src="https://github.com/user-attachments/assets/182cec9d-618e-43ac-b339-b6182ac8ba45">
Opened from DraftHandler ('Back' arrow) | -
<img width="359" alt="image" src="https://github.com/user-attachments/assets/a4d27710-2d95-4bb1-ae12-ba23d955a67e"> | -


### 🚧 Tasks

- [x] Dialog + Placement
  - [x] Empty View
- [x] Draft deletion
- [ ] Follow-ups:
  - [ ] Poll editor to 'normal' width
    - [ ] Make fields clearable
    - [ ] add EmojiPicker
  - [ ] Unify editor + drafts into a single dialog to avoid re-rendering

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [x] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required