### PR TITLE
feat: allow moderators to force speaker/grid view for everyone

### DIFF
--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -265,7 +265,19 @@ export default {
 			return this.callViewStore.isViewerOverlay
 		},
 
+		forcedCallViewMode() {
+			return this.localCallParticipantModel.attributes.forcedCallViewMode
+		},
+
 		isGrid() {
+			if (this.forcedCallViewMode === 'grid' && !this.$store.getters.isModerator) {
+				return true
+			}
+
+			if (this.forcedCallViewMode === 'speaker' && !this.$store.getters.isModerator) {
+				return false
+			}
+
 			return this.callViewStore.isGrid && !this.isSidebar
 		},
 
@@ -487,6 +499,7 @@ export default {
 	mounted() {
 		this.debounceFetchPeers = debounce(this.fetchPeers, 1500)
 		EventBus.on('refresh-peer-list', this.debounceFetchPeers)
+		EventBus.on('force-call-view-mode', this.forceCallViewMode)
 
 		callParticipantCollection.on('remove', this._lowerHandWhenParticipantLeaves)
 
@@ -498,6 +511,7 @@ export default {
 		this.debounceFetchPeers.clear?.()
 		this.callViewStore.setIsEmptyCallView(true)
 		EventBus.off('refresh-peer-list', this.debounceFetchPeers)
+		EventBus.off('force-call-view-mode', this.forceCallViewMode)
 
 		callParticipantCollection.off('remove', this._lowerHandWhenParticipantLeaves)
 
@@ -795,6 +809,10 @@ export default {
 			} else {
 				this.showPresenterOverlay = !this.showPresenterOverlay
 			}
+		},
+
+		forceCallViewMode(mode) {
+			this.localCallParticipantModel.forceCallViewMode(mode)
 		},
 
 	},

--- a/src/components/TopBar/CallModerationDialog.vue
+++ b/src/components/TopBar/CallModerationDialog.vue
@@ -1,0 +1,104 @@
+<template>
+	<NcModal v-if="showCallModerationDialog"
+		size="small"
+		:name="t('spreed', 'Moderate the call')"
+		@close="closeModal">
+		<div class="call_moderation">
+			<h2 class="call_moderation--header nc-dialog-alike-header">
+				{{ t('spreed', 'Moderate the call') }}
+			</h2>
+			<p>
+				{{ t('spreed', 'Force the view mode for all participants') }}
+			</p>
+			<div class="call_view_mode">
+				<NcCheckboxRadioSwitch button-variant
+					:checked.sync="forcedCallView"
+					value="grid"
+					name="grid_view_radio"
+					type="radio"
+					button-variant-grouped="vertical">
+					{{ t('spreed', 'Force Grid view') }}
+				</NcCheckboxRadioSwitch>
+				<NcCheckboxRadioSwitch button-variant
+					:checked.sync="forcedCallView"
+					value="speaker"
+					name="speaker_view_radio"
+					type="radio"
+					button-variant-grouped="vertical">
+					{{ t('spreed', 'Force Speaker view') }}
+				</NcCheckboxRadioSwitch>
+				<NcCheckboxRadioSwitch button-variant
+					:checked.sync="forcedCallView"
+					value="none"
+					name="none_view_radio"
+					type="radio"
+					button-variant-grouped="vertical">
+					{{ t('spreed', 'None') }}
+				</NcCheckboxRadioSwitch>
+			</div>
+		</div>
+	</NcModal>
+</template>
+
+<script>
+
+import { t } from '@nextcloud/l10n'
+
+import NcCheckboxRadioSwitch from '@nextcloud/vue/dist/Components/NcCheckboxRadioSwitch.js'
+import NcModal from '@nextcloud/vue/dist/Components/NcModal.js'
+
+import { EventBus } from '../../services/EventBus.js'
+import { localCallParticipantModel } from '../../utils/webrtc/index.js'
+
+export default {
+	name: 'CallModerationDialog',
+
+	components: {
+		NcModal,
+		NcCheckboxRadioSwitch
+	},
+
+	props: {
+		showCallModerationDialog: {
+			type: Boolean,
+			default: false
+		}
+	},
+
+    emits: ['update:showCallModerationDialog'],
+
+	setup() {
+		return {
+			localCallParticipantModel,
+		}
+	},
+
+	data() {
+		return {
+			forcedCallView: this.localCallParticipantModel.attributes.forcedCallView ?? 'none',
+		}
+	},
+
+	watch: {
+		forcedCallView(value) {
+			EventBus.emit('force-call-view-mode', value)
+		},
+	},
+
+	methods: {
+		t,
+		closeModal() {
+			this.$emit('update:showCallModerationDialog', false)
+		}
+	}
+}
+</script>
+
+<style lang="scss" scoped>
+.call_moderation {
+	padding: calc(var(--default-grid-baseline) * 5);
+	.call_view_mode {
+		width: fit-content;
+	}
+}
+</style>

--- a/src/utils/webrtc/simplewebrtc/simplewebrtc.js
+++ b/src/utils/webrtc/simplewebrtc/simplewebrtc.js
@@ -116,6 +116,8 @@ export default function SimpleWebRTC(opts) {
 				} else {
 					self.emit('mute', { id: message.payload.peerId })
 				}
+			} else if (message.payload.action === 'forceCallViewMode') {
+				self.emit('forcedCallViewMode', message.payload.callViewMode)
 			}
 		} else if (message.type === 'nickChanged') {
 			// "nickChanged" can be received from a participant without a Peer


### PR DESCRIPTION
### ☑️ Resolves

* Fix #13452

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
Screenshot before | Screenshot after

<!-- ☀️ Light theme | 🌑 Dark Theme -->

### 🚧 Tasks

- [x] Set the signaling emission
- [x] Apply the call view restriction 
- [x] Separate component for call moderation (taking into consideration future options to be included)
- [ ] Improve modal layout (kinda ugly rn)
- [ ] Migrate the new component to composition API
- [ ] Adjust the signaling attr to default to "none" instead of ""
- [x] disable view changing button for non-moderators

Missing functionalities to add
- [ ] Late joiners should have the view enforced if it was emitted before joining
- [ ] Hint for participants when the force view mode is on (?)
- [ ] Select specific video/screenshare to force on
- [ ] Show floating button to stop the force view mode on CallView when it is on (?)

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
