### PR TITLE
fix(moderator): Allow promoting self-joined participants to moderators

### DIFF
--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -2191,7 +2191,8 @@ class RoomController extends AEnvironmentAwareOCSController {
 			return new DataResponse(null, Http::STATUS_BAD_REQUEST);
 		}
 
-		if ($attendee->getParticipantType() === Participant::USER) {
+		if ($attendee->getParticipantType() === Participant::USER
+			|| $attendee->getParticipantType() === Participant::USER_SELF_JOINED) {
 			$newType = Participant::MODERATOR;
 		} elseif ($attendee->getParticipantType() === Participant::GUEST) {
 			$newType = Participant::GUEST_MODERATOR;

--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -140,7 +140,7 @@ class ParticipantService {
 		$attendee->setLastAttendeeActivity($this->timeFactory->getTime());
 		$this->attendeeMapper->update($attendee);
 
-		// XOR so we don't move the participant in and out when they are changed from moderator to owner or vice-versa
+		// XOR so we don't move the participant in and out when they are changed from moderator to owner or vice versa
 		if (($promotedToModerator xor $demotedFromModerator) && $room->getBreakoutRoomMode() !== BreakoutRoom::MODE_NOT_CONFIGURED) {
 			/** @var Manager $manager */
 			$manager = Server::get(Manager::class);

--- a/tests/integration/features/conversation-4/promotion-demotion.feature
+++ b/tests/integration/features/conversation-4/promotion-demotion.feature
@@ -71,6 +71,24 @@ Feature: conversation-2/promotion-demotion
       | users      | participant2 | SJLAVPM     |
       | users      | participant3 | SJAVPM      |
 
+  Scenario: Moderator promotes self-joined user
+    Given user "participant1" creates room "room" (v4)
+      | roomType | 3 |
+      | roomName | room |
+    And user "participant2" joins room "room" with 200 (v4)
+    And user "participant2" is participant of the following rooms (v4)
+      | id   | type | participantType |
+      | room | 3    | 5               |
+    And user "participant1" loads attendees attendee ids in room "room" (v4)
+    And user "participant1" promotes "participant2" in room "room" with 200 (v4)
+    And user "participant2" is participant of the following rooms (v4)
+      | id   | type | participantType |
+      | room | 3    | 2               |
+    When user "participant1" demotes "participant2" in room "room" with 200 (v4)
+    Then user "participant2" is participant of the following rooms (v4)
+      | id   | type | participantType |
+      | room | 3    | 3               |
+
   Scenario: User promotes/demotes moderator
     Given user "participant1" creates room "room" (v4)
       | roomType | 3 |


### PR DESCRIPTION
## 🛠️ API Checklist
- Create a public conversation
- Join as a second user
- With the first user try to promote the second one

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
