### PR TITLE
fix(calls): Add email to exported participant list and list everyone …

### DIFF
--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -1595,6 +1595,22 @@ class ParticipantService {
 	}
 
 	/**
+	 * @return Participant[]
+	 */
+	public function getParticipantsJoinedCurrentCall(Room $room, int $maxAge): array {
+		$query = $this->connection->getQueryBuilder();
+
+		$helper = new SelectHelper();
+		$helper->selectAttendeesTable($query);
+		$query->from('talk_attendees', 'a')
+			->where($query->expr()->eq('a.room_id', $query->createNamedParameter($room->getId(), IQueryBuilder::PARAM_INT)))
+			->andWhere($query->expr()->gte('a.last_joined_call', $query->createNamedParameter($maxAge, IQueryBuilder::PARAM_INT)))
+			->orderBy('a.id', 'ASC');
+
+		return $this->getParticipantsFromQuery($query, $room);
+	}
+
+	/**
 	 * @param Room $room
 	 * @param int $notificationLevel
 	 * @return Participant[]

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -2265,8 +2265,8 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 
 		$expected = [];
 		foreach ($tableNode->getRows() as $row) {
-			if ($row[1] === 'guests') {
-				$row[2] = self::$sessionNameToActorId[$row[2]];
+			if ($row[2] === 'guests') {
+				$row[3] = self::$sessionNameToActorId[$row[3]];
 			}
 			$expected[] = implode(',', $row);
 		}

--- a/tests/integration/features/callapi/public.feature
+++ b/tests/integration/features/callapi/public.feature
@@ -95,12 +95,18 @@ Feature: callapi/public
     And user "guest" joins call "room" with 200 (v4)
     Then user "participant1" sees 2 peers in call "room" with 200 (v4)
     And user "guest" sees 2 peers in call "room" with 200 (v4)
+    And invoking occ with "user:setting participant1 settings email participant1@example.tld"
     And user "participant2" downloads call participants from "room" as "csv" with 403 (v4)
     And user "participant1" downloads call participants from "room" as "csv" with 200 (v4)
-      | name                     | type   | identifier   |
-      | participant1-displayname | users  | participant1 |
-      |                          | guests | guest1       |
+      | name                     | email                    | type   | identifier   |
+      | participant1-displayname | participant1@example.tld | users  | participant1 |
+      |                          |                          | guests | guest1       |
     Then user "guest" leaves call "room" with 200 (v4)
+    And user "participant1" downloads call participants from "room" as "csv" with 200 (v4)
+      | name                     | email                    | type   | identifier   |
+      | participant1-displayname | participant1@example.tld | users  | participant1 |
+      |                          |                          | guests | guest1       |
+    And invoking occ with "user:setting participant1 settings email --delete"
     Then user "participant1" sees 1 peers in call "room" with 200 (v4)
     And user "guest" sees 1 peers in call "room" with 200 (v4)
     Then user "guest" leaves room "room" with 200 (v4)


### PR DESCRIPTION
…that had joined the call

### ☑️ Resolves

* Follow-up to #6098 and #13453 

## 🛠️ API Checklist

### 🚧 Tasks

- [x] Export the email addresses of email guests now that they are no longer the user id
- [x] Export all users that had joined the call

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
