### PR TITLE
test: Fix local integration tests with custom skeleton directory

### DIFF
--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -117,7 +117,7 @@ MAIN_SKELETON_DIR=$(occ_host config:system:get skeletondirectory)
 occ_host config:system:set overwrite.cli.url --value "http://localhost:8080/"
 if [[ "$MAIN_SKELETON_DIR" != "" ]]; then
 	echo "Resetting custom skeletondirectory so that tests pass"
-	${NEXTCLOUD_HOST_OCC} config:system:delete skeletondirectory
+	occ_host config:system:delete skeletondirectory
 fi
 
 REAL_FEDERATED_OVERWRITE_CLI_URL=$(occ_remote config:system:get overwrite.cli.url)


### PR DESCRIPTION
### ☑️ Resolves

```
System config value overwrite.cli.url set to string http://localhost:8080/
Resetting custom skeletondirectory so that tests pass
./run.sh: Zeile 120: config:system:delete: Befehl nicht gefunden
System config value overwrite.cli.url set to string http://localhost:8280/
```

And following that any integration test that checks files is failing.

- Follow up to the restructuring of https://github.com/nextcloud/spreed/pull/13967

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
