### PR TITLE
fix(chat): disable smooth scroll to bottom

### DIFF
--- a/src/components/ChatView.vue
+++ b/src/components/ChatView.vue
@@ -37,7 +37,7 @@
 					:aria-label="t('spreed', 'Scroll to bottom')"
 					:title="t('spreed', 'Scroll to bottom')"
 					class="scroll-to-bottom__button"
-					@click="smoothScrollToBottom">
+					@click="scrollToBottom">
 					<template #icon>
 						<ChevronDoubleDown :size="20" />
 					</template>
@@ -198,8 +198,8 @@ export default {
 			this.$store.dispatch('initialiseUpload', { files, token: this.token, uploadId })
 		},
 
-		smoothScrollToBottom() {
-			EventBus.emit('scroll-chat-to-bottom', { smooth: true, force: true })
+		scrollToBottom() {
+			EventBus.emit('scroll-chat-to-bottom', { smooth: false, force: true })
 		},
 	},
 

--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -298,7 +298,7 @@ export default {
 				}
 
 				// scroll to bottom if needed
-				this.scrollToBottom({ smooth: true })
+				this.scrollToBottom({ smooth: false })
 
 				if (this.conversation?.type === CONVERSATION.TYPE.NOTE_TO_SELF) {
 					this.$nextTick(() => {
@@ -639,7 +639,7 @@ export default {
 				if (!isFocused) {
 					// Safeguard 2: in case the fallback message is not found too
 					// scroll to bottom
-					this.scrollToBottom({ force: true })
+					this.scrollToBottom({ smooth: false, force: true })
 				} else {
 					this.$store.dispatch('setVisualLastReadMessageId', {
 						token: this.token,


### PR DESCRIPTION
### ☑️ Resolves
- disable smooth scroll to bottom
- update previous scroll position in scroll event (not after it's finished)
- store direction while scrolling
- ensure debounceHandleScroll is fired before endScroll

* Fix #13237

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![2024-10-17_16h55_35](https://github.com/user-attachments/assets/eb6d2421-4da5-44ab-b5dc-d78ef0b5b0dd) | ![2024-10-17_16h53_46](https://github.com/user-attachments/assets/9d907a2a-6657-4208-b846-1439a0a81805)

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team