### PR TITLE
style: move a hover effect to image container

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
@@ -543,7 +543,7 @@ export default {
 			visibility: visible;
 		}
 
-		.file-preview__image.media {
+		.image-container:has(.file-preview__image.media) {
 			outline: 2px solid var(--color-primary-element);
 		}
 	}


### PR DESCRIPTION
### ☑️ Resolves

* Fix hover effect when image is not loaded yet


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="359" alt="2024-11-06_10h28_58" src="https://github.com/user-attachments/assets/818d793f-d365-4c6e-b5e5-21240eb0040c"> | <img width="384" alt="2024-11-06_10h28_35" src="https://github.com/user-attachments/assets/9bd2db5b-3323-40a7-b7f2-4b52a9062e5c">




### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client