### PR TITLE
fix: leave call from system message 'call_ended_everyone'

### DIFF
--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -1132,6 +1132,11 @@ const actions = {
 						&& message.actorType === context.getters.getActorType())) {
 					const callViewStore = useCallViewStore()
 					callViewStore.setCallHasJustEnded(message.timestamp)
+
+					context.dispatch('leaveCall', {
+						token,
+						participantIdentifier: context.getters.getParticipantIdentifier(),
+					})
 				}
 			}
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix hanging interface when call with a lot of participants ended for everyone
* Client wait for signaling update (`usersInCallChanged`) to leave by itself
* Additionaly, system message in chat is a good equivalent of the fact call has ended

How to test: 
1) apply patch to imitate delay in receiving a signal
```diff
diff --git a/src/utils/webrtc/webrtc.js b/src/utils/webrtc/webrtc.js
--- a/src/utils/webrtc/webrtc.js	(revision c4a63ff18ae6aa83acb0f54e14c7d91832fabee5)
+++ b/src/utils/webrtc/webrtc.js	(date 1733849256161)
@@ -473,10 +473,12 @@
 		&& localUserInCall) {
 		console.info('Force leaving the call for current participant')
 
+		setTimeout(() => {
 		store.dispatch('leaveCall', {
 			token: store.getters.getToken(),
 			participantIdentifier: store.getters.getParticipantIdentifier(),
 		})
+		}, 3000)
 
 		// Do not return to disconnect already from the other participants
 		// without waiting for another signaling event about changed users.
```
2) Join call as user1 + user2
3) As user1, end call for everyone

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Not risky to browser differences / client
- [ ] ⛑️ Tests are included or not possible