### PR TITLE
fix(TopBarMenu): check capabilities for downloading participants in call

### DIFF
--- a/src/components/TopBar/TopBarMenu.vue
+++ b/src/components/TopBar/TopBarMenu.vue
@@ -139,7 +139,7 @@
 				</template>
 				{{ t('spreed', 'Conversation settings') }}
 			</NcActionButton>
-			<NcActionLink v-if="isInCall && canModerate"
+			<NcActionLink v-if="isInCall && canDownloadCallParticipants"
 				:href="downloadCallParticipantsLink"
 				target="_blank">
 				<template #icon>
@@ -189,7 +189,7 @@ import {
 } from '../../composables/useDocumentFullscreen.ts'
 import { useIsInCall } from '../../composables/useIsInCall.js'
 import { CALL, CONVERSATION, PARTICIPANT } from '../../constants.js'
-import { getTalkConfig } from '../../services/CapabilitiesManager.ts'
+import { getTalkConfig, hasTalkFeature } from '../../services/CapabilitiesManager.ts'
 import { useBreakoutRoomsStore } from '../../stores/breakoutRooms.ts'
 import { useCallViewStore } from '../../stores/callView.js'
 import { generateAbsoluteUrl } from '../../utils/handleUrl.ts'
@@ -379,6 +379,10 @@ export default {
 
 		showCallLayoutSwitch() {
 			return !this.callViewStore.isEmptyCallView
+		},
+
+		canDownloadCallParticipants() {
+			return hasTalkFeature(this.token, 'download-call-participants') && this.canModerate
 		},
 
 		downloadCallParticipantsLink() {


### PR DESCRIPTION
### ☑️ Resolves

* Missing in #13557

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required