### PR TITLE
fix: delegate message posting from NewMessage to parent components

### DIFF
--- a/src/components/BreakoutRoomsEditor/SendMessageDialog.vue
+++ b/src/components/BreakoutRoomsEditor/SendMessageDialog.vue
@@ -15,15 +15,14 @@
 			class="send-message-dialog"
 			:token="token"
 			:container="modalContainerId"
-			:aria-label="t('spreed', 'Post message')"
+			:aria-label="dialogTitle"
+			dialog
 			:broadcast="broadcast"
-			@sent="handleMessageSent"
-			@failure="handleMessageFailure" />
+			@submit="handleSubmit" />
 	</NcDialog>
 </template>
 
 <script>
-import { showError, showSuccess } from '@nextcloud/dialogs'
 import { t } from '@nextcloud/l10n'
 
 import NcDialog from '@nextcloud/vue/dist/Components/NcDialog.js'
@@ -40,7 +39,7 @@ export default {
 
 	props: {
 		/**
-		 * The Breakout room token.
+		 * The conversation token.
 		 */
 		token: {
 			type: String,
@@ -48,9 +47,9 @@ export default {
 		},
 
 		/**
-		 * The conversation display name
+		 * The dialog title
 		 */
-		displayName: {
+		dialogTitle: {
 			type: String,
 			default: '',
 		},
@@ -66,20 +65,12 @@ export default {
 		},
 	},
 
-	emits: ['close'],
+	emits: ['close', 'submit'],
 
 	data() {
 		return {
 			modalContainerId: null,
 		}
-	},
-
-	computed: {
-		dialogTitle() {
-			return this.broadcast
-				? t('spreed', 'Send a message to all breakout rooms')
-				: t('spreed', 'Send a message to "{roomName}"', { roomName: this.displayName })
-		},
 	},
 
 	mounted() {
@@ -92,16 +83,9 @@ export default {
 
 	methods: {
 		t,
-		handleMessageSent() {
-			showSuccess(this.broadcast
-				? t('spreed', 'The message was sent to all breakout rooms')
-				: t('spreed', 'The message was sent to "{roomName}"', { roomName: this.displayName }))
-			this.$emit('close')
-		},
 
-		handleMessageFailure() {
-			showError(t('spreed', 'The message could not be sent'))
-			this.$emit('close')
+		handleSubmit(event) {
+			this.$emit('submit', event)
 		},
 	},
 

--- a/src/components/NewMessage/NewMessage.vue
+++ b/src/components/NewMessage/NewMessage.vue
@@ -217,7 +217,6 @@ import BrowserStorage from '../../services/BrowserStorage.js'
 import { getTalkConfig, hasTalkFeature } from '../../services/CapabilitiesManager.ts'
 import { EventBus } from '../../services/EventBus.ts'
 import { shareFile } from '../../services/filesSharingServices.js'
-import { useBreakoutRoomsStore } from '../../stores/breakoutRooms.ts'
 import { useChatExtrasStore } from '../../stores/chatExtras.js'
 import { useSettingsStore } from '../../stores/settings.js'
 import { fetchClipboardContent } from '../../utils/clipboard.js'
@@ -269,6 +268,15 @@ export default {
 		},
 
 		/**
+		 * If component is used in a dialog, submit should emit an event to parent
+		 * instead of posting the message
+		 */
+		dialog: {
+			type: Boolean,
+			default: false,
+		},
+
+		/**
 		 * Broadcast messages to all breakout rooms of a given conversation.
 		 */
 		broadcast: {
@@ -293,7 +301,7 @@ export default {
 		},
 	},
 
-	emits: ['sent', 'failure', 'upload'],
+	emits: ['submit', 'dismiss'],
 
 	expose: ['focusInput'],
 
@@ -303,7 +311,6 @@ export default {
 		const { autoComplete, userData } = useChatMentions(token)
 		const { createTemporaryMessage } = useTemporaryMessage()
 		return {
-			breakoutRoomsStore: useBreakoutRoomsStore(),
 			chatExtrasStore: useChatExtrasStore(),
 			settingsStore: useSettingsStore(),
 			supportTypingStatus,
@@ -682,21 +689,7 @@ export default {
 			this.debouncedUpdateChatInput.clear()
 			this.chatExtrasStore.removeChatInput(this.token)
 
-			if (this.upload) {
-				// remove Quote component
-				this.chatExtrasStore.removeParentIdToReply(this.token)
-
-				if (this.$store.getters.getInitialisedUploads(this.currentUploadId).length) {
-					// If dialog contains files to upload, delegate sending
-					this.$emit('upload', { caption: this.text, options })
-					return
-				} else {
-					// Dismiss dialog, process as normal message sending otherwise
-					this.$emit('sent')
-				}
-			}
-
-			if (this.hasText) {
+			if (this.hasText || (this.dialog && this.upload)) {
 				const temporaryMessage = this.createTemporaryMessage({
 					message: this.text.trim(),
 					token: this.token,
@@ -707,8 +700,8 @@ export default {
 				// Also remove the message to be replied for this conversation
 				this.chatExtrasStore.removeParentIdToReply(this.token)
 
-				this.broadcast
-					? await this.broadcastMessage(this.token, temporaryMessage.message)
+				this.dialog
+					? await this.submitMessage(this.token, temporaryMessage, options)
 					: await this.postMessage(this.token, temporaryMessage, options)
 				this.resetTypingIndicator()
 			}
@@ -718,20 +711,14 @@ export default {
 		async postMessage(token, temporaryMessage, options) {
 			try {
 				await this.$store.dispatch('postNewMessage', { token, temporaryMessage, options })
-				this.$emit('sent')
-			} catch {
-				this.$emit('failure')
+			} catch (e) {
+				console.error(e)
 			}
 		},
 
 		// Broadcast message to all breakout rooms
-		async broadcastMessage(token, message) {
-			try {
-				await this.breakoutRoomsStore.broadcastMessageToBreakoutRooms({ token, message })
-				this.$emit('sent')
-			} catch {
-				this.$emit('failure')
-			}
+		async submitMessage(token, temporaryMessage, options) {
+			this.$emit('submit', { token, temporaryMessage, options })
 		},
 
 		async handleSubmitSpam(numberOfMessages) {
@@ -759,7 +746,7 @@ export default {
 				// refocus input as the user might want to type further
 				this.focusInput()
 			} catch {
-				this.$emit('failure')
+				this.$emit('dismiss')
 				showError(t('spreed', 'The message could not be edited'))
 			}
 		},

--- a/src/components/NewMessage/NewMessage.vue
+++ b/src/components/NewMessage/NewMessage.vue
@@ -34,11 +34,11 @@
 
 			<!-- Input area -->
 			<div class="new-message-form__input">
-				<NewMessageAbsenceInfo v-if="!upload && userAbsence"
+				<NewMessageAbsenceInfo v-if="!dialog && userAbsence"
 					:user-absence="userAbsence"
 					:display-name="conversation.displayName" />
 
-				<NewMessageChatSummary v-if="showChatSummary" />
+				<NewMessageChatSummary v-if="!dialog && showChatSummary" />
 
 				<div class="new-message-form__emoji-picker">
 					<NcEmojiPicker v-if="!disabled"
@@ -522,6 +522,8 @@ export default {
 		text(newValue) {
 			if (this.currentUploadId && !this.upload) {
 				return
+			} else if (this.dialog && this.broadcast) {
+				return
 			}
 			this.debouncedUpdateChatInput(newValue)
 		},
@@ -953,7 +955,7 @@ export default {
 		},
 
 		handleEditLastMessage(event) {
-			if (!this.canEditMessage || this.text || this.upload || this.broadcast || this.isRecordingAudio) {
+			if (!this.canEditMessage || this.text || this.dialog || this.isRecordingAudio) {
 				return
 			}
 

--- a/src/components/RightSidebar/BreakoutRooms/BreakoutRoomItem.vue
+++ b/src/components/RightSidebar/BreakoutRooms/BreakoutRoomItem.vue
@@ -46,8 +46,9 @@
 				</NcActions>
 				<!-- Send message dialog -->
 				<SendMessageDialog v-if="isDialogOpened"
-					:display-name="roomName"
+					:dialog-title="dialogTitle"
 					:token="roomToken"
+					@submit="sentMessageToRoom"
 					@close="isDialogOpened = false" />
 			</template>
 		</div>
@@ -65,7 +66,7 @@ import MenuDown from 'vue-material-design-icons/MenuDown.vue'
 import MenuRight from 'vue-material-design-icons/MenuRight.vue'
 import Send from 'vue-material-design-icons/Send.vue'
 
-import { showWarning } from '@nextcloud/dialogs'
+import { showSuccess, showWarning } from '@nextcloud/dialogs'
 import { t } from '@nextcloud/l10n'
 
 import NcActionButton from '@nextcloud/vue/dist/Components/NcActionButton.js'
@@ -143,6 +144,10 @@ export default {
 
 		roomName() {
 			return this.isParticipantsEditor ? this.name : this.breakoutRoom?.displayName
+		},
+
+		dialogTitle() {
+			return t('spreed', 'Send a message to "{roomName}"', { roomName: this.roomName })
 		},
 
 		roomToken() {
@@ -224,6 +229,16 @@ export default {
 
 		toggleParticipantsVisibility() {
 			this.showParticipants = !this.showParticipants
+		},
+
+		async sentMessageToRoom({ token, temporaryMessage, options }) {
+			try {
+				await this.$store.dispatch('postNewMessage', { token, temporaryMessage, options })
+				showSuccess(t('spreed', 'The message was sent to "{roomName}"', { roomName: this.roomName }))
+				this.isDialogOpened = false
+			} catch (e) {
+				console.error(e)
+			}
 		},
 	},
 }

--- a/src/components/RightSidebar/BreakoutRooms/BreakoutRoomItem.vue
+++ b/src/components/RightSidebar/BreakoutRooms/BreakoutRoomItem.vue
@@ -37,7 +37,7 @@
 						</template>
 						{{ t('spreed', 'Dismiss request for assistance') }}
 					</NcActionButton>
-					<NcActionButton @click="openSendMessageDialog">
+					<NcActionButton @click="isDialogOpened = true">
 						<template #icon>
 							<Send :size="16" />
 						</template>
@@ -48,7 +48,7 @@
 				<SendMessageDialog v-if="isDialogOpened"
 					:display-name="roomName"
 					:token="roomToken"
-					@close="closeSendMessageDialog" />
+					@close="isDialogOpened = false" />
 			</template>
 		</div>
 		<ul v-show="showParticipants">
@@ -195,13 +195,6 @@ export default {
 
 	methods: {
 		t,
-		openSendMessageDialog() {
-			this.isDialogOpened = true
-		},
-
-		closeSendMessageDialog() {
-			this.isDialogOpened = false
-		},
 
 		dismissRequestAssistance() {
 			this.breakoutRoomsStore.dismissRequestAssistance(this.roomToken)

--- a/src/components/RightSidebar/BreakoutRooms/BreakoutRoomsActions.vue
+++ b/src/components/RightSidebar/BreakoutRooms/BreakoutRoomsActions.vue
@@ -105,7 +105,9 @@
 		<!-- Send message dialog -->
 		<SendMessageDialog v-if="isSendMessageDialogOpened"
 			:token="mainToken"
+			:dialog-title="t('spreed', 'Send a message to all breakout rooms')"
 			:broadcast="true"
+			@submit="broadcastMessage"
 			@close="isSendMessageDialogOpened = false" />
 	</div>
 </template>
@@ -120,6 +122,7 @@ import Cog from 'vue-material-design-icons/Cog.vue'
 import Play from 'vue-material-design-icons/Play.vue'
 import Send from 'vue-material-design-icons/Send.vue'
 
+import { showSuccess } from '@nextcloud/dialogs'
 import { t } from '@nextcloud/l10n'
 
 import NcActionButton from '@nextcloud/vue/dist/Components/NcActionButton.js'
@@ -276,6 +279,12 @@ export default {
 				token: this.mainToken,
 			})
 		},
+
+		async broadcastMessage({ token, temporaryMessage, options }) {
+			await this.breakoutRoomsStore.broadcastMessageToBreakoutRooms({ token, message: temporaryMessage.message })
+			showSuccess(t('spreed', 'The message was sent to all breakout rooms'))
+			this.isSendMessageDialogOpened = false
+		}
 	},
 }
 </script>

--- a/src/components/RightSidebar/BreakoutRooms/BreakoutRoomsActions.vue
+++ b/src/components/RightSidebar/BreakoutRooms/BreakoutRoomsActions.vue
@@ -38,7 +38,7 @@
 				:aria-label="sendMessageLabel"
 				type="secondary"
 				:wide="true"
-				@click="openSendMessageDialog">
+				@click="isSendMessageDialogOpened = true">
 				<template #icon>
 					<Send :size="18" />
 				</template>
@@ -69,7 +69,7 @@
 			<NcActions v-if="canModerate" class="right">
 				<NcActionButton v-if="canModerate && isInBreakoutRoom"
 					:aria-label="sendMessageLabel"
-					@click="openSendMessageDialog">
+					@click="isSendMessageDialogOpened = true">
 					<template #icon>
 						<Send :size="20" />
 					</template>
@@ -103,10 +103,10 @@
 		</NcModal>
 
 		<!-- Send message dialog -->
-		<SendMessageDialog v-if="sendMessageDialogOpened"
+		<SendMessageDialog v-if="isSendMessageDialogOpened"
 			:token="mainToken"
 			:broadcast="true"
-			@close="closeSendMessageDialog" />
+			@close="isSendMessageDialogOpened = false" />
 	</div>
 </template>
 
@@ -181,14 +181,14 @@ export default {
 
 	setup() {
 		const showParticipantsEditor = ref(false)
-		const sendMessageDialogOpened = ref(false)
+		const isSendMessageDialogOpened = ref(false)
 		const dialogHeaderId = `breakout-rooms-actions-header-${useId()}`
 
 		return {
 			isInCall: useIsInCall(),
 			breakoutRoomsStore: useBreakoutRoomsStore(),
 			showParticipantsEditor,
-			sendMessageDialogOpened,
+			isSendMessageDialogOpened,
 			dialogHeaderId,
 		}
 	},
@@ -255,14 +255,6 @@ export default {
 
 		stopBreakoutRooms() {
 			this.breakoutRoomsStore.stopBreakoutRooms(this.mainToken)
-		},
-
-		openSendMessageDialog() {
-			this.sendMessageDialogOpened = true
-		},
-
-		closeSendMessageDialog() {
-			this.sendMessageDialogOpened = false
 		},
 
 		openParticipantsEditor() {


### PR DESCRIPTION
### ☑️ Resolves

  - remove breakoutRooms logic from reused SendMessageDialog


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

No visual changes

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required