### PR TITLE
fix: minor regressions

### DIFF
--- a/src/components/LeftSidebar/ConversationsList/Conversation.vue
+++ b/src/components/LeftSidebar/ConversationsList/Conversation.vue
@@ -112,7 +112,7 @@
 
 				<NcActionButton v-for="level in notificationLevels"
 					:key="level.value"
-					:model-value="notificationLevel.toString()"
+					:model-value="notificationLevel"
 					:value="level.value.toString()"
 					type="radio"
 					@click="setNotificationLevel(level.value)">
@@ -125,8 +125,8 @@
 				<NcActionSeparator />
 
 				<NcActionButton type="checkbox"
-					:model-value="notifyCalls"
-					@click="setNotificationCalls(!notifyCalls)">
+					:model-value="notificationCalls"
+					@click="setNotificationCalls(!notificationCalls)">
 					<template #icon>
 						<IconPhoneRing :size="16" />
 					</template>
@@ -285,6 +285,8 @@ export default {
 					displayName: '',
 					isFavorite: false,
 					lastMessage: {},
+					notificationLevel: PARTICIPANT.NOTIFY.DEFAULT,
+					notificationCalls: PARTICIPANT.NOTIFY_CALLS.ON,
 					canDeleteConversation: false,
 					canLeaveConversation: false,
 				}
@@ -301,9 +303,6 @@ export default {
 		const { item, isSearchResult } = toRefs(props)
 		const { counterType, conversationInformation } = useConversationInfo({ item, isSearchResult })
 
-		const notificationLevel = ref(item.value.notificationLevel)
-		const notifyCalls = ref(item.value.notificationCalls === PARTICIPANT.NOTIFY_CALLS.ON)
-
 		return {
 			supportsArchive,
 			submenu,
@@ -312,8 +311,6 @@ export default {
 			counterType,
 			conversationInformation,
 			notificationLevels,
-			notificationLevel,
-			notifyCalls,
 		}
 	},
 
@@ -358,7 +355,15 @@ export default {
 
 		isActive() {
 			return this.$route?.params?.token === this.item.token
-		}
+		},
+
+		notificationLevel() {
+			return this.item.notificationLevel.toString()
+		},
+
+		notificationCalls() {
+			return this.item.notificationCalls === PARTICIPANT.NOTIFY_CALLS.ON
+		},
 	},
 
 	methods: {
@@ -449,7 +454,6 @@ export default {
 				token: this.item.token,
 				notificationLevel: level,
 			})
-			this.notificationLevel = level
 		},
 
 		/**
@@ -462,7 +466,6 @@ export default {
 				token: this.item.token,
 				notificationCalls: value ? PARTICIPANT.NOTIFY_CALLS.ON : PARTICIPANT.NOTIFY_CALLS.OFF,
 			})
-			this.notifyCalls = value
 		},
 
 		onClick() {

--- a/src/components/NewMessage/NewMessageUploadEditor.vue
+++ b/src/components/NewMessage/NewMessageUploadEditor.vue
@@ -209,12 +209,14 @@ export default {
 					options,
 				})
 			} else {
-				// Proceed as a normal message
-				try {
-					await this.$store.dispatch('discardUpload', this.currentUploadId)
-					await this.$store.dispatch('postNewMessage', { token, temporaryMessage, options })
-				} catch (e) {
-					console.error(e)
+				this.$store.dispatch('discardUpload', this.currentUploadId)
+				if (temporaryMessage.message.trim()) {
+					// Proceed as a normal message
+					try {
+						await this.$store.dispatch('postNewMessage', { token, temporaryMessage, options })
+					} catch (e) {
+						console.error(e)
+					}
 				}
 			}
 		},

--- a/src/composables/useChatMentions.ts
+++ b/src/composables/useChatMentions.ts
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { createSharedComposable } from '@vueuse/core'
 import type { ComputedRef, Ref } from 'vue'
 import Vue, { computed, ref } from 'vue'
 
@@ -34,13 +33,14 @@ type ReturnType = {
 	userData: ComputedRef<UserData>,
 }
 
+const userDataTokenMap = ref<UserDataTokenMap>({})
+
 /**
  * Provides autoComplete fallback and cached mention object for NcRichContenteditable
  * @param token conversation token
  */
-function useChatMentionsComposable(token: Ref<string>): ReturnType {
+export function useChatMentions(token: Ref<string>): ReturnType {
 	const isDarkTheme = useIsDarkTheme()
-	const userDataTokenMap = ref<UserDataTokenMap>({})
 	const userData = computed(() => {
 		return userDataTokenMap.value[token.value] ?? {}
 	})
@@ -136,9 +136,3 @@ function useChatMentionsComposable(token: Ref<string>): ReturnType {
 		userData,
 	}
 }
-
-/**
- * Shared composable to provide autoComplete fallback and cached mention object for NcRichContenteditable
- * @param token conversation token
- */
-export const useChatMentions = createSharedComposable(useChatMentionsComposable)


### PR DESCRIPTION
### ☑️ Resolves

Fix regressions from:

---

* https://github.com/nextcloud/spreed/pull/13778
* Shared composable is not called, if one instance of component already mounted.
* To test:
  * open chat 1 with userList1 and '@' mention someone to get list of mentions
  * start a call, end a call
  * switch to chat 2 with userList2 and '@' mention someone 
  * suggestions should be requested for chat 2, not chat 1

---

* https://github.com/nextcloud/spreed/pull/13862
* Conversation components should not keep internal value for notification level, but get it from store
* To test:
  * open chat 1 and conversation settings
  * set notification level settings to 'Off' and 'Off'
  * open three-dot menu for same conversation -> Notifications
  * settings should be 'Off' and 'Off', not what was at the mounting moment

---

* https://github.com/nextcloud/spreed/pull/13813
* NewMessageUploadEditor now sends message to the chat
* To test:
  * drag and drop file into the chat
  * remove file from dialog
  * submit
  * Modal should be dismissed, instead of trying to send message with 400 response

---

## 🖌️ UI Checklist

### 🚧 Tasks

- [ ] See reproduction steps

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Not risky to browser differences / client
- [ ] ⛑️ Tests are included or not possible