### PR TITLE
fix(SpeakingWhileMutedWarner): show toast message 

### DIFF
--- a/src/components/CallView/shared/LocalAudioControlButton.vue
+++ b/src/components/CallView/shared/LocalAudioControlButton.vue
@@ -85,10 +85,6 @@ export default {
 				return t('spreed', 'No audio. Click to select device')
 			}
 
-			if (this.speakingWhileMutedNotification && !this.screenSharingMenuOpen) {
-				return this.speakingWhileMutedNotification
-			}
-
 			if (this.model.attributes.audioEnabled) {
 				return this.disableKeyboardShortcuts
 					? t('spreed', 'Mute audio')

--- a/src/components/TopBar/TopBarMediaControls.vue
+++ b/src/components/TopBar/TopBarMediaControls.vue
@@ -180,7 +180,6 @@ export default {
 
 	data() {
 		return {
-			speakingWhileMutedNotification: null,
 			screenSharingMenuOpen: false,
 			boundaryElement: document.querySelector('.main-view'),
 			mouseover: false,
@@ -398,7 +397,7 @@ export default {
 	},
 
 	mounted() {
-		this.speakingWhileMutedWarner = new SpeakingWhileMutedWarner(this.model, this)
+		this.speakingWhileMutedWarner = new SpeakingWhileMutedWarner(this.model)
 	},
 
 	beforeDestroy() {
@@ -407,10 +406,6 @@ export default {
 
 	methods: {
 		t,
-
-		setSpeakingWhileMutedNotification(message) {
-			this.speakingWhileMutedNotification = message
-		},
 
 		toggleVirtualBackground() {
 			if (this.model.attributes.virtualBackgroundEnabled) {


### PR DESCRIPTION
### ☑️ Resolves

* Fix regression from #9336 
  * Functionality was unclear, as passed via `this` and therefore it wasn't easy to track changes when moved to a new component

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

 🏡 After

![2024-12-18_20h42_25](https://github.com/user-attachments/assets/62ffc17a-5c9e-47c5-8305-77d1c7c1a983)

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
