### PR TITLE
fix: inverse left arrow icons when it is RTL

### DIFF
--- a/css/icons.css
+++ b/css/icons.css
@@ -145,6 +145,11 @@ body[data-theme-dark] .mention-bubble .icon-mail-forced-white.mention-bubble__ic
 	background-color: #3B3B3B;
 }
 
+/* Invert the icon direction */
+body[dir="rtl"] .bidirectional-icon {
+	transform: scaleX(-1);
+}
+
 .user-bubble__avatar .icon-group-forced-white.avatar-class-icon,
 .user-bubble__avatar .icon-user-forced-white.avatar-class-icon,
 .user-bubble__avatar .icon-mail-forced-white.avatar-class-icon,

--- a/src/components/BreakoutRoomsEditor/BreakoutRoomsParticipantsEditor.vue
+++ b/src/components/BreakoutRoomsEditor/BreakoutRoomsParticipantsEditor.vue
@@ -42,7 +42,7 @@
 				type="tertiary"
 				@click="goBack">
 				<template #icon>
-					<ArrowLeft :size="20" />
+					<IconArrowLeft class="bidirectional-icon" :size="20" />
 				</template>
 				{{ t('spreed', 'Back') }}
 			</NcButton>
@@ -92,7 +92,7 @@
 <script>
 import { provide } from 'vue'
 
-import ArrowLeft from 'vue-material-design-icons/ArrowLeft.vue'
+import IconArrowLeft from 'vue-material-design-icons/ArrowLeft.vue'
 import Delete from 'vue-material-design-icons/Delete.vue'
 import DotsCircle from 'vue-material-design-icons/DotsCircle.vue'
 import Reload from 'vue-material-design-icons/Reload.vue'
@@ -121,7 +121,7 @@ export default {
 		BreakoutRoomItem,
 		SelectableParticipant,
 		NcButton,
-		ArrowLeft,
+		IconArrowLeft,
 		Delete,
 		NcDialog,
 	},

--- a/src/components/LeftSidebar/ConversationsList/Conversation.vue
+++ b/src/components/LeftSidebar/ConversationsList/Conversation.vue
@@ -156,7 +156,7 @@
 		<template v-else-if="item.token" #actions>
 			<NcActionButton key="join-conversation" close-after-click @click="onActionClick">
 				<template #icon>
-					<IconArrowRight :size="16" />
+					<IconArrowRight class="bidirectional-icon" :size="16" />
 				</template>
 				{{ t('spreed', 'Join conversation') }}
 			</NcActionButton>

--- a/src/components/LeftSidebar/ConversationsList/Conversation.vue
+++ b/src/components/LeftSidebar/ConversationsList/Conversation.vue
@@ -121,7 +121,7 @@
 				<NcActionButton :aria-label="t('spreed', 'Back')"
 					@click.stop="submenu = null">
 					<template #icon>
-						<IconArrowLeft :size="16" />
+						<IconArrowLeft class="bidirectional-icon" :size="16" />
 					</template>
 					{{ t('spreed', 'Back') }}
 				</NcActionButton>

--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -292,7 +292,7 @@
 						wide
 						@click="showArchived = false">
 						<template #icon>
-							<IconArrowLeft :size="20" />
+							<IconArrowLeft class="bidirectional-icon" :size="20" />
 						</template>
 						{{ t('spreed', 'Back to conversations') }}
 					</NcButton>

--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
@@ -177,7 +177,7 @@
 					<NcActionButton :aria-label="t('spreed', 'Back')"
 						@click.stop="submenu = null">
 						<template #icon>
-							<ArrowLeft />
+							<IconArrowLeft class="bidirectional-icon" />
 						</template>
 						{{ t('spreed', 'Back') }}
 					</NcActionButton>
@@ -230,7 +230,7 @@
 				:aria-label="t('spreed', 'Close reactions menu')"
 				@click="closeReactionsMenu">
 				<template #icon>
-					<ArrowLeft :size="20" />
+					<IconArrowLeft class="bidirectional-icon" :size="20" />
 				</template>
 			</NcButton>
 			<NcButton v-for="emoji in frequentlyUsedEmojis"
@@ -265,7 +265,7 @@ import { toRefs } from 'vue'
 
 import AccountIcon from 'vue-material-design-icons/Account.vue'
 import AlarmIcon from 'vue-material-design-icons/Alarm.vue'
-import ArrowLeft from 'vue-material-design-icons/ArrowLeft.vue'
+import IconArrowLeft from 'vue-material-design-icons/ArrowLeft.vue'
 import IconBellOff from 'vue-material-design-icons/BellOff.vue'
 import CalendarClock from 'vue-material-design-icons/CalendarClock.vue'
 import Check from 'vue-material-design-icons/Check.vue'
@@ -327,7 +327,7 @@ export default {
 		// Icons
 		AccountIcon,
 		AlarmIcon,
-		ArrowLeft,
+		IconArrowLeft,
 		IconBellOff,
 		CalendarClock,
 		CloseCircleOutline,

--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageTranslateDialog.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageTranslateDialog.vue
@@ -20,7 +20,7 @@
 					:options="optionsFrom"
 					no-wrap />
 
-				<ArrowRight />
+				<ArrowRight class="bidirectional-icon" />
 
 				<NcSelect v-model="selectedTo"
 					class="translate-dialog__select"

--- a/src/components/NewMessage/NewMessage.vue
+++ b/src/components/NewMessage/NewMessage.vue
@@ -146,7 +146,7 @@
 					:aria-label="sendMessageLabel"
 					@click="handleSubmit">
 					<template #icon>
-						<SendIcon :size="16" />
+						<SendIcon class="bidirectional-icon" :size="16" />
 					</template>
 				</NcButton>
 			</template>

--- a/src/components/NewMessage/NewMessagePollEditor.vue
+++ b/src/components/NewMessage/NewMessagePollEditor.vue
@@ -15,7 +15,7 @@
 			:aria-label="t('spreed', 'Back')"
 			@click="goBack">
 			<template #icon>
-				<IconArrowLeft :size="20" />
+				<IconArrowLeft class="bidirectional-icon" :size="20" />
 			</template>
 		</NcButton>
 		<!-- Poll Question -->

--- a/src/components/NewMessage/NewMessagePollEditor.vue
+++ b/src/components/NewMessage/NewMessagePollEditor.vue
@@ -337,7 +337,7 @@ function goBack() {
 	&__back-button {
 		position: absolute !important;
 		top: var(--default-grid-baseline);
-		left: var(--default-grid-baseline);
+		inset-inline-start: var(--default-grid-baseline);
 		z-index: 1;
 	}
 }

--- a/src/components/RightSidebar/BreakoutRooms/BreakoutRoomsActions.vue
+++ b/src/components/RightSidebar/BreakoutRooms/BreakoutRoomsActions.vue
@@ -62,7 +62,7 @@
 				type="secondary"
 				@click="switchToBreakoutRoom">
 				<template #icon>
-					<ArrowRight :size="20" />
+					<ArrowRight class="bidirectional-icon" :size="20" />
 				</template>
 				{{ backToBreakoutRoomLabel }}
 			</NcButton>

--- a/src/components/RightSidebar/BreakoutRooms/BreakoutRoomsActions.vue
+++ b/src/components/RightSidebar/BreakoutRooms/BreakoutRoomsActions.vue
@@ -51,7 +51,7 @@
 				type="secondary"
 				@click="switchToParentRoom">
 				<template #icon>
-					<ArrowLeft :size="20" />
+					<IconArrowLeft class="bidirectional-icon" :size="20" />
 				</template>
 				{{ backToMainRoomLabel }}
 			</NcButton>
@@ -115,7 +115,7 @@
 <script>
 import { ref } from 'vue'
 
-import ArrowLeft from 'vue-material-design-icons/ArrowLeft.vue'
+import IconArrowLeft from 'vue-material-design-icons/ArrowLeft.vue'
 import ArrowRight from 'vue-material-design-icons/ArrowRight.vue'
 import Check from 'vue-material-design-icons/Check.vue'
 import Cog from 'vue-material-design-icons/Cog.vue'
@@ -155,7 +155,7 @@ export default {
 		Play,
 		Cog,
 		Check,
-		ArrowLeft,
+		IconArrowLeft,
 		ArrowRight,
 		Send,
 	},

--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -35,7 +35,7 @@
 				:title="t('spreed', 'Back')"
 				@click="showSearchMessagesTab = false">
 				<template #icon>
-					<IconArrowLeft :size="20" />
+					<IconArrowLeft class="bidirectional-icon" :size="20" />
 				</template>
 			</NcButton>
 		</template>

--- a/src/components/TopBar/CallButton.vue
+++ b/src/components/TopBar/CallButton.vue
@@ -60,12 +60,12 @@
 			<template #icon>
 				<NcLoadingIcon v-if="loading" :size="20" />
 				<IconPhoneHangup v-else-if="!isBreakoutRoom" :size="20" />
-				<IconArrowLeft v-else :size="20" />
+				<IconArrowLeft v-else class="bidirectional-icon" :size="20" />
 			</template>
 			<NcActionButton v-if="isBreakoutRoom"
 				@click="switchToParentRoom">
 				<template #icon>
-					<IconArrowLeft :size="20" />
+					<IconArrowLeft class="bidirectional-icon" :size="20" />
 				</template>
 				{{ backToMainRoomLabel }}
 			</NcActionButton>


### PR DESCRIPTION
### ☑️ Resolves


<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/user-attachments/assets/f077cd13-ad09-438e-9579-63abb72d0a22) | ![image](https://github.com/user-attachments/assets/c0322f78-f8cd-4196-b0fa-7ca72b2f05c4)

<!-- ☀️ Light theme | 🌑 Dark Theme -->

### 🚧 Tasks

- [x] If there is a left arrow icon that shouldn't be reversed
- [x] Off topic change was the back button in poll editor because it was overlapping the close button 
### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
