### PR TITLE
fix(guests): Don't force remove guests but leave it to the "purge logic"

### DIFF
--- a/lib/Controller/SignalingController.php
+++ b/lib/Controller/SignalingController.php
@@ -10,7 +10,6 @@ namespace OCA\Talk\Controller;
 
 use GuzzleHttp\Exception\ConnectException;
 use OCA\Talk\Config;
-use OCA\Talk\Events\AAttendeeRemovedEvent;
 use OCA\Talk\Events\BeforeSignalingResponseSentEvent;
 use OCA\Talk\Exceptions\ForbiddenException;
 use OCA\Talk\Exceptions\ParticipantNotFoundException;
@@ -924,15 +923,7 @@ class SignalingController extends OCSController {
 				$this->sessionService->updateLastPing($participant->getSession(), $this->timeFactory->getTime());
 			}
 		} elseif ($action === 'leave') {
-			// Guests are removed completely as they don't reuse attendees,
-			// but this is only true for guests that joined directly.
-			// Emails are retained as their PIN needs to remain and stay
-			// valid.
-			if ($participant->getAttendee()->getActorType() === Attendee::ACTOR_GUESTS) {
-				$this->participantService->removeAttendee($room, $participant, AAttendeeRemovedEvent::REASON_LEFT);
-			} else {
-				$this->participantService->leaveRoomAsSession($room, $participant);
-			}
+			$this->participantService->leaveRoomAsSession($room, $participant);
 		}
 
 		$this->logger->debug('Room request to "{action}" room {token} by actor {actorType}/{actorId}', [


### PR DESCRIPTION
Currently guests with a display name are not cleaned up, to keep their name for chat messages and other activity.

## 👣 Steps

1. Set up HPB
2. Create a conversation with public access
3. Join as a guest and set a name
4. Write a message
5. Reload the page
6. Check if the message from 4 still has the display name

x | Firefox | Chrome
---|---|---
Before | :white_check_mark: | :x:
After | :white_check_mark: |:white_check_mark: 

The main difference is that Firefox seems to keep the session and is still recognized as the previous guest, chrome creates a new attendees entry on each reload

## 🛠️ API Checklist

- As this is the reaction to a request from the HPB no suitable test can be written.

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [X] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
