### PR TITLE
fix(setupcheck): Downgrade setup check when warning opt-out is used

### DIFF
--- a/lib/SetupCheck/HighPerformanceBackend.php
+++ b/lib/SetupCheck/HighPerformanceBackend.php
@@ -37,7 +37,11 @@ class HighPerformanceBackend implements ISetupCheck {
 
 	public function run(): SetupResult {
 		if ($this->talkConfig->getSignalingMode() === Config::SIGNALING_INTERNAL) {
-			return SetupResult::error(
+			$setupResult = SetupResult::error(...);
+			if ($this->talkConfig->getHideSignalingWarning()) {
+				$setupResult = SetupResult::warning(...);
+			}
+			return $setupResult(
 				$this->l->t('No High-performance backend configured - Running Nextcloud Talk without the High-performance backend only scales for very small calls (max. 2-3 participants). Please set up the High-performance backend to ensure calls with multiple participants work seamlessly.'),
 				'https://portal.nextcloud.com/article/Nextcloud-Talk/High-Performance-Backend/Installation-of-Nextcloud-Talk-High-Performance-Backend',
 			);


### PR DESCRIPTION
### ☑️ Resolves

* Ref #14142 

## 🛠️ API Checklist

### 🏁 Checklist

- [X] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
