### PR TITLE
chore(deps): bump @nextcloud/vue lib from 8.19.0 to 8.20.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@nextcloud/router": "^3.0.1",
         "@nextcloud/sharing": "^0.2.3",
         "@nextcloud/upload": "^1.6.1",
-        "@nextcloud/vue": "^8.19.0",
+        "@nextcloud/vue": "^8.20.0",
         "@vueuse/components": "^11.2.0",
         "@vueuse/core": "^11.2.0",
         "blurhash": "^2.0.5",
@@ -3843,9 +3843,9 @@
       }
     },
     "node_modules/@nextcloud/vue": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.19.0.tgz",
-      "integrity": "sha512-mEawbIueee5fSGZreJV+/8h80SRriRTuib1UO9UWWEgqWvZQp0i99xXnIQj+UMw9AugxznJWd5R0ZOmZkN7p5w==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.20.0.tgz",
+      "integrity": "sha512-X8hsZGsJ4hRmPhTOZmpzXbHcXp4txvebIlRRos+Gm+nOESKTAaOqtMARHAk1f/B+WMULNCipQoNc1ef8AFLGZA==",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@floating-ui/dom": "^1.1.0",
@@ -3865,7 +3865,7 @@
         "@vueuse/components": "^11.0.0",
         "@vueuse/core": "^11.0.0",
         "clone": "^2.1.2",
-        "debounce": "2.1.1",
+        "debounce": "2.2.0",
         "dompurify": "^3.0.5",
         "emoji-mart-vue-fast": "^15.0.1",
         "escape-html": "^1.0.3",
@@ -3940,17 +3940,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/@nextcloud/vue/node_modules/debounce": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/debounce/-/debounce-2.1.1.tgz",
-      "integrity": "sha512-+xRWxgel9LgTC4PwKlm7TJUK6B6qsEK77NaiNvXmeQ7Y3e6OVVsBC4a9BSptS/mAYceyAz37Oa8JTTuPRft7uQ==",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@nextcloud/vue/node_modules/is-plain-obj": {
@@ -23874,9 +23863,9 @@
       }
     },
     "@nextcloud/vue": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.19.0.tgz",
-      "integrity": "sha512-mEawbIueee5fSGZreJV+/8h80SRriRTuib1UO9UWWEgqWvZQp0i99xXnIQj+UMw9AugxznJWd5R0ZOmZkN7p5w==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.20.0.tgz",
+      "integrity": "sha512-X8hsZGsJ4hRmPhTOZmpzXbHcXp4txvebIlRRos+Gm+nOESKTAaOqtMARHAk1f/B+WMULNCipQoNc1ef8AFLGZA==",
       "requires": {
         "@floating-ui/dom": "^1.1.0",
         "@linusborg/vue-simple-portal": "^0.1.5",
@@ -23895,7 +23884,7 @@
         "@vueuse/components": "^11.0.0",
         "@vueuse/core": "^11.0.0",
         "clone": "^2.1.2",
-        "debounce": "2.1.1",
+        "debounce": "2.2.0",
         "dompurify": "^3.0.5",
         "emoji-mart-vue-fast": "^15.0.1",
         "escape-html": "^1.0.3",
@@ -23949,11 +23938,6 @@
           "version": "6.0.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
           "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA=="
-        },
-        "debounce": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/debounce/-/debounce-2.1.1.tgz",
-          "integrity": "sha512-+xRWxgel9LgTC4PwKlm7TJUK6B6qsEK77NaiNvXmeQ7Y3e6OVVsBC4a9BSptS/mAYceyAz37Oa8JTTuPRft7uQ=="
         },
         "is-plain-obj": {
           "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@nextcloud/router": "^3.0.1",
     "@nextcloud/sharing": "^0.2.3",
     "@nextcloud/upload": "^1.6.1",
-    "@nextcloud/vue": "^8.19.0",
+    "@nextcloud/vue": "^8.20.0",
     "@vueuse/components": "^11.2.0",
     "@vueuse/core": "^11.2.0",
     "blurhash": "^2.0.5",

--- a/src/components/LeftSidebar/LeftSidebar.spec.js
+++ b/src/components/LeftSidebar/LeftSidebar.spec.js
@@ -642,7 +642,7 @@ describe('LeftSidebar.vue', () => {
 				expect(ncModalComponent.exists()).toBeTruthy()
 
 				const input = ncModalComponent.findComponent({ name: 'NcTextField', ref: 'conversationName' })
-				expect(input.props('value')).toBe(groupsResults[1].label)
+				expect(input.props('modelValue')).toBe(groupsResults[1].label)
 
 				// nothing created yet
 				expect(createOneToOneConversationAction).not.toHaveBeenCalled()
@@ -664,7 +664,7 @@ describe('LeftSidebar.vue', () => {
 				const ncModalComponent = wrapper.findComponent({ name: 'NcModal' })
 				expect(ncModalComponent.exists()).toBeTruthy()
 				const input = ncModalComponent.findComponent({ name: 'NcTextField', ref: 'conversationName' })
-				expect(input.props('value')).toBe(circlesResults[1].label)
+				expect(input.props('modelValue')).toBe(circlesResults[1].label)
 
 				// nothing created yet
 				expect(createOneToOneConversationAction).not.toHaveBeenCalled()

--- a/src/components/NewConversationDialog/NewConversationSetupPage.vue
+++ b/src/components/NewConversationDialog/NewConversationSetupPage.vue
@@ -115,8 +115,8 @@ export default {
 			get() {
 				return this.newConversation.displayName
 			},
-			set(event) {
-				this.updateNewConversation({ displayName: event.target.value })
+			set(displayName) {
+				this.updateNewConversation({ displayName })
 			},
 		},
 
@@ -124,8 +124,8 @@ export default {
 			get() {
 				return this.newConversation.description
 			},
-			set(event) {
-				this.updateNewConversation({ description: event.target.value })
+			set(description) {
+				this.updateNewConversation({ description })
 			},
 		},
 
@@ -172,8 +172,8 @@ export default {
 			get() {
 				return this.password
 			},
-			set(event) {
-				this.$emit('update:password', event.target.value)
+			set(value) {
+				this.$emit('update:password', value)
 			},
 		},
 


### PR DESCRIPTION
### ☑️ Resolves

* Bumps vue-library [Full Changelog](https://github.com/nextcloud-libraries/nextcloud-vue/compare/v8.19.0...v8.20.0)

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop ⚠️ might need adjustments in talk-desktop repo to support
  - [ ] Not risky to browser differences / client