### PR TITLE
fix: e-mail guests - frontend 📧 (part 1)

### DIFF
--- a/src/components/ConversationSettings/LinkShareSettings.vue
+++ b/src/components/ConversationSettings/LinkShareSettings.vue
@@ -214,12 +214,7 @@ export default {
 
 		async handleResendInvitations() {
 			this.isSendingInvitations = true
-			try {
-				await this.$store.dispatch('resendInvitations', { token: this.token })
-				showSuccess(t('spreed', 'Invitations sent'))
-			} catch (e) {
-				showError(t('spreed', 'Error occurred when sending invitations'))
-			}
+			await this.$store.dispatch('resendInvitations', { token: this.token })
 			this.isSendingInvitations = false
 		},
 	},

--- a/src/components/RightSidebar/Participants/Participant.spec.js
+++ b/src/components/RightSidebar/Participants/Participant.spec.js
@@ -25,7 +25,7 @@ import NcTextArea from '@nextcloud/vue/dist/Components/NcTextArea.js'
 import Participant from './Participant.vue'
 import AvatarWrapper from '../../AvatarWrapper/AvatarWrapper.vue'
 
-import { ATTENDEE, PARTICIPANT } from '../../../constants.js'
+import { ATTENDEE, PARTICIPANT, WEBINAR } from '../../../constants.js'
 import storeConfig from '../../../store/storeConfig.js'
 import { findNcActionButton, findNcButton } from '../../../test-helpers.js'
 
@@ -62,6 +62,7 @@ describe('Participant.vue', () => {
 		conversation = {
 			token: 'current-token',
 			participantType: PARTICIPANT.TYPE.USER,
+			lobbyState: WEBINAR.LOBBY.NONE,
 		}
 
 		const conversationGetterMock = jest.fn().mockReturnValue(conversation)
@@ -139,7 +140,7 @@ describe('Participant.vue', () => {
 
 		test('renders avatar with guest name when empty', () => {
 			participant.displayName = ''
-			participant.participantType = PARTICIPANT.TYPE.GUEST
+			participant.actorType = ATTENDEE.ACTOR_TYPE.GUESTS
 			const wrapper = mountParticipant(participant)
 			const avatarEl = wrapper.findComponent(AvatarWrapper)
 			expect(avatarEl.exists()).toBe(true)
@@ -167,11 +168,6 @@ describe('Participant.vue', () => {
 	})
 
 	describe('user name', () => {
-		beforeEach(() => {
-			participant.statusIcon = ''
-			participant.statusMessage = ''
-		})
-
 		/**
 		 * Check which text is currently rendered as a name
 		 * @param {object} participant participant object
@@ -179,34 +175,52 @@ describe('Participant.vue', () => {
 		 */
 		function checkUserNameRendered(participant, regexp) {
 			const wrapper = mountParticipant(participant)
-			expect(wrapper.find('.participant__user').exists()).toBeTruthy()
-			expect(wrapper.find('.participant__user').text()).toMatch(regexp)
+			const username = wrapper.find('.participant__user')
+			expect(username.exists()).toBeTruthy()
+			expect(username.text()).toMatch(regexp)
 		}
 
-		test('renders plain user name for regular user', async () => {
-			checkUserNameRendered(participant, /^Alice$/)
-		})
+		const testCases = [
+			['Alice', 'alice', ATTENDEE.ACTOR_TYPE.USERS, PARTICIPANT.TYPE.USER, /^Alice$/],
+			['Alice', 'guest-id', ATTENDEE.ACTOR_TYPE.GUESTS, PARTICIPANT.TYPE.GUEST, /^Alice\s+\(guest\)$/],
+			['Alice', 'guest-id', ATTENDEE.ACTOR_TYPE.EMAILS, PARTICIPANT.TYPE.GUEST, /^Alice\s+\(guest\)$/],
+			['', 'guest-id', ATTENDEE.ACTOR_TYPE.GUESTS, PARTICIPANT.TYPE.GUEST, /^Guest\s+\(guest\)$/],
+			['Alice', 'alice', ATTENDEE.ACTOR_TYPE.USERS, PARTICIPANT.TYPE.MODERATOR, /^Alice\s+\(moderator\)$/],
+			['Alice', 'guest-id', ATTENDEE.ACTOR_TYPE.GUESTS, PARTICIPANT.TYPE.GUEST_MODERATOR, /^Alice\s+\(moderator\)\s+\(guest\)$/],
+			['Bot', ATTENDEE.BRIDGE_BOT_ID, ATTENDEE.ACTOR_TYPE.USERS, PARTICIPANT.TYPE.USER, /^Bot\s+\(bot\)$/],
+		]
 
-		test('renders guest suffix for guests', async () => {
-			participant.participantType = PARTICIPANT.TYPE.GUEST
-			checkUserNameRendered(participant, /^Alice\s+\(guest\)$/)
-		})
+		const testLobbyCases = [
+			['Alice', 'alice', ATTENDEE.ACTOR_TYPE.USERS, PARTICIPANT.TYPE.USER, /^Alice\s+\(in the lobby\)$/],
+			['Alice', 'guest-id', ATTENDEE.ACTOR_TYPE.GUESTS, PARTICIPANT.TYPE.GUEST, /^Alice\s+\(guest\)\s+\(in the lobby\)$/],
+			['Alice', 'guest-id', ATTENDEE.ACTOR_TYPE.EMAILS, PARTICIPANT.TYPE.GUEST, /^Alice\s+\(guest\)\s+\(in the lobby\)$/],
+			['', 'guest-id', ATTENDEE.ACTOR_TYPE.GUESTS, PARTICIPANT.TYPE.GUEST, /^Guest\s+\(guest\)\s+\(in the lobby\)$/],
+			['Alice', 'alice', ATTENDEE.ACTOR_TYPE.USERS, PARTICIPANT.TYPE.MODERATOR, /^Alice\s+\(moderator\)$/],
+			['Alice', 'guest-id', ATTENDEE.ACTOR_TYPE.GUESTS, PARTICIPANT.TYPE.GUEST_MODERATOR, /^Alice\s+\(moderator\)\s+\(guest\)$/],
+		]
 
-		test('renders moderator suffix for moderators', async () => {
-			participant.participantType = PARTICIPANT.TYPE.MODERATOR
-			checkUserNameRendered(participant, /^Alice\s+\(moderator\)$/)
-		})
+		it.each(testCases)('renders name and badges for participant \'%s\' - \'%s\' - \'%s\' - \'%d\'',
+			(displayName, actorId, actorType, participantType, regexp) => {
+				checkUserNameRendered({
+					...participant,
+					actorId,
+					actorType,
+					participantType,
+					displayName,
+				}, regexp)
+			})
 
-		test('renders guest moderator suffix for guest moderators', async () => {
-			participant.participantType = PARTICIPANT.TYPE.GUEST_MODERATOR
-			checkUserNameRendered(participant, /^Alice\s+\(moderator\)\s+\(guest\)$/)
-		})
-
-		test('renders bot suffix for bots', async () => {
-			participant.actorType = ATTENDEE.ACTOR_TYPE.USERS
-			participant.actorId = ATTENDEE.BRIDGE_BOT_ID
-			checkUserNameRendered(participant, /^Alice\s+\(bot\)$/)
-		})
+		it.each(testLobbyCases)('renders name and badges for participant \'%s\' - \'%s\' - \'%s\' - \'%d\' with lobby enabled',
+			(displayName, actorId, actorType, participantType, regexp) => {
+				conversation.lobbyState = WEBINAR.LOBBY.NON_MODERATORS
+				checkUserNameRendered({
+					...participant,
+					actorId,
+					actorType,
+					participantType,
+					displayName,
+				}, regexp)
+			})
 	})
 
 	describe('user status', () => {

--- a/src/components/RightSidebar/Participants/Participant.vue
+++ b/src/components/RightSidebar/Participants/Participant.vue
@@ -32,7 +32,7 @@
 				<span class="participant__user-name">{{ computedName }}</span>
 				<span v-if="showModeratorLabel" class="participant__user-badge">({{ t('spreed', 'moderator') }})</span>
 				<span v-if="isBridgeBotUser" class="participant__user-badge">({{ t('spreed', 'bot') }})</span>
-				<span v-if="isGuest" class="participant__user-badge">({{ t('spreed', 'guest') }})</span>
+				<span v-if="isGuestActor || isEmailActor" class="participant__user-badge">({{ t('spreed', 'guest') }})</span>
 				<span v-if="!isSelf && isLobbyEnabled && !canSkipLobby" class="participant__user-badge">({{ t('spreed', 'in the lobby') }})</span>
 			</span>
 		</template>
@@ -454,7 +454,7 @@ export default {
 			if (this.isBridgeBotUser) {
 				text += ' (' + t('spreed', 'bot') + ')'
 			}
-			if (this.isGuest) {
+			if (this.isGuestActor || this.isEmailActor) {
 				text += ' (' + t('spreed', 'guest') + ')'
 			}
 			return text
@@ -547,7 +547,7 @@ export default {
 		computedName() {
 			const displayName = this.participant.displayName.trim()
 
-			if (displayName === '' && this.isGuest) {
+			if (displayName === '' && (this.isGuestActor || this.isEmailActor)) {
 				return t('spreed', 'Guest')
 			}
 
@@ -644,10 +644,6 @@ export default {
 		isOffline() {
 			return !this.sessionIds.length && (this.isUserActor || this.isFederatedActor || this.isGuestActor)
 				&& (hasTalkFeature(this.token, 'federation-v2') || !hasTalkFeature(this.token, 'federation-v1') || (!this.conversation.remoteServer && !this.isFederatedActor))
-		},
-
-		isGuest() {
-			return [PARTICIPANT.TYPE.GUEST, PARTICIPANT.TYPE.GUEST_MODERATOR].includes(this.participantType)
 		},
 
 		isModerator() {

--- a/src/components/RightSidebar/Participants/Participant.vue
+++ b/src/components/RightSidebar/Participants/Participant.vue
@@ -512,6 +512,10 @@ export default {
 					: '💬 ' + t('spreed', '{time} talking time', { time: formattedTime(this.timeSpeaking, true) })
 			}
 
+			if (this.isEmailActor && this.participant?.invitedActorId) {
+				return this.participant.invitedActorId
+			}
+
 			return getStatusMessage(this.participant)
 		},
 
@@ -815,15 +819,11 @@ export default {
 		},
 
 		async resendInvitation() {
-			try {
-				await this.$store.dispatch('resendInvitations', {
-					token: this.token,
-					attendeeId: this.attendeeId,
-				})
-				showSuccess(t('spreed', 'Invitation was sent to {actorId}', { actorId: this.participant.actorId }))
-			} catch (error) {
-				showError(t('spreed', 'Could not send invitation to {actorId}', { actorId: this.participant.actorId }))
-			}
+			await this.$store.dispatch('resendInvitations', {
+				token: this.token,
+				attendeeId: this.attendeeId,
+				actorId: this.participant.invitedActorId ?? this.participant.actorId,
+			})
 		},
 
 		async sendCallNotification() {

--- a/src/components/RightSidebar/Participants/ParticipantsTab.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsTab.vue
@@ -65,7 +65,7 @@ import { ref, toRefs } from 'vue'
 
 import IconInformationOutline from 'vue-material-design-icons/InformationOutline.vue'
 
-import { showError } from '@nextcloud/dialogs'
+import { showError, showSuccess } from '@nextcloud/dialogs'
 import { subscribe, unsubscribe } from '@nextcloud/event-bus'
 import { t } from '@nextcloud/l10n'
 
@@ -311,6 +311,9 @@ export default {
 		async addParticipants(item) {
 			try {
 				await addParticipant(this.token, item.id, item.source)
+				if (item.source === ATTENDEE.ACTOR_TYPE.EMAILS) {
+					showSuccess(t('spreed', 'Invitation was sent to {actorId}', { actorId: item.id }))
+				}
 				this.abortSearch()
 				this.cancelableGetParticipants()
 			} catch (exception) {

--- a/src/constants.js
+++ b/src/constants.js
@@ -119,6 +119,7 @@ export const ATTENDEE = {
 		BRIDGED: 'bridged',
 		FEDERATED_USERS: 'federated_users',
 		PHONES: 'phones',
+		DELETED_USERS: 'deleted_users',
 		/* @internal Only use with server APIs (like /core/autocomplete/get) and never with Talk APIs */
 		REMOTES: 'remotes',
 	},

--- a/src/services/participantsService.js
+++ b/src/services/participantsService.js
@@ -158,9 +158,9 @@ const setGuestUserName = async (token, userName) => {
  * If no userId is set, send to all applicable participants.
  *
  * @param {string} token conversation token
- * @param {number} attendeeId attendee id to target, or null for all
+ * @param {number|null} [attendeeId] attendee id to target, or null for all
  */
-const resendInvitations = async (token, { attendeeId = null }) => {
+const resendInvitations = async (token, attendeeId = null) => {
 	await axios.post(generateOcsUrl('apps/spreed/api/v4/room/{token}/participants/resend-invitations', { token }), {
 		attendeeId,
 	})

--- a/src/store/participantsStore.js
+++ b/src/store/participantsStore.js
@@ -883,10 +883,26 @@ const actions = {
 	 * @param {object} _ - unused.
 	 * @param {object} data - the wrapping object.
 	 * @param {string} data.token - conversation token.
-	 * @param {number} data.attendeeId - attendee id to target, or null for all.
+	 * @param {number} [data.attendeeId] - attendee id to target, or null for all.
+	 * @param {string} [data.actorId] - if attendee is provided, the actorId (e-mail) to show in the message.
 	 */
-	async resendInvitations(_, { token, attendeeId }) {
-		await resendInvitations(token, { attendeeId })
+	async resendInvitations(_, { token, attendeeId, actorId }) {
+		if (attendeeId) {
+			try {
+				await resendInvitations(token, attendeeId)
+				showSuccess(t('spreed', 'Invitation was sent to {actorId}', { actorId }))
+			} catch (error) {
+				showError(t('spreed', 'Could not send invitation to {actorId}', { actorId }))
+			}
+		} else {
+			try {
+				await resendInvitations(token)
+				showSuccess(t('spreed', 'Invitations sent'))
+			} catch (e) {
+				showError(t('spreed', 'Error occurred when sending invitations'))
+			}
+		}
+
 	},
 
 	/**

--- a/src/store/participantsStore.spec.js
+++ b/src/store/participantsStore.spec.js
@@ -693,7 +693,7 @@ describe('participantsStore', () => {
 			attendeeId: 1,
 		})
 
-		expect(resendInvitations).toHaveBeenCalledWith(TOKEN, { attendeeId: 1 })
+		expect(resendInvitations).toHaveBeenCalledWith(TOKEN, 1)
 	})
 
 	describe('joining conversation', () => {


### PR DESCRIPTION
### ☑️ Resolves

* Ref #13606


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="222" alt="image" src="https://github.com/user-attachments/assets/77b631c0-a9cf-49c2-abf4-3ffa9161695f"> | <img width="229" alt="image" src="https://github.com/user-attachments/assets/bbf80bdd-d963-4883-8a9c-d5b9faaf79e0">
<img width="186" alt="image" src="https://github.com/user-attachments/assets/a3e63f4f-bcdf-497f-b6e1-c9f96e0a0d37"> | <img width="195" alt="image" src="https://github.com/user-attachments/assets/65299347-8889-4c70-b6d8-cdc48d83aa4b">
![image](https://github.com/user-attachments/assets/87aeef35-07f1-4a86-a641-05e1185bd444) | ![image](https://github.com/user-attachments/assets/87aeef35-07f1-4a86-a641-05e1185bd444)
<img width="180" alt="image" src="https://github.com/user-attachments/assets/1c1a29f9-8292-4409-b3bf-4e1af9349f24"> | <img width="182" alt="image" src="https://github.com/user-attachments/assets/59e5f0dd-18a5-4291-8270-ae1c0fac677c">


### 🚧 Tasks

- [x] Show account icon for both moderators and users (👤, no questionmark anymore, should be the same as for former-one-to-one)
- [x] Show first letter when a custom name is set
- [x] Only show email icon for moderators when searching / adding a new participant (invite e-mail)
- [x] Show always (guest) badge
- [x] Show always on grey background
- [x] Show the invited email address to moderators in the participants list
- [x] Resending the invite shows the ID instead of the name

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required