### PR TITLE
fix(SIP): get dial-in info from signaling settings

### DIFF
--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -68,9 +68,7 @@
 				<InformationOutline :size="20" />
 			</template>
 			<SetGuestUsername v-if="!getUserId" />
-			<SipSettings v-if="showSIPSettings"
-				:meeting-id="conversation.token"
-				:attendee-pin="conversation.attendeePin" />
+			<SipSettings v-if="showSIPSettings" :conversation="conversation" />
 			<div v-if="!getUserId" id="app-settings">
 				<div id="app-settings-header">
 					<NcButton type="tertiary" @click="showSettings">

--- a/src/components/RightSidebar/SipSettings.vue
+++ b/src/components/RightSidebar/SipSettings.vue
@@ -3,51 +3,51 @@
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+
+import { t } from '@nextcloud/l10n'
+
+import { EventBus } from '../../services/EventBus.ts'
+import type { Conversation, SignalingSettings } from '../../types/index.ts'
+import { readableNumber } from '../../utils/readableNumber.ts'
+
+const props = defineProps<{
+	conversation: Conversation,
+}>()
+
+const dialInInfo = ref(t('spreed', 'Loading …'))
+const meetingId = computed(() => readableNumber(props.conversation.token))
+const attendeePin = computed(() => readableNumber(props.conversation.attendeePin))
+
+onMounted(() => {
+	EventBus.on('signaling-settings-updated', setDialInInfoFromSettings)
+})
+onBeforeUnmount(() => {
+	EventBus.off('signaling-settings-updated', setDialInInfoFromSettings)
+})
+
+/**
+ * @param payload emitted payload (array)
+ * @param payload."0" received signaling settings upon joining
+ */
+function setDialInInfoFromSettings([settings]: [SignalingSettings]) {
+	dialInInfo.value = settings.sipDialinInfo
+}
+</script>
+
 <template>
 	<div class="sip-settings">
 		<h3>{{ t('spreed', 'Dial-in information') }}</h3>
 		<p>{{ dialInInfo }}</p>
 
 		<h3>{{ t('spreed', 'Meeting ID') }}</h3>
-		<p>{{ readableNumber(meetingId) }}</p>
+		<p>{{ meetingId }}</p>
 
 		<h3>{{ t('spreed', 'Your PIN') }}</h3>
-		<p>{{ readableNumber(attendeePin) }}</p>
+		<p>{{ attendeePin }}</p>
 	</div>
 </template>
-
-<script>
-import { loadState } from '@nextcloud/initial-state'
-import { t } from '@nextcloud/l10n'
-
-import { readableNumber } from '../../utils/readableNumber.ts'
-
-export default {
-	name: 'SipSettings',
-
-	props: {
-		attendeePin: {
-			type: String,
-			required: true,
-		},
-		meetingId: {
-			type: String,
-			required: true,
-		},
-	},
-
-	data() {
-		return {
-			dialInInfo: loadState('spreed', 'sip_dialin_info'),
-		}
-	},
-
-	methods: {
-		t,
-		readableNumber,
-	}
-}
-</script>
 
 <style lang="scss" scoped>
 .sip-settings {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -55,6 +55,9 @@ export type Notification<T = Record<string, RichObject & Record<string, unknown>
 	actions: NotificationAction[],
 }
 
+// Signaling
+export type SignalingSettings = components['schemas']['SignalingSettings']
+
 // Conversations
 export type Conversation = components['schemas']['Room']
 

--- a/src/utils/signaling.js
+++ b/src/utils/signaling.js
@@ -124,6 +124,7 @@ Signaling.Base.prototype.setSettings = function(settings) {
 	}
 
 	this.settings = settings
+	this._trigger('settingsUpdated', [settings])
 
 	if (this._pendingUpdateSettingsPromise) {
 		this._pendingUpdateSettingsPromise.resolve()
@@ -364,6 +365,7 @@ function Internal(settings) {
 	}.bind(this), 500)
 
 	this._joinCallAgainOnceDisconnected = false
+	Signaling.Base.prototype._trigger.call(this, 'settingsUpdated', [settings])
 }
 
 Internal.prototype = new Signaling.Base()
@@ -611,6 +613,7 @@ function Standalone(settings, urls) {
 	this.joinedUsers = {}
 	this.rooms = []
 	this.connect()
+	Signaling.Base.prototype._trigger.call(this, 'settingsUpdated', [settings])
 }
 
 Standalone.prototype = new Signaling.Base()


### PR DESCRIPTION
### ☑️ Resolves

* Fix #13904
* Should be no visual changes

## 🖌️ UI Checklist

### 🚧 Tasks

- [x] Make `_trigger()` work when initially create from `Signaling`

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required