### PR TITLE
fix: check for false positive hidden parent when scroll

### DIFF
--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -1145,7 +1145,7 @@ export default {
 				return false // element not found
 			}
 
-			if (element.offsetParent === null) {
+			if (this.isChatVisible && element.offsetParent === null) {
 				console.debug('Message to focus is hidden, scrolling to its nearest visible parent', messageId)
 				element = element.closest('ul[style="display: none;"]').parentElement
 			}
@@ -1153,6 +1153,8 @@ export default {
 			console.debug('Scrolling to a focused message programmatically')
 			this.isFocusingMessage = true
 
+			// TODO: doesn't work if chat is hidden. Need to store
+			// delayed 'shouldScroll' and call after chat is visible
 			element.scrollIntoView({
 				behavior: smooth ? 'smooth' : 'auto',
 				block: 'center',


### PR DESCRIPTION
### ☑️ Resolves

* Follow-up to #12205 
* if chat is mounted, but hidden (in sidebar), offsetParent is also null

## 🖌️ UI Checklist

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/user-attachments/assets/7f92d4cc-23ce-4ab5-a57d-331b970d1b7e) | Clean console


### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client