### PR TITLE
fix(navigation): Improve sort order of navigation entry

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -382,7 +382,7 @@ class Application extends App implements IBootstrap {
 				'name' => $l->t('Talk'),
 				'href' => $urlGenerator->linkToRouteAbsolute('spreed.Page.index'),
 				'icon' => $urlGenerator->imagePath(self::APP_ID, 'app.svg'),
-				'order' => 3,
+				'order' => -5,
 				'type' => $user instanceof IUser && !$config->isDisabledForUser($user) ? 'link' : 'hidden',
 			];
 		});


### PR DESCRIPTION
- Moving Talk before Files (`0`)
- Have to move Dashboard (`-1`) ever further down, as there is currently no gap: https://github.com/nextcloud/server/pull/49915

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
