### PR TITLE
fix: use method of largest remainder to count poll votes

### DIFF
--- a/src/components/PollViewer/PollViewer.vue
+++ b/src/components/PollViewer/PollViewer.vue
@@ -39,7 +39,7 @@
 					<div class="results__option-title">
 						<p>{{ option }}</p>
 						<p class="percentage">
-							{{ getVotePercentage(index) + '%' }}
+							{{ votePercentage[index] + '%' }}
 						</p>
 					</div>
 					<div v-if="getFilteredDetails(index).length > 0 || selfHasVotedOption(index)"
@@ -52,7 +52,7 @@
 						</p>
 					</div>
 					<NcProgressBar class="results__option-progress"
-						:value="getVotePercentage(index)"
+						:value="votePercentage[index]"
 						size="medium" />
 				</div>
 			</div>
@@ -140,6 +140,7 @@ import { POLL } from '../../constants.js'
 import { hasTalkFeature } from '../../services/CapabilitiesManager.ts'
 import { EventBus } from '../../services/EventBus.ts'
 import { usePollsStore } from '../../stores/polls.ts'
+import { calculateVotePercentage } from '../../utils/calculateVotePercentage.ts'
 import { convertToJSONDataURI } from '../../utils/fileDownload.ts'
 
 export default {
@@ -265,6 +266,11 @@ export default {
 		canEndPoll() {
 			return this.isPollOpen && this.selfIsOwnerOrModerator
 		},
+
+		votePercentage() {
+			const votes = Object.keys(Object(this.poll?.options)).map(index => this.poll?.votes['option-' + index] ?? 0)
+			return calculateVotePercentage(votes, this.poll.numVoters)
+		},
 	},
 
 	watch: {
@@ -380,13 +386,6 @@ export default {
 
 		getFilteredDetails(index) {
 			return (this.poll?.details || []).filter(item => item.optionId === index)
-		},
-
-		getVotePercentage(index) {
-			if (!this.poll?.votes['option-' + index] || !this.poll?.numVoters) {
-				return 0
-			}
-			return parseInt(this.poll?.votes['option-' + index] / this.poll?.numVoters * 100)
 		},
 	},
 }

--- a/src/utils/__tests__/calculateVotePercentage.spec.js
+++ b/src/utils/__tests__/calculateVotePercentage.spec.js
@@ -1,0 +1,39 @@
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { calculateVotePercentage } from '../calculateVotePercentage.ts'
+
+describe('calculateVotePercentage', () => {
+	const tests = [
+		[0, [], 0],
+		[1, [1], 100],
+		// Math rounded to 100%
+		[4, [1, 3], 100],
+		[11, [1, 2, 8], 100],
+		[13, [11, 2], 100],
+		[13, [9, 4], 100],
+		[26, [16, 5, 5], 100],
+		// Rounded to 100% by largest remainder
+		[1000, [132, 494, 92, 282], 100],
+		[1000, [135, 480, 97, 288], 100],
+		// Best effort is 99%
+		[3, [1, 1, 1], 99],
+		[7, [2, 2, 3], 99],
+		[1000, [133, 491, 93, 283], 99],
+		[1000, [134, 488, 94, 284], 99],
+		// Best effort is 98%
+		[1000, [136, 482, 96, 286], 98],
+		[1000, [135, 140, 345, 95, 285], 98],
+		// Best effort is 97%
+		[1000, [137, 132, 347, 97, 287], 97],
+	]
+
+	it.each(tests)('test %d votes in %o distribution rounds to %d%%', (total, votes, result) => {
+		const percentageMap = calculateVotePercentage(votes, total)
+
+		expect(votes.reduce((a, b) => a + b, 0)).toBe(total)
+		expect(percentageMap.reduce((a, b) => a + b, 0)).toBe(result)
+	})
+})

--- a/src/utils/calculateVotePercentage.ts
+++ b/src/utils/calculateVotePercentage.ts
@@ -1,0 +1,72 @@
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * Finds indexes of largest remainders to distribute quota
+ * @param array array of numbers to compare
+ */
+function getLargestIndexes(array: number[]) {
+	let maxValue = 0
+	const maxIndexes: number[] = []
+
+	for (let i = 0; i < array.length; i++) {
+		if (array[i] > maxValue) {
+			maxValue = array[i]
+			maxIndexes.length = 0
+			maxIndexes.push(i)
+		} else if (array[i] === maxValue) {
+			maxIndexes.push(i)
+		}
+	}
+
+	return maxIndexes
+}
+
+/**
+ * Provide percentage distribution closest to 100 by method of largest remainder
+ * @param votes array of given votes
+ * @param total amount of votes
+ */
+export function calculateVotePercentage(votes: number[], total: number) {
+	if (!total) {
+		return votes
+	}
+
+	const rounded: number[] = []
+	const wholes: number[] = []
+	const remainders: number[] = []
+	let sumRounded = 0
+	let sumWholes = 0
+
+	for (const i in votes) {
+		const quota = votes[i] / total * 100
+		rounded.push(Math.round(quota))
+		wholes.push(Math.floor(quota))
+		remainders.push(Math.round((quota % 1) * 1000))
+		sumRounded += rounded[i]
+		sumWholes += wholes[i]
+	}
+
+	// Check if simple round gives 100%
+	if (sumRounded === 100) {
+		return rounded
+	}
+
+	// Increase values by largest remainder method if difference allows
+	for (let i = 100 - sumWholes; i > 0;) {
+		const largest = getLargestIndexes(remainders)
+		if (largest.length > i) {
+			return wholes
+		}
+
+		for (const idx of largest) {
+			wholes[idx]++
+			remainders[idx] = 0
+			i--
+		}
+	}
+
+	return wholes
+}


### PR DESCRIPTION
### ☑️ Resolves

* Fix #11867 
* Ref https://en.wikipedia.org/wiki/Quota_method
  * Rounds up total to 100% for most cases. Keeps it lower if there is no possibility to add up to equally high values

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/user-attachments/assets/439bf434-ad57-4826-853b-02cc969d139a) | ![image](https://github.com/user-attachments/assets/439bf434-ad57-4826-853b-02cc969d139a)
![image](https://github.com/user-attachments/assets/0cc2d1f1-b6e5-4255-9fe8-ba92e46e4736) | ![image](https://github.com/user-attachments/assets/0cc2d1f1-b6e5-4255-9fe8-ba92e46e4736)
![image](https://github.com/user-attachments/assets/505f30b6-a066-48e7-bf3a-3fb0d0400181) | ![image](https://github.com/user-attachments/assets/505f30b6-a066-48e7-bf3a-3fb0d0400181)
![image](https://github.com/user-attachments/assets/fa3e6c14-080c-49b2-b7ce-8bc7368462d4) | ![image](https://github.com/user-attachments/assets/b5f3ed06-a601-4b15-99a3-83f25e8cba73)
![image](https://github.com/user-attachments/assets/58d0ae07-d908-4c7d-9952-b6fc0cf8ea81) | ![image](https://github.com/user-attachments/assets/40597110-39f5-41c1-9409-b0bc5dbca8ed)


### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required