### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -306,12 +306,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "ed23f703c172ba167a62a76f7b2d8a6b4e37f44f"
+                "reference": "ba6108b934c18b629f78c48cca3fc038087f0dec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/ed23f703c172ba167a62a76f7b2d8a6b4e37f44f",
-                "reference": "ed23f703c172ba167a62a76f7b2d8a6b4e37f44f",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/ba6108b934c18b629f78c48cca3fc038087f0dec",
+                "reference": "ba6108b934c18b629f78c48cca3fc038087f0dec",
                 "shasum": ""
             },
             "require": {
@@ -347,7 +347,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2025-01-10T00:44:36+00:00"
+            "time": "2025-01-17T00:42:09+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency