### PR TITLE
Update Minimum Android Version for Nextcloud Talk

### DIFF
--- a/docs/user-requirements.md
+++ b/docs/user-requirements.md
@@ -24,5 +24,5 @@
 
 ## Mobile apps
 
-* Android: 6 or later
+* Android: 8 or later
 * iOS: 15 or later


### PR DESCRIPTION
The minimum supported Android version for Nextcloud Talk app is Android 8.


### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
