### PR TITLE
fix(NewMessage): prevent placeholder content overflow

### DIFF
--- a/src/components/NewMessage/NewMessage.vue
+++ b/src/components/NewMessage/NewMessage.vue
@@ -1032,6 +1032,9 @@ export default {
 }
 
 .new-message-form {
+	--emoji-button-size: calc(var(--default-clickable-area) - var(--border-width-input-focused, 2px) * 2);
+	--emoji-button-radius: calc(var(--border-radius-element, calc(var(--button-size) / 2)) - var(--border-width-input-focused, 2px));
+
 	align-items: flex-end;
 	display: flex;
 	gap: var(--default-grid-baseline);
@@ -1047,8 +1050,8 @@ export default {
 
 		:deep(.button-vue) {
 			// Overwrite NcButton styles to fit inside NcRichContenteditable
-			--button-size: calc(var(--default-clickable-area) - var(--border-width-input-focused, 2px) * 2) !important;
-			--button-radius: calc(var(--border-radius-element, calc(var(--button-size) / 2)) - var(--border-width-input-focused, 2px)) !important;
+			--button-size: var(--emoji-button-size) !important;
+			--button-radius: var(--emoji-button-radius) !important;
 		}
 	}
 
@@ -1061,10 +1064,9 @@ export default {
 	// Override NcRichContenteditable styles
 	:deep(.rich-contenteditable__input) {
 		--contenteditable-space: calc((var(--default-clickable-area) - 1lh - 4px) / 2);
-		border-radius: var(--border-radius-element, calc(var(--default-clickable-area) / 2));
-		padding: var(--contenteditable-space);
-		padding-left: calc(var(--contenteditable-space) + var(--default-clickable-area));
-		max-height: 180px;
+		--contenteditable-block-offset: var(--contenteditable-space);
+		--contenteditable-inline-end-offset: var(--contenteditable-space);
+		--contenteditable-inline-start-offset: calc(var(--emoji-button-size) + var(--contenteditable-space));
 	}
 
 	&__quote {


### PR DESCRIPTION
### ☑️ Resolves

* Follow-up to library bump (8.22)
* border-radius is set to upstream component (8px);
* max-height is set to upstream component (5.5 * 34px ~ 180px);
* padding is set with CSS variables;

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/user-attachments/assets/43616bb2-0492-42de-845e-55d39391c0e0) | ![image](https://github.com/user-attachments/assets/3cec7df6-3758-44fc-8a6a-003829335903)

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Not risky to browser differences / client