### PR TITLE
fix: minor regression fixes

### DIFF
--- a/src/composables/useChatMentions.ts
+++ b/src/composables/useChatMentions.ts
@@ -52,7 +52,11 @@ function useChatMentionsComposable(token: Ref<string>): ReturnType {
 	 * @param isDarkTheme whether current theme is dark
 	 */
 	function parseMention(possibleMention: ChatMention, token: string, isDarkTheme: boolean): AutocompleteChatMention {
-		const chatMention: AutocompleteChatMention = { ...possibleMention, status: undefined }
+		const chatMention: AutocompleteChatMention = {
+			...possibleMention,
+			id: possibleMention.mentionId ?? possibleMention.id, // mentionId should be the default match since 'federation-v1'
+			status: undefined,
+		}
 
 		// Set icon for candidate mentions that are not for users.
 		if (possibleMention.source === 'calls') {
@@ -85,13 +89,11 @@ function useChatMentionsComposable(token: Ref<string>): ReturnType {
 			}
 		}
 
-		// mentionId should be the default match since 'federation-v1'
-		const id = possibleMention.mentionId ?? possibleMention.id
 		// caching the user id data for each possible mention
 		if (!userDataTokenMap.value[token]) {
 			Vue.set(userDataTokenMap.value, token, {})
 		}
-		Vue.set(userDataTokenMap.value[token], id, chatMention)
+		Vue.set(userDataTokenMap.value[token], chatMention.id, chatMention)
 
 		return chatMention
 	}

--- a/src/composables/useDocumentTitle.ts
+++ b/src/composables/useDocumentTitle.ts
@@ -43,7 +43,7 @@ export function useDocumentTitle() {
 		 * - a conversation has a different last message id then previously
 		 */
 		const shouldShowAsterisk = Object.keys(newLastMessageMap).some(token => {
-			return !savedLastMessageMap.value[token] // Conversation is new
+			return savedLastMessageMap.value[token] === undefined // Conversation is new
 				|| (savedLastMessageMap.value[token] !== newLastMessageMap[token] // Last message changed
 					&& newLastMessageMap[token] !== -1) // But is not from the current user
 		})


### PR DESCRIPTION
### ☑️ Resolves

* Fix #13799 / regression from #13672
  * don't show asterisk if lastMessageMap has 0 (federated conversation do not have last message id, so 0 will be stored in the map)
* Fix regression from #13778
  * autocomplete federated users mentions with mentionId (for federated users mentionId contains prefix, which should be passed)


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/user-attachments/assets/104a2258-a251-445f-9f7b-d2e0bcddefcb) | ![image](https://github.com/user-attachments/assets/0ee28418-ddc1-4902-b412-478b7c68cf54)


### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] ⛑️ Tests are included or not possible