### PR TITLE
fix(chat): Fix infinite loading spinner when someone cleared the history

### DIFF
--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -12,6 +12,7 @@ use OCA\Circles\CirclesManager;
 use OCA\Circles\Model\Circle;
 use OCA\Circles\Model\Member;
 use OCA\Talk\CachePrefix;
+use OCA\Talk\Chat\ChatManager;
 use OCA\Talk\Config;
 use OCA\Talk\Events\AAttendeeRemovedEvent;
 use OCA\Talk\Events\AParticipantModifiedEvent;
@@ -1409,7 +1410,7 @@ class ParticipantService {
 	public function resetChatDetails(Room $room): void {
 		$update = $this->connection->getQueryBuilder();
 		$update->update('talk_attendees')
-			->set('last_read_message', $update->createNamedParameter(0, IQueryBuilder::PARAM_INT))
+			->set('last_read_message', $update->createNamedParameter(ChatManager::UNREAD_FIRST_MESSAGE, IQueryBuilder::PARAM_INT))
 			->set('last_mention_message', $update->createNamedParameter(0, IQueryBuilder::PARAM_INT))
 			->set('last_mention_direct', $update->createNamedParameter(0, IQueryBuilder::PARAM_INT))
 			->set('last_attendee_activity', $update->createNamedParameter($this->timeFactory->getTime(), IQueryBuilder::PARAM_INT))

--- a/tests/integration/features/chat-1/delete.feature
+++ b/tests/integration/features/chat-1/delete.feature
@@ -214,7 +214,19 @@ Feature: chat/delete
       | room  | actorType | actorId      | actorDisplayName         | message   | messageParameters |
       | room1 | users     | participant2 | participant2-displayname | Message 2 | []                |
       | room1 | users     | participant1 | participant1-displayname | Message 1 | []                |
+    Then user "participant1" is participant of room "room1" (v4)
+      | unreadMessages | lastReadMessage |
+      | 1              | Message 1       |
+    Then user "participant2" is participant of room "room1" (v4)
+      | unreadMessages | lastReadMessage |
+      | 0              | Message 2       |
     And user "participant1" deletes chat history for room "room1" with 200
+    Then user "participant1" is participant of room "room1" (v4)
+      | unreadMessages | lastReadMessage      |
+      | 1              | FIRST_MESSAGE_UNREAD |
+    Then user "participant2" is participant of room "room1" (v4)
+      | unreadMessages | lastReadMessage      |
+      | 1              | FIRST_MESSAGE_UNREAD |
     Then user "participant1" sees the following messages in room "room1" with 200
       | room  | actorType | actorId      | actorDisplayName         | message   | messageParameters |
     Then user "participant1" sees the following system messages in room "room1" with 200 (v1)


### PR DESCRIPTION
## 🛠️ API Checklist
- Add users to a chat
- Purge history
- As user from step 1 try to load the chat

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
