### PR TITLE
fix: introduce submenu logic in Conversation component

### DIFF
--- a/src/components/LeftSidebar/ConversationsList/Conversation.vue
+++ b/src/components/LeftSidebar/ConversationsList/Conversation.vue
@@ -25,69 +25,71 @@
 			<span v-html="conversationInformation" />
 		</template>
 		<template v-if="!isSearchResult" #actions>
-			<NcActionButton v-if="canFavorite"
-				key="toggle-favorite"
-				close-after-click
-				@click="toggleFavoriteConversation">
-				<template #icon>
-					<IconStar :size="16" :fill-color="!item.isFavorite ? '#FFCC00' : undefined" />
-				</template>
-				{{ labelFavorite }}
-			</NcActionButton>
+			<template v-if="submenu === null">
+				<NcActionButton v-if="canFavorite"
+					key="toggle-favorite"
+					close-after-click
+					@click="toggleFavoriteConversation">
+					<template #icon>
+						<IconStar :size="16" :fill-color="!item.isFavorite ? '#FFCC00' : undefined" />
+					</template>
+					{{ labelFavorite }}
+				</NcActionButton>
 
-			<NcActionButton key="copy-link" @click.stop="handleCopyLink">
-				<template #icon>
-					<IconContentCopy :size="16" />
-				</template>
-				{{ t('spreed', 'Copy link') }}
-			</NcActionButton>
+				<NcActionButton key="copy-link" @click.stop="handleCopyLink">
+					<template #icon>
+						<IconContentCopy :size="16" />
+					</template>
+					{{ t('spreed', 'Copy link') }}
+				</NcActionButton>
 
-			<NcActionButton key="toggle-read" close-after-click @click="toggleReadConversation">
-				<template #icon>
-					<IconEye v-if="item.unreadMessages" :size="16" />
-					<IconEyeOff v-else :size="16" />
-				</template>
-				{{ labelRead }}
-			</NcActionButton>
+				<NcActionButton key="toggle-read" close-after-click @click="toggleReadConversation">
+					<template #icon>
+						<IconEye v-if="item.unreadMessages" :size="16" />
+						<IconEyeOff v-else :size="16" />
+					</template>
+					{{ labelRead }}
+				</NcActionButton>
 
-			<NcActionButton key="show-settings" close-after-click @click="showConversationSettings">
-				<template #icon>
-					<IconCog :size="16" />
-				</template>
-				{{ t('spreed', 'Conversation settings') }}
-			</NcActionButton>
+				<NcActionButton key="show-settings" close-after-click @click="showConversationSettings">
+					<template #icon>
+						<IconCog :size="16" />
+					</template>
+					{{ t('spreed', 'Conversation settings') }}
+				</NcActionButton>
 
-			<NcActionButton v-if="supportsArchive"
-				key="toggle-archive"
-				close-after-click
-				@click="toggleArchiveConversation">
-				<template #icon>
-					<IconArchive v-if="!item.isArchived" :size="16" />
-					<IconArchiveOff v-else :size="16" />
-				</template>
-				{{ labelArchive }}
-			</NcActionButton>
+				<NcActionButton v-if="supportsArchive"
+					key="toggle-archive"
+					close-after-click
+					@click="toggleArchiveConversation">
+					<template #icon>
+						<IconArchive v-if="!item.isArchived" :size="16" />
+						<IconArchiveOff v-else :size="16" />
+					</template>
+					{{ labelArchive }}
+				</NcActionButton>
 
-			<NcActionButton v-if="item.canLeaveConversation"
-				key="leave-conversation"
-				close-after-click
-				@click="isLeaveDialogOpen = true">
-				<template #icon>
-					<IconExitToApp :size="16" />
-				</template>
-				{{ t('spreed', 'Leave conversation') }}
-			</NcActionButton>
+				<NcActionButton v-if="item.canLeaveConversation"
+					key="leave-conversation"
+					close-after-click
+					@click="isLeaveDialogOpen = true">
+					<template #icon>
+						<IconExitToApp :size="16" />
+					</template>
+					{{ t('spreed', 'Leave conversation') }}
+				</NcActionButton>
 
-			<NcActionButton v-if="item.canDeleteConversation"
-				key="delete-conversation"
-				close-after-click
-				class="critical"
-				@click="isDeleteDialogOpen = true">
-				<template #icon>
-					<IconDelete :size="16" />
-				</template>
-				{{ t('spreed', 'Delete conversation') }}
-			</NcActionButton>
+				<NcActionButton v-if="item.canDeleteConversation"
+					key="delete-conversation"
+					close-after-click
+					class="critical"
+					@click="isDeleteDialogOpen = true">
+					<template #icon>
+						<IconDelete :size="16" />
+					</template>
+					{{ t('spreed', 'Delete conversation') }}
+				</NcActionButton>
+			</template>
 		</template>
 
 		<template v-else-if="item.token" #actions>
@@ -231,6 +233,7 @@ export default {
 	emits: ['click'],
 
 	setup(props) {
+		const submenu = ref(null)
 		const isLeaveDialogOpen = ref(false)
 		const isDeleteDialogOpen = ref(false)
 		const { item, isSearchResult } = toRefs(props)
@@ -238,6 +241,7 @@ export default {
 
 		return {
 			supportsArchive,
+			submenu,
 			isLeaveDialogOpen,
 			isDeleteDialogOpen,
 			counterType,

--- a/src/components/LeftSidebar/ConversationsList/Conversation.vue
+++ b/src/components/LeftSidebar/ConversationsList/Conversation.vue
@@ -51,6 +51,15 @@
 					{{ labelRead }}
 				</NcActionButton>
 
+				<NcActionButton key="show-notifications"
+					is-menu
+					@click="submenu = 'notifications'">
+					<template #icon>
+						<IconBell :size="16" />
+					</template>
+					{{ t('spreed', 'Notifications') }}
+				</NcActionButton>
+
 				<NcActionButton key="show-settings" close-after-click @click="showConversationSettings">
 					<template #icon>
 						<IconCog :size="16" />
@@ -89,6 +98,17 @@
 					</template>
 					{{ t('spreed', 'Delete conversation') }}
 				</NcActionButton>
+			</template>
+			<template v-else-if="submenu === 'notifications'">
+				<NcActionButton :aria-label="t('spreed', 'Back')"
+					@click.stop="submenu = null">
+					<template #icon>
+						<IconArrowLeft :size="16" />
+					</template>
+					{{ t('spreed', 'Back') }}
+				</NcActionButton>
+
+				<NcActionSeparator />
 			</template>
 		</template>
 
@@ -155,7 +175,9 @@ import { isNavigationFailure, NavigationFailureType } from 'vue-router'
 
 import IconArchive from 'vue-material-design-icons/Archive.vue'
 import IconArchiveOff from 'vue-material-design-icons/ArchiveOff.vue'
+import IconArrowLeft from 'vue-material-design-icons/ArrowLeft.vue'
 import IconArrowRight from 'vue-material-design-icons/ArrowRight.vue'
+import IconBell from 'vue-material-design-icons/Bell.vue'
 import IconCog from 'vue-material-design-icons/Cog.vue'
 import IconContentCopy from 'vue-material-design-icons/ContentCopy.vue'
 import IconDelete from 'vue-material-design-icons/Delete.vue'
@@ -169,6 +191,7 @@ import { emit } from '@nextcloud/event-bus'
 import { t } from '@nextcloud/l10n'
 
 import NcActionButton from '@nextcloud/vue/dist/Components/NcActionButton.js'
+import NcActionSeparator from '@nextcloud/vue/dist/Components/NcActionSeparator.js'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import NcDialog from '@nextcloud/vue/dist/Components/NcDialog.js'
 import NcListItem from '@nextcloud/vue/dist/Components/NcListItem.js'
@@ -186,21 +209,24 @@ export default {
 	name: 'Conversation',
 
 	components: {
-		NcButton,
 		ConversationIcon,
-		NcActionButton,
-		NcDialog,
-		NcListItem,
 		IconArchive,
 		IconArchiveOff,
+		IconArrowLeft,
 		IconArrowRight,
+		IconBell,
 		IconCog,
 		IconContentCopy,
 		IconDelete,
 		IconExitToApp,
-		IconEyeOff,
 		IconEye,
+		IconEyeOff,
 		IconStar,
+		NcActionButton,
+		NcActionSeparator,
+		NcButton,
+		NcDialog,
+		NcListItem,
 	},
 
 	props: {

--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
@@ -67,7 +67,7 @@
 					<NcActionSeparator />
 
 					<NcActionButton v-if="supportReminders"
-						class="action--nested"
+						is-menu
 						@click.stop="submenu = 'reminder'">
 						<template #icon>
 							<AlarmIcon :size="20" />
@@ -753,16 +753,6 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.action--nested {
-	:deep(.action-button::after) {
-		content: " ";
-		width: 20px;
-		height: var(--default-clickable-area);
-		margin-left: auto;
-		background: no-repeat center var(--icon-triangle-e-dark);
-	}
-}
-
 .edit-timestamp :deep(.action-text__longtext-wrapper) {
 	padding: 0;
 }


### PR DESCRIPTION
### ☑️ Resolves

* Fix #13176
* No-whitespaces diff: https://github.com/nextcloud/spreed/pull/13862/files?w=1

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/user-attachments/assets/33d90469-7534-46bf-bd87-65a0f7938f67) | ![image](https://github.com/user-attachments/assets/7e83e6cf-7cee-4f05-b7a5-e67e56a1afd3)
no | ![image](https://github.com/user-attachments/assets/3c3d3694-2aa5-475a-8f90-09cc8ba72131)


### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Not risky to browser differences / client
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required