### PR TITLE
fix(meeting): adjust styles and wording

### DIFF
--- a/src/components/CalendarEventsDialog.vue
+++ b/src/components/CalendarEventsDialog.vue
@@ -6,6 +6,7 @@
 <script setup lang="ts">
 import { computed, onBeforeMount, provide, ref, watch } from 'vue'
 
+import IconAccountPlus from 'vue-material-design-icons/AccountPlus.vue'
 import IconAccountSearch from 'vue-material-design-icons/AccountSearch.vue'
 import IconCalendarBlank from 'vue-material-design-icons/CalendarBlank.vue'
 import IconCheck from 'vue-material-design-icons/Check.vue'
@@ -96,14 +97,14 @@ const invalidHint = computed(() => {
 	case null:
 		return ''
 	case 'calendar':
-		return t('spreed', 'Error: Invalid calendar selected')
+		return t('spreed', 'Invalid calendar selected')
 	case 'start':
-		return t('spreed', 'Error: Invalid start time selected')
+		return t('spreed', 'Invalid start time selected')
 	case 'end':
-		return t('spreed', 'Error: Invalid end time selected')
+		return t('spreed', 'Invalid end time selected')
 	case 'unknown':
 	default:
-		return t('spreed', 'Error: Unknown error occurred')
+		return t('spreed', 'Unknown error occurred')
 	}
 })
 
@@ -289,59 +290,62 @@ async function submitNewMeeting() {
 		</NcPopover>
 
 		<NcDialog v-if="canScheduleMeeting"
+			id="calendar-meeting"
 			:open.sync="isFormOpen"
-			class="calendar-events"
+			class="calendar-meeting"
 			:name="t('spreed', 'Schedule a meeting')"
 			size="normal"
 			close-on-click-outside
 			:container="container">
-			<div id="calendar-meeting" class="calendar-meeting">
-				<NcTextField v-model="newMeetingTitle"
-					:label="t('spreed', 'Meeting title')"
-					label-visible />
-				<NcTextArea v-model="newMeetingDescription"
-					:label="t('spreed', 'Description')"
-					resize="vertical"
-					label-visible />
-				<div class="calendar-meeting__flex-wrapper">
-					<NcDateTimePickerNative id="schedule_meeting_input"
-						v-model="selectedDateTimeStart"
-						:class="{ 'invalid-time': invalid === 'start' }"
-						:min="new Date()"
-						:step="300"
-						:label="t('spreed', 'From')"
-						type="datetime-local" />
-					<NcDateTimePickerNative id="schedule_meeting_input"
-						v-model="selectedDateTimeEnd"
-						:class="{ 'invalid-time': invalid === 'end' }"
-						:min="new Date()"
-						:step="300"
-						:label="t('spreed', 'To')"
-						type="datetime-local" />
-				</div>
-				<NcSelect id="schedule_meeting_select"
-					v-model="selectedCalendar"
-					:options="calendarOptions"
-					:input-label="t('spreed', 'Calendar')">
-					<template #selected-option="option">
-						<span class="calendar-badge" :style="{ backgroundColor: option.color }" />
-						{{ option.label }}
-					</template>
-					<template #option="option">
-						<span class="calendar-badge" :style="{ backgroundColor: option.color }" />
-						{{ option.label }}
-					</template>
-				</NcSelect>
-				<NcCheckboxRadioSwitch v-model="selectAll" type="switch" @update:modelValue="toggleAll">
-					{{ t('spreed', 'Invite all users and email guests') }}
-				</NcCheckboxRadioSwitch>
-				<div class="calendar-meeting__flex-wrapper">
-					<p>{{ attendeeHint }}</p>
-					<NcButton @click="isSelectorOpen = true">
-						{{ t('spreed', 'Select attendees') }}
-					</NcButton>
-				</div>
+			<NcTextField v-model="newMeetingTitle"
+				:label="t('spreed', 'Meeting title')"
+				label-visible />
+			<NcTextArea v-model="newMeetingDescription"
+				:label="t('spreed', 'Description')"
+				resize="vertical"
+				label-visible />
+			<div class="calendar-meeting__flex-wrapper">
+				<NcDateTimePickerNative id="schedule_meeting_input"
+					v-model="selectedDateTimeStart"
+					:class="{ 'invalid-time': invalid === 'start' }"
+					:min="new Date()"
+					:step="300"
+					:label="t('spreed', 'From')"
+					type="datetime-local" />
+				<NcDateTimePickerNative id="schedule_meeting_input"
+					v-model="selectedDateTimeEnd"
+					:class="{ 'invalid-time': invalid === 'end' }"
+					:min="new Date()"
+					:step="300"
+					:label="t('spreed', 'To')"
+					type="datetime-local" />
 			</div>
+			<NcSelect id="schedule_meeting_select"
+				v-model="selectedCalendar"
+				:options="calendarOptions"
+				:input-label="t('spreed', 'Calendar')">
+				<template #selected-option="option">
+					<span class="calendar-badge" :style="{ backgroundColor: option.color }" />
+					{{ option.label }}
+				</template>
+				<template #option="option">
+					<span class="calendar-badge" :style="{ backgroundColor: option.color }" />
+					{{ option.label }}
+				</template>
+			</NcSelect>
+			<h5 class="calendar-meeting__header">
+				{{ t('spreed', 'Attendees') }}
+			</h5>
+			<NcCheckboxRadioSwitch v-model="selectAll" @update:modelValue="toggleAll">
+				{{ t('spreed', 'Invite all users and emails') }}
+			</NcCheckboxRadioSwitch>
+			<NcButton type="tertiary" @click="isSelectorOpen = true">
+				<template #icon>
+					<IconAccountPlus :size="20" />
+				</template>
+				{{ t('spreed', 'Add attendees') }}
+			</NcButton>
+			<p>{{ attendeeHint }}</p>
 
 			<template #actions>
 				<p v-if="invalidHint" class="calendar-meeting__invalid-hint">
@@ -361,7 +365,8 @@ async function submitNewMeeting() {
 
 		<NcDialog v-if="canScheduleMeeting"
 			:open.sync="isSelectorOpen"
-			:name="t('spreed', 'Select attendees')"
+			:name="t('spreed', 'Add attendees')"
+			class="calendar-meeting"
 			close-on-click-outside
 			container="#calendar-meeting">
 			<SearchBox class="calendar-meeting__searchbox"
@@ -376,27 +381,25 @@ async function submitNewMeeting() {
 					:participant="participant"
 					@update:checked="checkSelection" />
 			</ul>
-			<NcEmptyContent v-else class="calendar-events__empty-content" :name="t('spreed', 'No results')">
+			<NcEmptyContent v-else class="calendar-meeting__empty-content" :name="t('spreed', 'No results')">
 				<template #icon>
 					<IconAccountSearch />
 				</template>
 			</NcEmptyContent>
+			<template #actions>
+				<NcButton type="primary" @click="isSelectorOpen = false">
+					<template #icon>
+						<IconCheck :size="20" />
+					</template>
+					{{ t('spreed', 'Done') }}
+				</NcButton>
+			</template>
 		</NcDialog>
 	</div>
 </template>
 
 <style lang="scss" scoped>
 .calendar-events {
-	margin-block-end: calc(var(--default-grid-baseline) * 2);
-
-	:deep(.dialog__content) {
-		padding-block-end: calc(var(--default-grid-baseline) * 3);
-	}
-
-	:deep(.dialog__actions) {
-		align-items: center;
-	}
-
 	&__list {
 		--item-height: calc(2lh + var(--default-grid-baseline) * 3);
 		display: flex;
@@ -468,14 +471,21 @@ async function submitNewMeeting() {
 }
 
 .calendar-meeting {
-	display: flex;
-	flex-direction: column;
-	margin: calc(var(--default-grid-baseline) / 2);
-	gap: var(--default-grid-baseline);
+	--item-height: calc(2lh + var(--default-grid-baseline) * 2);
+
+	:deep(.dialog__content) {
+		display: flex;
+		flex-direction: column;
+		margin: calc(var(--default-grid-baseline) / 2);
+		gap: var(--default-grid-baseline);
+	}
+
+	:deep(.dialog__actions) {
+		align-items: center;
+	}
 
 	&__header {
-		margin-block: calc(var(--default-grid-baseline) * 3);
-		text-align: center;
+		margin-block: calc(var(--default-grid-baseline) * 2);
 	}
 
 	&__invalid-hint {
@@ -495,9 +505,14 @@ async function submitNewMeeting() {
 	}
 
 	&__attendees {
-		height: calc(100% - var(--default-clickable-area) - 2 * var(--default-grid-baseline));
+		height: calc(5.5 * var(--item-height));
 		padding-block: var(--default-grid-baseline);
 		overflow-y: auto;
+	}
+
+	&__empty-content {
+		height: calc(5.5 * var(--item-height));
+		margin-block: auto !important;
 	}
 
 	// Overwrite default NcDateTimePickerNative styles

--- a/src/components/UIShared/ContactSelectionBubble.vue
+++ b/src/components/UIShared/ContactSelectionBubble.vue
@@ -3,7 +3,7 @@
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
-<script setup>
+<script setup lang="ts">
 import { computed } from 'vue'
 
 import { t } from '@nextcloud/l10n'
@@ -13,27 +13,37 @@ import NcChip from '@nextcloud/vue/dist/Components/NcChip.js'
 import AvatarWrapper from '../AvatarWrapper/AvatarWrapper.vue'
 
 import { AVATAR } from '../../constants.js'
+import type { Participant, ParticipantSearchResult } from '../../types/index.ts'
 
-const props = defineProps({
-	participant: {
-		type: Object,
-		required: true,
-	},
-})
+const props = defineProps<{
+	participant: Participant | ParticipantSearchResult,
+}>()
 const emit = defineEmits(['update'])
 
-const removeLabel = computed(() => t('spreed', 'Remove participant {name}', { name: props.participant.label }))
+const actorId = computed(() => {
+	return ('actorId' in props.participant) ? props.participant.actorId : props.participant.id
+})
+const actorType = computed(() => {
+	return ('actorId' in props.participant) ? props.participant.actorType : props.participant.source
+})
+const computedName = computed(() => {
+	return (('actorId' in props.participant) ? props.participant.displayName : props.participant.label) || t('spreed', 'Guest')
+})
+const token = computed(() => {
+	return ('actorId' in props.participant) ? props.participant.roomToken : 'new'
+})
+const removeLabel = computed(() => t('spreed', 'Remove participant {name}', { name: computedName.value }))
 </script>
 
 <template>
-	<NcChip :text="participant.label"
+	<NcChip :text="computedName"
 		:aria-label-close="removeLabel"
 		@close="emit('update', participant)">
 		<template #icon>
-			<AvatarWrapper :id="participant.id"
-				token="new"
-				:name="participant.label"
-				:source="participant.source"
+			<AvatarWrapper :id="actorId"
+				:token="token"
+				:name="computedName"
+				:source="actorType"
 				:size="AVATAR.SIZE.EXTRA_SMALL"
 				disable-menu
 				disable-tooltip />


### PR DESCRIPTION
### ☑️ Resolves

* Follow-up to #14097

- [x] Distinguish the entire section by adding a heading "Attendees"
- [x] Instead of a toggle, use a checkmark
- [x] "Select attendees" button can be tertiary with icon
- [x] "Select attendees" button and summary can be in different rows to prevent the button position shifting slightly when the number changes 
- [ ] Wording adjustments:
  - [ ] It took a second for me to understand `Invite all users and email guests` --> `Invite all participants in the conversation and email guests`
  - [x] `Select attendees` --> `Add attendees`
  - [ ] `Sending 14 invitations` --> `[👩 Alice Doe], [👨 Sam Smith] and 12 more guests will receive invites` (ideal) or `14 guests will receive invites`
    - [x] ⚠️  Using of rich components is troublesome, approached with what is used for reactions
  - [x] For errors, don't prefix with "Error: "
- [x] If possible, show the selected attendees up top like when you create a new group conversation in Talk (in fact, the whole modal can just be replicated)
- [x] Add a `✔️ Done` or `✔️ Save` button at the end to prevent confusion about whether or not the attendees are added  
 
## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="412" alt="image" src="https://github.com/user-attachments/assets/10bc9a53-f8ae-4c7c-bf24-07dbeb839bbd" /> | <img width="415" alt="image" src="https://github.com/user-attachments/assets/d6bf4a8a-0c1f-44c9-90b6-8781664348fa" />
<img width="413" alt="image" src="https://github.com/user-attachments/assets/731ceedc-0a0d-4700-994f-5d5820a725b1" /> | <img width="418" alt="image" src="https://github.com/user-attachments/assets/be4d9b39-2a7b-4758-abc8-247014f17bea" />
loader | ![image](https://github.com/user-attachments/assets/72a11b28-3717-45bc-ae52-dd20c39128ed)

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Not risky to browser differences / client
- [x] 🖌️ Design was reviewed, approved or inspired by the design team