### PR TITLE
Fix (known) false positives in connection warning

### DIFF
--- a/src/utils/webrtc/analyzers/AverageStatValue.js
+++ b/src/utils/webrtc/analyzers/AverageStatValue.js
@@ -20,7 +20,7 @@ const STAT_VALUE_TYPE = {
  *
  * The number of items to keep track of must be set when the AverageStatValue is
  * created. Once N items have been added adding a new one will discard the
- * oldest value. "hasEnoughData()" can be used to check if at least N items have
+ * oldest value. "hasEnoughData()" can be used to check if enough items have
  * been added already and the average is reliable.
  *
  * An RTCStatsReport value can be cumulative since the creation of the
@@ -34,6 +34,10 @@ const STAT_VALUE_TYPE = {
  * however, that the first value added to a cumulative AverageStatValue after
  * creating or resetting it will be treated as 0 in the average calculation,
  * as it will be the base from which the rest of relative values are calculated.
+ * Therefore, if the values added to an AverageStatValue are relative,
+ * "hasEnoughData()" will not return true until at least N items were added,
+ * but if the values are cumulative, it will not return true until at least N+1
+ * items were added.
  *
  * Besides the weighted average it is possible to "peek" the last value, either
  * the raw value that was added or the relative one after the conversion (which,
@@ -54,15 +58,25 @@ function AverageStatValue(count, type = STAT_VALUE_TYPE.CUMULATIVE, lastValueWei
 
 	this._rawValues = []
 	this._relativeValues = []
+
+	this._hasEnoughData = false
 }
 AverageStatValue.prototype = {
 
 	reset() {
 		this._rawValues = []
 		this._relativeValues = []
+
+		this._hasEnoughData = false
 	},
 
 	add(value) {
+		if ((this._type === STAT_VALUE_TYPE.CUMULATIVE && this._rawValues.length === this._count)
+			|| (this._type === STAT_VALUE_TYPE.RELATIVE && this._rawValues.length >= (this._count - 1))
+		) {
+			this._hasEnoughData = true
+		}
+
 		if (this._rawValues.length === this._count) {
 			this._rawValues.shift()
 			this._relativeValues.shift()
@@ -97,7 +111,7 @@ AverageStatValue.prototype = {
 	},
 
 	hasEnoughData() {
-		return this._rawValues.length === this._count
+		return this._hasEnoughData
 	},
 
 	getWeightedAverage() {

--- a/src/utils/webrtc/analyzers/AverageStatValue.spec.js
+++ b/src/utils/webrtc/analyzers/AverageStatValue.spec.js
@@ -25,17 +25,92 @@ describe('AverageStatValue', () => {
 		})
 	})
 
-	test('returns whether there are enough values for a meaningful calculation', () => {
-		const testValues = [100, 200, 150, 123, 30, 50, 22, 33]
-		const stat = new AverageStatValue(3, STAT_VALUE_TYPE.CUMULATIVE, 3)
-		const stat2 = new AverageStatValue(3, STAT_VALUE_TYPE.RELATIVE, 3)
+	describe('returns whether there are enough values for a meaningful calculation', () => {
+		test('after creating', () => {
+			const testValues = [100, 200, 150, 123, 30, 50, 22, 33]
+			const stat = new AverageStatValue(3, STAT_VALUE_TYPE.CUMULATIVE, 3)
+			const stat2 = new AverageStatValue(3, STAT_VALUE_TYPE.RELATIVE, 3)
 
-		testValues.forEach((val, index) => {
-			stat.add(val)
-			expect(stat.hasEnoughData()).toBe(index >= 2)
+			testValues.forEach((val, index) => {
+				stat.add(val)
+				expect(stat.hasEnoughData()).toBe(index >= 3)
 
-			stat2.add(val)
-			expect(stat2.hasEnoughData()).toBe(index >= 2)
+				stat2.add(val)
+				expect(stat2.hasEnoughData()).toBe(index >= 2)
+			})
+		})
+
+		describe('resetting', () => {
+			let stat
+			let stat2
+
+			const addValues = (values) => {
+				values.forEach(val => {
+					stat.add(val)
+					stat2.add(val)
+				})
+			}
+
+			beforeEach(() => {
+				stat = new AverageStatValue(3, STAT_VALUE_TYPE.CUMULATIVE, 3)
+				stat2 = new AverageStatValue(3, STAT_VALUE_TYPE.RELATIVE, 3)
+			})
+
+			test('before having enough values', () => {
+				addValues([100, 200])
+
+				expect(stat.hasEnoughData()).toBe(false)
+				expect(stat2.hasEnoughData()).toBe(false)
+
+				stat.reset()
+				stat2.reset()
+
+				expect(stat.hasEnoughData()).toBe(false)
+				expect(stat2.hasEnoughData()).toBe(false)
+
+				addValues([150, 123])
+
+				expect(stat.hasEnoughData()).toBe(false)
+				expect(stat2.hasEnoughData()).toBe(false)
+
+				addValues([30])
+
+				expect(stat.hasEnoughData()).toBe(false)
+				expect(stat2.hasEnoughData()).toBe(true)
+
+				addValues([50])
+
+				expect(stat.hasEnoughData()).toBe(true)
+				expect(stat2.hasEnoughData()).toBe(true)
+			})
+
+			test('after having enough values', () => {
+				addValues([100, 200, 150, 123])
+
+				expect(stat.hasEnoughData()).toBe(true)
+				expect(stat2.hasEnoughData()).toBe(true)
+
+				stat.reset()
+				stat2.reset()
+
+				expect(stat.hasEnoughData()).toBe(false)
+				expect(stat2.hasEnoughData()).toBe(false)
+
+				addValues([30, 50])
+
+				expect(stat.hasEnoughData()).toBe(false)
+				expect(stat2.hasEnoughData()).toBe(false)
+
+				addValues([22])
+
+				expect(stat.hasEnoughData()).toBe(false)
+				expect(stat2.hasEnoughData()).toBe(true)
+
+				addValues([33])
+
+				expect(stat.hasEnoughData()).toBe(true)
+				expect(stat2.hasEnoughData()).toBe(true)
+			})
 		})
 	})
 

--- a/src/utils/webrtc/analyzers/PeerConnectionAnalyzer.js
+++ b/src/utils/webrtc/analyzers/PeerConnectionAnalyzer.js
@@ -396,6 +396,19 @@ PeerConnectionAnalyzer.prototype = {
 				packetsLost[kind] = this._packetsLost[kind].getLastRawValue()
 			}
 
+			// In some (also strange) cases a newer stat may report a lower
+			// value than a previous one (it happens sometimes with garbage
+			// remote reports in simulcast video that cause the values to
+			// overflow, although it was also seen with a small value regression
+			// when enabling video). If that happens the stats are reset to
+			// prevent distorting the analysis with negative packet counts; note
+			// that in this case the previous value is not kept because it is
+			// not just an isolated wrong value, all the following stats
+			// increase from the regressed value.
+			if (packets[kind] >= 0 && packets[kind] < this._packets[kind].getLastRawValue()) {
+				this._resetStats(kind)
+			}
+
 			this._addStats(kind, packets[kind], packetsLost[kind], timestamp[kind], roundTripTime[kind])
 		}
 	},

--- a/src/utils/webrtc/analyzers/PeerConnectionAnalyzer.js
+++ b/src/utils/webrtc/analyzers/PeerConnectionAnalyzer.js
@@ -680,10 +680,13 @@ PeerConnectionAnalyzer.prototype = {
 		// quality to keep a smooth video, albeit on a lower resolution. Thus
 		// with a threshold of 10 packets issues can be detected too for videos,
 		// although only once they can not be further downscaled.
+		// Despite all of the above it has been observed that less than 10
+		// packets are sometimes sent without any connection problem (for
+		// example, when the background is blurred and the video quality is
+		// reduced due to being in a call with several participants), so for now
+		// it is only logged but not reported.
 		if (packetsPerSecond.getWeightedAverage() < 10) {
 			this._logStats(kind, 'Low packets per second: ' + packetsPerSecond.getWeightedAverage())
-
-			return CONNECTION_QUALITY.VERY_BAD
 		}
 
 		if (packetsLostRatioWeightedAverage > 0.3) {

--- a/src/utils/webrtc/analyzers/PeerConnectionAnalyzer.js
+++ b/src/utils/webrtc/analyzers/PeerConnectionAnalyzer.js
@@ -612,11 +612,19 @@ PeerConnectionAnalyzer.prototype = {
 	},
 
 	_calculateConnectionQuality(kind) {
+		const packets = this._packets[kind]
+		const packetsLost = this._packetsLost[kind]
+		const timestamps = this._timestamps[kind]
 		const packetsLostRatio = this._packetsLostRatio[kind]
 		const packetsPerSecond = this._packetsPerSecond[kind]
 		const roundTripTime = this._roundTripTime[kind]
 
-		if (!packetsLostRatio.hasEnoughData() || !packetsPerSecond.hasEnoughData()) {
+		// packetsLostRatio and packetsPerSecond are relative values, but they
+		// are calculated from cumulative values. Therefore, it is necessary to
+		// check if the cumulative values that are their source have enough data
+		// or not, rather than checking if the relative values themselves have
+		// enough data.
+		if (!packets.hasEnoughData() || !packetsLost.hasEnoughData() || !timestamps.hasEnoughData()) {
 			return CONNECTION_QUALITY.UNKNOWN
 		}
 

--- a/src/utils/webrtc/analyzers/PeerConnectionAnalyzer.js
+++ b/src/utils/webrtc/analyzers/PeerConnectionAnalyzer.js
@@ -466,12 +466,13 @@ PeerConnectionAnalyzer.prototype = {
 	 * The stats reported by the browser can sometimes stall for a second (or
 	 * more, but typically they stall only for a single report). When that
 	 * happens the stats are still reported, but with the same number of packets
-	 * as in the previous report (timestamp and round trip time are updated,
-	 * though). In that case the given stats are not added yet to the average
-	 * stats; they are kept on hold until more stats are provided by the browser
-	 * and it can be determined if the previous stats were stalled or not. If
-	 * they were stalled the previous and new stats are distributed, and if they
-	 * were not they are added as is to the average stats.
+	 * as in the previous report (timestamp and round trip time may be updated
+	 * or not, apparently depending on browser version and/or Janus version). In
+	 * that case the given stats are not added yet to the average stats; they
+	 * are kept on hold until more stats are provided by the browser and it can
+	 * be determined if the previous stats were stalled or not. If they were
+	 * stalled the previous and new stats are distributed, and if they were not
+	 * they are added as is to the average stats.
 	 *
 	 * @param {string} kind the type of the stats ("audio" or "video")
 	 * @param {number} packets the cumulative number of packets
@@ -536,6 +537,18 @@ PeerConnectionAnalyzer.prototype = {
 		let packetsLostTotal = 0
 		let timestampsTotal = 0
 
+		// If the first timestamp stalled it is assumed that all of them
+		// stalled and are thus evenly distributed based on the new timestamp.
+		if (this._stagedTimestamps[kind][0] === timestampsBase) {
+			const lastTimestamp = this._stagedTimestamps[kind][this._stagedTimestamps[kind].length - 1]
+			const timestampsTotalDifference = lastTimestamp - timestampsBase
+			const timestampsDelta = timestampsTotalDifference / this._stagedTimestamps[kind].length
+
+			for (let i = 0; i < this._stagedTimestamps[kind].length - 1; i++) {
+				this._stagedTimestamps[kind][i] += timestampsDelta * (i + 1)
+			}
+		}
+
 		for (let i = 0; i < this._stagedPackets[kind].length; i++) {
 			packetsTotal += (this._stagedPackets[kind][i] - packetsBase)
 			packetsBase = this._stagedPackets[kind][i]
@@ -562,7 +575,11 @@ PeerConnectionAnalyzer.prototype = {
 			packetsLostBase = this._stagedPacketsLost[kind][i]
 
 			// Timestamps and round trip time are not distributed, as those
-			// values are properly updated even if the stats are stalled.
+			// values may be properly updated even if the stats are stalled. In
+			// case they were not timestamps were already evenly distributed
+			// above, and round trip time can not be distributed, as it is
+			// already provided in the stats as a relative value rather than a
+			// cumulative one.
 		}
 	},
 

--- a/src/utils/webrtc/analyzers/PeerConnectionAnalyzer.spec.js
+++ b/src/utils/webrtc/analyzers/PeerConnectionAnalyzer.spec.js
@@ -1,0 +1,999 @@
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import {
+	CONNECTION_QUALITY,
+	PEER_DIRECTION,
+	PeerConnectionAnalyzer,
+} from './PeerConnectionAnalyzer.js'
+
+/**
+ * Helper function to create RTCPeerConnection mocks with just the attributes
+ * and methods used by PeerConnectionAnalyzer.
+ */
+function newRTCPeerConnection() {
+	/**
+	 * RTCPeerConnectionMock constructor.
+	 */
+	function RTCPeerConnectionMock() {
+		this._listeners = []
+		this.iceConnectionState = 'new'
+		this.connectionState = 'new'
+		this.getStats = jest.fn()
+		this.addEventListener = jest.fn((type, listener) => {
+			if (type !== 'iceconnectionstatechange' || type !== 'connectionstatechange') {
+				return
+			}
+
+			if (!Object.prototype.hasOwnProperty.call(this._listeners, type)) {
+				this._listeners[type] = [listener]
+			} else {
+				this._listeners[type].push(listener)
+			}
+		})
+		this.dispatchEvent = (event) => {
+			let listeners = this._listeners[event.type]
+			if (!listeners) {
+				return
+			}
+
+			listeners = listeners.slice(0)
+			for (let i = 0; i < listeners.length; i++) {
+				const listener = listeners[i]
+				listener.apply(listener, event)
+			}
+		}
+		this.removeEventListener = jest.fn((type, listener) => {
+			if (type !== 'iceconnectionstatechange' || type !== 'connectionstatechange') {
+				return
+			}
+
+			const listeners = this._listeners[type]
+			if (!listeners) {
+				return
+			}
+
+			const index = listeners.indexOf(listener)
+			if (index !== -1) {
+				listeners.splice(index, 1)
+			}
+		})
+		this._setIceConnectionState = (iceConnectionState) => {
+			this.iceConnectionState = iceConnectionState
+
+			this.dispatchEvent(new Event('iceconnectionstatechange'))
+		}
+		this._setConnectionState = (connectionState) => {
+			this.connectionState = connectionState
+
+			this.dispatchEvent(new Event('connectionstatechange'))
+		}
+	}
+	return new RTCPeerConnectionMock()
+}
+
+/**
+ * Helper function to create RTCStatsReport mocks with just the attributes and
+ * methods used by PeerConnectionAnalyzer.
+ *
+ * @param {Array} stats the values of the stats
+ */
+function newRTCStatsReport(stats) {
+	/**
+	 * RTCStatsReport constructor.
+	 */
+	function RTCStatsReport() {
+		this.values = () => {
+			return stats
+		}
+	}
+	return new RTCStatsReport()
+}
+
+describe('PeerConnectionAnalyzer', () => {
+
+	let peerConnectionAnalyzer
+	let peerConnection
+
+	beforeEach(() => {
+		jest.useFakeTimers()
+
+		peerConnectionAnalyzer = new PeerConnectionAnalyzer()
+
+		peerConnection = newRTCPeerConnection()
+	})
+
+	afterEach(() => {
+		peerConnectionAnalyzer.setPeerConnection(null)
+
+		jest.clearAllMocks()
+	})
+
+	describe('analyze sender connection', () => {
+
+		beforeEach(() => {
+			peerConnection._setIceConnectionState('connected')
+			peerConnection._setConnectionState('connected')
+		})
+
+		test.each([
+			['good quality', 'audio'],
+			['good quality', 'video'],
+		])('%s, %s', async (name, kind) => {
+			peerConnection.getStats
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 50, timestamp: 10000 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 50, timestamp: 10000, packetsLost: 0, roundTripTime: 0.1 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 100, timestamp: 11000 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 100, timestamp: 11000, packetsLost: 0, roundTripTime: 0.1 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 150, timestamp: 11950 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 150, timestamp: 11950, packetsLost: 0, roundTripTime: 0.1 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 200, timestamp: 13020 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 200, timestamp: 13020, packetsLost: 0, roundTripTime: 0.1 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 250, timestamp: 14010 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 250, timestamp: 14010, packetsLost: 0, roundTripTime: 0.1 },
+				]))
+				// A sixth report is needed for the initial calculation due to
+				// the first stats report being used as the base to calculate
+				// relative values of cumulative stats.
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 300, timestamp: 14985 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 300, timestamp: 14985, packetsLost: 0, roundTripTime: 0.1 },
+				]))
+
+			peerConnectionAnalyzer.setPeerConnection(peerConnection, PEER_DIRECTION.SENDER)
+
+			jest.advanceTimersByTime(6000)
+			// Force the promises returning the stats to be executed.
+			await null
+
+			expect(peerConnection.getStats).toHaveBeenCalledTimes(6)
+
+			if (kind === 'audio') {
+				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.GOOD)
+				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			} else {
+				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
+				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.GOOD)
+			}
+		})
+
+		test.each([
+			['medium quality', 'audio'],
+			['medium quality', 'video'],
+		])('%s, %s', async (name, kind) => {
+			peerConnection.getStats
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 50, timestamp: 10000 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 50, timestamp: 10000, packetsLost: 0, roundTripTime: 0.1 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 100, timestamp: 11000 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 95, timestamp: 11000, packetsLost: 5, roundTripTime: 0.1 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 150, timestamp: 11950 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 145, timestamp: 11950, packetsLost: 5, roundTripTime: 0.1 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 200, timestamp: 13020 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 185, timestamp: 13020, packetsLost: 15, roundTripTime: 0.1 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 250, timestamp: 14010 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 230, timestamp: 14010, packetsLost: 20, roundTripTime: 0.1 },
+				]))
+				// A sixth report is needed for the initial calculation due to
+				// the first stats report being used as the base to calculate
+				// relative values of cumulative stats.
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 300, timestamp: 14985 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 275, timestamp: 14985, packetsLost: 25, roundTripTime: 0.1 },
+				]))
+
+			peerConnectionAnalyzer.setPeerConnection(peerConnection, PEER_DIRECTION.SENDER)
+
+			jest.advanceTimersByTime(6000)
+			// Force the promises returning the stats to be executed.
+			await null
+
+			expect(peerConnection.getStats).toHaveBeenCalledTimes(6)
+
+			if (kind === 'audio') {
+				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.MEDIUM)
+				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			} else {
+				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
+				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.MEDIUM)
+			}
+		})
+
+		test.each([
+			['bad quality', 'audio'],
+			['bad quality', 'video'],
+		])('%s, %s', async (name, kind) => {
+			peerConnection.getStats
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 50, timestamp: 10000 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 50, timestamp: 10000, packetsLost: 0, roundTripTime: 0.1 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 100, timestamp: 11000 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 95, timestamp: 11000, packetsLost: 5, roundTripTime: 0.1 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 150, timestamp: 11950 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 145, timestamp: 11950, packetsLost: 5, roundTripTime: 0.1 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 200, timestamp: 13020 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 185, timestamp: 13020, packetsLost: 15, roundTripTime: 0.1 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 250, timestamp: 14010 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 220, timestamp: 14010, packetsLost: 30, roundTripTime: 0.1 },
+				]))
+				// A sixth report is needed for the initial calculation due to
+				// the first stats report being used as the base to calculate
+				// relative values of cumulative stats.
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 300, timestamp: 14985 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 255, timestamp: 14985, packetsLost: 45, roundTripTime: 0.1 },
+				]))
+
+			peerConnectionAnalyzer.setPeerConnection(peerConnection, PEER_DIRECTION.SENDER)
+
+			jest.advanceTimersByTime(6000)
+			// Force the promises returning the stats to be executed.
+			await null
+
+			expect(peerConnection.getStats).toHaveBeenCalledTimes(6)
+
+			if (kind === 'audio') {
+				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.BAD)
+				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			} else {
+				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
+				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.BAD)
+			}
+		})
+
+		test.each([
+			['very bad quality', 'audio'],
+			['very bad quality', 'video'],
+		])('%s, %s', async (name, kind) => {
+			peerConnection.getStats
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 50, timestamp: 10000 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 45, timestamp: 10000, packetsLost: 5, roundTripTime: 0.1 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 100, timestamp: 11000 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 90, timestamp: 11000, packetsLost: 10, roundTripTime: 0.1 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 150, timestamp: 11950 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 130, timestamp: 11950, packetsLost: 20, roundTripTime: 0.1 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 200, timestamp: 13020 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 160, timestamp: 13020, packetsLost: 40, roundTripTime: 0.1 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 250, timestamp: 14010 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 190, timestamp: 14010, packetsLost: 60, roundTripTime: 0.1 },
+				]))
+				// A sixth report is needed for the initial calculation due to
+				// the first stats report being used as the base to calculate
+				// relative values of cumulative stats.
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 300, timestamp: 14985 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 225, timestamp: 14985, packetsLost: 75, roundTripTime: 0.1 },
+				]))
+
+			peerConnectionAnalyzer.setPeerConnection(peerConnection, PEER_DIRECTION.SENDER)
+
+			jest.advanceTimersByTime(6000)
+			// Force the promises returning the stats to be executed.
+			await null
+
+			expect(peerConnection.getStats).toHaveBeenCalledTimes(6)
+
+			if (kind === 'audio') {
+				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.VERY_BAD)
+				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			} else {
+				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
+				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.VERY_BAD)
+			}
+		})
+
+		test.each([
+			['very bad quality due to low packets', 'audio'],
+			['very bad quality due to low packets', 'video'],
+		])('%s, %s', async (name, kind) => {
+			peerConnection.getStats
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 5, timestamp: 10000 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 5, timestamp: 10000, packetsLost: 0, roundTripTime: 0.1 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 10, timestamp: 11000 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 10, timestamp: 11000, packetsLost: 0, roundTripTime: 0.1 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 15, timestamp: 11950 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 15, timestamp: 11950, packetsLost: 0, roundTripTime: 0.1 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 20, timestamp: 13020 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 20, timestamp: 13020, packetsLost: 0, roundTripTime: 0.1 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 25, timestamp: 14010 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 25, timestamp: 14010, packetsLost: 0, roundTripTime: 0.1 },
+				]))
+				// A sixth report is needed for the initial calculation due to
+				// the first stats report being used as the base to calculate
+				// relative values of cumulative stats.
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 30, timestamp: 14985 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 30, timestamp: 14985, packetsLost: 0, roundTripTime: 0.1 },
+				]))
+
+			peerConnectionAnalyzer.setPeerConnection(peerConnection, PEER_DIRECTION.SENDER)
+
+			jest.advanceTimersByTime(6000)
+			// Force the promises returning the stats to be executed.
+			await null
+
+			expect(peerConnection.getStats).toHaveBeenCalledTimes(6)
+
+			if (kind === 'audio') {
+				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.VERY_BAD)
+				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			} else {
+				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
+				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.VERY_BAD)
+			}
+		})
+
+		test.each([
+			['very bad quality due to high round trip time', 'audio'],
+			['very bad quality due to high round trip time', 'video'],
+		])('%s, %s', async (name, kind) => {
+			peerConnection.getStats
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 50, timestamp: 10000 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 50, timestamp: 10000, packetsLost: 0, roundTripTime: 1.5 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 100, timestamp: 11000 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 100, timestamp: 11000, packetsLost: 0, roundTripTime: 1.4 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 150, timestamp: 11950 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 150, timestamp: 11950, packetsLost: 0, roundTripTime: 1.5 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 200, timestamp: 13020 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 200, timestamp: 13020, packetsLost: 0, roundTripTime: 1.6 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 250, timestamp: 14010 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 250, timestamp: 14010, packetsLost: 0, roundTripTime: 1.5 },
+				]))
+				// A sixth report is needed for the initial calculation due to
+				// the first stats report being used as the base to calculate
+				// relative values of cumulative stats.
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 300, timestamp: 14985 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 300, timestamp: 14985, packetsLost: 0, roundTripTime: 1.5 },
+				]))
+
+			peerConnectionAnalyzer.setPeerConnection(peerConnection, PEER_DIRECTION.SENDER)
+
+			jest.advanceTimersByTime(6000)
+			// Force the promises returning the stats to be executed.
+			await null
+
+			expect(peerConnection.getStats).toHaveBeenCalledTimes(6)
+
+			if (kind === 'audio') {
+				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.VERY_BAD)
+				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			} else {
+				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
+				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.VERY_BAD)
+			}
+		})
+
+		test.each([
+			['no transmitted data due to full packet loss', 'audio'],
+			['no transmitted data due to full packet loss', 'video'],
+		])('%s, %s', async (name, kind) => {
+			peerConnection.getStats
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 50, timestamp: 10000 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 50, timestamp: 10000, packetsLost: 0, roundTripTime: 0.1 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 100, timestamp: 11000 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 50, timestamp: 11000, packetsLost: 50, roundTripTime: 0.1 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 150, timestamp: 11950 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 50, timestamp: 11950, packetsLost: 100, roundTripTime: 0.1 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 200, timestamp: 13020 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 50, timestamp: 13020, packetsLost: 150, roundTripTime: 0.1 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 250, timestamp: 14010 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 50, timestamp: 14010, packetsLost: 200, roundTripTime: 0.1 },
+				]))
+				// A sixth report is needed for the initial calculation due to
+				// the first stats report being used as the base to calculate
+				// relative values of cumulative stats.
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 300, timestamp: 14985 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 50, timestamp: 14985, packetsLost: 250, roundTripTime: 0.1 },
+				]))
+
+			peerConnectionAnalyzer.setPeerConnection(peerConnection, PEER_DIRECTION.SENDER)
+
+			jest.advanceTimersByTime(6000)
+			// Force the promises returning the stats to be executed.
+			await null
+
+			expect(peerConnection.getStats).toHaveBeenCalledTimes(6)
+
+			if (kind === 'audio') {
+				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.NO_TRANSMITTED_DATA)
+				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			} else {
+				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
+				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.NO_TRANSMITTED_DATA)
+			}
+		})
+
+		test.each([
+			['no transmitted data due to packets not updated', 'audio'],
+			['no transmitted data due to packets not updated', 'video'],
+		])('%s, %s', async (name, kind) => {
+			peerConnection.getStats
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 50, timestamp: 10000 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 50, timestamp: 10000, packetsLost: 0, roundTripTime: 0.1 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 100, timestamp: 11000 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 100, timestamp: 11000, packetsLost: 0, roundTripTime: 0.1 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 150, timestamp: 11950 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 150, timestamp: 11950, packetsLost: 0, roundTripTime: 0.1 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 150, timestamp: 13020 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 150, timestamp: 13020, packetsLost: 0, roundTripTime: 0.1 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 150, timestamp: 14010 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 150, timestamp: 14010, packetsLost: 0, roundTripTime: 0.1 },
+				]))
+				// A sixth report is needed for the initial calculation due to
+				// the first stats report being used as the base to calculate
+				// relative values of cumulative stats.
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 150, timestamp: 14985 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 150, timestamp: 14985, packetsLost: 0, roundTripTime: 0.1 },
+				]))
+				// When the packets do not increase the analysis is kept on hold
+				// until more stat reports are received, as it is not possible
+				// to know if the packets were not transmitted or the stats
+				// temporarily stalled.
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 150, timestamp: 16010 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 150, timestamp: 16010, packetsLost: 0, roundTripTime: 0.1 },
+				]))
+
+			peerConnectionAnalyzer.setPeerConnection(peerConnection, PEER_DIRECTION.SENDER)
+
+			jest.advanceTimersByTime(7000)
+			// Force the promises returning the stats to be executed.
+			await null
+
+			expect(peerConnection.getStats).toHaveBeenCalledTimes(7)
+
+			if (kind === 'audio') {
+				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.NO_TRANSMITTED_DATA)
+				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			} else {
+				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
+				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.NO_TRANSMITTED_DATA)
+			}
+		})
+
+		test.each([
+			['stats stalled for a second', 'audio'],
+			['stats stalled for a second', 'video'],
+		])('%s, %s', async (name, kind) => {
+			peerConnection.getStats
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 50, timestamp: 10000 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 50, timestamp: 10000, packetsLost: 0, roundTripTime: 0.1 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 100, timestamp: 11000 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 100, timestamp: 11000, packetsLost: 0, roundTripTime: 0.1 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 150, timestamp: 11950 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 150, timestamp: 11950, packetsLost: 0, roundTripTime: 0.1 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 200, timestamp: 13020 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 200, timestamp: 13020, packetsLost: 0, roundTripTime: 0.1 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 250, timestamp: 14010 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 250, timestamp: 14010, packetsLost: 0, roundTripTime: 0.1 },
+				]))
+				// A sixth report is needed for the initial calculation due to
+				// the first stats report being used as the base to calculate
+				// relative values of cumulative stats.
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 250, timestamp: 14985 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 250, timestamp: 14985, packetsLost: 0, roundTripTime: 0.1 },
+				]))
+				// When the packets do not increase the analysis is kept on hold
+				// until more stat reports are received, as it is not possible
+				// to know if the packets were not transmitted or the stats
+				// temporarily stalled.
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 350, timestamp: 16010 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 350, timestamp: 16010, packetsLost: 0, roundTripTime: 0.1 },
+				]))
+
+			peerConnectionAnalyzer.setPeerConnection(peerConnection, PEER_DIRECTION.SENDER)
+
+			jest.advanceTimersByTime(7000)
+			// Force the promises returning the stats to be executed.
+			await null
+
+			expect(peerConnection.getStats).toHaveBeenCalledTimes(7)
+
+			if (kind === 'audio') {
+				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.GOOD)
+				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			} else {
+				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
+				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.GOOD)
+			}
+		})
+
+		test.each([
+			['no transmitted data for two seconds', 'audio'],
+			['no transmitted data for two seconds', 'video'],
+		])('%s, %s', async (name, kind) => {
+			peerConnection.getStats
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 50, timestamp: 10000 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 50, timestamp: 10000, packetsLost: 0, roundTripTime: 0.1 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 100, timestamp: 11000 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 100, timestamp: 11000, packetsLost: 0, roundTripTime: 0.1 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 150, timestamp: 11950 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 150, timestamp: 11950, packetsLost: 0, roundTripTime: 0.1 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 200, timestamp: 13020 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 200, timestamp: 13020, packetsLost: 0, roundTripTime: 0.1 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 250, timestamp: 14010 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 250, timestamp: 14010, packetsLost: 0, roundTripTime: 0.1 },
+				]))
+				// A sixth report is needed for the initial calculation due to
+				// the first stats report being used as the base to calculate
+				// relative values of cumulative stats.
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 250, timestamp: 14985 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 250, timestamp: 14985, packetsLost: 0, roundTripTime: 0.1 },
+				]))
+				// When the packets do not increase the analysis is kept on hold
+				// until more stat reports are received, as it is not possible
+				// to know if the packets were not transmitted or the stats
+				// temporarily stalled. But if the packets are not updated three
+				// times in a row it is assumed that the packets were not
+				// transmitted.
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 250, timestamp: 16010 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 250, timestamp: 16010, packetsLost: 0, roundTripTime: 0.1 },
+				]))
+
+			peerConnectionAnalyzer.setPeerConnection(peerConnection, PEER_DIRECTION.SENDER)
+
+			jest.advanceTimersByTime(7000)
+			// Force the promises returning the stats to be executed.
+			await null
+
+			expect(peerConnection.getStats).toHaveBeenCalledTimes(7)
+
+			if (kind === 'audio') {
+				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.VERY_BAD)
+				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			} else {
+				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
+				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.VERY_BAD)
+			}
+		})
+
+		test.each([
+			['good quality degrading to very bad', 'audio'],
+			['good quality degrading to very bad', 'video'],
+		])('%s, %s', async (name, kind) => {
+			peerConnection.getStats
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 50, timestamp: 10000 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 50, timestamp: 10000, packetsLost: 0, roundTripTime: 0.1 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 100, timestamp: 11000 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 100, timestamp: 11000, packetsLost: 0, roundTripTime: 0.1 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 150, timestamp: 11950 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 150, timestamp: 11950, packetsLost: 0, roundTripTime: 0.1 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 200, timestamp: 13020 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 200, timestamp: 13020, packetsLost: 0, roundTripTime: 0.1 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 250, timestamp: 14010 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 250, timestamp: 14010, packetsLost: 0, roundTripTime: 0.1 },
+				]))
+				// A sixth report is needed for the initial calculation due to
+				// the first stats report being used as the base to calculate
+				// relative values of cumulative stats.
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 300, timestamp: 14985 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 300, timestamp: 14985, packetsLost: 0, roundTripTime: 0.1 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 350, timestamp: 16010 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 340, timestamp: 16010, packetsLost: 10, roundTripTime: 0.1 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 400, timestamp: 17000 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 380, timestamp: 17000, packetsLost: 20, roundTripTime: 0.1 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 450, timestamp: 17990 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 410, timestamp: 17990, packetsLost: 40, roundTripTime: 0.1 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 500, timestamp: 19005 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 435, timestamp: 19005, packetsLost: 65, roundTripTime: 0.1 },
+				]))
+
+			peerConnectionAnalyzer.setPeerConnection(peerConnection, PEER_DIRECTION.SENDER)
+
+			jest.advanceTimersByTime(6000)
+			// Force the promises returning the stats to be executed.
+			await null
+
+			expect(peerConnection.getStats).toHaveBeenCalledTimes(6)
+
+			if (kind === 'audio') {
+				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.GOOD)
+				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			} else {
+				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
+				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.GOOD)
+			}
+
+			jest.advanceTimersByTime(1000)
+			// Force the promises returning the stats to be executed.
+			await null
+
+			expect(peerConnection.getStats).toHaveBeenCalledTimes(7)
+
+			if (kind === 'audio') {
+				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.GOOD)
+				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			} else {
+				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
+				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.GOOD)
+			}
+
+			jest.advanceTimersByTime(1000)
+			// Force the promises returning the stats to be executed.
+			await null
+
+			expect(peerConnection.getStats).toHaveBeenCalledTimes(8)
+
+			if (kind === 'audio') {
+				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.MEDIUM)
+				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			} else {
+				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
+				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.MEDIUM)
+			}
+
+			jest.advanceTimersByTime(1000)
+			// Force the promises returning the stats to be executed.
+			await null
+
+			expect(peerConnection.getStats).toHaveBeenCalledTimes(9)
+
+			if (kind === 'audio') {
+				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.BAD)
+				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			} else {
+				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
+				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.BAD)
+			}
+
+			jest.advanceTimersByTime(1000)
+			// Force the promises returning the stats to be executed.
+			await null
+
+			expect(peerConnection.getStats).toHaveBeenCalledTimes(10)
+
+			if (kind === 'audio') {
+				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.VERY_BAD)
+				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			} else {
+				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
+				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.VERY_BAD)
+			}
+		})
+
+		test.each([
+			['very bad quality improving to good', 'audio'],
+			['very bad quality improving to good', 'video'],
+		])('%s, %s', async (name, kind) => {
+			peerConnection.getStats
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 50, timestamp: 10000 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 45, timestamp: 10000, packetsLost: 5, roundTripTime: 0.1 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 100, timestamp: 11000 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 90, timestamp: 11000, packetsLost: 10, roundTripTime: 0.1 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 150, timestamp: 11950 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 130, timestamp: 11950, packetsLost: 20, roundTripTime: 0.1 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 200, timestamp: 13020 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 160, timestamp: 13020, packetsLost: 40, roundTripTime: 0.1 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 250, timestamp: 14010 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 190, timestamp: 14010, packetsLost: 60, roundTripTime: 0.1 },
+				]))
+				// A sixth report is needed for the initial calculation due to
+				// the first stats report being used as the base to calculate
+				// relative values of cumulative stats.
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 300, timestamp: 14985 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 225, timestamp: 14985, packetsLost: 75, roundTripTime: 0.1 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 350, timestamp: 16010 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 260, timestamp: 16010, packetsLost: 90, roundTripTime: 0.1 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 400, timestamp: 17000 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 305, timestamp: 17000, packetsLost: 95, roundTripTime: 0.1 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 450, timestamp: 17990 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 355, timestamp: 17990, packetsLost: 95, roundTripTime: 0.1 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind, packetsSent: 500, timestamp: 19005 },
+					{ type: 'remote-inbound-rtp', kind, packetsReceived: 405, timestamp: 19005, packetsLost: 95, roundTripTime: 0.1 },
+				]))
+
+			peerConnectionAnalyzer.setPeerConnection(peerConnection, PEER_DIRECTION.SENDER)
+
+			jest.advanceTimersByTime(6000)
+			// Force the promises returning the stats to be executed.
+			await null
+
+			expect(peerConnection.getStats).toHaveBeenCalledTimes(6)
+
+			if (kind === 'audio') {
+				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.VERY_BAD)
+				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			} else {
+				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
+				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.VERY_BAD)
+			}
+
+			jest.advanceTimersByTime(1000)
+			// Force the promises returning the stats to be executed.
+			await null
+
+			expect(peerConnection.getStats).toHaveBeenCalledTimes(7)
+
+			if (kind === 'audio') {
+				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.VERY_BAD)
+				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			} else {
+				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
+				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.VERY_BAD)
+			}
+
+			jest.advanceTimersByTime(1000)
+			// Force the promises returning the stats to be executed.
+			await null
+
+			expect(peerConnection.getStats).toHaveBeenCalledTimes(8)
+
+			if (kind === 'audio') {
+				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.BAD)
+				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			} else {
+				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
+				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.BAD)
+			}
+
+			jest.advanceTimersByTime(1000)
+			// Force the promises returning the stats to be executed.
+			await null
+
+			expect(peerConnection.getStats).toHaveBeenCalledTimes(9)
+
+			if (kind === 'audio') {
+				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.MEDIUM)
+				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			} else {
+				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
+				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.MEDIUM)
+			}
+
+			jest.advanceTimersByTime(1000)
+			// Force the promises returning the stats to be executed.
+			await null
+
+			expect(peerConnection.getStats).toHaveBeenCalledTimes(10)
+
+			if (kind === 'audio') {
+				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.GOOD)
+				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			} else {
+				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
+				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.GOOD)
+			}
+		})
+
+		test('good audio quality, very bad video quality', async () => {
+			peerConnection.getStats
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind: 'audio', packetsSent: 50, timestamp: 10000 },
+					{ type: 'remote-inbound-rtp', kind: 'audio', packetsReceived: 50, timestamp: 10000, packetsLost: 0, roundTripTime: 0.1 },
+					{ type: 'outbound-rtp', kind: 'video', packetsSent: 50, timestamp: 10000 },
+					{ type: 'remote-inbound-rtp', kind: 'video', packetsReceived: 45, timestamp: 10000, packetsLost: 5, roundTripTime: 0.1 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind: 'audio', packetsSent: 100, timestamp: 11000 },
+					{ type: 'remote-inbound-rtp', kind: 'audio', packetsReceived: 100, timestamp: 11000, packetsLost: 0, roundTripTime: 0.1 },
+					{ type: 'outbound-rtp', kind: 'video', packetsSent: 100, timestamp: 11000 },
+					{ type: 'remote-inbound-rtp', kind: 'video', packetsReceived: 90, timestamp: 11000, packetsLost: 10, roundTripTime: 0.1 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind: 'audio', packetsSent: 150, timestamp: 11950 },
+					{ type: 'remote-inbound-rtp', kind: 'audio', packetsReceived: 150, timestamp: 11950, packetsLost: 0, roundTripTime: 0.1 },
+					{ type: 'outbound-rtp', kind: 'video', packetsSent: 150, timestamp: 11950 },
+					{ type: 'remote-inbound-rtp', kind: 'video', packetsReceived: 130, timestamp: 11950, packetsLost: 20, roundTripTime: 0.1 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind: 'audio', packetsSent: 200, timestamp: 13020 },
+					{ type: 'remote-inbound-rtp', kind: 'audio', packetsReceived: 200, timestamp: 13020, packetsLost: 0, roundTripTime: 0.1 },
+					{ type: 'outbound-rtp', kind: 'video', packetsSent: 200, timestamp: 13020 },
+					{ type: 'remote-inbound-rtp', kind: 'video', packetsReceived: 160, timestamp: 13020, packetsLost: 40, roundTripTime: 0.1 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind: 'audio', packetsSent: 250, timestamp: 14010 },
+					{ type: 'remote-inbound-rtp', kind: 'audio', packetsReceived: 250, timestamp: 14010, packetsLost: 0, roundTripTime: 0.1 },
+					{ type: 'outbound-rtp', kind: 'video', packetsSent: 250, timestamp: 14010 },
+					{ type: 'remote-inbound-rtp', kind: 'video', packetsReceived: 190, timestamp: 14010, packetsLost: 60, roundTripTime: 0.1 },
+				]))
+				// A sixth report is needed for the initial calculation due to
+				// the first stats report being used as the base to calculate
+				// relative values of cumulative stats.
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind: 'audio', packetsSent: 300, timestamp: 14985 },
+					{ type: 'remote-inbound-rtp', kind: 'audio', packetsReceived: 300, timestamp: 14985, packetsLost: 0, roundTripTime: 0.1 },
+					{ type: 'outbound-rtp', kind: 'video', packetsSent: 300, timestamp: 14985 },
+					{ type: 'remote-inbound-rtp', kind: 'video', packetsReceived: 225, timestamp: 14985, packetsLost: 75, roundTripTime: 0.1 },
+				]))
+
+			peerConnectionAnalyzer.setPeerConnection(peerConnection, PEER_DIRECTION.SENDER)
+
+			jest.advanceTimersByTime(6000)
+			// Force the promises returning the stats to be executed.
+			await null
+
+			expect(peerConnection.getStats).toHaveBeenCalledTimes(6)
+
+			expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.GOOD)
+			expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.VERY_BAD)
+		})
+
+		test('very bad audio quality, good video quality', async () => {
+			peerConnection.getStats
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind: 'audio', packetsSent: 50, timestamp: 10000 },
+					{ type: 'remote-inbound-rtp', kind: 'audio', packetsReceived: 45, timestamp: 10000, packetsLost: 5, roundTripTime: 0.1 },
+					{ type: 'outbound-rtp', kind: 'video', packetsSent: 50, timestamp: 10000 },
+					{ type: 'remote-inbound-rtp', kind: 'video', packetsReceived: 50, timestamp: 10000, packetsLost: 0, roundTripTime: 0.1 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind: 'audio', packetsSent: 100, timestamp: 11000 },
+					{ type: 'remote-inbound-rtp', kind: 'audio', packetsReceived: 90, timestamp: 11000, packetsLost: 10, roundTripTime: 0.1 },
+					{ type: 'outbound-rtp', kind: 'video', packetsSent: 100, timestamp: 11000 },
+					{ type: 'remote-inbound-rtp', kind: 'video', packetsReceived: 100, timestamp: 11000, packetsLost: 0, roundTripTime: 0.1 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind: 'audio', packetsSent: 150, timestamp: 11950 },
+					{ type: 'remote-inbound-rtp', kind: 'audio', packetsReceived: 130, timestamp: 11950, packetsLost: 20, roundTripTime: 0.1 },
+					{ type: 'outbound-rtp', kind: 'video', packetsSent: 150, timestamp: 11950 },
+					{ type: 'remote-inbound-rtp', kind: 'video', packetsReceived: 150, timestamp: 11950, packetsLost: 0, roundTripTime: 0.1 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind: 'audio', packetsSent: 200, timestamp: 13020 },
+					{ type: 'remote-inbound-rtp', kind: 'audio', packetsReceived: 160, timestamp: 13020, packetsLost: 40, roundTripTime: 0.1 },
+					{ type: 'outbound-rtp', kind: 'video', packetsSent: 200, timestamp: 13020 },
+					{ type: 'remote-inbound-rtp', kind: 'video', packetsReceived: 200, timestamp: 13020, packetsLost: 0, roundTripTime: 0.1 },
+				]))
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind: 'audio', packetsSent: 250, timestamp: 14010 },
+					{ type: 'remote-inbound-rtp', kind: 'audio', packetsReceived: 190, timestamp: 14010, packetsLost: 60, roundTripTime: 0.1 },
+					{ type: 'outbound-rtp', kind: 'video', packetsSent: 250, timestamp: 14010 },
+					{ type: 'remote-inbound-rtp', kind: 'video', packetsReceived: 250, timestamp: 14010, packetsLost: 0, roundTripTime: 0.1 },
+				]))
+				// A sixth report is needed for the initial calculation due to
+				// the first stats report being used as the base to calculate
+				// relative values of cumulative stats.
+				.mockResolvedValueOnce(newRTCStatsReport([
+					{ type: 'outbound-rtp', kind: 'audio', packetsSent: 300, timestamp: 14985 },
+					{ type: 'remote-inbound-rtp', kind: 'audio', packetsReceived: 225, timestamp: 14985, packetsLost: 75, roundTripTime: 0.1 },
+					{ type: 'outbound-rtp', kind: 'video', packetsSent: 300, timestamp: 14985 },
+					{ type: 'remote-inbound-rtp', kind: 'video', packetsReceived: 300, timestamp: 14985, packetsLost: 0, roundTripTime: 0.1 },
+				]))
+
+			peerConnectionAnalyzer.setPeerConnection(peerConnection, PEER_DIRECTION.SENDER)
+
+			jest.advanceTimersByTime(6000)
+			// Force the promises returning the stats to be executed.
+			await null
+
+			expect(peerConnection.getStats).toHaveBeenCalledTimes(6)
+
+			expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.VERY_BAD)
+			expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.GOOD)
+		})
+	})
+})

--- a/src/utils/webrtc/analyzers/PeerConnectionAnalyzer.spec.js
+++ b/src/utils/webrtc/analyzers/PeerConnectionAnalyzer.spec.js
@@ -95,12 +95,20 @@ function newRTCStatsReport(stats) {
 describe('PeerConnectionAnalyzer', () => {
 
 	let peerConnectionAnalyzer
+	let changeConnectionQualityAudioHandler
+	let changeConnectionQualityVideoHandler
 	let peerConnection
 
 	beforeEach(() => {
 		jest.useFakeTimers()
 
 		peerConnectionAnalyzer = new PeerConnectionAnalyzer()
+
+		changeConnectionQualityAudioHandler = jest.fn()
+		peerConnectionAnalyzer.on('change:connectionQualityAudio', changeConnectionQualityAudioHandler)
+
+		changeConnectionQualityVideoHandler = jest.fn()
+		peerConnectionAnalyzer.on('change:connectionQualityVideo', changeConnectionQualityVideoHandler)
 
 		peerConnection = newRTCPeerConnection()
 	})
@@ -153,7 +161,18 @@ describe('PeerConnectionAnalyzer', () => {
 
 			peerConnectionAnalyzer.setPeerConnection(peerConnection, PEER_DIRECTION.SENDER)
 
-			jest.advanceTimersByTime(6000)
+			jest.advanceTimersByTime(5000)
+			// Force the promises returning the stats to be executed.
+			await null
+
+			expect(peerConnection.getStats).toHaveBeenCalledTimes(5)
+
+			expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(0)
+			expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(0)
+
+			jest.advanceTimersByTime(1000)
 			// Force the promises returning the stats to be executed.
 			await null
 
@@ -162,9 +181,15 @@ describe('PeerConnectionAnalyzer', () => {
 			if (kind === 'audio') {
 				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.GOOD)
 				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+				expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(1)
+				expect(changeConnectionQualityAudioHandler).toHaveBeenCalledWith(peerConnectionAnalyzer, CONNECTION_QUALITY.GOOD)
+				expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(0)
 			} else {
 				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
 				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.GOOD)
+				expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(0)
+				expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(1)
+				expect(changeConnectionQualityVideoHandler).toHaveBeenCalledWith(peerConnectionAnalyzer, CONNECTION_QUALITY.GOOD)
 			}
 		})
 
@@ -203,7 +228,18 @@ describe('PeerConnectionAnalyzer', () => {
 
 			peerConnectionAnalyzer.setPeerConnection(peerConnection, PEER_DIRECTION.SENDER)
 
-			jest.advanceTimersByTime(6000)
+			jest.advanceTimersByTime(5000)
+			// Force the promises returning the stats to be executed.
+			await null
+
+			expect(peerConnection.getStats).toHaveBeenCalledTimes(5)
+
+			expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(0)
+			expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(0)
+
+			jest.advanceTimersByTime(1000)
 			// Force the promises returning the stats to be executed.
 			await null
 
@@ -212,9 +248,15 @@ describe('PeerConnectionAnalyzer', () => {
 			if (kind === 'audio') {
 				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.GOOD)
 				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+				expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(1)
+				expect(changeConnectionQualityAudioHandler).toHaveBeenCalledWith(peerConnectionAnalyzer, CONNECTION_QUALITY.GOOD)
+				expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(0)
 			} else {
 				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
 				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.GOOD)
+				expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(0)
+				expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(1)
+				expect(changeConnectionQualityVideoHandler).toHaveBeenCalledWith(peerConnectionAnalyzer, CONNECTION_QUALITY.GOOD)
 			}
 		})
 
@@ -253,7 +295,18 @@ describe('PeerConnectionAnalyzer', () => {
 
 			peerConnectionAnalyzer.setPeerConnection(peerConnection, PEER_DIRECTION.SENDER)
 
-			jest.advanceTimersByTime(6000)
+			jest.advanceTimersByTime(5000)
+			// Force the promises returning the stats to be executed.
+			await null
+
+			expect(peerConnection.getStats).toHaveBeenCalledTimes(5)
+
+			expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(0)
+			expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(0)
+
+			jest.advanceTimersByTime(1000)
 			// Force the promises returning the stats to be executed.
 			await null
 
@@ -262,9 +315,15 @@ describe('PeerConnectionAnalyzer', () => {
 			if (kind === 'audio') {
 				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.MEDIUM)
 				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+				expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(1)
+				expect(changeConnectionQualityAudioHandler).toHaveBeenCalledWith(peerConnectionAnalyzer, CONNECTION_QUALITY.MEDIUM)
+				expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(0)
 			} else {
 				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
 				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.MEDIUM)
+				expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(0)
+				expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(1)
+				expect(changeConnectionQualityVideoHandler).toHaveBeenCalledWith(peerConnectionAnalyzer, CONNECTION_QUALITY.MEDIUM)
 			}
 		})
 
@@ -303,7 +362,18 @@ describe('PeerConnectionAnalyzer', () => {
 
 			peerConnectionAnalyzer.setPeerConnection(peerConnection, PEER_DIRECTION.SENDER)
 
-			jest.advanceTimersByTime(6000)
+			jest.advanceTimersByTime(5000)
+			// Force the promises returning the stats to be executed.
+			await null
+
+			expect(peerConnection.getStats).toHaveBeenCalledTimes(5)
+
+			expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(0)
+			expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(0)
+
+			jest.advanceTimersByTime(1000)
 			// Force the promises returning the stats to be executed.
 			await null
 
@@ -312,9 +382,15 @@ describe('PeerConnectionAnalyzer', () => {
 			if (kind === 'audio') {
 				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.MEDIUM)
 				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+				expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(1)
+				expect(changeConnectionQualityAudioHandler).toHaveBeenCalledWith(peerConnectionAnalyzer, CONNECTION_QUALITY.MEDIUM)
+				expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(0)
 			} else {
 				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
 				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.MEDIUM)
+				expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(0)
+				expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(1)
+				expect(changeConnectionQualityVideoHandler).toHaveBeenCalledWith(peerConnectionAnalyzer, CONNECTION_QUALITY.MEDIUM)
 			}
 		})
 
@@ -353,7 +429,18 @@ describe('PeerConnectionAnalyzer', () => {
 
 			peerConnectionAnalyzer.setPeerConnection(peerConnection, PEER_DIRECTION.SENDER)
 
-			jest.advanceTimersByTime(6000)
+			jest.advanceTimersByTime(5000)
+			// Force the promises returning the stats to be executed.
+			await null
+
+			expect(peerConnection.getStats).toHaveBeenCalledTimes(5)
+
+			expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(0)
+			expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(0)
+
+			jest.advanceTimersByTime(1000)
 			// Force the promises returning the stats to be executed.
 			await null
 
@@ -362,9 +449,15 @@ describe('PeerConnectionAnalyzer', () => {
 			if (kind === 'audio') {
 				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.BAD)
 				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+				expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(1)
+				expect(changeConnectionQualityAudioHandler).toHaveBeenCalledWith(peerConnectionAnalyzer, CONNECTION_QUALITY.BAD)
+				expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(0)
 			} else {
 				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
 				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.BAD)
+				expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(0)
+				expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(1)
+				expect(changeConnectionQualityVideoHandler).toHaveBeenCalledWith(peerConnectionAnalyzer, CONNECTION_QUALITY.BAD)
 			}
 		})
 
@@ -403,7 +496,18 @@ describe('PeerConnectionAnalyzer', () => {
 
 			peerConnectionAnalyzer.setPeerConnection(peerConnection, PEER_DIRECTION.SENDER)
 
-			jest.advanceTimersByTime(6000)
+			jest.advanceTimersByTime(5000)
+			// Force the promises returning the stats to be executed.
+			await null
+
+			expect(peerConnection.getStats).toHaveBeenCalledTimes(5)
+
+			expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(0)
+			expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(0)
+
+			jest.advanceTimersByTime(1000)
 			// Force the promises returning the stats to be executed.
 			await null
 
@@ -412,9 +516,15 @@ describe('PeerConnectionAnalyzer', () => {
 			if (kind === 'audio') {
 				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.BAD)
 				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+				expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(1)
+				expect(changeConnectionQualityAudioHandler).toHaveBeenCalledWith(peerConnectionAnalyzer, CONNECTION_QUALITY.BAD)
+				expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(0)
 			} else {
 				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
 				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.BAD)
+				expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(0)
+				expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(1)
+				expect(changeConnectionQualityVideoHandler).toHaveBeenCalledWith(peerConnectionAnalyzer, CONNECTION_QUALITY.BAD)
 			}
 		})
 
@@ -453,7 +563,18 @@ describe('PeerConnectionAnalyzer', () => {
 
 			peerConnectionAnalyzer.setPeerConnection(peerConnection, PEER_DIRECTION.SENDER)
 
-			jest.advanceTimersByTime(6000)
+			jest.advanceTimersByTime(5000)
+			// Force the promises returning the stats to be executed.
+			await null
+
+			expect(peerConnection.getStats).toHaveBeenCalledTimes(5)
+
+			expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(0)
+			expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(0)
+
+			jest.advanceTimersByTime(1000)
 			// Force the promises returning the stats to be executed.
 			await null
 
@@ -462,9 +583,15 @@ describe('PeerConnectionAnalyzer', () => {
 			if (kind === 'audio') {
 				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.VERY_BAD)
 				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+				expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(1)
+				expect(changeConnectionQualityAudioHandler).toHaveBeenCalledWith(peerConnectionAnalyzer, CONNECTION_QUALITY.VERY_BAD)
+				expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(0)
 			} else {
 				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
 				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.VERY_BAD)
+				expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(0)
+				expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(1)
+				expect(changeConnectionQualityVideoHandler).toHaveBeenCalledWith(peerConnectionAnalyzer, CONNECTION_QUALITY.VERY_BAD)
 			}
 		})
 
@@ -503,7 +630,18 @@ describe('PeerConnectionAnalyzer', () => {
 
 			peerConnectionAnalyzer.setPeerConnection(peerConnection, PEER_DIRECTION.SENDER)
 
-			jest.advanceTimersByTime(6000)
+			jest.advanceTimersByTime(5000)
+			// Force the promises returning the stats to be executed.
+			await null
+
+			expect(peerConnection.getStats).toHaveBeenCalledTimes(5)
+
+			expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(0)
+			expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(0)
+
+			jest.advanceTimersByTime(1000)
 			// Force the promises returning the stats to be executed.
 			await null
 
@@ -512,9 +650,15 @@ describe('PeerConnectionAnalyzer', () => {
 			if (kind === 'audio') {
 				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.VERY_BAD)
 				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+				expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(1)
+				expect(changeConnectionQualityAudioHandler).toHaveBeenCalledWith(peerConnectionAnalyzer, CONNECTION_QUALITY.VERY_BAD)
+				expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(0)
 			} else {
 				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
 				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.VERY_BAD)
+				expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(0)
+				expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(1)
+				expect(changeConnectionQualityVideoHandler).toHaveBeenCalledWith(peerConnectionAnalyzer, CONNECTION_QUALITY.VERY_BAD)
 			}
 		})
 
@@ -553,7 +697,18 @@ describe('PeerConnectionAnalyzer', () => {
 
 			peerConnectionAnalyzer.setPeerConnection(peerConnection, PEER_DIRECTION.SENDER)
 
-			jest.advanceTimersByTime(6000)
+			jest.advanceTimersByTime(5000)
+			// Force the promises returning the stats to be executed.
+			await null
+
+			expect(peerConnection.getStats).toHaveBeenCalledTimes(5)
+
+			expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(0)
+			expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(0)
+
+			jest.advanceTimersByTime(1000)
 			// Force the promises returning the stats to be executed.
 			await null
 
@@ -562,9 +717,15 @@ describe('PeerConnectionAnalyzer', () => {
 			if (kind === 'audio') {
 				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.VERY_BAD)
 				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+				expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(1)
+				expect(changeConnectionQualityAudioHandler).toHaveBeenCalledWith(peerConnectionAnalyzer, CONNECTION_QUALITY.VERY_BAD)
+				expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(0)
 			} else {
 				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
 				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.VERY_BAD)
+				expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(0)
+				expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(1)
+				expect(changeConnectionQualityVideoHandler).toHaveBeenCalledWith(peerConnectionAnalyzer, CONNECTION_QUALITY.VERY_BAD)
 			}
 		})
 
@@ -603,7 +764,18 @@ describe('PeerConnectionAnalyzer', () => {
 
 			peerConnectionAnalyzer.setPeerConnection(peerConnection, PEER_DIRECTION.SENDER)
 
-			jest.advanceTimersByTime(6000)
+			jest.advanceTimersByTime(5000)
+			// Force the promises returning the stats to be executed.
+			await null
+
+			expect(peerConnection.getStats).toHaveBeenCalledTimes(5)
+
+			expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(0)
+			expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(0)
+
+			jest.advanceTimersByTime(1000)
 			// Force the promises returning the stats to be executed.
 			await null
 
@@ -612,9 +784,15 @@ describe('PeerConnectionAnalyzer', () => {
 			if (kind === 'audio') {
 				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.VERY_BAD)
 				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+				expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(1)
+				expect(changeConnectionQualityAudioHandler).toHaveBeenCalledWith(peerConnectionAnalyzer, CONNECTION_QUALITY.VERY_BAD)
+				expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(0)
 			} else {
 				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
 				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.VERY_BAD)
+				expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(0)
+				expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(1)
+				expect(changeConnectionQualityVideoHandler).toHaveBeenCalledWith(peerConnectionAnalyzer, CONNECTION_QUALITY.VERY_BAD)
 			}
 		})
 
@@ -653,7 +831,18 @@ describe('PeerConnectionAnalyzer', () => {
 
 			peerConnectionAnalyzer.setPeerConnection(peerConnection, PEER_DIRECTION.SENDER)
 
-			jest.advanceTimersByTime(6000)
+			jest.advanceTimersByTime(5000)
+			// Force the promises returning the stats to be executed.
+			await null
+
+			expect(peerConnection.getStats).toHaveBeenCalledTimes(5)
+
+			expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(0)
+			expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(0)
+
+			jest.advanceTimersByTime(1000)
 			// Force the promises returning the stats to be executed.
 			await null
 
@@ -662,9 +851,15 @@ describe('PeerConnectionAnalyzer', () => {
 			if (kind === 'audio') {
 				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.VERY_BAD)
 				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+				expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(1)
+				expect(changeConnectionQualityAudioHandler).toHaveBeenCalledWith(peerConnectionAnalyzer, CONNECTION_QUALITY.VERY_BAD)
+				expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(0)
 			} else {
 				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
 				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.VERY_BAD)
+				expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(0)
+				expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(1)
+				expect(changeConnectionQualityVideoHandler).toHaveBeenCalledWith(peerConnectionAnalyzer, CONNECTION_QUALITY.VERY_BAD)
 			}
 		})
 
@@ -703,7 +898,18 @@ describe('PeerConnectionAnalyzer', () => {
 
 			peerConnectionAnalyzer.setPeerConnection(peerConnection, PEER_DIRECTION.SENDER)
 
-			jest.advanceTimersByTime(6000)
+			jest.advanceTimersByTime(5000)
+			// Force the promises returning the stats to be executed.
+			await null
+
+			expect(peerConnection.getStats).toHaveBeenCalledTimes(5)
+
+			expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(0)
+			expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(0)
+
+			jest.advanceTimersByTime(1000)
 			// Force the promises returning the stats to be executed.
 			await null
 
@@ -712,9 +918,15 @@ describe('PeerConnectionAnalyzer', () => {
 			if (kind === 'audio') {
 				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.VERY_BAD)
 				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+				expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(1)
+				expect(changeConnectionQualityAudioHandler).toHaveBeenCalledWith(peerConnectionAnalyzer, CONNECTION_QUALITY.VERY_BAD)
+				expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(0)
 			} else {
 				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
 				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.VERY_BAD)
+				expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(0)
+				expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(1)
+				expect(changeConnectionQualityVideoHandler).toHaveBeenCalledWith(peerConnectionAnalyzer, CONNECTION_QUALITY.VERY_BAD)
 			}
 		})
 
@@ -753,7 +965,18 @@ describe('PeerConnectionAnalyzer', () => {
 
 			peerConnectionAnalyzer.setPeerConnection(peerConnection, PEER_DIRECTION.SENDER)
 
-			jest.advanceTimersByTime(6000)
+			jest.advanceTimersByTime(5000)
+			// Force the promises returning the stats to be executed.
+			await null
+
+			expect(peerConnection.getStats).toHaveBeenCalledTimes(5)
+
+			expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(0)
+			expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(0)
+
+			jest.advanceTimersByTime(1000)
 			// Force the promises returning the stats to be executed.
 			await null
 
@@ -762,9 +985,15 @@ describe('PeerConnectionAnalyzer', () => {
 			if (kind === 'audio') {
 				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.NO_TRANSMITTED_DATA)
 				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+				expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(1)
+				expect(changeConnectionQualityAudioHandler).toHaveBeenCalledWith(peerConnectionAnalyzer, CONNECTION_QUALITY.NO_TRANSMITTED_DATA)
+				expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(0)
 			} else {
 				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
 				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.NO_TRANSMITTED_DATA)
+				expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(0)
+				expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(1)
+				expect(changeConnectionQualityVideoHandler).toHaveBeenCalledWith(peerConnectionAnalyzer, CONNECTION_QUALITY.NO_TRANSMITTED_DATA)
 			}
 		})
 
@@ -803,7 +1032,18 @@ describe('PeerConnectionAnalyzer', () => {
 
 			peerConnectionAnalyzer.setPeerConnection(peerConnection, PEER_DIRECTION.SENDER)
 
-			jest.advanceTimersByTime(6000)
+			jest.advanceTimersByTime(5000)
+			// Force the promises returning the stats to be executed.
+			await null
+
+			expect(peerConnection.getStats).toHaveBeenCalledTimes(5)
+
+			expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(0)
+			expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(0)
+
+			jest.advanceTimersByTime(1000)
 			// Force the promises returning the stats to be executed.
 			await null
 
@@ -812,9 +1052,15 @@ describe('PeerConnectionAnalyzer', () => {
 			if (kind === 'audio') {
 				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.NO_TRANSMITTED_DATA)
 				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+				expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(1)
+				expect(changeConnectionQualityAudioHandler).toHaveBeenCalledWith(peerConnectionAnalyzer, CONNECTION_QUALITY.NO_TRANSMITTED_DATA)
+				expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(0)
 			} else {
 				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
 				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.NO_TRANSMITTED_DATA)
+				expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(0)
+				expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(1)
+				expect(changeConnectionQualityVideoHandler).toHaveBeenCalledWith(peerConnectionAnalyzer, CONNECTION_QUALITY.NO_TRANSMITTED_DATA)
 			}
 		})
 
@@ -861,7 +1107,18 @@ describe('PeerConnectionAnalyzer', () => {
 
 			peerConnectionAnalyzer.setPeerConnection(peerConnection, PEER_DIRECTION.SENDER)
 
-			jest.advanceTimersByTime(7000)
+			jest.advanceTimersByTime(6000)
+			// Force the promises returning the stats to be executed.
+			await null
+
+			expect(peerConnection.getStats).toHaveBeenCalledTimes(6)
+
+			expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(0)
+			expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(0)
+
+			jest.advanceTimersByTime(1000)
 			// Force the promises returning the stats to be executed.
 			await null
 
@@ -870,9 +1127,15 @@ describe('PeerConnectionAnalyzer', () => {
 			if (kind === 'audio') {
 				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.NO_TRANSMITTED_DATA)
 				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+				expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(1)
+				expect(changeConnectionQualityAudioHandler).toHaveBeenCalledWith(peerConnectionAnalyzer, CONNECTION_QUALITY.NO_TRANSMITTED_DATA)
+				expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(0)
 			} else {
 				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
 				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.NO_TRANSMITTED_DATA)
+				expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(0)
+				expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(1)
+				expect(changeConnectionQualityVideoHandler).toHaveBeenCalledWith(peerConnectionAnalyzer, CONNECTION_QUALITY.NO_TRANSMITTED_DATA)
 			}
 		})
 
@@ -919,7 +1182,18 @@ describe('PeerConnectionAnalyzer', () => {
 
 			peerConnectionAnalyzer.setPeerConnection(peerConnection, PEER_DIRECTION.SENDER)
 
-			jest.advanceTimersByTime(7000)
+			jest.advanceTimersByTime(6000)
+			// Force the promises returning the stats to be executed.
+			await null
+
+			expect(peerConnection.getStats).toHaveBeenCalledTimes(6)
+
+			expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(0)
+			expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(0)
+
+			jest.advanceTimersByTime(1000)
 			// Force the promises returning the stats to be executed.
 			await null
 
@@ -928,9 +1202,15 @@ describe('PeerConnectionAnalyzer', () => {
 			if (kind === 'audio') {
 				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.NO_TRANSMITTED_DATA)
 				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+				expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(1)
+				expect(changeConnectionQualityAudioHandler).toHaveBeenCalledWith(peerConnectionAnalyzer, CONNECTION_QUALITY.NO_TRANSMITTED_DATA)
+				expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(0)
 			} else {
 				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
 				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.NO_TRANSMITTED_DATA)
+				expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(0)
+				expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(1)
+				expect(changeConnectionQualityVideoHandler).toHaveBeenCalledWith(peerConnectionAnalyzer, CONNECTION_QUALITY.NO_TRANSMITTED_DATA)
 			}
 		})
 
@@ -977,7 +1257,18 @@ describe('PeerConnectionAnalyzer', () => {
 
 			peerConnectionAnalyzer.setPeerConnection(peerConnection, PEER_DIRECTION.SENDER)
 
-			jest.advanceTimersByTime(7000)
+			jest.advanceTimersByTime(6000)
+			// Force the promises returning the stats to be executed.
+			await null
+
+			expect(peerConnection.getStats).toHaveBeenCalledTimes(6)
+
+			expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(0)
+			expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(0)
+
+			jest.advanceTimersByTime(1000)
 			// Force the promises returning the stats to be executed.
 			await null
 
@@ -986,9 +1277,15 @@ describe('PeerConnectionAnalyzer', () => {
 			if (kind === 'audio') {
 				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.GOOD)
 				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+				expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(1)
+				expect(changeConnectionQualityAudioHandler).toHaveBeenCalledWith(peerConnectionAnalyzer, CONNECTION_QUALITY.GOOD)
+				expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(0)
 			} else {
 				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
 				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.GOOD)
+				expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(0)
+				expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(1)
+				expect(changeConnectionQualityVideoHandler).toHaveBeenCalledWith(peerConnectionAnalyzer, CONNECTION_QUALITY.GOOD)
 			}
 		})
 
@@ -1035,7 +1332,18 @@ describe('PeerConnectionAnalyzer', () => {
 
 			peerConnectionAnalyzer.setPeerConnection(peerConnection, PEER_DIRECTION.SENDER)
 
-			jest.advanceTimersByTime(7000)
+			jest.advanceTimersByTime(6000)
+			// Force the promises returning the stats to be executed.
+			await null
+
+			expect(peerConnection.getStats).toHaveBeenCalledTimes(6)
+
+			expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(0)
+			expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(0)
+
+			jest.advanceTimersByTime(1000)
 			// Force the promises returning the stats to be executed.
 			await null
 
@@ -1044,9 +1352,15 @@ describe('PeerConnectionAnalyzer', () => {
 			if (kind === 'audio') {
 				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.GOOD)
 				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+				expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(1)
+				expect(changeConnectionQualityAudioHandler).toHaveBeenCalledWith(peerConnectionAnalyzer, CONNECTION_QUALITY.GOOD)
+				expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(0)
 			} else {
 				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
 				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.GOOD)
+				expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(0)
+				expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(1)
+				expect(changeConnectionQualityVideoHandler).toHaveBeenCalledWith(peerConnectionAnalyzer, CONNECTION_QUALITY.GOOD)
 			}
 		})
 
@@ -1095,7 +1409,18 @@ describe('PeerConnectionAnalyzer', () => {
 
 			peerConnectionAnalyzer.setPeerConnection(peerConnection, PEER_DIRECTION.SENDER)
 
-			jest.advanceTimersByTime(7000)
+			jest.advanceTimersByTime(6000)
+			// Force the promises returning the stats to be executed.
+			await null
+
+			expect(peerConnection.getStats).toHaveBeenCalledTimes(6)
+
+			expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(0)
+			expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(0)
+
+			jest.advanceTimersByTime(1000)
 			// Force the promises returning the stats to be executed.
 			await null
 
@@ -1104,9 +1429,15 @@ describe('PeerConnectionAnalyzer', () => {
 			if (kind === 'audio') {
 				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.VERY_BAD)
 				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+				expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(1)
+				expect(changeConnectionQualityAudioHandler).toHaveBeenCalledWith(peerConnectionAnalyzer, CONNECTION_QUALITY.VERY_BAD)
+				expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(0)
 			} else {
 				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
 				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.VERY_BAD)
+				expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(0)
+				expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(1)
+				expect(changeConnectionQualityVideoHandler).toHaveBeenCalledWith(peerConnectionAnalyzer, CONNECTION_QUALITY.VERY_BAD)
 			}
 		})
 
@@ -1155,7 +1486,18 @@ describe('PeerConnectionAnalyzer', () => {
 
 			peerConnectionAnalyzer.setPeerConnection(peerConnection, PEER_DIRECTION.SENDER)
 
-			jest.advanceTimersByTime(7000)
+			jest.advanceTimersByTime(6000)
+			// Force the promises returning the stats to be executed.
+			await null
+
+			expect(peerConnection.getStats).toHaveBeenCalledTimes(6)
+
+			expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(0)
+			expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(0)
+
+			jest.advanceTimersByTime(1000)
 			// Force the promises returning the stats to be executed.
 			await null
 
@@ -1164,9 +1506,15 @@ describe('PeerConnectionAnalyzer', () => {
 			if (kind === 'audio') {
 				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.VERY_BAD)
 				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+				expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(1)
+				expect(changeConnectionQualityAudioHandler).toHaveBeenCalledWith(peerConnectionAnalyzer, CONNECTION_QUALITY.VERY_BAD)
+				expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(0)
 			} else {
 				expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
 				expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.VERY_BAD)
+				expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(0)
+				expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(1)
+				expect(changeConnectionQualityVideoHandler).toHaveBeenCalledWith(peerConnectionAnalyzer, CONNECTION_QUALITY.VERY_BAD)
 			}
 		})
 
@@ -1221,7 +1569,18 @@ describe('PeerConnectionAnalyzer', () => {
 
 			peerConnectionAnalyzer.setPeerConnection(peerConnection, PEER_DIRECTION.SENDER)
 
-			jest.advanceTimersByTime(6000)
+			jest.advanceTimersByTime(5000)
+			// Force the promises returning the stats to be executed.
+			await null
+
+			expect(peerConnection.getStats).toHaveBeenCalledTimes(5)
+
+			expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(0)
+			expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(0)
+
+			jest.advanceTimersByTime(1000)
 			// Force the promises returning the stats to be executed.
 			await null
 
@@ -1343,7 +1702,18 @@ describe('PeerConnectionAnalyzer', () => {
 
 			peerConnectionAnalyzer.setPeerConnection(peerConnection, PEER_DIRECTION.SENDER)
 
-			jest.advanceTimersByTime(6000)
+			jest.advanceTimersByTime(5000)
+			// Force the promises returning the stats to be executed.
+			await null
+
+			expect(peerConnection.getStats).toHaveBeenCalledTimes(5)
+
+			expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(0)
+			expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(0)
+
+			jest.advanceTimersByTime(1000)
 			// Force the promises returning the stats to be executed.
 			await null
 
@@ -1465,7 +1835,18 @@ describe('PeerConnectionAnalyzer', () => {
 
 			peerConnectionAnalyzer.setPeerConnection(peerConnection, PEER_DIRECTION.SENDER)
 
-			jest.advanceTimersByTime(6000)
+			jest.advanceTimersByTime(5000)
+			// Force the promises returning the stats to be executed.
+			await null
+
+			expect(peerConnection.getStats).toHaveBeenCalledTimes(5)
+
+			expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(0)
+			expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(0)
+
+			jest.advanceTimersByTime(1000)
 			// Force the promises returning the stats to be executed.
 			await null
 
@@ -1587,7 +1968,18 @@ describe('PeerConnectionAnalyzer', () => {
 
 			peerConnectionAnalyzer.setPeerConnection(peerConnection, PEER_DIRECTION.SENDER)
 
-			jest.advanceTimersByTime(6000)
+			jest.advanceTimersByTime(5000)
+			// Force the promises returning the stats to be executed.
+			await null
+
+			expect(peerConnection.getStats).toHaveBeenCalledTimes(5)
+
+			expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(0)
+			expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(0)
+
+			jest.advanceTimersByTime(1000)
 			// Force the promises returning the stats to be executed.
 			await null
 
@@ -1702,7 +2094,18 @@ describe('PeerConnectionAnalyzer', () => {
 
 			peerConnectionAnalyzer.setPeerConnection(peerConnection, PEER_DIRECTION.SENDER)
 
-			jest.advanceTimersByTime(6000)
+			jest.advanceTimersByTime(5000)
+			// Force the promises returning the stats to be executed.
+			await null
+
+			expect(peerConnection.getStats).toHaveBeenCalledTimes(5)
+
+			expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(0)
+			expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(0)
+
+			jest.advanceTimersByTime(1000)
 			// Force the promises returning the stats to be executed.
 			await null
 
@@ -1710,6 +2113,10 @@ describe('PeerConnectionAnalyzer', () => {
 
 			expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.GOOD)
 			expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.VERY_BAD)
+			expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(1)
+			expect(changeConnectionQualityAudioHandler).toHaveBeenCalledWith(peerConnectionAnalyzer, CONNECTION_QUALITY.GOOD)
+			expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(1)
+			expect(changeConnectionQualityVideoHandler).toHaveBeenCalledWith(peerConnectionAnalyzer, CONNECTION_QUALITY.VERY_BAD)
 		})
 
 		test('very bad audio quality, good video quality', async () => {
@@ -1756,7 +2163,18 @@ describe('PeerConnectionAnalyzer', () => {
 
 			peerConnectionAnalyzer.setPeerConnection(peerConnection, PEER_DIRECTION.SENDER)
 
-			jest.advanceTimersByTime(6000)
+			jest.advanceTimersByTime(5000)
+			// Force the promises returning the stats to be executed.
+			await null
+
+			expect(peerConnection.getStats).toHaveBeenCalledTimes(5)
+
+			expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.UNKNOWN)
+			expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(0)
+			expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(0)
+
+			jest.advanceTimersByTime(1000)
 			// Force the promises returning the stats to be executed.
 			await null
 
@@ -1764,6 +2182,10 @@ describe('PeerConnectionAnalyzer', () => {
 
 			expect(peerConnectionAnalyzer.getConnectionQualityAudio()).toBe(CONNECTION_QUALITY.VERY_BAD)
 			expect(peerConnectionAnalyzer.getConnectionQualityVideo()).toBe(CONNECTION_QUALITY.GOOD)
+			expect(changeConnectionQualityAudioHandler).toHaveBeenCalledTimes(1)
+			expect(changeConnectionQualityAudioHandler).toHaveBeenCalledWith(peerConnectionAnalyzer, CONNECTION_QUALITY.VERY_BAD)
+			expect(changeConnectionQualityVideoHandler).toHaveBeenCalledTimes(1)
+			expect(changeConnectionQualityVideoHandler).toHaveBeenCalledWith(peerConnectionAnalyzer, CONNECTION_QUALITY.GOOD)
 		})
 	})
 })


### PR DESCRIPTION
Fixes (non-UI part of) #14019

There are some known false positives that cause the connection warning to be shown when the connection is fine:
- Stat timestamp may not be updated when the stats stall: sometimes the same number of packets is reported two times in a row. The code currently keeps the quality calculation on hold if the same number of packets is reported twice in a row until a third value is received, and then updates the quality based on that third value. In the past it was observed that when the stats stalled the timestamps were updated. However, it seems that it can also happen that the timestamp is also repeated, which messes with the calculations and causes the connection to be reported as very bad even if the same number of packets is reported twice in a row (which was expected to be correctly handled already, but due to this new finding turns out that it is not).
  - [X] Fixed by evenly distributing the timestamps when they stall
  - This seems to be exclusive of Firefox, as Chromium does not provide a `packetsReceived` value in `remote-inbound-rtp`.
  - It is unclear whether the stats can stall more than two times in a row. It was assumed that the connection warning was caused by that, but it is most likely that the stalled timestamp was the actual problem and that it was mistakenly identified as the stats stalling three times in a row. For now it will be assumed that if the same stats are repeated three times in a row there is a connection problem, and it will be adjusted in a follow up if it is found out that it is a false positive.
- Videos with mostly static images and low information (like a blurred background with the video quality reduced due to being in a call with several participants), which may send even less packets per second than the current threshold (10) used to mark the connection as very bad (and therefore show the connection warning)
  - [X] Workarounded by no longer showing a connection warning to the user when the packets per second are low; further investigation would be needed, but in any case it seemed to cause more false positives to be reported than actual positives
- The reported packet count may "go back in time" to a previous value (it seems to happen when enabling the video, but it is not reproducible at will), which messes with the quality calculation.
  - [X] After endless tests it was not reproducible once... It was just found in provided logs, so a "synthetic" test was added that reproduces what was seen in those logs and the issue was fixed by resetting the stats when the received packet count regresses.
  - Although the issue from the logs could not be reproduced a similar (but not fully matching) issue was also found: due to a bug in Firefox and/or Janus ([the stats overflowing is a bug in Firefox and even the spec](https://bugzilla.mozilla.org/show_bug.cgi?id=1853717), but in theory it should not happen unless it received invalid values from Janus) the received packet count may overflow. This typically happens in the stats of the lower quality stream of a simulcast video.

## Follow ups
- [ ] Fix distribution of staged stats (as right now they can be distributed when the values are staged three times due to [a wrong `if (packets > 0) {` condition](https://github.com/nextcloud/spreed/blob/1ccbf67da231c37801c1406b10000144125aec35/src/utils/webrtc/analyzers/PeerConnectionAnalyzer.js#L497))
- [ ] Maybe log stats returned by `getStats()` and not only the processed values in case of strange scenarios (like the packet count regressing) to try to better understand it