### PR TITLE
feat(ooo): Add start and end dates to out-of-office view

### DIFF
--- a/src/components/NewMessage/NewMessageAbsenceInfo.vue
+++ b/src/components/NewMessage/NewMessageAbsenceInfo.vue
@@ -16,6 +16,7 @@
 				disable-tooltip />
 		</template>
 		<p class="absence-reminder__caption">{{ userAbsenceCaption }}</p>
+		<p v-if="userAbsencePeriod">{{ userAbsencePeriod }}</p>
 		<div v-if="userAbsence.replacementUserId" class="absence-reminder__replacement">
 			<!-- TRANSLATORS An acting person during the period of absence of the main contact -->
 			<p>{{ t('spreed','Replacement: ') }}</p>
@@ -42,6 +43,7 @@
 import ChevronUp from 'vue-material-design-icons/ChevronUp.vue'
 
 import { t } from '@nextcloud/l10n'
+import moment from '@nextcloud/moment'
 
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import NcNoteCard from '@nextcloud/vue/dist/Components/NcNoteCard.js'
@@ -104,6 +106,16 @@ export default {
 
 		userAbsenceMessage() {
 			return this.userAbsence.message || this.userAbsence.shortMessage
+		},
+
+		userAbsencePeriod() {
+			if (!this.userAbsence.startDate || !this.userAbsence.endDate) {
+				return ''
+			}
+			return t('spreed', 'Absence period: {startDate} - {endDate}', {
+				startDate: moment.unix(this.userAbsence.startDate).format('ll'),
+				endDate: moment.unix(this.userAbsence.endDate).format('ll'),
+			})
 		},
 	},
 

--- a/src/services/coreService.ts
+++ b/src/services/coreService.ts
@@ -8,7 +8,10 @@ import { generateOcsUrl } from '@nextcloud/router'
 
 import { getTalkConfig, hasTalkFeature } from './CapabilitiesManager.ts'
 import { SHARE } from '../constants.js'
-import type { TaskProcessingResponse } from '../types/index.ts'
+import type {
+	OutOfOfficeResponse,
+	TaskProcessingResponse,
+} from '../types/index.ts'
 
 const canInviteToFederation = hasTalkFeature('local', 'federation-v1')
 	&& getTalkConfig('local', 'federation', 'enabled')
@@ -61,8 +64,18 @@ const deleteTaskById = async function(id: number, options?: object): Promise<nul
 	return axios.delete(generateOcsUrl('taskprocessing/task/{id}', { id }), options)
 }
 
+/**
+ * Get absence information for a user (in a given 1-1 conversation).
+ *
+ * @param userId user id
+ */
+const getUserAbsence = async (userId: string): OutOfOfficeResponse => {
+	return axios.get(generateOcsUrl('/apps/dav/api/v1/outOfOffice/{userId}/now', { userId }))
+}
+
 export {
 	autocompleteQuery,
 	getTaskById,
 	deleteTaskById,
+	getUserAbsence,
 }

--- a/src/services/participantsService.js
+++ b/src/services/participantsService.js
@@ -271,15 +271,6 @@ const setTyping = (typing) => {
 	signalingSetTyping(typing)
 }
 
-/**
- * Get absence information for a user (in a given 1-1 conversation).
- *
- * @param {string} userId user id
- */
-const getUserAbsence = async (userId) => {
-	return axios.get(generateOcsUrl('/apps/dav/api/v1/outOfOffice/{userId}/now', { userId }))
-}
-
 export {
 	joinConversation,
 	rejoinConversation,
@@ -300,5 +291,4 @@ export {
 	setPermissions,
 	setSessionState,
 	setTyping,
-	getUserAbsence,
 }

--- a/src/stores/__tests__/chatExtras.spec.js
+++ b/src/stores/__tests__/chatExtras.spec.js
@@ -5,12 +5,12 @@
 import { setActivePinia, createPinia } from 'pinia'
 
 import BrowserStorage from '../../services/BrowserStorage.js'
+import { getUserAbsence } from '../../services/coreService.ts'
 import { EventBus } from '../../services/EventBus.ts'
-import { getUserAbsence } from '../../services/participantsService.js'
 import { generateOCSErrorResponse, generateOCSResponse } from '../../test-helpers.js'
 import { useChatExtrasStore } from '../chatExtras.js'
 
-jest.mock('../../services/participantsService', () => ({
+jest.mock('../../services/coreService', () => ({
 	getUserAbsence: jest.fn(),
 }))
 

--- a/src/stores/chatExtras.js
+++ b/src/stores/chatExtras.js
@@ -11,9 +11,9 @@ import { generateUrl, getBaseUrl } from '@nextcloud/router'
 
 import BrowserStorage from '../services/BrowserStorage.js'
 import { getUpcomingEvents } from '../services/conversationsService.js'
+import { getUserAbsence } from '../services/coreService.ts'
 import { EventBus } from '../services/EventBus.ts'
 import { summarizeChat } from '../services/messagesService.ts'
-import { getUserAbsence } from '../services/participantsService.js'
 import { parseSpecialSymbols, parseMentions } from '../utils/textParse.ts'
 
 /**
@@ -81,7 +81,7 @@ export const useChatExtrasStore = defineStore('chatExtras', {
 
 	actions: {
 		/**
-		 * Fetch an absence status for user and save to store
+		 * Get chat input for current conversation (from store or BrowserStorage)
 		 *
 		 * @param {string} token The conversation token
 		 * @return {string} The input text

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -214,3 +214,18 @@ export type TaskProcessingResponse = ApiResponseUnwrapped<{
 		endedAt: number
 	}
 }>
+
+// Out of office response
+// From https://docs.nextcloud.com/server/latest/developer_manual/client_apis/OCS/ocs-out-of-office-api.html
+export type OutOfOfficeResponse = ApiResponseUnwrapped<{
+	task: {
+		id: string,
+		userId: string,
+		startDate: number,
+		endDate: number,
+		shortMessage: string,
+		message: string,
+		replacementUserId?: string|null,
+		replacementUserDisplayName?: string|null,
+	}
+}>


### PR DESCRIPTION
### ☑️ Resolves

* Show absence period (start and end date)
  * Similar to https://github.com/nextcloud/talk-ios/pull/1899
* also add typings for out-of-office response
  * Ref: https://github.com/nextcloud/documentation/pull/12406


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

Eng locale | Other locale
-- | --
<img width="383" alt="image" src="https://github.com/user-attachments/assets/e5ad42a9-7685-493e-8286-a4767b9da115"> | <img width="381" alt="image" src="https://github.com/user-attachments/assets/34cba6df-6bc8-45a4-b37e-8b1bb1aa9d60">


### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required