### PR TITLE
fix(popover): do not steal focus with connection warning

### DIFF
--- a/src/components/TopBar/TopBarMediaControls.vue
+++ b/src/components/TopBar/TopBarMediaControls.vue
@@ -10,6 +10,7 @@
 				:aria-label="qualityWarningAriaLabel"
 				trigger="hover"
 				:auto-hide="false"
+				:focus-trap="false"
 				:shown="showQualityWarningTooltip">
 				<template #trigger>
 					<NcButton id="quality_warning_button"


### PR DESCRIPTION
### ☑️ Resolves

* Ref #14019

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After - focus is still in chat
Reproducable with static screenshare

<img width="306" alt="image" src="https://github.com/user-attachments/assets/12dbeb36-674b-4a2e-ac84-a046d5278941" />

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Not risky to browser differences / client