### PR TITLE
fix: reduce amount of EventBus listeners on messages

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -11,9 +11,9 @@
 		:data-next-message-id="nextMessageId"
 		:data-previous-message-id="previousMessageId"
 		class="message"
-		:class="{'message--highlighted': isHighlighted, 'message--hovered': showMessageButtonsBar}"
+		:class="{'message--hovered': showMessageButtonsBar}"
 		tabindex="0"
-		@animationend="isHighlighted = false"
+		@animationend="clearHighlightedClass"
 		@mouseover="handleMouseover"
 		@mouseleave="handleMouseleave">
 		<div :class="{'normal-message-body': !isSystemMessage && !isDeletedMessage,
@@ -191,7 +191,6 @@ export default {
 		return {
 			isHovered: false,
 			isDeleting: false,
-			isHighlighted: false,
 			// whether the message was seen, only used if this was marked as last read message
 			seen: false,
 			isActionMenuOpen: false,
@@ -344,14 +343,6 @@ export default {
 		},
 	},
 
-	mounted() {
-		EventBus.on('highlight-message', this.highlightMessage)
-	},
-
-	beforeDestroy() {
-		EventBus.off('highlight-message', this.highlightMessage)
-	},
-
 	methods: {
 		t,
 		lastReadMessageVisibilityChanged([{ isIntersecting }]) {
@@ -360,10 +351,8 @@ export default {
 			}
 		},
 
-		highlightMessage(messageId) {
-			if (this.message.id === messageId) {
-				this.isHighlighted = true
-			}
+		clearHighlightedClass() {
+			this.$refs.message.classList.remove('message--highlighted')
 		},
 
 		handleMouseover() {

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/MessageBody.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/MessageBody.vue
@@ -322,12 +322,19 @@ export default {
 	},
 
 	mounted() {
-		EventBus.on('editing-message-processing', this.setIsEditing)
+		if (this.isEditable) {
+			EventBus.on('editing-message-processing', this.setIsEditing)
+		}
+
 		if (!this.containsCodeBlocks) {
 			return
 		}
 
 		this.codeBlocks = Array.from(this.$refs.messageMain?.querySelectorAll('pre'))
+	},
+
+	beforeDestroy() {
+		EventBus.off('editing-message-processing', this.setIsEditing)
 	},
 
 	methods: {

--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -1136,7 +1136,7 @@ export default {
 		 * @return {boolean} true if element was found, false otherwise
 		 */
 		focusMessage(messageId, smooth = true, highlightAnimation = true) {
-			let element = document.getElementById(`message_${messageId}`)
+			const element = document.getElementById(`message_${messageId}`)
 			if (!element) {
 				// Message id doesn't exist
 				// TODO: in some cases might need to trigger a scroll up if this is an older message
@@ -1145,9 +1145,10 @@ export default {
 				return false // element not found
 			}
 
-			if (this.isChatVisible && element.offsetParent === null) {
+			let scrollElement = element
+			if (this.isChatVisible && scrollElement.offsetParent === null) {
 				console.debug('Message to focus is hidden, scrolling to its nearest visible parent', messageId)
-				element = element.closest('ul[style="display: none;"]').parentElement
+				scrollElement = scrollElement.closest('ul[style="display: none;"]').parentElement
 			}
 
 			console.debug('Scrolling to a focused message programmatically')
@@ -1155,7 +1156,7 @@ export default {
 
 			// TODO: doesn't work if chat is hidden. Need to store
 			// delayed 'shouldScroll' and call after chat is visible
-			element.scrollIntoView({
+			scrollElement.scrollIntoView({
 				behavior: smooth ? 'smooth' : 'auto',
 				block: 'center',
 				inline: 'nearest',
@@ -1171,8 +1172,9 @@ export default {
 				this.setChatScrolledToBottom(true)
 			}
 
-			if (highlightAnimation) {
-				EventBus.emit('highlight-message', messageId)
+			if (highlightAnimation && scrollElement === element) {
+				// element is visible, highlight it
+				element.classList.add('message--highlighted')
 			}
 			this.isFocusingMessage = false
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix regression from #12550 
  * listeners weren't removed from unmounted components
* Follow-up to 7bc38ae53f0fbf306de5e784413f5fa906185e7d
  *  Toggle CSS class with native method rather than emitting event, which should be listened to all mounted components


## 🖌️ UI Checklist


### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] ⛑️ Tests are included or not possible