### PR TITLE
fix(i18n): replace 'e-mail' to 'email' in strings

### DIFF
--- a/src/components/AdminSettings/SignalingServers.vue
+++ b/src/components/AdminSettings/SignalingServers.vue
@@ -69,7 +69,6 @@
 				{{ t('spreed', 'Don\'t warn about connectivity issues in calls with more than 2 participants') }}
 			</NcCheckboxRadioSwitch>
 		</template>
-
 	</section>
 </template>
 

--- a/src/components/ConversationSettings/LobbySettings.vue
+++ b/src/components/ConversationSettings/LobbySettings.vue
@@ -56,7 +56,7 @@
 				<template #icon>
 					<IconFileUpload :size="20" />
 				</template>
-				{{ t('spreed', 'Import e-mail participants') }}
+				{{ t('spreed', 'Import email participants') }}
 			</NcButton>
 
 			<ImportEmailsDialog v-if="isImportEmailsDialogOpen"

--- a/src/components/NewConversationDialog/NewConversationContactsPage.vue
+++ b/src/components/NewConversationDialog/NewConversationContactsPage.vue
@@ -212,7 +212,7 @@ export default {
 				const response = await request({
 					searchText: this.searchText,
 					token: 'new',
-					forceTypes: [SHARE.TYPE.EMAIL], // e-mail guests are allowed directly after conversation creation
+					forceTypes: [SHARE.TYPE.EMAIL], // email guests are allowed directly after conversation creation
 				})
 
 				this.searchResults = response?.data?.ocs?.data || []

--- a/src/components/RightSidebar/Participants/Participant.spec.js
+++ b/src/components/RightSidebar/Participants/Participant.spec.js
@@ -259,7 +259,7 @@ describe('Participant.vue', () => {
 				}, result)
 			})
 
-		it('renders e-mail as status for e-mail guest', async () => {
+		it('renders email as status for email guest', async () => {
 			participant.actorType = ATTENDEE.ACTOR_TYPE.EMAILS
 			participant.participantType = PARTICIPANT.TYPE.GUEST
 			participant.invitedActorId = 'test@mail.com'

--- a/src/store/participantsStore.js
+++ b/src/store/participantsStore.js
@@ -978,7 +978,7 @@ const actions = {
 	 * @param {object} data - the wrapping object.
 	 * @param {string} data.token - conversation token.
 	 * @param {number} [data.attendeeId] - attendee id to target, or null for all.
-	 * @param {string} [data.actorId] - if attendee is provided, the actorId (e-mail) to show in the message.
+	 * @param {string} [data.actorId] - if attendee is provided, the actorId (email) to show in the message.
 	 */
 	async resendInvitations(_, { token, attendeeId, actorId }) {
 		if (attendeeId) {


### PR DESCRIPTION
### ☑️ Resolves

* Fix 'email' writing (as in other translated strings)

## 🖌️ UI Checklist

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team