### PR TITLE
fix: remove "formatted" from copy message button

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
@@ -97,7 +97,7 @@
 						<template #icon>
 							<ContentCopy :size="20" />
 						</template>
-						{{ t('spreed', 'Copy formatted message') }}
+						{{ t('spreed', 'Copy message') }}
 					</NcActionButton>
 					<NcActionButton close-after-click
 						@click.stop="handleCopyMessageLink">


### PR DESCRIPTION
### ☑️ Resolves

* Fix #13990

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/user-attachments/assets/7dfd6fd3-8412-44c4-a9a0-82e32c8aec69) | ![image](https://github.com/user-attachments/assets/098c2835-1128-439a-bb73-e544cfa556a8)
<!-- ☀️ Light theme | 🌑 Dark Theme -->


### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [X] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required

---