### PR TITLE
feat: invite email guests when creating a conversation

### DIFF
--- a/src/components/LeftSidebar/LeftSidebar.spec.js
+++ b/src/components/LeftSidebar/LeftSidebar.spec.js
@@ -15,15 +15,18 @@ import { loadState } from '@nextcloud/initial-state'
 import LeftSidebar from './LeftSidebar.vue'
 
 import router from '../../__mocks__/router.js'
-import { searchPossibleConversations, searchListedConversations } from '../../services/conversationsService.js'
+import { searchListedConversations } from '../../services/conversationsService.js'
+import { autocompleteQuery } from '../../services/coreService.ts'
 import { EventBus } from '../../services/EventBus.ts'
 import storeConfig from '../../store/storeConfig.js'
 import { findNcListItems, findNcActionButton, findNcButton } from '../../test-helpers.js'
 import { requestTabLeadership } from '../../utils/requestTabLeadership.js'
 
 jest.mock('../../services/conversationsService', () => ({
-	searchPossibleConversations: jest.fn(),
 	searchListedConversations: jest.fn(),
+}))
+jest.mock('../../services/coreService', () => ({
+	autocompleteQuery: jest.fn(),
 }))
 
 // short-circuit debounce
@@ -296,7 +299,7 @@ describe('LeftSidebar.vue', () => {
 		 * @param {object} loadStateSettingsOverride Allows to override some properties
 		 */
 		async function testSearch(searchTerm, possibleResults, listedResults, loadStateSettingsOverride) {
-			searchPossibleConversations.mockResolvedValue({
+			autocompleteQuery.mockResolvedValue({
 				data: {
 					ocs: {
 						data: possibleResults,

--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -364,9 +364,9 @@ import { getTalkConfig, hasTalkFeature } from '../../services/CapabilitiesManage
 import {
 	createPrivateConversation,
 	fetchNoteToSelfConversation,
-	searchPossibleConversations,
 	searchListedConversations,
 } from '../../services/conversationsService.js'
+import { autocompleteQuery } from '../../services/coreService.ts'
 import { EventBus } from '../../services/EventBus.ts'
 import { talkBroadcastChannel } from '../../services/talkBroadcastChannel.js'
 import { useFederationStore } from '../../stores/federation.ts'
@@ -737,7 +737,7 @@ export default {
 			try {
 				// FIXME: move to conversationsStore
 				this.cancelSearchPossibleConversations('canceled')
-				const { request, cancel } = CancelableRequest(searchPossibleConversations)
+				const { request, cancel } = CancelableRequest(autocompleteQuery)
 				this.cancelSearchPossibleConversations = cancel
 
 				const response = await request({

--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -742,7 +742,7 @@ export default {
 
 				const response = await request({
 					searchText: this.searchText,
-					token: undefined,
+					token: 'new',
 					onlyUsers: !this.canStartConversations,
 				})
 

--- a/src/components/NewConversationDialog/NewConversationContactsPage.vue
+++ b/src/components/NewConversationDialog/NewConversationContactsPage.vue
@@ -76,6 +76,7 @@ import DialpadPanel from '../UIShared/DialpadPanel.vue'
 import TransitionWrapper from '../UIShared/TransitionWrapper.vue'
 
 import { useArrowNavigation } from '../../composables/useArrowNavigation.js'
+import { SHARE } from '../../constants.js'
 import { autocompleteQuery } from '../../services/coreService.ts'
 import CancelableRequest from '../../utils/cancelableRequest.js'
 
@@ -208,7 +209,11 @@ export default {
 				const { request, cancel } = CancelableRequest(autocompleteQuery)
 				this.cancelSearchPossibleConversations = cancel
 
-				const response = await request({ searchText: this.searchText })
+				const response = await request({
+					searchText: this.searchText,
+					token: 'new',
+					forceTypes: [SHARE.TYPE.EMAIL], // e-mail guests are allowed directly after conversation creation
+				})
 
 				this.searchResults = response?.data?.ocs?.data || []
 				if (this.searchResults.length === 0) {

--- a/src/components/NewConversationDialog/NewConversationContactsPage.vue
+++ b/src/components/NewConversationDialog/NewConversationContactsPage.vue
@@ -76,7 +76,7 @@ import DialpadPanel from '../UIShared/DialpadPanel.vue'
 import TransitionWrapper from '../UIShared/TransitionWrapper.vue'
 
 import { useArrowNavigation } from '../../composables/useArrowNavigation.js'
-import { searchPossibleConversations } from '../../services/conversationsService.js'
+import { autocompleteQuery } from '../../services/coreService.ts'
 import CancelableRequest from '../../utils/cancelableRequest.js'
 
 export default {
@@ -205,7 +205,7 @@ export default {
 			this.contactsLoading = true
 			try {
 				this.cancelSearchPossibleConversations('canceled')
-				const { request, cancel } = CancelableRequest(searchPossibleConversations)
+				const { request, cancel } = CancelableRequest(autocompleteQuery)
 				this.cancelSearchPossibleConversations = cancel
 
 				const response = await request({ searchText: this.searchText })

--- a/src/components/RightSidebar/Participants/ParticipantsTab.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsTab.vue
@@ -86,7 +86,7 @@ import { useIsInCall } from '../../../composables/useIsInCall.js'
 import { useSortParticipants } from '../../../composables/useSortParticipants.js'
 import { ATTENDEE } from '../../../constants.js'
 import { getTalkConfig, hasTalkFeature } from '../../../services/CapabilitiesManager.ts'
-import { searchPossibleConversations } from '../../../services/conversationsService.js'
+import { autocompleteQuery } from '../../../services/coreService.ts'
 import { EventBus } from '../../../services/EventBus.ts'
 import { addParticipant } from '../../../services/participantsService.js'
 import { useSidebarStore } from '../../../stores/sidebar.js'
@@ -279,7 +279,7 @@ export default {
 			this.resetNavigation()
 			try {
 				this.cancelSearchPossibleConversations('canceled')
-				const { request, cancel } = CancelableRequest(searchPossibleConversations)
+				const { request, cancel } = CancelableRequest(autocompleteQuery)
 				this.cancelSearchPossibleConversations = cancel
 
 				const response = await request({

--- a/src/services/CapabilitiesManager.ts
+++ b/src/services/CapabilitiesManager.ts
@@ -72,14 +72,18 @@ export function hasTalkFeature(token: string = 'local', feature: string): boolea
  * @param key1 top-level key (e.g. 'attachments')
  * @param key2 second-level key (e.g. 'allowed')
  */
-export function getTalkConfig(token: string = 'local', key1: keyof Config, key2: keyof Config[keyof Config]) {
+export function getTalkConfig(token: string = 'local', key1: keyof Config, key2: string) {
 	const remoteCapabilities = getRemoteCapability(token)
+	const locals = localCapabilities?.spreed?.config?.[key1]
 	if (localCapabilities?.spreed?.['config-local']?.[key1]?.includes(key2)) {
+		// @ts-expect-error Vue: Element implicitly has an any type because expression of type string can't be used to index type
 		return localCapabilities?.spreed?.config?.[key1]?.[key2]
 	} else if (token === 'local' || !remoteCapabilities) {
+		// @ts-expect-error Vue: Element implicitly has an any type because expression of type string can't be used to index type
 		return localCapabilities?.spreed?.config?.[key1]?.[key2]
 	} else {
 		// TODO discuss handling remote config (respect remote only / both / minimal)
+		// @ts-expect-error Vue: Element implicitly has an any type because expression of type string can't be used to index type
 		return remoteCapabilities?.spreed?.config?.[key1]?.[key2]
 	}
 }

--- a/src/services/__tests__/coreService.spec.js
+++ b/src/services/__tests__/coreService.spec.js
@@ -5,8 +5,8 @@
 import axios from '@nextcloud/axios'
 import { generateOcsUrl } from '@nextcloud/router'
 
-import { searchPossibleConversations } from './conversationsService.js'
-import { SHARE } from '../constants.js'
+import { SHARE } from '../../constants.js'
+import { autocompleteQuery } from '../coreService.ts'
 
 jest.mock('@nextcloud/axios', () => ({
 	get: jest.fn(),
@@ -24,7 +24,7 @@ jest.mock('@nextcloud/capabilities', () => ({
 	}))
 }))
 
-describe('conversationsService', () => {
+describe('coreService', () => {
 	afterEach(() => {
 		// cleaning up the mess left behind the previous test
 		jest.clearAllMocks()
@@ -35,8 +35,8 @@ describe('conversationsService', () => {
 	 * @param {boolean} onlyUsers Whether or not to only search for users
 	 * @param {Array} expectedShareTypes The expected search types to look for
 	 */
-	function testSearchPossibleConversations(token, onlyUsers, expectedShareTypes) {
-		searchPossibleConversations(
+	function testAutocompleteQuery(token, onlyUsers, expectedShareTypes) {
+		autocompleteQuery(
 			{
 				searchText: 'search-text',
 				token,
@@ -60,8 +60,8 @@ describe('conversationsService', () => {
 		)
 	}
 
-	test('searchPossibleConversations with only users', () => {
-		testSearchPossibleConversations(
+	test('autocompleteQuery with only users', () => {
+		testAutocompleteQuery(
 			'conversation-token',
 			true,
 			[
@@ -70,8 +70,8 @@ describe('conversationsService', () => {
 		)
 	})
 
-	test('searchPossibleConversations with other share types', () => {
-		testSearchPossibleConversations(
+	test('autocompleteQuery with other share types', () => {
+		testAutocompleteQuery(
 			'conversation-token',
 			false,
 			[
@@ -84,8 +84,8 @@ describe('conversationsService', () => {
 		)
 	})
 
-	test('searchPossibleConversations with other share types and a new token', () => {
-		testSearchPossibleConversations(
+	test('autocompleteQuery with other share types and a new token', () => {
+		testAutocompleteQuery(
 			'new',
 			false,
 			[

--- a/src/services/conversationsService.js
+++ b/src/services/conversationsService.js
@@ -6,12 +6,7 @@
 import axios from '@nextcloud/axios'
 import { generateOcsUrl } from '@nextcloud/router'
 
-import { getTalkConfig, hasTalkFeature } from './CapabilitiesManager.ts'
-import { ATTENDEE, CONVERSATION, SHARE } from '../constants.js'
-
-const canInviteToFederation = hasTalkFeature('local', 'federation-v1')
-	&& getTalkConfig('local', 'federation', 'enabled')
-	&& getTalkConfig('local', 'federation', 'outgoing-enabled')
+import { ATTENDEE, CONVERSATION } from '../constants.js'
 
 /**
  * Fetches the conversations from the server.
@@ -68,38 +63,6 @@ const searchListedConversations = async function({ searchText }, options) {
  */
 const fetchNoteToSelfConversation = async function() {
 	return axios.get(generateOcsUrl('apps/spreed/api/v4/room/note-to-self'))
-}
-
-/**
- * Fetch possible conversations
- *
- * @param {object} data the wrapping object;
- * @param {string} data.searchText The string that will be used in the search query.
- * @param {string} [data.token] The token of the conversation (if any), or "new" for a new one
- * @param {boolean} [data.onlyUsers] Only return users
- * @param {object} options options
- */
-const searchPossibleConversations = async function({ searchText, token, onlyUsers }, options) {
-	token = token || 'new'
-	onlyUsers = !!onlyUsers
-
-	const shareTypes = [
-		SHARE.TYPE.USER,
-		!onlyUsers ? SHARE.TYPE.GROUP : null,
-		!onlyUsers ? SHARE.TYPE.CIRCLE : null,
-		(!onlyUsers && token !== 'new') ? SHARE.TYPE.EMAIL : null,
-		(!onlyUsers && canInviteToFederation) ? SHARE.TYPE.REMOTE : null,
-	].filter(type => type !== null)
-
-	return axios.get(generateOcsUrl('core/autocomplete/get'), {
-		...options,
-		params: {
-			search: searchText,
-			itemType: 'call',
-			itemId: token,
-			shareTypes,
-		},
-	})
 }
 
 /**
@@ -390,7 +353,6 @@ export {
 	fetchNoteToSelfConversation,
 	getUpcomingEvents,
 	searchListedConversations,
-	searchPossibleConversations,
 	createOneToOneConversation,
 	createGroupConversation,
 	createPrivateConversation,

--- a/src/services/coreService.ts
+++ b/src/services/coreService.ts
@@ -1,0 +1,56 @@
+/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import axios from '@nextcloud/axios'
+import { generateOcsUrl } from '@nextcloud/router'
+
+import { getTalkConfig, hasTalkFeature } from './CapabilitiesManager.ts'
+import { SHARE } from '../constants.js'
+
+const canInviteToFederation = hasTalkFeature('local', 'federation-v1')
+	&& getTalkConfig('local', 'federation', 'enabled')
+	&& getTalkConfig('local', 'federation', 'outgoing-enabled')
+
+type SearchPayload = {
+	searchText: string
+	token?: string
+	onlyUsers?: boolean
+}
+
+/**
+ * Fetch possible conversations
+ *
+ * @param data the wrapping object;
+ * @param data.searchText The string that will be used in the search query.
+ * @param [data.token] The token of the conversation (if any), or "new" for a new one
+ * @param [data.onlyUsers] Only return users
+ * @param options options
+ */
+const autocompleteQuery = async function({ searchText, token, onlyUsers }: SearchPayload, options: object) {
+	token = token || 'new'
+	onlyUsers = !!onlyUsers
+
+	const shareTypes = [
+		SHARE.TYPE.USER,
+		!onlyUsers ? SHARE.TYPE.GROUP : null,
+		!onlyUsers ? SHARE.TYPE.CIRCLE : null,
+		(!onlyUsers && token !== 'new') ? SHARE.TYPE.EMAIL : null,
+		(!onlyUsers && canInviteToFederation) ? SHARE.TYPE.REMOTE : null,
+	].filter(type => type !== null)
+
+	return axios.get(generateOcsUrl('core/autocomplete/get'), {
+		...options,
+		params: {
+			search: searchText,
+			itemType: 'call',
+			itemId: token,
+			shareTypes,
+		},
+	})
+}
+
+export {
+	autocompleteQuery,
+}

--- a/src/services/coreService.ts
+++ b/src/services/coreService.ts
@@ -15,30 +15,29 @@ const canInviteToFederation = hasTalkFeature('local', 'federation-v1')
 
 type SearchPayload = {
 	searchText: string
-	token?: string
+	token?: string | 'new'
 	onlyUsers?: boolean
 }
 
 /**
  * Fetch possible conversations
  *
- * @param data the wrapping object;
- * @param data.searchText The string that will be used in the search query.
- * @param [data.token] The token of the conversation (if any), or "new" for a new one
- * @param [data.onlyUsers] Only return users
+ * @param payload the wrapping object;
+ * @param payload.searchText The string that will be used in the search query.
+ * @param [payload.token] The token of the conversation (if any) | 'new' for new conversations
+ * @param [payload.onlyUsers] Whether to return only registered users
  * @param options options
  */
-const autocompleteQuery = async function({ searchText, token, onlyUsers }: SearchPayload, options: object) {
-	token = token || 'new'
-	onlyUsers = !!onlyUsers
-
-	const shareTypes = [
-		SHARE.TYPE.USER,
-		!onlyUsers ? SHARE.TYPE.GROUP : null,
-		!onlyUsers ? SHARE.TYPE.CIRCLE : null,
-		(!onlyUsers && token !== 'new') ? SHARE.TYPE.EMAIL : null,
-		(!onlyUsers && canInviteToFederation) ? SHARE.TYPE.REMOTE : null,
-	].filter(type => type !== null)
+const autocompleteQuery = async function({ searchText, token = 'new', onlyUsers = false }: SearchPayload, options: object) {
+	const shareTypes = onlyUsers
+		? [SHARE.TYPE.USER]
+		: [
+			SHARE.TYPE.USER,
+			SHARE.TYPE.GROUP,
+			SHARE.TYPE.CIRCLE,
+			token !== 'new' ? SHARE.TYPE.EMAIL : null,
+			canInviteToFederation ? SHARE.TYPE.REMOTE : null,
+		].filter(type => type !== null)
 
 	return axios.get(generateOcsUrl('core/autocomplete/get'), {
 		...options,

--- a/src/services/coreService.ts
+++ b/src/services/coreService.ts
@@ -17,6 +17,7 @@ type SearchPayload = {
 	searchText: string
 	token?: string | 'new'
 	onlyUsers?: boolean
+	forceTypes?: typeof SHARE.TYPE[keyof typeof SHARE.TYPE][]
 }
 
 /**
@@ -26,18 +27,19 @@ type SearchPayload = {
  * @param payload.searchText The string that will be used in the search query.
  * @param [payload.token] The token of the conversation (if any) | 'new' for new conversations
  * @param [payload.onlyUsers] Whether to return only registered users
+ * @param [payload.forceTypes] Whether to force some types to be included in query
  * @param options options
  */
-const autocompleteQuery = async function({ searchText, token = 'new', onlyUsers = false }: SearchPayload, options: object) {
+const autocompleteQuery = async function({ searchText, token = 'new', onlyUsers = false, forceTypes = [] }: SearchPayload, options: object) {
 	const shareTypes = onlyUsers
-		? [SHARE.TYPE.USER]
+		? [SHARE.TYPE.USER].concat(forceTypes)
 		: [
 			SHARE.TYPE.USER,
 			SHARE.TYPE.GROUP,
 			SHARE.TYPE.CIRCLE,
 			token !== 'new' ? SHARE.TYPE.EMAIL : null,
 			canInviteToFederation ? SHARE.TYPE.REMOTE : null,
-		].filter(type => type !== null)
+		].filter(type => type !== null).concat(forceTypes)
 
 	return axios.get(generateOcsUrl('core/autocomplete/get'), {
 		...options,


### PR DESCRIPTION
### ☑️ Resolves

* Fix #4937
* As for now participants added after conversation is created and token is known, that works the same way as adding participant from the right sidebar
* ~~If at least one participant is e-mail, create a public conversation instead of rewriting it later on backend~~
* Also extract API call for 'core/autocomplete/get' to not mix with conversation services

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/user-attachments/assets/b12a8005-8ce0-491b-9b61-1ff3c282672b) | ![image](https://github.com/user-attachments/assets/f2c3ab98-fef5-4816-bef2-a1c1aa229da8)


### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Not risky to browser differences / client