### PR TITLE
fix(call): Fix call notification when being pinged again after leavin…

### DIFF
--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -1653,6 +1653,18 @@ class ParticipantService {
 		if ($activeSince->getTimestamp() >= $row['last_joined_call']) {
 			return CallNotificationController::CASE_STILL_CURRENT;
 		}
+
+		// The participant had joined the call, but left again.
+		// In this case we should not ring any more, but clients stop
+		// pinging the endpoint 45s after receiving the push anyway.
+		// However, it is also possible that the participant was ringed
+		// again by a moderator after they had joined the call before.
+		// So if a client pings the endpoint after 45s initial ringing
+		// + 15 seconds for worst case push notification delay, we will
+		// again tell them to show the call notification.
+		if (($activeSince->getTimestamp() + 45 + 15) < $this->timeFactory->getTime()) {
+			return CallNotificationController::CASE_STILL_CURRENT;
+		}
 		return CallNotificationController::CASE_PARTICIPANT_JOINED;
 	}
 


### PR DESCRIPTION
…g a call


### ☑️ Resolves

Fix #13966

The participant had joined the call, but left again.
In this case we should not ring any more, but clients stop
pinging the endpoint 45s after receiving the push anyway.
However, it is also possible that the participant was ringed
again by a moderator after they had joined the call before.
So if a client pings the endpoint after 45s initial ringing
\+ 15 seconds for worst case push notification delay, we will
again tell them to show the call notification.


## 🛠️ API Checklist

### 🚧 Tasks

- I don't feel like making an integration test that waits 60+ seconds, so can't add a test for this.

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
