### PR TITLE
fix(AdminSettings): move signaling state to the root

### DIFF
--- a/src/components/AdminSettings/GeneralSettings.vue
+++ b/src/components/AdminSettings/GeneralSettings.vue
@@ -86,6 +86,13 @@ export default {
 		NcSelect,
 	},
 
+	props: {
+		hasSignalingServers: {
+			type: Boolean,
+			required: true,
+		},
+	},
+
 	data() {
 		return {
 			loading: true,
@@ -99,7 +106,6 @@ export default {
 			conversationsFilesPublicShares: parseInt(loadState('spreed', 'conversations_files_public_shares')) === 1,
 
 			hasFeatureJoinFeatures: false,
-			hasSignalingServers: false,
 			isE2EECallsEnabled: false,
 			hasSIPBridge: !!loadState('spreed', 'sip_bridge_shared_secret'),
 		}
@@ -122,25 +128,17 @@ export default {
 		this.defaultGroupNotification = defaultGroupNotificationOptions[parseInt(loadState('spreed', 'default_group_notification')) - 1]
 		this.loading = false
 
-		const signaling = loadState('spreed', 'signaling_servers')
-		this.updateSignalingServers(signaling.servers)
-		EventBus.on('signaling-servers-updated', this.updateSignalingServers)
 		EventBus.on('signaling-server-connected', this.updateSignalingDetails)
 		EventBus.on('sip-settings-updated', this.updateSipDetails)
 	},
 
 	beforeDestroy() {
-		EventBus.off('signaling-servers-updated', this.updateSignalingServers)
 		EventBus.off('signaling-server-connected', this.updateSignalingDetails)
 		EventBus.off('sip-settings-updated', this.updateSipDetails)
 	},
 
 	methods: {
 		t,
-
-		updateSignalingServers(servers) {
-			this.hasSignalingServers = servers.length > 0
-		},
 
 		updateSignalingDetails(signaling) {
 			this.hasFeatureJoinFeatures = signaling.hasFeature('join-features')

--- a/src/components/AdminSettings/HostedSignalingServer.vue
+++ b/src/components/AdminSettings/HostedSignalingServer.vue
@@ -4,7 +4,7 @@
 -->
 
 <template>
-	<section v-if="showForm"
+	<section v-if="!hasSignalingServers || trialAccount.length !== 0"
 		id="hosted_signaling_server"
 		class="hosted-signaling section">
 		<h2>
@@ -140,6 +140,13 @@ export default {
 		NcTextField,
 	},
 
+	props: {
+		hasSignalingServers: {
+			type: Boolean,
+			required: true,
+		},
+	},
+
 	data() {
 		return {
 			hostedHPBNextcloudUrl: '',
@@ -209,14 +216,6 @@ export default {
 
 		this.hostedHPBLanguage = this.languages.find(language => language.code === state.language) ?? this.languages[0]
 		this.hostedHPBCountry = this.countries.find(country => country.code === state.country) ?? this.countries[0]
-
-		const signaling = loadState('spreed', 'signaling_servers')
-		this.updateSignalingServers(signaling.servers)
-		EventBus.on('signaling-servers-updated', this.updateSignalingServers)
-	},
-
-	beforeDestroy() {
-		EventBus.off('signaling-servers-updated', this.updateSignalingServers)
 	},
 
 	methods: {
@@ -255,10 +254,6 @@ export default {
 			} finally {
 				this.loading = false
 			}
-		},
-
-		updateSignalingServers(servers) {
-			this.showForm = this.trialAccount.length !== 0 || servers.length === 0
 		},
 	},
 }

--- a/src/components/AdminSettings/RecordingServers.vue
+++ b/src/components/AdminSettings/RecordingServers.vue
@@ -10,7 +10,7 @@
 			{{ t('spreed', 'Recording backend') }}
 		</h2>
 
-		<NcNoteCard v-if="!showForm"
+		<NcNoteCard v-if="!hasSignalingServers"
 			type="warning"
 			:text="t('spreed', 'Recording backend configuration is only possible with a High-performance backend.')" />
 
@@ -138,6 +138,13 @@ export default {
 		TransitionWrapper,
 	},
 
+	props: {
+		hasSignalingServers: {
+			type: Boolean,
+			required: true,
+		},
+	},
+
 	setup() {
 		return {
 			recordingConsentCapability,
@@ -152,7 +159,6 @@ export default {
 			uploadLimit: 0,
 			loading: false,
 			saved: false,
-			showForm: true,
 			recordingConsentSelected: loadState('spreed', 'recording_consent').toString(),
 			recordingTranscriptionEnabled: loadState('spreed', 'call_recording_transcription'),
 			recordingSummaryEnabled: loadState('spreed', 'call_recording_summary'),
@@ -178,15 +184,10 @@ export default {
 		this.servers = state.servers
 		this.secret = state.secret
 		this.uploadLimit = parseInt(state.uploadLimit, 10)
-
-		const signaling = loadState('spreed', 'signaling_servers')
-		this.updateSignalingServers(signaling.servers)
-		EventBus.on('signaling-servers-updated', this.updateSignalingServers)
 	},
 
 	beforeDestroy() {
 		this.debounceUpdateServers.clear?.()
-		EventBus.off('signaling-servers-updated', this.updateSignalingServers)
 	},
 
 	methods: {
@@ -264,10 +265,6 @@ export default {
 			setTimeout(() => {
 				this.saved = false
 			}, 3000)
-		},
-
-		updateSignalingServers(servers) {
-			this.showForm = servers.length > 0
 		},
 	},
 }

--- a/src/components/AdminSettings/SIPBridge.vue
+++ b/src/components/AdminSettings/SIPBridge.vue
@@ -7,7 +7,7 @@
 	<div id="sip-bridge" class="sip-bridge section">
 		<h2>{{ t('spreed', 'SIP configuration') }}</h2>
 
-		<NcNoteCard v-if="!showForm"
+		<NcNoteCard v-if="!hasSignalingServers"
 			type="warning"
 			:text="t('spreed', 'SIP configuration is only possible with a High-performance backend.')" />
 
@@ -110,11 +110,17 @@ export default {
 		NcPasswordField,
 	},
 
+	props: {
+		hasSignalingServers: {
+			type: Boolean,
+			required: true,
+		},
+	},
+
 	data() {
 		return {
 			loading: false,
 			loadingGroups: false,
-			showForm: true,
 			groups: [],
 			sipGroups: [],
 			dialInInfo: '',
@@ -148,17 +154,11 @@ export default {
 		this.debounceSearchGroup('')
 		this.loading = false
 		this.saveCurrentSetup()
-
-		const signaling = loadState('spreed', 'signaling_servers')
-		this.updateSignalingServers(signaling.servers)
-		EventBus.on('signaling-servers-updated', this.updateSignalingServers)
-
 		this.isDialoutSupported()
 	},
 
 	beforeDestroy() {
 		this.debounceSearchGroup.clear?.()
-		EventBus.off('signaling-servers-updated', this.updateSignalingServers)
 	},
 
 	methods: {
@@ -228,10 +228,6 @@ export default {
 					this.dialOutSupported = false
 				}
 			}
-		},
-
-		updateSignalingServers(servers) {
-			this.showForm = servers.length > 0
 		},
 	},
 }

--- a/src/components/AdminSettings/SignalingServers.vue
+++ b/src/components/AdminSettings/SignalingServers.vue
@@ -87,7 +87,6 @@ import NcPasswordField from '@nextcloud/vue/dist/Components/NcPasswordField.js'
 import SignalingServer from '../../components/AdminSettings/SignalingServer.vue'
 
 import { SIGNALING } from '../../constants.js'
-import { EventBus } from '../../services/EventBus.ts'
 import type { InitialState } from '../../types/index.ts'
 
 const isCacheConfigured = loadState('spreed', 'has_cache_configured')
@@ -180,7 +179,6 @@ function updateServers() {
 	}), {
 		success: () => {
 			showSuccess(t('spreed', 'High-performance backend settings saved'))
-			EventBus.emit('signaling-servers-updated', serversProxy.value)
 			loading.value = false
 		},
 	})

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -15,6 +15,12 @@ declare global {
 		webkitRequestFullscreen: RequestFullscreen;
 	}
 
+	const OCP: {
+		AppConfig: {
+			setValue: (app: string, key: string, value: string | number | boolean, options?: { success?: () => void, error?: () => void }) => void,
+		},
+	}
+
 	// @nextcloud/webpack-vue-config build globals
 	const appName: string
 	const appVersion: string

--- a/src/services/EventBus.ts
+++ b/src/services/EventBus.ts
@@ -36,7 +36,6 @@ type Events = Record<EventType, unknown> & {
 	'signaling-join-room': [string],
 	'signaling-participant-list-changed': void,
 	'signaling-recording-status-changed': [string, number],
-	'signaling-servers-updated': { server: string, verify: boolean }[],
 	'signaling-users-changed': [(Partial<Participant> & ({ sessionId: string } | { nextcloudSessionId: string }))[]],
 	'signaling-users-in-room': [{ sessionId: string, userId: string }[]],
 	'smart-picker-open': void,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -42,6 +42,17 @@ export type Capabilities = {
 
 export type getCapabilitiesResponse = ApiResponse<operations['room-get-capabilities']['responses'][200]['content']['application/json']>
 
+// Initial state
+export type InitialState = {
+	spreed: {
+		'signaling_servers': {
+			hideWarning: boolean,
+			secret: string,
+			servers: { server: string, verify: boolean }[],
+		},
+	},
+}
+
 // Notifications
 type NotificationAction = {
 	label: string,

--- a/src/views/AdminSettings.vue
+++ b/src/views/AdminSettings.vue
@@ -4,7 +4,7 @@
 -->
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 
 import { loadState } from '@nextcloud/initial-state'
 
@@ -31,6 +31,7 @@ const signalingServers = ref<InitialState['spreed']['signaling_servers']>(loadSt
 	secret: '',
 	servers: [],
 }))
+const hasSignalingServers = computed(() => signalingServers.value.servers.length > 0)
 </script>
 
 <template>
@@ -38,16 +39,16 @@ const signalingServers = ref<InitialState['spreed']['signaling_servers']>(loadSt
 		<SignalingServers :servers.sync="signalingServers.servers"
 			:secret.sync="signalingServers.secret"
 			:hide-warning.sync="signalingServers.hideWarning" />
-		<HostedSignalingServer />
-		<GeneralSettings />
+		<HostedSignalingServer :has-signaling-servers="hasSignalingServers" />
+		<GeneralSettings :has-signaling-servers="hasSignalingServers" />
 		<AllowedGroups />
 		<Federation v-if="supportFederation" />
 		<BotsSettings />
 		<WebServerSetupChecks />
 		<StunServers />
 		<TurnServers />
-		<RecordingServers />
-		<SIPBridge />
+		<RecordingServers :has-signaling-servers="hasSignalingServers" />
+		<SIPBridge :has-signaling-servers="hasSignalingServers" />
 		<MatterbridgeIntegration />
 	</div>
 </template>

--- a/src/views/AdminSettings.vue
+++ b/src/views/AdminSettings.vue
@@ -3,24 +3,7 @@
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
-<template>
-	<div>
-		<SignalingServers />
-		<HostedSignalingServer />
-		<GeneralSettings />
-		<AllowedGroups />
-		<Federation v-if="supportFederation" />
-		<BotsSettings />
-		<WebServerSetupChecks />
-		<StunServers />
-		<TurnServers />
-		<RecordingServers />
-		<SIPBridge />
-		<MatterbridgeIntegration />
-	</div>
-</template>
-
-<script>
+<script setup lang="ts">
 import AllowedGroups from '../components/AdminSettings/AllowedGroups.vue'
 import BotsSettings from '../components/AdminSettings/BotsSettings.vue'
 import Federation from '../components/AdminSettings/Federation.vue'
@@ -37,27 +20,21 @@ import WebServerSetupChecks from '../components/AdminSettings/WebServerSetupChec
 import { hasTalkFeature } from '../services/CapabilitiesManager.ts'
 
 const supportFederation = hasTalkFeature('local', 'federation-v1')
-
-export default {
-	name: 'AdminSettings',
-
-	components: {
-		AllowedGroups,
-		BotsSettings,
-		Federation,
-		GeneralSettings,
-		HostedSignalingServer,
-		MatterbridgeIntegration,
-		RecordingServers,
-		SignalingServers,
-		SIPBridge,
-		StunServers,
-		TurnServers,
-		WebServerSetupChecks,
-	},
-
-	setup() {
-		return { supportFederation }
-	}
-}
 </script>
+
+<template>
+	<div>
+		<SignalingServers />
+		<HostedSignalingServer />
+		<GeneralSettings />
+		<AllowedGroups />
+		<Federation v-if="supportFederation" />
+		<BotsSettings />
+		<WebServerSetupChecks />
+		<StunServers />
+		<TurnServers />
+		<RecordingServers />
+		<SIPBridge />
+		<MatterbridgeIntegration />
+	</div>
+</template>

--- a/src/views/AdminSettings.vue
+++ b/src/views/AdminSettings.vue
@@ -4,6 +4,10 @@
 -->
 
 <script setup lang="ts">
+import { ref } from 'vue'
+
+import { loadState } from '@nextcloud/initial-state'
+
 import AllowedGroups from '../components/AdminSettings/AllowedGroups.vue'
 import BotsSettings from '../components/AdminSettings/BotsSettings.vue'
 import Federation from '../components/AdminSettings/Federation.vue'
@@ -18,13 +22,22 @@ import TurnServers from '../components/AdminSettings/TurnServers.vue'
 import WebServerSetupChecks from '../components/AdminSettings/WebServerSetupChecks.vue'
 
 import { hasTalkFeature } from '../services/CapabilitiesManager.ts'
+import type { InitialState } from '../types/index.ts'
 
 const supportFederation = hasTalkFeature('local', 'federation-v1')
+
+const signalingServers = ref<InitialState['spreed']['signaling_servers']>(loadState('spreed', 'signaling_servers', {
+	hideWarning: false,
+	secret: '',
+	servers: [],
+}))
 </script>
 
 <template>
 	<div>
-		<SignalingServers />
+		<SignalingServers :servers.sync="signalingServers.servers"
+			:secret.sync="signalingServers.secret"
+			:hide-warning.sync="signalingServers.hideWarning" />
 		<HostedSignalingServer />
 		<GeneralSettings />
 		<AllowedGroups />


### PR DESCRIPTION
### ☑️ Resolves

* Ref #14132


## 🖌️ UI Checklist

### 🚧 Tasks

- [x] Move current components to TS (2/17)
- [x] replace `EventBus.emit('signaling-servers-updated')`, with reactive state

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client