### PR TITLE
fix: non-moderators should not query participants from server

### DIFF
--- a/src/components/RightSidebar/Participants/ParticipantsTab.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsTab.vue
@@ -267,6 +267,9 @@ export default {
 		},
 
 		handleInput() {
+			if (!this.canAdd) {
+				return
+			}
 			this.contactsLoading = true
 			this.searchResults = []
 			this.debounceFetchSearchResults()


### PR DESCRIPTION
### ☑️ Resolves

* Blocks non-moderators to send query requests from ParticipantsTab


### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Not risky to browser differences / client