### PR TITLE
[stable30] style: fix public share layout

### DIFF
--- a/css/publicshare.css
+++ b/css/publicshare.css
@@ -19,6 +19,11 @@
 	position: static;
 }
 
+/* Overwrites styles from public.scss in public share after re-parenting footer */
+#body-public {
+   --footer-height: 0 !important;
+}
+
 #content.full-height {
 	/* Always full height without header. */
 	height: calc(100% - 50px);


### PR DESCRIPTION
### ☑️ Resolves

* remove empty space reserved for re-parented footer in public share
* Fixed differently in `main` branch


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="959" alt="image" src="https://github.com/user-attachments/assets/a119a5a4-3b47-4fc8-be9f-34bc0ddab8f4"> | <img width="959" alt="image" src="https://github.com/user-attachments/assets/73deb354-0b31-40e0-9229-6621c3f8c956">


### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] ~~Talk Desktop~~
  - [x] Not risky to browser differences / client