### PR TITLE
fix(tests): Remove unstable sharing field from tests

### DIFF
--- a/tests/integration/features/bootstrap/SharingContext.php
+++ b/tests/integration/features/bootstrap/SharingContext.php
@@ -614,6 +614,19 @@ class SharingContext implements Context {
 			$defaultExpectedFields['share_with_link'] = 'URL';
 		}
 
+		if (isset($fields['share_type']) && ($fields['share_type'] === '0' || $fields['share_type'] === '1')) {
+			/**
+			 * This field was changed so often in the server,
+			 * that we simply don't care any more. We want to test Talk,
+			 * not normal user shares.
+			 * Refs:
+			 * - https://github.com/nextcloud/server/pull/49898
+			 * - https://github.com/nextcloud/server/pull/48381
+			 * - https://github.com/nextcloud/spreed/pull/13632
+			 */
+			unset($defaultExpectedFields['mail_send']);
+		}
+
 		$expectedFields = array_merge($defaultExpectedFields, $fields);
 
 		if (!array_key_exists('uid_file_owner', $expectedFields) &&

--- a/tests/integration/features/sharing-1/create.feature
+++ b/tests/integration/features/sharing-1/create.feature
@@ -425,7 +425,6 @@ Feature: create
     And share is returned with
       | permissions            | 1 |
       | share_type             | 0 |
-      | mail_send              | 0 |
     And user "participant1" accepts last share
     When user "participant1" shares "welcome (2).txt" with room "group room"
     Then the OCS status code should be "404"
@@ -738,7 +737,6 @@ Feature: create
       | share_with             | participant2 |
       | share_with_displayname | participant2-displayname |
       | share_type             | 0 |
-      | mail_send              | 0 |
     And user "participant2" gets all received shares
     And the list of returned shares has 2 shares
     And share 0 is returned with


### PR DESCRIPTION
This field was changed so often in the server,
that we simply don't care any more. We want to test Talk, not normal user shares.

- https://github.com/nextcloud/server/pull/49898
- https://github.com/nextcloud/server/pull/48381
- https://github.com/nextcloud/spreed/pull/13632

### ☑️ Resolves

* Make tests green again

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
