### PR TITLE
fix(federation): Fix protocol handling of invitations

### DIFF
--- a/lib/Federation/CloudFederationProviderTalk.php
+++ b/lib/Federation/CloudFederationProviderTalk.php
@@ -648,7 +648,7 @@ class CloudFederationProviderTalk implements ICloudFederationProvider, ISignedCl
 		}
 
 		try {
-			$invite = $this->invitationMapper->getByRemoteServerAndAccessToken($remoteServerUrl, $sharedSecret);
+			$invite = $this->invitationMapper->getByRemoteServerAndAccessToken($payload['remoteServerUrl'], $sharedSecret);
 			return $invite->getInviterCloudId();
 		} catch (DoesNotExistException) {
 		}


### PR DESCRIPTION
Invitations are always stored with the protocol,
so when checking for invitations we use the original remoteServerUrl
which contains the protocol in http and https cases

## 🛠️ API Checklist

### 🚧 Tasks

- [x] Test federation with https in both directions (main being sender and receiver)
- [x] No integration test possible while https is not supported there

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
