### PR TITLE
fix: localURL previews

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
@@ -214,9 +214,6 @@ export default {
 		},
 
 		fallbackLocalUrl() {
-			if (!this.file.mimetype.startsWith('image/') && !this.file.mimetype.startsWith('video/')) {
-				return undefined
-			}
 			return this.$store.getters.getLocalUrl(this.referenceId)
 		},
 

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
@@ -235,6 +235,7 @@ export default {
 					name: this.file.name,
 					path: this.file.path,
 					link: this.file.link,
+					localUrl: this.fallbackLocalUrl,
 					messageId: Number(this.messageId),
 					nextMessageId: Number(this.nextMessageId),
 				}

--- a/src/components/NewMessage/NewMessageAudioRecorder.vue
+++ b/src/components/NewMessage/NewMessageAudioRecorder.vue
@@ -247,7 +247,6 @@ export default {
 				const fileName = this.generateFileName()
 				// Convert blob to file
 				const audioFile = new File([this.blob], fileName)
-				audioFile.localURL = window.URL.createObjectURL(this.blob)
 				this.$emit('audio-file', audioFile)
 				this.$emit('recording', false)
 			}

--- a/src/components/NewMessage/NewMessageUploadEditor.vue
+++ b/src/components/NewMessage/NewMessageUploadEditor.vue
@@ -164,10 +164,7 @@ export default {
 		},
 
 		voiceMessageLocalURL() {
-			if (!this.firstFile?.file?.localURL) {
-				return ''
-			}
-			return this.firstFile.file.localURL
+			return this.$store.getters.getLocalUrl(this.firstFile.temporaryMessage.referenceId)
 		},
 	},
 

--- a/src/store/fileUploadStore.js
+++ b/src/store/fileUploadStore.js
@@ -127,7 +127,9 @@ const mutations = {
 			totalSize: file.size,
 			temporaryMessage,
 		 })
-		Vue.set(state.localUrls, temporaryMessage.referenceId, localUrl)
+		if (localUrl) {
+			Vue.set(state.localUrls, temporaryMessage.referenceId, localUrl)
+		}
 	},
 
 	// Marks a given file as initialized (for retry)
@@ -244,8 +246,6 @@ const actions = {
 				localUrl = URL.createObjectURL(file)
 			} else if (isVoiceMessage) {
 				localUrl = file.localUrl
-			} else {
-				localUrl = OC.MimeType.getIconUrl(file.type)
 			}
 			// Create a unique index for each file
 			const date = new Date()

--- a/src/store/fileUploadStore.js
+++ b/src/store/fileUploadStore.js
@@ -240,13 +240,11 @@ const actions = {
 					+ getFileExtension(file.name)
 			}
 
-			// Get localurl for some image previews
-			let localUrl = ''
-			if (SHARED_ITEM.MEDIA_ALLOWED_PREVIEW.includes(file.type)) {
-				localUrl = URL.createObjectURL(file)
-			} else if (isVoiceMessage) {
-				localUrl = file.localUrl
-			}
+			// Get localUrl for allowed image previews and voice messages uploads
+			const localUrl = (isVoiceMessage || SHARED_ITEM.MEDIA_ALLOWED_PREVIEW.includes(file.type))
+				? URL.createObjectURL(file)
+				: undefined
+
 			// Create a unique index for each file
 			const date = new Date()
 			const index = 'temp_' + date.getTime() + Math.random()

--- a/src/store/fileUploadStore.spec.js
+++ b/src/store/fileUploadStore.spec.js
@@ -74,9 +74,6 @@ describe('fileUploadStore', () => {
 		}
 
 		global.URL.createObjectURL = jest.fn().mockImplementation((file) => 'local-url:' + file.name)
-		global.OC.MimeType = {
-			getIconUrl: jest.fn().mockImplementation((type) => 'icon-url:' + type),
-		}
 
 		storeConfig = cloneDeep(fileUploadStore)
 		storeConfig.actions = Object.assign(storeConfig.actions, mockedActions)
@@ -127,7 +124,7 @@ describe('fileUploadStore', () => {
 					lastModified: Date.UTC(2021, 3, 25, 15, 30, 0),
 				},
 			]
-			const localUrls = ['local-url:pngimage.png', 'local-url:jpgimage.jpg', 'icon-url:text/plain']
+			const localUrls = ['local-url:pngimage.png', 'local-url:jpgimage.jpg', undefined]
 
 			await store.dispatch('initialiseUpload', {
 				uploadId: 'upload-id1',


### PR DESCRIPTION
### ☑️ Resolves

* Fix broken video preview, when user uploads
* Use local files for voice messages, when user uploads
* Fix store usage, when no preview is needed

⚠️ Technically, fallbackLocalUrl is not needed for upload rather than images, but if preview is available and server doesn't return it, client should fall back to mime icon anyway, so no need to duplicate it

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
Voice messages | --
![2024-10-22_16h44_23](https://github.com/user-attachments/assets/9f988ba2-88de-4958-aa83-9f6d96b55af0) | ![2024-10-22_16h42_54](https://github.com/user-attachments/assets/7c170cc5-305f-4fc7-a953-4bd1877d0e7f)
Video previews | --
![2024-10-22_16h46_25](https://github.com/user-attachments/assets/d05c31c1-8d8b-46f6-b208-5a0f4cc9d60a) | ![2024-10-22_16h47_19](https://github.com/user-attachments/assets/1c058f43-ab5f-46c5-97ce-91cfe6e5bfd6)


### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] ⛑️ Tests are included or not possibleSigned-off-by: Maksim Sukharev <antreesy.web@gmail.com>