### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -258,12 +258,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "b5b767571ac461011820e8d292509dd0e5bff59d"
+                "reference": "3dfbf63feaf67f0634622b949a5eec46be3e246d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/b5b767571ac461011820e8d292509dd0e5bff59d",
-                "reference": "b5b767571ac461011820e8d292509dd0e5bff59d",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/3dfbf63feaf67f0634622b949a5eec46be3e246d",
+                "reference": "3dfbf63feaf67f0634622b949a5eec46be3e246d",
                 "shasum": ""
             },
             "require": {
@@ -295,7 +295,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2024-10-23T11:48:49+00:00"
+            "time": "2024-10-30T00:43:43+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency