### PR TITLE
chore(release): Bump version to 18.0.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 18.0.13 – 2024-11-07
+### Changed
+- Update translations
+- Update dependencies
+
+### Fixed
+- fix(chat): Fix layout for guests on public conversations
+  [#13620](https://github.com/nextcloud/spreed/issues/13620)
+- fix(UI): Improve handling of sidebar on mobile view
+  [#12693](https://github.com/nextcloud/spreed/issues/12693)
+
 ## 18.0.12 – 2024-10-10
 ### Changed
 - Update translations

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -16,7 +16,7 @@ And in the works for the [coming versions](https://github.com/nextcloud/spreed/m
 
 	]]></description>
 
-	<version>18.0.12</version>
+	<version>18.0.13</version>
 	<licence>agpl</licence>
 
 	<author>Daniel Calviño Sánchez</author>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "talk",
-  "version": "18.0.12",
+  "version": "18.0.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "talk",
-      "version": "18.0.12",
+      "version": "18.0.13",
       "license": "agpl",
       "dependencies": {
         "@linusborg/vue-simple-portal": "^0.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "talk",
-  "version": "18.0.12",
+  "version": "18.0.13",
   "private": true,
   "description": "",
   "author": "Joas Schilling <coding@schilljs.com>",


### PR DESCRIPTION
## 18.0.13 – 2024-11-07
### Changed
- Update translations
- Update dependencies

### Fixed
- fix(chat): Fix layout for guests on public conversations [#13620](https://github.com/nextcloud/spreed/issues/13620)
- fix(UI): Improve handling of sidebar on mobile view [#12693](https://github.com/nextcloud/spreed/issues/12693)