### PR TITLE
fix(PresenterOverlay): limit overlay to video_promoted wrapper borders

### DIFF
--- a/src/components/CallView/shared/PresenterOverlay.vue
+++ b/src/components/CallView/shared/PresenterOverlay.vue
@@ -4,7 +4,7 @@
 -->
 <template>
 	<VueDraggableResizable v-if="!isCollapsed"
-		:key="presenterOverlaySize"
+		ref="presenterOverlay"
 		parent
 		class="presenter-overlay"
 		:resizable="false"
@@ -108,6 +108,7 @@ export default {
 
 	data() {
 		return {
+			resizeObserver: null,
 			presenterOverlaySize: 128,
 			isDragging: false,
 		}
@@ -115,16 +116,34 @@ export default {
 
 	mounted() {
 		window.addEventListener('resize', this.updateSize)
+
+		this.resizeObserver = new ResizeObserver(this.updateSize)
+		this.resizeObserver.observe(this.$refs.presenterOverlay.$el.parentElement)
 	},
 
 	beforeDestroy() {
 		window.removeEventListener('resize', this.updateSize)
+
+		if (this.resizeObserver) {
+			this.resizeObserver.disconnect()
+		}
 	},
 
 	methods: {
 		t,
 		updateSize() {
-			this.presenterOverlaySize = Math.min(Math.max(window.innerWidth * 0.1, 100), 242)
+			// Size should be proportionate to the screen share size
+			const newSize = Math.round(this.$refs.presenterOverlay.$el.parentElement.clientWidth * 0.1)
+			this.presenterOverlaySize = Math.min(Math.max(newSize, 100), 242)
+			// FIXME: inner method should be triggered to re-parent element
+			this.$refs.presenterOverlay.checkParentSize()
+			// FIXME: if it stays out of bounds (right and bottom), bring it back
+			if (this.$refs.presenterOverlay.right < 0) {
+				this.$refs.presenterOverlay.moveHorizontally(this.$refs.presenterOverlay.parentWidth - this.presenterOverlaySize)
+			}
+			if (this.$refs.presenterOverlay.bottom < 0) {
+				this.$refs.presenterOverlay.moveVertically(this.$refs.presenterOverlay.parentHeight - this.presenterOverlaySize)
+			}
 		},
 	},
 }

--- a/src/components/CallView/shared/PresenterOverlay.vue
+++ b/src/components/CallView/shared/PresenterOverlay.vue
@@ -6,6 +6,7 @@
 	<VueDraggableResizable v-if="!isCollapsed"
 		:key="presenterOverlaySize"
 		parent
+		class="presenter-overlay"
 		:resizable="false"
 		:h="presenterOverlaySize"
 		:w="presenterOverlaySize"
@@ -130,17 +131,22 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+.presenter-overlay {
+	position: absolute;
+	top: 0;
+	left: 0;
+}
+
 .presenter-overlay__video {
 	position: relative;
 	--max-size: 242px;
 	--min-size: 100px;
-	width: 10vw;
-	height: 10vw;
 	max-width: var(--max-size);
 	max-height: var(--max-size);
 	min-width: var(--min-size);
 	min-height: var(--min-size);
 	z-index: 10;
+	aspect-ratio: 1;
 
 	&:hover {
 		cursor: grab;

--- a/src/components/CallView/shared/Screen.vue
+++ b/src/components/CallView/shared/Screen.vue
@@ -165,6 +165,11 @@ export default {
 
 <style lang="scss" scoped>
 
+.screenContainer {
+	width: 100%;
+	height: 100%;
+}
+
 .screen {
 	width: 100%;
 	height: 100%;


### PR DESCRIPTION
### ☑️ Resolves

* Fix overlay positioning
  * Should not exceed `video__promoted` borders
  * Should be initially positioned absolute


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![2024-12-23_13h35_25](https://github.com/user-attachments/assets/46c1340f-747b-4c1f-9a22-21d007693603) | ![2024-12-23_13h33_48](https://github.com/user-attachments/assets/18f2c1df-ebf1-4c0b-b7fb-815f33ff05d9)

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required