### PR TITLE
fix: hide archive-conversations feature from 20.1.0rc1

### DIFF
--- a/src/__mocks__/capabilities.ts
+++ b/src/__mocks__/capabilities.ts
@@ -86,6 +86,7 @@ export const mockedCapabilities: Capabilities = {
 			'edit-messages-note-to-self',
 			'archived-conversations',
 			'talk-polls-drafts',
+			'archived-conversations-v2',
 		],
 		'features-local': [
 			'favorites',
@@ -98,6 +99,7 @@ export const mockedCapabilities: Capabilities = {
 			'remind-me-later',
 			'note-to-self',
 			'archived-conversations',
+			'archived-conversations-v2',
 		],
 		config: {
 			attachments: {

--- a/src/components/ConversationSettings/ConversationSettingsDialog.vue
+++ b/src/components/ConversationSettings/ConversationSettingsDialog.vue
@@ -132,7 +132,7 @@ import { CALL, CONFIG, PARTICIPANT, CONVERSATION } from '../../constants.js'
 import { getTalkConfig, hasTalkFeature } from '../../services/CapabilitiesManager.ts'
 import { useSettingsStore } from '../../stores/settings.js'
 
-const supportsArchive = hasTalkFeature('local', 'archived-conversations')
+const supportsArchive = hasTalkFeature('local', 'archived-conversations-v2')
 
 export default {
 	name: 'ConversationSettingsDialog',

--- a/src/components/ConversationSettings/DangerZone.vue
+++ b/src/components/ConversationSettings/DangerZone.vue
@@ -110,7 +110,7 @@ import NcNoteCard from '@nextcloud/vue/dist/Components/NcNoteCard.js'
 
 import { hasTalkFeature } from '../../services/CapabilitiesManager.ts'
 
-const supportsArchive = hasTalkFeature('local', 'archived-conversations')
+const supportsArchive = hasTalkFeature('local', 'archived-conversations-v2')
 
 export default {
 	name: 'DangerZone',

--- a/src/components/LeftSidebar/ConversationsList/Conversation.vue
+++ b/src/components/LeftSidebar/ConversationsList/Conversation.vue
@@ -178,7 +178,7 @@ import { PARTICIPANT } from '../../../constants.js'
 import { hasTalkFeature } from '../../../services/CapabilitiesManager.ts'
 import { copyConversationLinkToClipboard } from '../../../utils/handleUrl.ts'
 
-const supportsArchive = hasTalkFeature('local', 'archived-conversations')
+const supportsArchive = hasTalkFeature('local', 'archived-conversations-v2')
 
 export default {
 	name: 'Conversation',

--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -381,7 +381,7 @@ const canModerateSipDialOut = hasTalkFeature('local', 'sip-support-dialout')
 	&& getTalkConfig('local', 'call', 'sip-dialout-enabled')
 	&& getTalkConfig('local', 'call', 'can-enable-sip')
 const canNoteToSelf = hasTalkFeature('local', 'note-to-self')
-const supportsArchive = hasTalkFeature('local', 'archived-conversations')
+const supportsArchive = hasTalkFeature('local', 'archived-conversations-v2')
 
 export default {
 	name: 'LeftSidebar',

--- a/src/utils/conversation.js
+++ b/src/utils/conversation.js
@@ -5,7 +5,7 @@
 import { CONVERSATION, PARTICIPANT } from '../constants.js'
 import { hasTalkFeature } from '../services/CapabilitiesManager.ts'
 
-const supportsArchive = hasTalkFeature('local', 'archived-conversations')
+const supportsArchive = hasTalkFeature('local', 'archived-conversations-v2')
 
 /**
  * check if the conversation has unread messages


### PR DESCRIPTION
### ☑️ Resolves

* Set frontend code for unexisting (yet) capability
* Mock is kept so test won't fail

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Not risky to browser differences / client
- [x] ⛑️ Tests are included or not possible