### PR TITLE
fix(federation): Fix compatibility with Nextcloud 30 when using https

### DIFF
--- a/lib/Federation/CloudFederationProviderTalk.php
+++ b/lib/Federation/CloudFederationProviderTalk.php
@@ -642,15 +642,20 @@ class CloudFederationProviderTalk implements ICloudFederationProvider, ISignedCl
 		string $sharedSecret,
 		array $payload,
 	): string {
+		$remoteServerUrl = $payload['remoteServerUrl'];
+		if (str_starts_with($remoteServerUrl, 'https://')) {
+			$remoteServerUrl = substr($remoteServerUrl, strlen('https://'));
+		}
+
 		try {
-			$invite = $this->invitationMapper->getByRemoteServerAndAccessToken($payload['remoteServerUrl'], $sharedSecret);
+			$invite = $this->invitationMapper->getByRemoteServerAndAccessToken($remoteServerUrl, $sharedSecret);
 			return $invite->getInviterCloudId();
 		} catch (DoesNotExistException) {
 		}
 
 		$attendees = $this->attendeeMapper->getByAccessToken($sharedSecret);
 		foreach ($attendees as $attendee) {
-			if (str_ends_with($attendee->getActorId(), $payload['remoteServerUrl'])) {
+			if (str_ends_with($attendee->getActorId(), '@' . $remoteServerUrl)) {
 				return $attendee->getActorId();
 			}
 		}


### PR DESCRIPTION
## 🛠️ API Checklist

* we can not test this as tests are done with `http://` which always has the protocol
* But this prevented Nimisha from joining our federation room:
    - c.nc.c log: `Failed to send notification for share from https://s….nextcloud.com/, received status code 400`
    - s.nc.c log: `entry  does not contains @`

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
