### PR TITLE
fix: respect user changes of devices state when toggling it

### DIFF
--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -197,15 +197,15 @@ export default {
 		},
 	},
 
-	setup() {
+	setup(props) {
 		// For debug and screenshot purposes. Set to true to enable
 		const devMode = ref(false)
 		provide('CallView:devModeEnabled', devMode)
 		const screenshotMode = ref(false)
 		provide('CallView:screenshotModeEnabled', screenshotMode)
 		const settingsStore = useSettingsStore()
-		const startWithoutMediaEnabled = settingsStore.startWithoutMedia
-		if (startWithoutMediaEnabled) {
+		// If media settings was not used, we check the global config of default devices state here
+		if (!settingsStore.getShowMediaSettings(props.token) && settingsStore.startWithoutMedia) {
 			localMediaModel.disableAudio()
 			localMediaModel.disableVideo()
 		}

--- a/src/components/MediaSettings/MediaSettings.vue
+++ b/src/components/MediaSettings/MediaSettings.vue
@@ -438,8 +438,17 @@ export default {
 	watch: {
 		modal(newValue) {
 			if (newValue) {
-				this.audioOn = !BrowserStorage.getItem('audioDisabled_' + this.token)
-				this.videoOn = !BrowserStorage.getItem('videoDisabled_' + this.token)
+				if (this.settingsStore.startWithoutMedia) {
+					// Disable audio
+					this.audioOn = false
+					BrowserStorage.setItem('audioDisabled_' + this.token, 'true')
+					// Disable video
+					this.videoOn = false
+					BrowserStorage.setItem('videoDisabled_' + this.token, 'true')
+				} else {
+					this.audioOn = !BrowserStorage.getItem('audioDisabled_' + this.token)
+					this.videoOn = !BrowserStorage.getItem('videoDisabled_' + this.token)
+				}
 				this.silentCall = !!BrowserStorage.getItem('silentCall_' + this.token)
 
 				// Set virtual background depending on BrowserStorage's settings


### PR DESCRIPTION
### ☑️ Resolves

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before 
If you have default device state to be off and you toggle either audio or video on before joining the call, your changes won't be considered

 🏡 After
If you have default device state to be off and you toggle either audio or video on before joining the call, your changes will be considered

<!-- ☀️ Light theme | 🌑 Dark Theme -->


### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [x] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required

