### PR TITLE
fix(summary): Don't add share button to failed summary notification

### DIFF
--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -395,7 +395,7 @@ class Notifier implements INotifier {
 					],
 				]);
 
-		if ($notification->getSubject() !== 'transcript_failed') {
+		if ($notification->getSubject() !== 'transcript_failed' && $notification->getSubject() !== 'summary_failed') {
 			$notification->addParsedAction($shareAction);
 			$notification->addParsedAction($dismissAction);
 		}


### PR DESCRIPTION
### ☑️ Resolves

🏚️ Before | 🏡 After
-- | --
![grafik](https://github.com/user-attachments/assets/d9771696-baf6-4e75-97d2-34c98253b37f) | ![grafik](https://github.com/user-attachments/assets/c98701c5-e0a4-45b6-8ad1-c60343bfeb57)

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
