### PR TITLE
fix: make useIsInCall a shared composable

### DIFF
--- a/src/composables/useIsInCall.js
+++ b/src/composables/useIsInCall.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import { createSharedComposable } from '@vueuse/core'
 import { computed, onBeforeMount, onBeforeUnmount, ref } from 'vue'
 
 import { useStore } from './useStore.js'
@@ -16,7 +17,7 @@ import { useCallViewStore } from '../stores/callView.js'
  *
  * @return {import('vue').ComputedRef<boolean>}
  */
-export function useIsInCall() {
+function useIsInCallComposable() {
 	const store = useStore()
 	const callViewStore = useCallViewStore()
 
@@ -42,3 +43,9 @@ export function useIsInCall() {
 		return sessionStorageJoinedConversation.value === store.getters.getToken() && store.getters.isInCall(store.getters.getToken())
 	})
 }
+
+/**
+ * Shared composable to check whether the user joined the call of the current token in this PHP session or not
+ * @return {import('vue').ComputedRef<boolean>}
+ */
+export const useIsInCall = createSharedComposable(useIsInCallComposable)


### PR DESCRIPTION
### ☑️ Resolves

* Fix creating a separate composable instance for each component it uses


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![2024-11-08_14h33_38](https://github.com/user-attachments/assets/9fdd1a3d-0d88-4ae3-8ba5-defea37dec8f) | ![2024-11-08_14h35_46](https://github.com/user-attachments/assets/72c9adc9-397e-4027-b3d3-df1deff3b424)

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Not risky to browser differences / client