### PR TITLE
fix(chat): Add a repair-step to handle the last-read-message=0 case

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -81,6 +81,7 @@
 		<post-migration>
 			<step>OCA\Talk\Migration\ClearResourceAccessCache</step>
 			<step>OCA\Talk\Migration\CacheUserDisplayNames</step>
+			<step>OCA\Talk\Migration\FixLastReadMessageZero</step>
 		</post-migration>
 	</repair-steps>
 

--- a/lib/Migration/FixLastReadMessageZero.php
+++ b/lib/Migration/FixLastReadMessageZero.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Talk\Migration;
+
+use OCA\Talk\Chat\ChatManager;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+
+/**
+ * In previous versions of Talk, the value 0 was used to mark a chat as
+ * completely unread. This meant that the next time a client/browser loaded the
+ * chat it would start all from the beginning. However, there were various
+ * issues over the time that made the frontend getting `null` or `undefined`
+ * into the wrong place and then accidentally loading 8 years of chat from the
+ * beginning. So it was agreed that the frontend manually blocks loading with
+ * last-read-message=0 and the special cases use -2 for this situation.
+ */
+class FixLastReadMessageZero implements IRepairStep {
+	public function __construct(
+		protected IDBConnection $connection,
+	) {
+	}
+
+	public function getName(): string {
+		return 'Fix the namespace in database tables';
+	}
+
+	public function run(IOutput $output): void {
+		$update = $this->connection->getQueryBuilder();
+		$update->update('talk_attendees')
+			/**
+			 * -2 is {@see ChatManager::UNREAD_FIRST_MESSAGE}, but we can't use
+			 * it in update code, because ChatManager is already loaded with the
+			 * previous implementation.
+			 */
+			->set('last_read_message', $update->createNamedParameter(-2, IQueryBuilder::PARAM_INT))
+			->where($update->expr()->eq('last_read_message', $update->createNamedParameter(0, IQueryBuilder::PARAM_INT)));
+		$updatedEntries = $update->executeStatement();
+		if ($updatedEntries) {
+			$output->info($updatedEntries . ' attendees have been updated.');
+		}
+	}
+}


### PR DESCRIPTION
### ☑️ Resolves

**Repair step doc block**
- In previous versions of Talk, the value 0 was used to mark a chat as
completely unread. This meant that the next time a client/browser loaded the
chat it would start all from the beginning. However, there were various
issues over the time that made the frontend getting `null` or `undefined`
into the wrong place and then accidentally loading 8 years of chat from the
beginning. So it was agreed that the frontend manually blocks loading with
last-read-message=0 and the special cases use -2 for this situation.

## 🛠️ API Checklist
### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
