### PR TITLE
Warn the admin when no High-performance backend is set up

### DIFF
--- a/docs/internal-signaling.md
+++ b/docs/internal-signaling.md
@@ -53,4 +53,4 @@ Todo
 
 ### External signaling API
 
-See [External signaling API](https://nextcloud-spreed-signaling.readthedocs.io/en/latest/) for the Signaling API of the High-Performance Backend.
+See [External signaling API](https://nextcloud-spreed-signaling.readthedocs.io/en/latest/) for the Signaling API of the High-performance backend.

--- a/lib/SetupCheck/Configuration.php
+++ b/lib/SetupCheck/Configuration.php
@@ -30,7 +30,7 @@ class Configuration implements ISetupCheck {
 	}
 
 	public function getName(): string {
-		return $this->l10n->t('Talk configuration');
+		return $this->l10n->t('Talk configuration values');
 	}
 
 	public function run(): SetupResult {

--- a/lib/SetupCheck/HighPerformanceBackend.php
+++ b/lib/SetupCheck/HighPerformanceBackend.php
@@ -34,7 +34,10 @@ class HighPerformanceBackend implements ISetupCheck {
 
 	public function run(): SetupResult {
 		if ($this->talkConfig->getSignalingMode() === Config::SIGNALING_INTERNAL) {
-			return SetupResult::success();
+			return SetupResult::error(
+				$this->l->t('No High-performance backend configured - Running Nextcloud Talk without the High-performance backend only scales for very small calls (max. 2-3 participants). Please set up the High-performance backend to ensure calls with multiple participants work seamlessly.'),
+				'https://portal.nextcloud.com/article/Nextcloud-Talk/High-Performance-Backend/Installation-of-Nextcloud-Talk-High-Performance-Backend',
+			);
 		}
 
 		if ($this->talkConfig->getSignalingMode() === Config::SIGNALING_CLUSTER_CONVERSATION) {

--- a/lib/SetupCheck/RecordingBackend.php
+++ b/lib/SetupCheck/RecordingBackend.php
@@ -33,7 +33,7 @@ class RecordingBackend implements ISetupCheck {
 			return SetupResult::success();
 		}
 		if (empty($this->talkConfig->getRecordingServers())) {
-			return SetupResult::success();
+			return SetupResult::info($this->l->t('No recording backend configured'));
 		}
 		return SetupResult::error($this->l->t('Using the recording backend requires a High-performance backend.'));
 	}

--- a/lib/SetupCheck/SIPConfiguration.php
+++ b/lib/SetupCheck/SIPConfiguration.php
@@ -33,7 +33,7 @@ class SIPConfiguration implements ISetupCheck {
 			return SetupResult::success();
 		}
 		if ($this->talkConfig->getSIPSharedSecret() === '' && $this->talkConfig->getDialInInfo() === '') {
-			return SetupResult::success();
+			return SetupResult::info($this->l->t('No SIP backend configured'));
 		}
 		return SetupResult::error($this->l->t('Using the SIP functionality requires a High-performance backend.'));
 	}

--- a/lib/TInitialState.php
+++ b/lib/TInitialState.php
@@ -45,7 +45,7 @@ trait TInitialState {
 		if ($signalingMode === Config::SIGNALING_CLUSTER_CONVERSATION
 			&& !$this->memcacheFactory->isAvailable()) {
 			throw new HintException(
-				'High Performance Back-end clustering is only supported with a distributed cache!'
+				'High-performance backend clustering is only supported with a distributed cache!'
 			);
 		}
 

--- a/src/components/AdminSettings/Federation.vue
+++ b/src/components/AdminSettings/Federation.vue
@@ -10,6 +10,10 @@
 			<small>{{ t('spreed', 'Beta') }}</small>
 		</h2>
 
+		<p class="settings-hint additional-top-margin">
+			{{ t('spreed', 'Federated chats and calls work already. Attachment handling is coming in a future version.') }}
+		</p>
+
 		<NcCheckboxRadioSwitch :model-value="isFederationEnabled"
 			:disabled="loading"
 			type="switch"

--- a/src/components/AdminSettings/HostedSignalingServer.vue
+++ b/src/components/AdminSettings/HostedSignalingServer.vue
@@ -8,7 +8,7 @@
 		id="hosted_signaling_server"
 		class="hosted-signaling section">
 		<h2>
-			{{ t('spreed', 'Hosted high-performance backend') }}
+			{{ t('spreed', 'Hosted High-performance backend') }}
 		</h2>
 
 		<p class="settings-hint">

--- a/src/components/AdminSettings/RecordingServers.vue
+++ b/src/components/AdminSettings/RecordingServers.vue
@@ -12,7 +12,7 @@
 
 		<NcNoteCard v-if="!showForm"
 			type="warning"
-			:text="t('spreed', 'Recording backend configuration is only possible with a high-performance backend.')" />
+			:text="t('spreed', 'Recording backend configuration is only possible with a High-performance backend.')" />
 
 		<template v-else>
 			<NcNoteCard v-if="showUploadLimitWarning" type="warning" :text="uploadLimitWarning" />

--- a/src/components/AdminSettings/SIPBridge.vue
+++ b/src/components/AdminSettings/SIPBridge.vue
@@ -9,7 +9,7 @@
 
 		<NcNoteCard v-if="!showForm"
 			type="warning"
-			:text="t('spreed', 'SIP configuration is only possible with a high-performance backend.')" />
+			:text="t('spreed', 'SIP configuration is only possible with a High-performance backend.')" />
 
 		<template v-else>
 			<NcCheckboxRadioSwitch v-model="dialOutEnabled"

--- a/src/components/AdminSettings/SignalingServers.vue
+++ b/src/components/AdminSettings/SignalingServers.vue
@@ -45,7 +45,7 @@
 				<span v-if="loading" class="icon icon-loading-small" />
 				<Plus v-else :size="20" />
 			</template>
-			{{ t('spreed', 'Add high-performance backend server') }}
+			{{ t('spreed', 'Add High-performance backend server') }}
 		</NcButton>
 
 		<NcPasswordField v-if="servers.length"
@@ -150,7 +150,7 @@ export default {
 
 			OCP.AppConfig.setValue('spreed', 'hide_signaling_warning', this.hideWarning ? 'yes' : 'no', {
 				success: () => {
-					showSuccess(t('spreed', 'Missing high-performance backend warning hidden'))
+					showSuccess(t('spreed', 'Missing High-performance backend warning hidden'))
 					this.loading = false
 					this.toggleSave()
 				},

--- a/src/components/AdminSettings/SignalingServers.vue
+++ b/src/components/AdminSettings/SignalingServers.vue
@@ -5,17 +5,22 @@
 
 <template>
 	<section id="signaling_server" class="signaling-servers section">
+		<NcNoteCard v-if="!servers.length"
+			type="error"
+			:heading="t('spreed', 'Nextcloud Talk setup not complete')"
+			:text="t('spreed', 'Install the High-performance backend to ensure calls with multiple participants work seamlessly.')" />
+
 		<h2>
 			{{ t('spreed', 'High-performance backend') }}
 		</h2>
 
 		<p class="settings-hint">
-			{{ t('spreed', 'An external signaling server should optionally be used for larger installations. Leave empty to use the internal signaling server.') }}
+			{{ t('spreed', 'The High-performance backend is required for calls and conversations with multiple participants. Without the backend, all participants have to upload their own video individually for each other participant, which will most likely cause connectivity issues and a high load on participating devices.') }}
 		</p>
 
-		<NcNoteCard v-if="!isCacheConfigured"
+		<NcNoteCard v-if="servers.length && !isCacheConfigured"
 			type="warning"
-			:text="t('spreed', 'It is highly recommended to set up a distributed cache when using Nextcloud Talk together with a High Performance Back-end.')" />
+			:text="t('spreed', 'It is highly recommended to set up a distributed cache when using Nextcloud Talk with a High-performance backend.')" />
 
 		<TransitionWrapper v-if="servers.length"
 			name="fade"
@@ -40,21 +45,11 @@
 				<span v-if="loading" class="icon icon-loading-small" />
 				<Plus v-else :size="20" />
 			</template>
-			{{ t('spreed', 'Add a new high-performance backend server') }}
+			{{ t('spreed', 'Add high-performance backend server') }}
 		</NcButton>
 
-		<template v-if="!servers.length">
-			<p class="settings-hint additional-top-margin">
-				{{ t('spreed', 'Please note that in calls with more than 4 participants without external signaling server, participants can experience connectivity issues and cause high load on participating devices.') }}
-			</p>
-			<NcCheckboxRadioSwitch v-model="hideWarning"
-				:disabled="loading"
-				@update:model-value="updateHideWarning">
-				{{ t('spreed', 'Don\'t warn about connectivity issues in calls with more than 4 participants') }}
-			</NcCheckboxRadioSwitch>
-		</template>
-
-		<NcPasswordField v-model="secret"
+		<NcPasswordField v-if="servers.length"
+			v-model="secret"
 			class="form__textfield additional-top-margin"
 			name="signaling_secret"
 			as-text
@@ -63,6 +58,18 @@
 			:label="t('spreed', 'Shared secret')"
 			label-visible
 			@update:model-value="debounceUpdateServers" />
+
+		<template v-if="!servers.length">
+			<NcNoteCard type="warning"
+				class="additional-top-margin"
+				:text="t('spreed', 'Please note that in calls with more than 2 participants without the High-performance backend, participants will most likely experience connectivity issues and cause high load on participating devices.')" />
+			<NcCheckboxRadioSwitch v-model="hideWarning"
+				:disabled="loading"
+				@update:model-value="updateHideWarning">
+				{{ t('spreed', 'Don\'t warn about connectivity issues in calls with more than 2 participants') }}
+			</NcCheckboxRadioSwitch>
+		</template>
+
 	</section>
 </template>
 
@@ -134,7 +141,7 @@ export default {
 		newServer() {
 			this.servers.push({
 				server: '',
-				verify: false,
+				verify: true,
 			})
 		},
 
@@ -186,6 +193,6 @@ export default {
 }
 
 .additional-top-margin {
-	margin-top: 10px;
+	margin-top: 35px !important;
 }
 </style>

--- a/src/views/AdminSettings.vue
+++ b/src/views/AdminSettings.vue
@@ -5,18 +5,18 @@
 
 <template>
 	<div>
+		<SignalingServers />
+		<HostedSignalingServer />
 		<GeneralSettings />
-		<MatterbridgeIntegration />
 		<AllowedGroups />
 		<Federation v-if="supportFederation" />
 		<BotsSettings />
 		<WebServerSetupChecks />
 		<StunServers />
 		<TurnServers />
-		<SignalingServers />
-		<HostedSignalingServer />
 		<RecordingServers />
 		<SIPBridge />
+		<MatterbridgeIntegration />
 	</div>
 </template>
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix part 2 of #14018 

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
**Beginning of the page**<br>
![Bildschirmfoto vom 2025-01-02 10-23-04](https://github.com/user-attachments/assets/c6906dd2-0c8b-4c23-87ff-e6733c0548ed)<br>**Somewhere later on the page**<br>![Bildschirmfoto vom 2025-01-02 10-23-15](https://github.com/user-attachments/assets/8c6c276e-0805-49f8-bcba-fba07d863a26) | **Beginning of the page**<br>![Bildschirmfoto vom 2025-01-02 10-22-39](https://github.com/user-attachments/assets/e992a81b-bf45-43f0-a423-5cc12043d23c)
![Bildschirmfoto vom 2025-01-02 09-34-49](https://github.com/user-attachments/assets/f3fc296a-d626-4899-981b-0e3e98f9081e) | ![Bildschirmfoto vom 2025-01-02 09-34-31](https://github.com/user-attachments/assets/6b3770df-4756-4b65-80f8-6585437a820b)
![Bildschirmfoto vom 2025-01-02 10-29-16](https://github.com/user-attachments/assets/099e7d8d-2f1a-46f2-8cf9-7a9a0ed24669) | ![grafik](https://github.com/user-attachments/assets/b92fbcbc-c250-41e9-b4df-deeb5a17d4f1)



## 🛠️ API Checklist

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
