### PR TITLE
fix: hide 'Browse drafts' button in Note to self and 1-1 rooms

### DIFF
--- a/src/components/RightSidebar/SharedItems/SharedItemsTab.vue
+++ b/src/components/RightSidebar/SharedItems/SharedItemsTab.vue
@@ -97,6 +97,7 @@ import {
 	sharedItemsWithPreviewLimit,
 	sharedItemTitle,
 } from './sharedItemsConstants.js'
+import { CONVERSATION } from '../../../constants.js'
 import { hasTalkFeature } from '../../../services/CapabilitiesManager.ts'
 import { EventBus } from '../../../services/EventBus.ts'
 import { useSharedItemsStore } from '../../../stores/sharedItems.js'
@@ -162,6 +163,7 @@ export default {
 
 		canCreatePollDrafts() {
 			return hasTalkFeature(this.token, 'talk-polls-drafts') && this.$store.getters.isModerator
+				&& [CONVERSATION.TYPE.GROUP, CONVERSATION.TYPE.PUBLIC].includes(this.conversation.type)
 		},
 
 		loading() {


### PR DESCRIPTION
### ☑️ Resolves

* Fix regression from #13518

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/user-attachments/assets/ffed7b51-b144-433b-8e19-88ca8378a3ef) | ![image](https://github.com/user-attachments/assets/d6e18e46-8213-446f-aeaf-673772b33e17)

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Not risky to browser differences / client