### PR TITLE
fix(sharing): Align expected sharing behaviour after server change

### DIFF
--- a/tests/integration/features/sharing-1/create.feature
+++ b/tests/integration/features/sharing-1/create.feature
@@ -425,7 +425,7 @@ Feature: create
     And share is returned with
       | permissions            | 1 |
       | share_type             | 0 |
-      | mail_send              | 1 |
+      | mail_send              | 0 |
     And user "participant1" accepts last share
     When user "participant1" shares "welcome (2).txt" with room "group room"
     Then the OCS status code should be "404"
@@ -738,7 +738,7 @@ Feature: create
       | share_with             | participant2 |
       | share_with_displayname | participant2-displayname |
       | share_type             | 0 |
-      | mail_send              | 1 |
+      | mail_send              | 0 |
     And user "participant2" gets all received shares
     And the list of returned shares has 2 shares
     And share 0 is returned with


### PR DESCRIPTION
- Ref https://github.com/nextcloud/server/pull/48381

Fixes https://github.com/nextcloud/spreed/actions/runs/11511042812/job/32043844236#step:13:3316

## 🛠️ API Checklist

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
