### PR TITLE
Release 18.0.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 18.0.13 – 2025-01-16
+### Changed
+- Update translations
+- Update dependencies
+
+### Fixed
+- fix(calls): Retain names of guests when they disconnect from the High-performance backend
+  [#13982](https://github.com/nextcloud/spreed/issues/13982)
+- fix(search): Add pagination support to the conversation search in unified search
+  [#14032](https://github.com/nextcloud/spreed/issues/14032)
+- fix(setupcheck): Check server times of Webserver nodes and High-performance backend to be in sync
+  [#14014](https://github.com/nextcloud/spreed/issues/14014)
+- fix(moderation): Allow promoting self-joined users
+  [#14080](https://github.com/nextcloud/spreed/issues/14080)
+
 ## 18.0.13 – 2024-11-07
 ### Changed
 - Update translations

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -16,7 +16,7 @@ And in the works for the [coming versions](https://github.com/nextcloud/spreed/m
 
 	]]></description>
 
-	<version>18.0.13</version>
+	<version>18.0.14</version>
 	<licence>agpl</licence>
 
 	<author>Daniel Calviño Sánchez</author>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "talk",
-  "version": "18.0.13",
+  "version": "18.0.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "talk",
-      "version": "18.0.13",
+      "version": "18.0.14",
       "license": "agpl",
       "dependencies": {
         "@linusborg/vue-simple-portal": "^0.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "talk",
-  "version": "18.0.13",
+  "version": "18.0.14",
   "private": true,
   "description": "",
   "author": "Joas Schilling <coding@schilljs.com>",


### PR DESCRIPTION
## Changed
- Update translations
- Update dependencies

## Fixed
- fix(calls): Retain names of guests when they disconnect from the High-performance backend [#13982](https://github.com/nextcloud/spreed/issues/13982)
- fix(search): Add pagination support to the conversation search in unified search [#14032](https://github.com/nextcloud/spreed/issues/14032)
- fix(setupcheck): Check server times of Webserver nodes and High-performance backend to be in sync [#14014](https://github.com/nextcloud/spreed/issues/14014)
- fix(moderation): Allow promoting self-joined users [#14080](https://github.com/nextcloud/spreed/issues/14080)
