### PR TITLE
fix(settings): verify hello-v1 response (shared secret)

### DIFF
--- a/src/components/AdminSettings/SignalingServer.vue
+++ b/src/components/AdminSettings/SignalingServer.vue
@@ -237,6 +237,14 @@ export default {
 					{ caption: t('spreed', 'WebSocket URL'), description: signalingTest.url },
 					{ caption: t('spreed', 'Available features'), description: signalingTest.features.join(', ') },
 				]
+				if (signalingTest.hasFeature('hello-v2')) {
+					// additionally verify hello-v1 ticket
+					const signalingTestV1 = createConnection(settings, url, true)
+					await signalingTestV1.connect()
+					this.signalingTestInfo.push(
+						{ caption: t('spreed', '"Hello" response'), description: 'OK' },
+					)
+				}
 			} catch (exception) {
 				console.error(exception)
 				this.errorMessage = t('spreed', 'Error: Websocket connection failed. Check browser console')

--- a/src/utils/SignalingStandaloneTest.js
+++ b/src/utils/SignalingStandaloneTest.js
@@ -14,8 +14,9 @@ import { generateOcsUrl } from '@nextcloud/router'
 
 class StandaloneTest {
 
-	constructor(settings, url) {
+	constructor(settings, url, forceHelloV1 = false) {
 		this.settings = settings
+		this.forceHelloV1 = forceHelloV1
 		this.features = null
 		this.version = null
 
@@ -128,7 +129,7 @@ class StandaloneTest {
 	}
 
 	sendHello() {
-		const version = this.hasFeature('hello-v2') ? '2.0' : '1.0'
+		const version = (!this.forceHelloV1 && this.hasFeature('hello-v2')) ? '2.0' : '1.0'
 
 		const msg = {
 			type: 'hello',
@@ -162,13 +163,14 @@ class StandaloneTest {
  * Returns test instance
  * @param {object} settings signaling settings
  * @param {string} url HPB server URL
+ * @param {boolean} [forceHelloV1] param to test hello-v1 connection
  */
-function createConnection(settings, url) {
+function createConnection(settings, url, forceHelloV1 = false) {
 	if (!settings) {
 		console.error('Signaling settings are not given')
 	}
 
-	return new StandaloneTest(settings, url)
+	return new StandaloneTest(settings, url, forceHelloV1)
 }
 
 export { createConnection }


### PR DESCRIPTION
### ☑️ Resolves

* Follow-up to #13973

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
Screenshot before | Screenshot after

<!-- ☀️ Light theme | 🌑 Dark Theme -->

### 🚧 Tasks

Although I'm unable to catch failed secret: 
<img width="454" alt="image" src="https://github.com/user-attachments/assets/cdf031a1-5fdd-4188-a2c7-e7cedc0c909c" />
Maybe, there is no actual request made (as in `Listener.php`; `BackendNotifier.php`)

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required

---


## 🛠️ API Checklist

### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not possible
- [ ] 📘 API documentation in `docs/` has been updated or is not required
- [ ] 🔖 Capability is added or not needed 
