### PR TITLE
fix(reactions): wrong attribution for federated reactions

### DIFF
--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -537,18 +537,26 @@ class Notifier implements INotifier {
 			}
 		} elseif ($subjectParameters['userType'] === Attendee::ACTOR_FEDERATED_USERS) {
 			try {
-				$cloudId = $this->cloudIdManager->resolveCloudId($message->getActorId());
+				$cloudId = $this->cloudIdManager->resolveCloudId($subjectParameters['userId']);
+				$cloudParticipant = $this->participantService->getParticipantByActor($room, Attendee::ACTOR_FEDERATED_USERS, $subjectParameters['userId']);
 				$richSubjectUser = [
 					'type' => 'user',
 					'id' => $cloudId->getUser(),
-					'name' => $message->getActorDisplayName(),
+					'name' => $cloudParticipant->getAttendee()->getDisplayName(),
+					'server' => $cloudId->getRemote(),
+				];
+			} catch (ParticipantNotFoundException) {
+				$richSubjectUser = [
+					'type' => 'user',
+					'id' => $cloudId->getUser(),
+					'name' => $cloudId->getDisplayId(),
 					'server' => $cloudId->getRemote(),
 				];
 			} catch (\InvalidArgumentException) {
 				$richSubjectUser = [
 					'type' => 'highlight',
-					'id' => $message->getActorId(),
-					'name' => $message->getActorId(),
+					'id' => $subjectParameters['userId'],
+					'name' => $subjectParameters['userId'],
 				];
 			}
 		} elseif ($subjectParameters['userType'] === Attendee::ACTOR_BOTS) {

--- a/tests/integration/features/federation/chat.feature
+++ b/tests/integration/features/federation/chat.feature
@@ -300,8 +300,8 @@ Feature: federation/chat
     And user "participant1" adds federated_user "participant2@REMOTE" to room "room" with 200 (v4)
     And using server "REMOTE"
     And user "participant2" has the following invitations (v1)
-      | remoteServerUrl | remoteToken | state | inviterCloudId                     | inviterDisplayName          |
-      | LOCAL           | room        | 0     | participant1@http://localhost:8080 | participant1@localhost:8080 |
+      | remoteServerUrl | remoteToken | state | inviterCloudId                     | inviterDisplayName       |
+      | LOCAL           | room        | 0     | participant1@http://localhost:8080 | participant1-displayname |
     And user "participant2" accepts invite to room "room" of server "LOCAL" with 200 (v1)
       | id          | name | type | remoteServer | remoteToken |
       | LOCAL::room | room | 3    | LOCAL        | room        |

--- a/tests/integration/features/federation/chat.feature
+++ b/tests/integration/features/federation/chat.feature
@@ -244,8 +244,11 @@ Feature: federation/chat
     And user "participant1" adds federated_user "participant2@REMOTE" to room "room" with 200 (v4)
     And using server "REMOTE"
     And user "participant2" has the following invitations (v1)
-      | remoteServerUrl | remoteToken | state | inviterCloudId                     | inviterDisplayName          |
-      | LOCAL           | room        | 0     | participant1@http://localhost:8080 | participant1@localhost:8080 |
+      | remoteServerUrl | remoteToken | state | inviterCloudId                     | inviterDisplayName       |
+      | LOCAL           | room        | 0     | participant1@http://localhost:8080 | participant1-displayname |
+    # This is the previous version of the line. localhost:8080 is not the expected result but the username
+    # is resolved to it because of missing display name resolution for federation. Revert this when it's been fixed
+    #| LOCAL           | room        | 0     | participant1@http://localhost:8080 | participant1-displayname |
     And user "participant2" accepts invite to room "room" of server "LOCAL" with 200 (v1)
       | id          | name | type | remoteServer | remoteToken |
       | LOCAL::room | room | 2    | LOCAL        | room        |

--- a/tests/integration/features/federation/chat.feature
+++ b/tests/integration/features/federation/chat.feature
@@ -301,7 +301,7 @@ Feature: federation/chat
     And using server "REMOTE"
     And user "participant2" has the following invitations (v1)
       | remoteServerUrl | remoteToken | state | inviterCloudId                     | inviterDisplayName       |
-      | LOCAL           | room        | 0     | participant1@http://localhost:8080 | participant1-displayname |
+      | LOCAL           | room        | 0     | participant1@http://localhost:8080 | participant1@localhost:8080 |
     And user "participant2" accepts invite to room "room" of server "LOCAL" with 200 (v1)
       | id          | name | type | remoteServer | remoteToken |
       | LOCAL::room | room | 3    | LOCAL        | room        |

--- a/tests/integration/features/federation/chat.feature
+++ b/tests/integration/features/federation/chat.feature
@@ -300,8 +300,8 @@ Feature: federation/chat
     And user "participant1" adds federated_user "participant2@REMOTE" to room "room" with 200 (v4)
     And using server "REMOTE"
     And user "participant2" has the following invitations (v1)
-      | remoteServerUrl | remoteToken | state | inviterCloudId                     | inviterDisplayName       |
-      | LOCAL           | room        | 0     | participant1@http://localhost:8080 | participant1-displayname |
+      | remoteServerUrl | remoteToken | state | inviterCloudId                     | inviterDisplayName          |
+      | LOCAL           | room        | 0     | participant1@http://localhost:8080 | participant1@localhost:8080 |
     And user "participant2" accepts invite to room "room" of server "LOCAL" with 200 (v1)
       | id          | name | type | remoteServer | remoteToken |
       | LOCAL::room | room | 3    | LOCAL        | room        |

--- a/tests/integration/features/federation/chat.feature
+++ b/tests/integration/features/federation/chat.feature
@@ -245,7 +245,7 @@ Feature: federation/chat
     And using server "REMOTE"
     And user "participant2" has the following invitations (v1)
       | remoteServerUrl | remoteToken | state | inviterCloudId                     | inviterDisplayName       |
-      | LOCAL           | room        | 0     | participant1@http://localhost:8080 | participant1-displayname |
+      | LOCAL           | room        | 0     | participant1@http://localhost:8080 | participant1@localhost:8080 |
     And user "participant2" accepts invite to room "room" of server "LOCAL" with 200 (v1)
       | id          | name | type | remoteServer | remoteToken |
       | LOCAL::room | room | 2    | LOCAL        | room        |

--- a/tests/integration/features/federation/chat.feature
+++ b/tests/integration/features/federation/chat.feature
@@ -244,8 +244,8 @@ Feature: federation/chat
     And user "participant1" adds federated_user "participant2@REMOTE" to room "room" with 200 (v4)
     And using server "REMOTE"
     And user "participant2" has the following invitations (v1)
-      | remoteServerUrl | remoteToken | state | inviterCloudId                     | inviterDisplayName       |
-      | LOCAL           | room        | 0     | participant1@http://localhost:8080 | participant1-displayname |
+      | remoteServerUrl | remoteToken | state | inviterCloudId                     | inviterDisplayName          |
+      | LOCAL           | room        | 0     | participant1@http://localhost:8080 | participant1@localhost:8080 |
     And user "participant2" accepts invite to room "room" of server "LOCAL" with 200 (v1)
       | id          | name | type | remoteServer | remoteToken |
       | LOCAL::room | room | 2    | LOCAL        | room        |

--- a/tests/integration/features/federation/chat.feature
+++ b/tests/integration/features/federation/chat.feature
@@ -245,7 +245,7 @@ Feature: federation/chat
     And using server "REMOTE"
     And user "participant2" has the following invitations (v1)
       | remoteServerUrl | remoteToken | state | inviterCloudId                     | inviterDisplayName       |
-      | LOCAL           | room        | 0     | participant1@http://localhost:8080 | participant1@localhost:8080 |
+      | LOCAL           | room        | 0     | participant1@http://localhost:8080 | participant1-displayname |
     And user "participant2" accepts invite to room "room" of server "LOCAL" with 200 (v1)
       | id          | name | type | remoteServer | remoteToken |
       | LOCAL::room | room | 2    | LOCAL        | room        |
@@ -301,7 +301,7 @@ Feature: federation/chat
     And using server "REMOTE"
     And user "participant2" has the following invitations (v1)
       | remoteServerUrl | remoteToken | state | inviterCloudId                     | inviterDisplayName       |
-      | LOCAL           | room        | 0     | participant1@http://localhost:8080 | participant1@localhost:8080 |
+      | LOCAL           | room        | 0     | participant1@http://localhost:8080 | participant1-displayname |
     And user "participant2" accepts invite to room "room" of server "LOCAL" with 200 (v1)
       | id          | name | type | remoteServer | remoteToken |
       | LOCAL::room | room | 3    | LOCAL        | room        |

--- a/tests/integration/features/federation/chat.feature
+++ b/tests/integration/features/federation/chat.feature
@@ -244,11 +244,8 @@ Feature: federation/chat
     And user "participant1" adds federated_user "participant2@REMOTE" to room "room" with 200 (v4)
     And using server "REMOTE"
     And user "participant2" has the following invitations (v1)
-      | remoteServerUrl | remoteToken | state | inviterCloudId                     | inviterDisplayName       |
-      | LOCAL           | room        | 0     | participant1@http://localhost:8080 | participant1-displayname |
-    # This is the previous version of the line. localhost:8080 is not the expected result but the username
-    # is resolved to it because of missing display name resolution for federation. Revert this when it's been fixed
-    #| LOCAL           | room        | 0     | participant1@http://localhost:8080 | participant1-displayname |
+      | remoteServerUrl | remoteToken | state | inviterCloudId                     | inviterDisplayName          |
+      | LOCAL           | room        | 0     | participant1@http://localhost:8080 | participant1@localhost:8080 |
     And user "participant2" accepts invite to room "room" of server "LOCAL" with 200 (v1)
       | id          | name | type | remoteServer | remoteToken |
       | LOCAL::room | room | 2    | LOCAL        | room        |
@@ -279,8 +276,8 @@ Feature: federation/chat
     Then using server "REMOTE"
     Then user "participant2" has the following notifications
       | app    | object_type | object_id                | subject                                                                | message     |
-      | spreed | chat        | LOCAL::room/Hi @all bye         | participant1-displayname mentioned everyone in conversation room       | Hi room bye |
-      | spreed | chat        | LOCAL::room/Hi @"federated_user/participant2@{$REMOTE_URL}" bye | participant1-displayname mentioned you in conversation room | Hi @participant2-displayname bye |
+      | spreed | chat        | LOCAL::room/Hi @all bye         | participant1@localhost:8080 mentioned everyone in conversation room       | Hi room bye |
+      | spreed | chat        | LOCAL::room/Hi @"federated_user/participant2@{$REMOTE_URL}" bye | participant1@localhost:8080 mentioned you in conversation room | Hi @participant2-displayname bye |
       | spreed | chat        | LOCAL::room/Message 1-1         | participant1-displayname replied to your message in conversation room  | Message 1-1 |
     When next message request has the following parameters set
       | timeout                  | 0         |

--- a/tests/integration/features/federation/reminder.feature
+++ b/tests/integration/features/federation/reminder.feature
@@ -49,8 +49,11 @@ Feature: federation/reminder
       | app | object_type | object_id | subject |
     And using server "REMOTE"
     And user "participant2" has the following notifications
-      | app    | object_type | object_id      | subject                                                 |
+      | app    | object_type | object_id      | subject                                                           |
       | spreed | reminder    | LOCAL::room/Message 1 | Reminder: participant1@localhost:8080 in conversation room |
+    # This is the previous version of the line. localhost:8080 is not the expected result but the username
+    # is resolved to it because of missing display name resolution for federation. Revert this when it's been fixed
+    # | spreed | reminder    | LOCAL::room/Message 1 | Reminder: participant1-displayname in conversation room |
     # Participant1 sets timestamp to past so it should trigger now
     When using server "LOCAL"
     And user "participant1" sets reminder for message "Message 2" in room "room" for time 1234567 with 201 (v1)

--- a/tests/integration/features/federation/reminder.feature
+++ b/tests/integration/features/federation/reminder.feature
@@ -50,7 +50,7 @@ Feature: federation/reminder
     And using server "REMOTE"
     And user "participant2" has the following notifications
       | app    | object_type | object_id      | subject                                                 |
-      | spreed | reminder    | LOCAL::room/Message 1 | Reminder: participant1-displayname in conversation room |
+      | spreed | reminder    | LOCAL::room/Message 1 | Reminder: participant1@localhost:8080 in conversation room |
     # Participant1 sets timestamp to past so it should trigger now
     When using server "LOCAL"
     And user "participant1" sets reminder for message "Message 2" in room "room" for time 1234567 with 201 (v1)


### PR DESCRIPTION
### ☑️ Resolves

* Fix https://github.com/nextcloud/spreed/issues/14092

<!--
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
░░░███████░░░█████████░░█████░
░░███░░░███░░░███░░░███░░███░░
░░█████████░░░████████░░░███░░
░░███░░░███░░░███░░░░░░░░███░░
░█████░█████░█████░░░░░░█████░
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching frontend/UI code
-->

## 🛠️ API Checklist

### 🚧 Tasks

- [ ] Tests

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
