### PR TITLE
fix(Matterbridge): add a hint about Discord Channel ID usage

### DIFF
--- a/src/components/ConversationSettings/Matterbridge/matterbridgeTypes.ts
+++ b/src/components/ConversationSettings/Matterbridge/matterbridgeTypes.ts
@@ -211,7 +211,7 @@ export const matterbridgeTypes: Record<string, MatterbridgeType> = {
 			},
 			channel: {
 				type: 'text',
-				placeholder: t('spreed', 'Channel ID or name'),
+				placeholder: t('spreed', 'Channel ID (prefixed with "ID:") or name'),
 				icon: 'icon-group',
 			},
 		},


### PR DESCRIPTION
### ☑️ Resolves

* Fix #13877

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

![image](https://github.com/user-attachments/assets/32e0d8c8-f5ff-46b5-a05a-67ed06f73e00)


### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Not risky to browser differences / client