### PR TITLE
fix: appearance of public conversation for guests

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -798,6 +798,11 @@ body.talk-in-fullscreen {
 		border-radius: 0;
 	}
 }
+
+// Overwrites styles from public.scss in public conversations
+body#body-public {
+	--footer-height: 0;
+}
 </style>
 
 <style lang="scss" scoped>

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -8,6 +8,7 @@
 		:class="{
 			'top-bar--sidebar': isSidebar,
 			'top-bar--in-call': isInCall,
+			'top-bar--authorised': getUserId,
 		}">
 		<ConversationIcon :key="conversation.token"
 			class="conversation-icon"
@@ -382,6 +383,12 @@ export default {
 			margin-left: 0;
 		}
 	}
+
+	&--authorised {
+		.conversation-icon {
+			margin-left: calc(var(--default-clickable-area) + var(--default-grid-baseline));
+		}
+	}
 }
 
 .top-bar__wrapper {
@@ -391,10 +398,6 @@ export default {
 	gap: 3px;
 	align-items: center;
 	justify-content: flex-end;
-}
-
-.conversation-icon {
-	margin-left: 48px;
 }
 
 .conversation-header {


### PR DESCRIPTION
### ☑️ Resolves

* Removes gap left to conversation icon
* Removes gap under message input

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="540" alt="image" src="https://github.com/user-attachments/assets/6acdd3a4-e034-4311-8917-d155f501662d"> | <img width="540" alt="image" src="https://github.com/user-attachments/assets/34cc7427-cabf-4cbf-a5be-e5b085831760">


### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Not risky to browser differences / client- same logic that is used for showing LeftSidebar

Signed-off-by: Maksim Sukharev <antreesy.web@gmail.com>