### PR TITLE
[stable30] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -258,12 +258,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "6f98dac2ddd6c42e605bc453e5328c0a61f75b8d"
+                "reference": "8f9f1452b564a514938d0e7361479bb9afacab27"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/6f98dac2ddd6c42e605bc453e5328c0a61f75b8d",
-                "reference": "6f98dac2ddd6c42e605bc453e5328c0a61f75b8d",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/8f9f1452b564a514938d0e7361479bb9afacab27",
+                "reference": "8f9f1452b564a514938d0e7361479bb9afacab27",
                 "shasum": ""
             },
             "require": {
@@ -294,7 +294,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable30"
             },
-            "time": "2024-11-29T00:46:59+00:00"
+            "time": "2025-01-08T10:49:45+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency