### PR TITLE
style: fix e-mail guests icons

### DIFF
--- a/css/icons.css
+++ b/css/icons.css
@@ -4,6 +4,7 @@
  */
 .app-talk .icon-user,
 .modal-mask .icon-user,
+.v-popper__popper .icon-user,
 .talk-sidebar-callview .icon-user,
 #talk-panel .icon-user,
 #talk-sidebar .icon-user,
@@ -14,6 +15,7 @@
 
 .app-talk .icon-public,
 .modal-mask .icon-public,
+.v-popper__popper .icon-public,
 .talk-sidebar-callview .icon-public,
 #talk-panel .icon-public,
 #talk-sidebar .icon-public,
@@ -24,6 +26,7 @@
 
 .app-talk .icon-contacts,
 .modal-mask .icon-contacts,
+.v-popper__popper .icon-contacts,
 .talk-sidebar-callview .icon-contacts,
 #talk-panel .icon-contacts,
 #talk-sidebar .icon-contacts,
@@ -34,6 +37,7 @@
 
 .app-talk .icon-phone,
 .modal-mask .icon-phone,
+.v-popper__popper .icon-phone,
 .talk-sidebar-callview .icon-phone,
 #talk-panel .icon-phone,
 #talk-sidebar .icon-phone,
@@ -44,6 +48,7 @@
 
 .app-talk .icon-password,
 .modal-mask .icon-password,
+.v-popper__popper .icon-password,
 .talk-sidebar-callview .icon-password,
 #talk-panel .icon-password,
 #talk-sidebar .icon-password,
@@ -54,6 +59,7 @@
 
 .app-talk .icon-file,
 .modal-mask .icon-file,
+.v-popper__popper .icon-file,
 .talk-sidebar-callview .icon-file,
 #talk-panel .icon-file,
 #talk-sidebar .icon-file,
@@ -64,6 +70,7 @@
 
 .app-talk .icon-mail,
 .modal-mask .icon-mail,
+.v-popper__popper .icon-mail,
 .talk-sidebar-callview .icon-mail,
 #talk-panel .icon-mail,
 #talk-sidebar .icon-mail,
@@ -74,6 +81,7 @@
 
 .app-talk .icon-team,
 .modal-mask .icon-team,
+.v-popper__popper .icon-team,
 .talk-sidebar-callview .icon-team,
 #talk-panel .icon-team,
 #talk-sidebar .icon-team,
@@ -84,6 +92,7 @@
 
 .app-talk .icon-changelog,
 .modal-mask .icon-changelog,
+.v-popper__popper .icon-changelog,
 .talk-sidebar-callview .icon-changelog,
 #talk-panel .icon-changelog,
 #talk-sidebar .icon-changelog,

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/Mention.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/Mention.vue
@@ -74,9 +74,6 @@ export default {
 		isGroupMention() {
 			return this.type === 'user-group' || this.type === 'group'
 		},
-		isEmailGuest() {
-			return this.type === 'guest' && this.id.startsWith('email/')
-		},
 		isMentionToGuest() {
 			return this.type === 'guest'
 		},
@@ -117,8 +114,6 @@ export default {
 					: 'icon-user-forced-white'
 			} else if (this.isGroupMention) {
 				return 'icon-group-forced-white'
-			} else if (this.isEmailGuest) {
-				return 'icon-mail-forced-white'
 			} else if (this.isMentionToGuest) {
 				return 'icon-user-forced-white'
 			} else if (!this.isMentionToAll) {


### PR DESCRIPTION
### ☑️ Resolves

- Ref #13606
- do not show as mail in mentions
- show correct color in popover

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="160" alt="image" src="https://github.com/user-attachments/assets/dcea843e-15e7-4b44-b72a-ac7962157fe6"> | <img width="157" alt="image" src="https://github.com/user-attachments/assets/c0bf4e9f-5896-4569-b28d-9b56a0ada659">
<img width="178" alt="image" src="https://github.com/user-attachments/assets/52b186fc-d4bb-4676-9f5d-07413014ea0a"> | <img width="170" alt="image" src="https://github.com/user-attachments/assets/8fa87257-32c7-4b29-b335-dec4d9fc4a98">


### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Not risky to browser differences / client