### PR TITLE
ci: Always reset the skeleton directory

### DIFF
--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -92,7 +92,7 @@ export NEXTCLOUD_CONFIG_DIR="$MAIN_SERVER_CONFIG_DIR"
 MAIN_OVERWRITE_CLI_URL=$(${ROOT_DIR}/occ config:system:get overwrite.cli.url)
 MAIN_SKELETON_DIR=$(${ROOT_DIR}/occ config:system:get skeletondirectory)
 ${ROOT_DIR}/occ config:system:set overwrite.cli.url --value "http://localhost:8080/"
-if [[ "$MAIN_SKELETON_DIR" != "" && -d $MAIN_SKELETON_DIR ]]; then
+if [[ "$MAIN_SKELETON_DIR" != "" ]]; then
 	echo "Resetting custom skeletondirectory so that tests pass"
 	${ROOT_DIR}/occ config:system:delete skeletondirectory
 fi
@@ -101,7 +101,7 @@ export NEXTCLOUD_CONFIG_DIR="$REAL_FEDERATED_SERVER_CONFIG_DIR"
 REAL_FEDERATED_OVERWRITE_CLI_URL=$(${ROOT_DIR}/occ config:system:get overwrite.cli.url)
 REAL_FEDERATED_SKELETON_DIR=$(${ROOT_DIR}/occ config:system:get skeletondirectory)
 ${ROOT_DIR}/occ config:system:set overwrite.cli.url --value "$TEST_REMOTE_URL"
-if [[ "$REAL_FEDERATED_SKELETON_DIR" != "" && -d $REAL_FEDERATED_SKELETON_DIR ]]; then
+if [[ "$REAL_FEDERATED_SKELETON_DIR" != "" ]]; then
 	echo "Resetting custom skeletondirectory so that tests pass"
 	${ROOT_DIR}/occ config:system:delete skeletondirectory
 fi
@@ -198,18 +198,18 @@ echo -e "\033[0;36m#\033[0m"
 export NEXTCLOUD_CONFIG_DIR="$MAIN_SERVER_CONFIG_DIR"
 ${ROOT_DIR}/occ app:disable spreedcheats
 ${ROOT_DIR}/occ config:system:set overwrite.cli.url --value "$MAIN_OVERWRITE_CLI_URL"
-if [[ "$MAIN_SKELETON_DIR" != "" && -d $MAIN_SKELETON_DIR ]]; then
+if [[ "$MAIN_SKELETON_DIR" != "" ]]; then
 	${ROOT_DIR}/occ config:system:set skeletondirectory --value "$MAIN_SKELETON_DIR"
 fi
 
 # Real federated server
 if $DESTROY_REAL_FEDERATED_SERVER; then
-	rm -rf "'$REAL_FEDERATED_SERVER_CONFIG_DIR'" "'$REAL_FEDERATED_SERVER_DATA_DIR'"
+	rm -rf "$REAL_FEDERATED_SERVER_CONFIG_DIR" "$REAL_FEDERATED_SERVER_DATA_DIR"
 else
 	export NEXTCLOUD_CONFIG_DIR="$REAL_FEDERATED_SERVER_CONFIG_DIR"
 	${ROOT_DIR}/occ app:disable spreedcheats
 	${ROOT_DIR}/occ config:system:set overwrite.cli.url --value "$REAL_FEDERATED_OVERWRITE_CLI_URL"
-	if [[ "$REAL_FEDERATED_SKELETON_DIR" != "" && -d $REAL_FEDERATED_SKELETON_DIR ]]; then
+	if [[ "$REAL_FEDERATED_SKELETON_DIR" != "" ]]; then
 		${ROOT_DIR}/occ config:system:set skeletondirectory --value "$REAL_FEDERATED_SKELETON_DIR"
 	fi
 fi


### PR DESCRIPTION
### ☑️ Resolves

* Fix comments from #13581 

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
