### PR TITLE
Release 19.0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,40 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 19.0.12 – 2025-01-16
+### Changed
+- Update translations
+- Update dependencies
+
+### Fixed
+- fix(calls): Retain names of guests when they disconnect from the High-performance backend
+  [#13983](https://github.com/nextcloud/spreed/issues/13983)
+- fix(search): Add pagination support to the conversation search in unified search
+  [#14033](https://github.com/nextcloud/spreed/issues/14033)
+- fix(setupcheck): Check server times of Webserver nodes and High-performance backend to be in sync
+  [#14015](https://github.com/nextcloud/spreed/issues/14015)
+- fix(moderation): Allow promoting self-joined users
+  [#14081](https://github.com/nextcloud/spreed/issues/14081)
+- fix(calls): Fix "Talk while muted" toast
+  [#14026](https://github.com/nextcloud/spreed/issues/14026)
+- fix(firstrun): Create default conversations when loading the dashboard
+  [#14090](https://github.com/nextcloud/spreed/issues/14090)
+
+## 18.0.13 – 2025-01-16
+### Changed
+- Update translations
+- Update dependencies
+
+### Fixed
+- fix(calls): Retain names of guests when they disconnect from the High-performance backend
+  [#13982](https://github.com/nextcloud/spreed/issues/13982)
+- fix(search): Add pagination support to the conversation search in unified search
+  [#14032](https://github.com/nextcloud/spreed/issues/14032)
+- fix(setupcheck): Check server times of Webserver nodes and High-performance backend to be in sync
+  [#14014](https://github.com/nextcloud/spreed/issues/14014)
+- fix(moderation): Allow promoting self-joined users
+  [#14080](https://github.com/nextcloud/spreed/issues/14080)
+
 ## 19.0.11 – 2024-11-07
 ### Changed
 - Update translations

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -14,7 +14,7 @@
 * 🌉 **Sync with other chat solutions** With [Matterbridge](https://github.com/42wim/matterbridge/) being integrated in Talk, you can easily sync a lot of other chat solutions to Nextcloud Talk and vice-versa.
 ]]></description>
 
-	<version>19.0.11</version>
+	<version>19.0.12</version>
 	<licence>agpl</licence>
 
 	<author>Daniel Calviño Sánchez</author>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "talk",
-  "version": "19.0.11",
+  "version": "19.0.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "talk",
-      "version": "19.0.11",
+      "version": "19.0.12",
       "license": "agpl",
       "dependencies": {
         "@linusborg/vue-simple-portal": "^0.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "talk",
-  "version": "19.0.11",
+  "version": "19.0.12",
   "private": true,
   "description": "",
   "author": "Joas Schilling <coding@schilljs.com>",


### PR DESCRIPTION
## Changed
- Update translations
- Update dependencies

## Fixed
- fix(calls): Retain names of guests when they disconnect from the High-performance backend [#13983](https://github.com/nextcloud/spreed/issues/13983)
- fix(search): Add pagination support to the conversation search in unified search [#14033](https://github.com/nextcloud/spreed/issues/14033)
- fix(setupcheck): Check server times of Webserver nodes and High-performance backend to be in sync [#14015](https://github.com/nextcloud/spreed/issues/14015)
- fix(moderation): Allow promoting self-joined users [#14081](https://github.com/nextcloud/spreed/issues/14081)
- fix(calls): Fix "Talk while muted" toast [#14026](https://github.com/nextcloud/spreed/issues/14026)
- fix(firstrun): Create default conversations when loading the dashboard [#14090](https://github.com/nextcloud/spreed/issues/14090)