### PR TITLE
Move the message hover position

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -475,7 +475,7 @@ export default {
 
 	&__scroll {
 		position: absolute;
-		top: 0;
+		top: 20px;
 		right: 0;
 		width: fit-content;
 		height: 100%;


### PR DESCRIPTION
## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![message-hover-position-before](https://github.com/user-attachments/assets/29274c48-bf64-4f40-bda1-cc9f6baf16a3) | ![message-hover-position-after](https://github.com/user-attachments/assets/452df6a1-92f3-4584-9aa3-0a8ce98bae6a)



### 🏁 Checklist

- [X] 🌏 Tested with different browsers / clients:
  - [X] Chromium (Chrome / Edge / Opera / Brave)
  - [X] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [X] Not risky to browser differences / client

### Purpose

Being able to get the info from the check icon and send date even when hovering the message. Until now, if it's my first message, I can't be sure if it's the sent or read status.