### PR TITLE
chore(deps): bump @nextcloud/dialogs library from 6.0.0 to 6.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@nextcloud/axios": "^2.5.1",
         "@nextcloud/browser-storage": "^0.4.0",
         "@nextcloud/capabilities": "^1.2.0",
-        "@nextcloud/dialogs": "^6.0.0",
+        "@nextcloud/dialogs": "^6.0.1",
         "@nextcloud/event-bus": "^3.3.1",
         "@nextcloud/files": "^3.9.1",
         "@nextcloud/initial-state": "^2.2.0",
@@ -3442,23 +3442,25 @@
       }
     },
     "node_modules/@nextcloud/dialogs": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/dialogs/-/dialogs-6.0.0.tgz",
-      "integrity": "sha512-Yoye/BezFN/hQCic+OHNPSESNI3k7D85YQJU1fW4s/yMi+P6VVNLixp4lbQ7xHF+po5lXZbJhultrOyoNhqaGw==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@nextcloud/dialogs/-/dialogs-6.0.1.tgz",
+      "integrity": "sha512-TlzNUy0eFPIjnop2Wfom45xJdUjLOoUwd/E8V/6ehh+PifrgIWGy6jqBYMRoQfUASc/LKtSYUrCN3yDgVrK8Tw==",
+      "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@mdi/js": "^7.4.47",
-        "@nextcloud/auth": "^2.3.0",
-        "@nextcloud/axios": "^2.5.0",
+        "@nextcloud/auth": "^2.4.0",
+        "@nextcloud/axios": "^2.5.1",
         "@nextcloud/event-bus": "^3.3.1",
-        "@nextcloud/files": "^3.8.0",
+        "@nextcloud/files": "^3.9.0",
         "@nextcloud/initial-state": "^2.2.0",
         "@nextcloud/l10n": "^3.1.0",
         "@nextcloud/router": "^3.0.1",
         "@nextcloud/sharing": "^0.2.3",
         "@nextcloud/typings": "^1.9.1",
         "@types/toastify-js": "^1.12.3",
-        "@vueuse/core": "^10.11.1",
+        "@vueuse/core": "^11.2.0",
         "cancelable-promise": "^4.3.1",
+        "p-queue": "^8.0.1",
         "toastify-js": "^1.12.0",
         "vue-frag": "^1.4.3",
         "webdav": "^5.7.1"
@@ -3470,53 +3472,6 @@
       "peerDependencies": {
         "@nextcloud/vue": "^8.16.0",
         "vue": "^2.7.16"
-      }
-    },
-    "node_modules/@nextcloud/dialogs/node_modules/@vueuse/core": {
-      "version": "10.11.1",
-      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-10.11.1.tgz",
-      "integrity": "sha512-guoy26JQktXPcz+0n3GukWIy/JDNKti9v6VEMu6kV2sYBsWuGiTU8OWdg+ADfUbHg3/3DlqySDe7JmdHrktiww==",
-      "dependencies": {
-        "@types/web-bluetooth": "^0.0.20",
-        "@vueuse/metadata": "10.11.1",
-        "@vueuse/shared": "10.11.1",
-        "vue-demi": ">=0.14.8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
-    },
-    "node_modules/@nextcloud/dialogs/node_modules/@vueuse/core/node_modules/vue-demi": {
-      "version": "0.14.10",
-      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
-      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
-      "hasInstallScript": true,
-      "bin": {
-        "vue-demi-fix": "bin/vue-demi-fix.js",
-        "vue-demi-switch": "bin/vue-demi-switch.js"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      },
-      "peerDependencies": {
-        "@vue/composition-api": "^1.0.0-rc.1",
-        "vue": "^3.0.0-0 || ^2.6.0"
-      },
-      "peerDependenciesMeta": {
-        "@vue/composition-api": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@nextcloud/dialogs/node_modules/@vueuse/metadata": {
-      "version": "10.11.1",
-      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-10.11.1.tgz",
-      "integrity": "sha512-IGa5FXd003Ug1qAZmyE8wF3sJ81xGLSqTqtQ6jaVfkeZ4i5kS2mwQF61yhVqojRnenVew5PldLyRgvdl4YYuSw==",
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@nextcloud/eslint-config": {
@@ -23657,52 +23612,27 @@
       }
     },
     "@nextcloud/dialogs": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/dialogs/-/dialogs-6.0.0.tgz",
-      "integrity": "sha512-Yoye/BezFN/hQCic+OHNPSESNI3k7D85YQJU1fW4s/yMi+P6VVNLixp4lbQ7xHF+po5lXZbJhultrOyoNhqaGw==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@nextcloud/dialogs/-/dialogs-6.0.1.tgz",
+      "integrity": "sha512-TlzNUy0eFPIjnop2Wfom45xJdUjLOoUwd/E8V/6ehh+PifrgIWGy6jqBYMRoQfUASc/LKtSYUrCN3yDgVrK8Tw==",
       "requires": {
         "@mdi/js": "^7.4.47",
-        "@nextcloud/auth": "^2.3.0",
-        "@nextcloud/axios": "^2.5.0",
+        "@nextcloud/auth": "^2.4.0",
+        "@nextcloud/axios": "^2.5.1",
         "@nextcloud/event-bus": "^3.3.1",
-        "@nextcloud/files": "^3.8.0",
+        "@nextcloud/files": "^3.9.0",
         "@nextcloud/initial-state": "^2.2.0",
         "@nextcloud/l10n": "^3.1.0",
         "@nextcloud/router": "^3.0.1",
         "@nextcloud/sharing": "^0.2.3",
         "@nextcloud/typings": "^1.9.1",
         "@types/toastify-js": "^1.12.3",
-        "@vueuse/core": "^10.11.1",
+        "@vueuse/core": "^11.2.0",
         "cancelable-promise": "^4.3.1",
+        "p-queue": "^8.0.1",
         "toastify-js": "^1.12.0",
         "vue-frag": "^1.4.3",
         "webdav": "^5.7.1"
-      },
-      "dependencies": {
-        "@vueuse/core": {
-          "version": "10.11.1",
-          "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-10.11.1.tgz",
-          "integrity": "sha512-guoy26JQktXPcz+0n3GukWIy/JDNKti9v6VEMu6kV2sYBsWuGiTU8OWdg+ADfUbHg3/3DlqySDe7JmdHrktiww==",
-          "requires": {
-            "@types/web-bluetooth": "^0.0.20",
-            "@vueuse/metadata": "10.11.1",
-            "@vueuse/shared": "10.11.1",
-            "vue-demi": ">=0.14.8"
-          },
-          "dependencies": {
-            "vue-demi": {
-              "version": "0.14.10",
-              "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
-              "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
-              "requires": {}
-            }
-          }
-        },
-        "@vueuse/metadata": {
-          "version": "10.11.1",
-          "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-10.11.1.tgz",
-          "integrity": "sha512-IGa5FXd003Ug1qAZmyE8wF3sJ81xGLSqTqtQ6jaVfkeZ4i5kS2mwQF61yhVqojRnenVew5PldLyRgvdl4YYuSw=="
-        }
       }
     },
     "@nextcloud/eslint-config": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@nextcloud/axios": "^2.5.1",
     "@nextcloud/browser-storage": "^0.4.0",
     "@nextcloud/capabilities": "^1.2.0",
-    "@nextcloud/dialogs": "^6.0.0",
+    "@nextcloud/dialogs": "^6.0.1",
     "@nextcloud/event-bus": "^3.3.1",
     "@nextcloud/files": "^3.9.1",
     "@nextcloud/initial-state": "^2.2.0",


### PR DESCRIPTION
### ☑️ Resolves

* Rate-limit image previews in FilePicker


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏡 After
![image](https://github.com/user-attachments/assets/0571d6c4-f652-4e25-9d1e-21bf0611ccac)


### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Not risky to browser differences / client