### PR TITLE
fix(SpeakingWhileMutedWarner): show warning in the popup

### DIFF
--- a/src/components/TopBar/TopBarMediaControls.vue
+++ b/src/components/TopBar/TopBarMediaControls.vue
@@ -131,7 +131,6 @@ import { useIsInCall } from '../../composables/useIsInCall.js'
 import { PARTICIPANT } from '../../constants.js'
 import { CONNECTION_QUALITY } from '../../utils/webrtc/analyzers/PeerConnectionAnalyzer.js'
 import { callAnalyzer } from '../../utils/webrtc/index.js'
-import SpeakingWhileMutedWarner from '../../utils/webrtc/SpeakingWhileMutedWarner.js'
 
 export default {
 
@@ -395,14 +394,6 @@ export default {
 				this.qualityWarningInGracePeriodTimeout = null
 			}, 10000)
 		},
-	},
-
-	mounted() {
-		this.speakingWhileMutedWarner = new SpeakingWhileMutedWarner(this.model)
-	},
-
-	beforeDestroy() {
-		this.speakingWhileMutedWarner.destroy()
 	},
 
 	methods: {

--- a/src/utils/webrtc/SpeakingWhileMutedWarner.js
+++ b/src/utils/webrtc/SpeakingWhileMutedWarner.js
@@ -3,36 +3,38 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { showWarning, TOAST_PERMANENT_TIMEOUT } from '@nextcloud/dialogs'
+import { showWarning, TOAST_PERMANENT_TIMEOUT, TOAST_DEFAULT_TIMEOUT } from '@nextcloud/dialogs'
 import { t } from '@nextcloud/l10n'
 
 /**
-	* Helper to warn the user if they are talking while muted.
-	*
-	* The WebRTC helper emits events when it detects that the user is speaking
-	* while muted; this helper shows a warning to the user based on those
-	* events.
-	*
-	* The warning is not immediately shown, though; the WebRTC helper flags
-	* even short sounds as "speaking" (provided they are strong enough), so to
-	* prevent unnecesary warnings the user has to speak for a few seconds for
-	* the warning to be shown. On the other hand, the warning is hidden as soon
-	* as the WebRTC helper detects that the speaking has stopped; in this case
-	* there is no delay, as the helper itself has a delay before emitting the
-	* event.
-	*
-	* The way of warning the user changes depending on whether Talk is visible
-	* or not; if it is visible the warning is shown in the Talk UI, but if it
-	* is not it is shown using a browser notification, which will be visible
-	* to the user even if the browser window is not in the foreground (provided
-	* the user granted the permissions to receive notifications from the site).
-	*
-	* @param {object} LocalMediaModel the model that emits "speakingWhileMuted"
-	* events.
-	* "setSpeakingWhileMutedNotification" method.
-	*/
+ * Helper to warn the user if they are talking while muted.
+ *
+ * The WebRTC helper emits events when it detects that the user is speaking
+ * while muted; this helper shows a warning to the user based on those
+ * events.
+ *
+ * The warning is not immediately shown, though; the WebRTC helper flags
+ * even short sounds as "speaking" (provided they are strong enough), so to
+ * prevent unnecessary warnings the user has to speak for a few seconds for
+ * the warning to be shown. On the other hand, the warning is hidden as soon
+ * as the WebRTC helper detects that the speaking has stopped; in this case
+ * there is no delay, as the helper itself has a delay before emitting the
+ * event.
+ *
+ * The way of warning the user changes depending on whether Talk is visible
+ * or not; if it is visible the warning is shown in the Talk UI, but if it
+ * is not it is shown using a browser notification, which will be visible
+ * to the user even if the browser window is not in the foreground (provided
+ * the user granted the permissions to receive notifications from the site).
+ *
+ * @param {object} LocalMediaModel the model that emits "speakingWhileMuted"
+ * events.
+ */
 export default function SpeakingWhileMutedWarner(LocalMediaModel) {
 	this._model = LocalMediaModel
+	this._startedSpeakingTimeout = undefined
+	this._startedShowWarningTimeout = undefined
+
 	this._toast = null
 
 	this._handleSpeakingWhileMutedChangeBound = this._handleSpeakingWhileMutedChange.bind(this)
@@ -42,6 +44,7 @@ export default function SpeakingWhileMutedWarner(LocalMediaModel) {
 SpeakingWhileMutedWarner.prototype = {
 
 	destroy() {
+		this._hideWarning()
 		this._model.off('change:speakingWhileMuted', this._handleSpeakingWhileMutedChangeBound)
 	},
 
@@ -86,6 +89,12 @@ SpeakingWhileMutedWarner.prototype = {
 				}
 			}.bind(this))
 		}
+
+		this._startedShowWarningTimeout = setTimeout(function() {
+			delete this._startedShowWarningTimeout
+
+			this._hideWarning()
+		}.bind(this), TOAST_DEFAULT_TIMEOUT)
 	},
 
 	_showNotification(message) {
@@ -158,6 +167,11 @@ SpeakingWhileMutedWarner.prototype = {
 			this._browserNotification.close()
 
 			this._browserNotification = null
+		}
+
+		if (this._startedShowWarningTimeout) {
+			clearTimeout(this._startedShowWarningTimeout)
+			delete this._startedShowWarningTimeout
 		}
 	},
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix #14029

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/user-attachments/assets/a01354c7-a4d0-428b-8144-47682fc8c570) | ![image](https://github.com/user-attachments/assets/095b1330-3549-4eac-b99a-6c02b588e0b7)

### TODO 
- [x] add timeout to fade notification/popup (if microphone noise is static)
- [x] move visual logic to LocalAudio*
- [x] Check for obstructions (to not show popover above other elements)

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [x] 🖌️ Design was reviewed, approved or inspired by the design team