### PR TITLE
chore(release): Prepare 21.0.0-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 21.0.0-beta.2 – 2025-01-17
+### Added
+- feat(search): Add message search to the right sidebar
+  [#14125](https://github.com/nextcloud/spreed/issues/14125)
+- feat(conversations): Add sample conversation mechanism
+  [#14124](https://github.com/nextcloud/spreed/issues/14124)
+- feat(calls): Add end-to-end encryption for calls with the High-performance backend
+  [#14005](https://github.com/nextcloud/spreed/issues/14005)
+
+### Changed
+- Update translations
+- Update dependencies
+
+### Fixed
+- fix(federation): Fix federation from Nextcloud 30 to 31 with https
+  [#14141](https://github.com/nextcloud/spreed/issues/14141)
+- fix(conversations): Make compact list more compact and avatar bigger
+  [#14118](https://github.com/nextcloud/spreed/issues/14118)
+- fix(signaling): Test actual websocket connection in admin settings
+  [#13973](https://github.com/nextcloud/spreed/issues/13973)
+- fix(archive): Don't add asterix to title for unread messages in archived conversations
+  [#14101](https://github.com/nextcloud/spreed/issues/14101)
+- 
 ## 20.1.2 – 2025-01-16
 ### Changed
 - Update translations

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -18,7 +18,7 @@
 * 🌉 **Sync with other chat solutions** With [Matterbridge](https://github.com/42wim/matterbridge/) being integrated in Talk, you can easily sync a lot of other chat solutions to Nextcloud Talk and vice-versa.
 ]]></description>
 
-	<version>21.0.0-beta.1</version>
+	<version>21.0.0-beta.2</version>
 	<licence>agpl</licence>
 
 	<author>Anna Larch</author>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "talk",
-  "version": "21.0.0-beta.1",
+  "version": "21.0.0-beta.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "talk",
-      "version": "21.0.0-beta.1",
+      "version": "21.0.0-beta.2",
       "license": "agpl",
       "dependencies": {
         "@linusborg/vue-simple-portal": "^0.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "talk",
-  "version": "21.0.0-beta.1",
+  "version": "21.0.0-beta.2",
   "private": true,
   "description": "",
   "author": "Joas Schilling <coding@schilljs.com>",


### PR DESCRIPTION
## Added
- feat(search): Add message search to the right sidebar [#14125](https://github.com/nextcloud/spreed/issues/14125)
- feat(conversations): Add sample conversation mechanism [#14124](https://github.com/nextcloud/spreed/issues/14124)
- feat(calls): Add end-to-end encryption for calls with the High-performance backend [#14005](https://github.com/nextcloud/spreed/issues/14005)

## Changed
- Update translations
- Update dependencies

## Fixed
- fix(federation): Fix federation from Nextcloud 30 to 31 with https [#14141](https://github.com/nextcloud/spreed/issues/14141)
- fix(conversations): Make compact list more compact and avatar bigger [#14118](https://github.com/nextcloud/spreed/issues/14118)
- fix(signaling): Test actual websocket connection in admin settings [#13973](https://github.com/nextcloud/spreed/issues/13973)
- fix(archive): Don't add asterix to title for unread messages in archived conversations [#14101](https://github.com/nextcloud/spreed/issues/14101)