### PR TITLE
fix: omit 'with 0 guests' in system messages when call ends

### DIFF
--- a/lib/Chat/Parser/SystemMessage.php
+++ b/lib/Chat/Parser/SystemMessage.php
@@ -1113,30 +1113,50 @@ class SystemMessage implements IEventListener {
 		switch ($numUsers) {
 			case 0:
 				if ($actorIsSystem) {
-					$subject = $this->l->n(
-						'Call with %n guest was ended, as it reached the maximum call duration (Duration {duration})',
-						'Call with %n guests was ended, as it reached the maximum call duration (Duration {duration})',
-						$parameters['guests']
-					);
+					if ($parameters['guests'] === 0) {
+						$subject = $this->l->t('Call was ended, as it reached the maximum call duration (Duration {duration})');
+					} else {
+						$subject = $this->l->n(
+							'Call with %n guest was ended, as it reached the maximum call duration (Duration {duration})',
+							'Call with %n guests was ended, as it reached the maximum call duration (Duration {duration})',
+							$parameters['guests']
+						);
+					}
 				} elseif ($message === 'call_ended') {
-					$subject = $this->l->n(
-						'Call with %n guest ended (Duration {duration})',
-						'Call with %n guests ended (Duration {duration})',
-						$parameters['guests']
-					);
+					if ($parameters['guests'] === 0) {
+						$subject = $this->l->t('Call ended (Duration {duration})');
+					} else {
+						$subject = $this->l->n(
+							'Call with %n guest ended (Duration {duration})',
+							'Call with %n guests ended (Duration {duration})',
+							$parameters['guests']
+						);
+					}
 				} else {
-					$subject = $this->l->n(
-						'{actor} ended the call with %n guest (Duration {duration})',
-						'{actor} ended the call with %n guests (Duration {duration})',
-						$parameters['guests']
-					);
+					if ($parameters['guests'] === 0) {
+						$subject = $this->l->t('{actor} ended the call (Duration {duration})');
+					} else {
+						$subject = $this->l->n(
+							'{actor} ended the call with %n guest (Duration {duration})',
+							'{actor} ended the call with %n guests (Duration {duration})',
+							$parameters['guests']
+						);
+					}
 				}
 				break;
 			case 1:
 				if ($actorIsSystem) {
-					$subject = $this->l->t('Call with {user1} and {user2} was ended, as it reached the maximum call duration (Duration {duration})');
+					if ($parameters['guests'] === 0) {
+						$subject = $this->l->t('Call with {user1} was ended, as it reached the maximum call duration (Duration {duration})');
+					} else {
+						$subject = $this->l->t('Call with {user1} and {user2} was ended, as it reached the maximum call duration (Duration {duration})');
+					}
 				} elseif ($message === 'call_ended') {
-					$subject = $this->l->t('Call with {user1} and {user2} ended (Duration {duration})');
+					if ($parameters['guests'] === 0) {
+						$subject = $this->l->t('Call with {user1} ended (Duration {duration})');
+					} else {
+						$subject = $this->l->t('Call with {user1} and {user2} ended (Duration {duration})');
+					}
 				} else {
 					if ($parameters['guests'] === 0) {
 						$subject = $this->l->t('{actor} ended the call with {user1} (Duration {duration})');

--- a/lib/Chat/Parser/SystemMessage.php
+++ b/lib/Chat/Parser/SystemMessage.php
@@ -1112,29 +1112,28 @@ class SystemMessage implements IEventListener {
 
 		switch ($numUsers) {
 			case 0:
-				if ($actorIsSystem) {
-					if ($parameters['guests'] === 0) {
+				if ($parameters['guests'] === 0) {
+					// Call without users and guests
+					if ($actorIsSystem) {
 						$subject = $this->l->t('Call was ended, as it reached the maximum call duration (Duration {duration})');
+					} elseif ($message === 'call_ended') {
+						$subject = $this->l->t('Call ended (Duration {duration})');
 					} else {
+						$subject = $this->l->t('{actor} ended the call (Duration {duration})');
+					}
+				} else {
+					if ($actorIsSystem) {
 						$subject = $this->l->n(
 							'Call with %n guest was ended, as it reached the maximum call duration (Duration {duration})',
 							'Call with %n guests was ended, as it reached the maximum call duration (Duration {duration})',
 							$parameters['guests']
 						);
-					}
-				} elseif ($message === 'call_ended') {
-					if ($parameters['guests'] === 0) {
-						$subject = $this->l->t('Call ended (Duration {duration})');
-					} else {
+					} elseif ($message === 'call_ended') {
 						$subject = $this->l->n(
 							'Call with %n guest ended (Duration {duration})',
 							'Call with %n guests ended (Duration {duration})',
 							$parameters['guests']
 						);
-					}
-				} else {
-					if ($parameters['guests'] === 0) {
-						$subject = $this->l->t('{actor} ended the call (Duration {duration})');
 					} else {
 						$subject = $this->l->n(
 							'{actor} ended the call with %n guest (Duration {duration})',
@@ -1145,26 +1144,24 @@ class SystemMessage implements IEventListener {
 				}
 				break;
 			case 1:
-				if ($actorIsSystem) {
-					if ($parameters['guests'] === 0) {
+				if ($parameters['guests'] === 0) {
+					if ($actorIsSystem) {
 						$subject = $this->l->t('Call with {user1} was ended, as it reached the maximum call duration (Duration {duration})');
-					} else {
-						$subject = $this->l->t('Call with {user1} and {user2} was ended, as it reached the maximum call duration (Duration {duration})');
-					}
-				} elseif ($message === 'call_ended') {
-					if ($parameters['guests'] === 0) {
+					} elseif ($message === 'call_ended') {
 						$subject = $this->l->t('Call with {user1} ended (Duration {duration})');
 					} else {
-						$subject = $this->l->t('Call with {user1} and {user2} ended (Duration {duration})');
+						$subject = $this->l->t('{actor} ended the call with {user1} (Duration {duration})');
 					}
 				} else {
-					if ($parameters['guests'] === 0) {
-						$subject = $this->l->t('{actor} ended the call with {user1} (Duration {duration})');
+					if ($actorIsSystem) {
+						$subject = $this->l->t('Call with {user1} and {user2} was ended, as it reached the maximum call duration (Duration {duration})');
+					} elseif ($message === 'call_ended') {
+						$subject = $this->l->t('Call with {user1} and {user2} ended (Duration {duration})');
 					} else {
 						$subject = $this->l->t('{actor} ended the call with {user1} and {user2} (Duration {duration})');
 					}
+					$subject = str_replace('{user2}', $this->l->n('%n guest', '%n guests', $parameters['guests']), $subject);
 				}
-				$subject = str_replace('{user2}', $this->l->n('%n guest', '%n guests', $parameters['guests']), $subject);
 				break;
 			case 2:
 				if ($parameters['guests'] === 0) {

--- a/tests/php/Chat/Parser/SystemMessageTest.php
+++ b/tests/php/Chat/Parser/SystemMessageTest.php
@@ -1300,6 +1300,15 @@ class SystemMessageTest extends TestCase {
 
 	public static function dataParseCall(): array {
 		return [
+			'1 user' => [
+				'call_ended',
+				['users' => ['user1'], 'guests' => 0, 'duration' => 42],
+				['type' => 'user', 'id' => 'admin', 'name' => 'Admin'],
+				[
+					'Call with {user1} ended (Duration "duration")',
+					['user1' => ['data' => 'user1']],
+				],
+			],
 			'1 user + guests' => [
 				'call_ended',
 				['users' => ['user1'], 'guests' => 3, 'duration' => 42],
@@ -1417,6 +1426,15 @@ class SystemMessageTest extends TestCase {
 				[
 					'{actor} ended the call with {user1} and 3 guests (Duration "duration")',
 					['user1' => ['data' => 'user2']],
+				],
+			],
+			'meeting 1 user' => [
+				'call_ended_everyone',
+				['users' => ['user1'], 'guests' => 0, 'duration' => 42],
+				['type' => 'user', 'id' => 'user1', 'name' => 'user1'],
+				[
+					'{actor} ended the call (Duration "duration")',
+					[],
 				],
 			],
 			'meeting 1 user + guests' => [


### PR DESCRIPTION
### ☑️ Resolves

* Fix #10080
* Add translations for ''0 guests' cases

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![2024-10-14_14h44_07](https://github.com/user-attachments/assets/87d574c7-2963-416d-a430-fc741181fdf3) | ![image](https://github.com/user-attachments/assets/8e73d7cd-15b6-4650-9f16-c4470a01a406)


## 🛠️ API Checklist

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
