### PR TITLE
fix: add max description length as a capability

### DIFF
--- a/src/components/ConversationSettings/BasicInfo.vue
+++ b/src/components/ConversationSettings/BasicInfo.vue
@@ -27,7 +27,7 @@
 				:loading="isDescriptionLoading"
 				:edit-button-aria-label="t('spreed', 'Edit conversation description')"
 				:placeholder="t('spreed', 'Enter a description for this conversation')"
-				:max-length="CONVERSATION.MAX_DESCRIPTION_LENGTH"
+				:max-length="maxDescriptionLength"
 				multiline
 				use-markdown
 				@submit-text="handleUpdateDescription"
@@ -53,9 +53,10 @@ import ConversationAvatarEditor from './ConversationAvatarEditor.vue'
 import EditableTextField from '../UIShared/EditableTextField.vue'
 
 import { CONVERSATION } from '../../constants.js'
-import { hasTalkFeature } from '../../services/CapabilitiesManager.ts'
+import { hasTalkFeature, getTalkConfig } from '../../services/CapabilitiesManager.ts'
 
 const supportsAvatar = hasTalkFeature('local', 'avatar')
+const maxDescriptionLength = getTalkConfig('local', 'conversations', 'description-length') || 500
 
 export default {
 	name: 'BasicInfo',
@@ -82,6 +83,7 @@ export default {
 		return {
 			supportsAvatar,
 			CONVERSATION,
+			maxDescriptionLength
 		}
 	},
 

--- a/src/components/NewConversationDialog/NewConversationDialog.vue
+++ b/src/components/NewConversationDialog/NewConversationDialog.vue
@@ -124,6 +124,7 @@ import LoadingComponent from '../LoadingComponent.vue'
 import { useId } from '../../composables/useId.ts'
 import { useIsInCall } from '../../composables/useIsInCall.js'
 import { CONVERSATION } from '../../constants.js'
+import { getTalkConfig } from '../../services/CapabilitiesManager.ts'
 import { addParticipant } from '../../services/participantsService.js'
 import { copyConversationLinkToClipboard } from '../../utils/handleUrl.ts'
 
@@ -135,7 +136,7 @@ const NEW_CONVERSATION = {
 	type: CONVERSATION.TYPE.GROUP,
 	isDummyConversation: true,
 }
-
+const maxDescriptionLength = getTalkConfig('local', 'conversations', 'description-length') || 500
 export default {
 	name: 'NewConversationDialog',
 
@@ -205,7 +206,7 @@ export default {
 		disabled() {
 			return this.conversationName === '' || (this.newConversation.hasPassword && (this.password === '' || !this.isPasswordValid))
 				|| this.conversationName.length > CONVERSATION.MAX_NAME_LENGTH
-				|| this.newConversation.description.length > CONVERSATION.MAX_DESCRIPTION_LENGTH
+				|| this.newConversation.description.length > maxDescriptionLength
 		},
 
 		isFilled() {

--- a/src/components/NewConversationDialog/NewConversationSetupPage.vue
+++ b/src/components/NewConversationDialog/NewConversationSetupPage.vue
@@ -79,6 +79,7 @@ import generatePassword from '../../utils/generatePassword.ts'
 
 const supportsAvatar = hasTalkFeature('local', 'avatar')
 const forcePasswordProtection = getTalkConfig('local', 'conversations', 'force-passwords')
+const maxDescriptionLength = getTalkConfig('local', 'conversations', 'description-length') || 500
 export default {
 
 	name: 'NewConversationSetupPage',
@@ -143,10 +144,10 @@ export default {
 		},
 
 		descriptionErrorLabel() {
-			if (this.conversationDescription.length <= CONVERSATION.MAX_DESCRIPTION_LENGTH) {
+			if (this.conversationDescription.length <= maxDescriptionLength) {
 				return
 			}
-			return t('spreed', 'Maximum length exceeded ({maxlength} characters)', { maxlength: CONVERSATION.MAX_DESCRIPTION_LENGTH })
+			return t('spreed', 'Maximum length exceeded ({maxlength} characters)', { maxlength: maxDescriptionLength })
 		},
 
 		isPublic: {

--- a/src/constants.js
+++ b/src/constants.js
@@ -110,7 +110,6 @@ export const CONVERSATION = {
 	},
 
 	MAX_NAME_LENGTH: 255,
-	MAX_DESCRIPTION_LENGTH: 500,
 }
 
 export const ATTENDEE = {


### PR DESCRIPTION
### ☑️ Resolves

* Fix #14131


### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required


