### PR TITLE
feat(calls): Allow moderators to download a call participants list

### DIFF
--- a/appinfo/routes/routesCallController.php
+++ b/appinfo/routes/routesCallController.php
@@ -15,6 +15,8 @@ return [
 	'ocs' => [
 		/** @see \OCA\Talk\Controller\CallController::getPeersForCall() */
 		['name' => 'Call#getPeersForCall', 'url' => '/api/{apiVersion}/call/{token}', 'verb' => 'GET', 'requirements' => $requirements],
+		/** @see \OCA\Talk\Controller\CallController::downloadParticipantsForCall() */
+		['name' => 'Call#downloadParticipantsForCall', 'url' => '/api/{apiVersion}/call/{token}/download', 'verb' => 'GET', 'requirements' => $requirements],
 		/** @see \OCA\Talk\Controller\CallController::joinCall() */
 		['name' => 'Call#joinCall', 'url' => '/api/{apiVersion}/call/{token}', 'verb' => 'POST', 'requirements' => $requirements],
 		/** @see \OCA\Talk\Controller\CallController::joinFederatedCall() */

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -159,5 +159,6 @@
 ## 20.1
 * `archived-conversations` (local) - Conversations can be marked as archived which will hide them from the conversation list by default
 * `talk-polls-drafts` - Whether moderators can store and retrieve poll drafts
+* `download-call-participants` - Whether the endpoints for moderators to download the call participants is available
 * `config => call => start-without-media` (local) - Boolean, whether media should be disabled when starting or joining a conversation
 * `config => call => max-duration` - Integer, maximum call duration in seconds. Please note that this should only be used with system cron and with a reasonable high value, due to the expended duration until the background job ran.

--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -105,6 +105,7 @@ class Capabilities implements IPublicCapability {
 		'edit-messages-note-to-self',
 		'archived-conversations',
 		'talk-polls-drafts',
+		'download-call-participants',
 	];
 
 	public const LOCAL_FEATURES = [

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -4544,6 +4544,93 @@
                 }
             }
         },
+        "/ocs/v2.php/apps/spreed/api/{apiVersion}/call/{token}/download": {
+            "get": {
+                "operationId": "call-download-participants-for-call",
+                "summary": "Download the list of current call participants",
+                "description": "Required capability: `download-call-participants`",
+                "tags": [
+                    "call"
+                ],
+                "security": [
+                    {},
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v4"
+                            ],
+                            "default": "v4"
+                        }
+                    },
+                    {
+                        "name": "token",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^[a-z0-9]{4,30}$"
+                        }
+                    },
+                    {
+                        "name": "format",
+                        "in": "query",
+                        "description": "Download format",
+                        "schema": {
+                            "type": "string",
+                            "default": "csv",
+                            "enum": [
+                                "csv",
+                                "pdf"
+                            ]
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of participants in the call downloaded in the requested format",
+                        "content": {
+                            "text/csv": {
+                                "schema": {
+                                    "type": "string",
+                                    "format": "binary"
+                                }
+                            },
+                            "application/pdf": {
+                                "schema": {
+                                    "type": "string",
+                                    "format": "binary"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "No call in progress"
+                    }
+                }
+            }
+        },
         "/ocs/v2.php/apps/spreed/api/{apiVersion}/call/{token}/federation": {
             "post": {
                 "operationId": "call-join-federated-call",

--- a/openapi.json
+++ b/openapi.json
@@ -4431,6 +4431,93 @@
                 }
             }
         },
+        "/ocs/v2.php/apps/spreed/api/{apiVersion}/call/{token}/download": {
+            "get": {
+                "operationId": "call-download-participants-for-call",
+                "summary": "Download the list of current call participants",
+                "description": "Required capability: `download-call-participants`",
+                "tags": [
+                    "call"
+                ],
+                "security": [
+                    {},
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v4"
+                            ],
+                            "default": "v4"
+                        }
+                    },
+                    {
+                        "name": "token",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^[a-z0-9]{4,30}$"
+                        }
+                    },
+                    {
+                        "name": "format",
+                        "in": "query",
+                        "description": "Download format",
+                        "schema": {
+                            "type": "string",
+                            "default": "csv",
+                            "enum": [
+                                "csv",
+                                "pdf"
+                            ]
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of participants in the call downloaded in the requested format",
+                        "content": {
+                            "text/csv": {
+                                "schema": {
+                                    "type": "string",
+                                    "format": "binary"
+                                }
+                            },
+                            "application/pdf": {
+                                "schema": {
+                                    "type": "string",
+                                    "format": "binary"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "No call in progress"
+                    }
+                }
+            }
+        },
         "/ocs/v2.php/apps/spreed/api/{apiVersion}/call/{token}/federation": {
             "post": {
                 "operationId": "call-join-federated-call",

--- a/src/types/openapi/openapi-full.ts
+++ b/src/types/openapi/openapi-full.ts
@@ -261,6 +261,26 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
+    "/ocs/v2.php/apps/spreed/api/{apiVersion}/call/{token}/download": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Download the list of current call participants
+         * @description Required capability: `download-call-participants`
+         */
+        get: operations["call-download-participants-for-call"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/ocs/v2.php/apps/spreed/api/{apiVersion}/call/{token}/federation": {
         parameters: {
             query?: never;
@@ -3440,6 +3460,43 @@ export interface operations {
                         };
                     };
                 };
+            };
+        };
+    };
+    "call-download-participants-for-call": {
+        parameters: {
+            query?: {
+                /** @description Download format */
+                format?: "csv" | "pdf";
+            };
+            header: {
+                /** @description Required to be true for the API request to pass */
+                "OCS-APIRequest": boolean;
+            };
+            path: {
+                apiVersion: "v4";
+                token: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description List of participants in the call downloaded in the requested format */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/csv": string;
+                    "application/pdf": string;
+                };
+            };
+            /** @description No call in progress */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };

--- a/src/types/openapi/openapi.ts
+++ b/src/types/openapi/openapi.ts
@@ -261,6 +261,26 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
+    "/ocs/v2.php/apps/spreed/api/{apiVersion}/call/{token}/download": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Download the list of current call participants
+         * @description Required capability: `download-call-participants`
+         */
+        get: operations["call-download-participants-for-call"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/ocs/v2.php/apps/spreed/api/{apiVersion}/call/{token}/federation": {
         parameters: {
             query?: never;
@@ -2921,6 +2941,43 @@ export interface operations {
                         };
                     };
                 };
+            };
+        };
+    };
+    "call-download-participants-for-call": {
+        parameters: {
+            query?: {
+                /** @description Download format */
+                format?: "csv" | "pdf";
+            };
+            header: {
+                /** @description Required to be true for the API request to pass */
+                "OCS-APIRequest": boolean;
+            };
+            path: {
+                apiVersion: "v4";
+                token: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description List of participants in the call downloaded in the requested format */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/csv": string;
+                    "application/pdf": string;
+                };
+            };
+            /** @description No call in progress */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -2234,6 +2234,31 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 	}
 
 	/**
+	 * @Then /^user "([^"]*)" downloads call participants from "([^"]*)" as "(csv)" with (\d+) \((v4)\)$/
+	 */
+	public function userDownloadsPeersInCall(string $user, string $identifier, string $format, int $statusCode, string $apiVersion, ?TableNode $tableNode = null): void {
+		$this->setCurrentUser($user);
+		$this->sendRequest('GET', '/apps/spreed/api/' . $apiVersion . '/call/' . self::$identifierToToken[$identifier] . '/download', [
+			'format' => $format,
+		]);
+		$this->assertStatusCode($this->response, $statusCode);
+
+		if ($statusCode !== 200) {
+			return;
+		}
+
+		$expected = [];
+		foreach ($tableNode->getRows() as $row) {
+			if ($row[1] === 'guests') {
+				$row[2] = self::$sessionNameToActorId[$row[2]];
+			}
+			$expected[] = implode(',', $row);
+		}
+
+		Assert::assertEquals(implode("\n", $expected) . "\n", $this->response->getBody()->getContents());
+	}
+
+	/**
 	 * @Then /^user "([^"]*)" (silent sends|sends) message ("[^"]*"|'[^']*') to room "([^"]*)" with (\d+)(?: \((v1)\))?$/
 	 *
 	 * @param string $user

--- a/tests/integration/features/callapi/public.feature
+++ b/tests/integration/features/callapi/public.feature
@@ -89,12 +89,17 @@ Feature: callapi/public
     Then user "participant1" joins call "room" with 200 (v4)
     Then user "participant1" sees 1 peers in call "room" with 200 (v4)
     And user "guest" sees 0 peers in call "room" with 404 (v4)
-    Then user "guest" joins room "room" with 200 (v4)
+    Then user "guest" joins room "room" with 200 (v4) session name "guest1"
     Then user "participant1" sees 1 peers in call "room" with 200 (v4)
     And user "guest" sees 1 peers in call "room" with 200 (v4)
     And user "guest" joins call "room" with 200 (v4)
     Then user "participant1" sees 2 peers in call "room" with 200 (v4)
     And user "guest" sees 2 peers in call "room" with 200 (v4)
+    And user "participant2" downloads call participants from "room" as "csv" with 403 (v4)
+    And user "participant1" downloads call participants from "room" as "csv" with 200 (v4)
+      | name                     | type   | identifier   |
+      | participant1-displayname | users  | participant1 |
+      |                          | guests | guest1       |
     Then user "guest" leaves call "room" with 200 (v4)
     Then user "participant1" sees 1 peers in call "room" with 200 (v4)
     And user "guest" sees 1 peers in call "room" with 200 (v4)


### PR DESCRIPTION
### ☑️ Resolves

* Fix #13453 

## 🛠️ API Checklist

### 🚧 Tasks

- [x] Download as CSV
- [x] Add docs
- [x] Add tests

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
