### PR TITLE
fix(federation): Always return pending invitation header

### DIFF
--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -283,9 +283,7 @@ class RoomController extends AEnvironmentAwareOCSController {
 		$headers = ['X-Nextcloud-Talk-Modified-Before' => (string)$nextModifiedSince];
 		if ($this->talkConfig->isFederationEnabledForUserId($user)) {
 			$numInvites = $this->federationManager->getNumberOfPendingInvitationsForUser($user);
-			if ($numInvites !== 0) {
-				$headers['X-Nextcloud-Talk-Federation-Invites'] = (string)$numInvites;
-			}
+			$headers['X-Nextcloud-Talk-Federation-Invites'] = (string)$numInvites;
 		}
 
 		/** @var array{X-Nextcloud-Talk-Hash: string, X-Nextcloud-Talk-Modified-Before: numeric-string, X-Nextcloud-Talk-Federation-Invites?: numeric-string} $headers */

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -3567,12 +3567,8 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 	 * @param string $count
 	 */
 	public function hasFederationInvitesHeader(string $count): void {
-		if ($count === 'NULL') {
-			Assert::assertFalse($this->response->hasHeader('X-Nextcloud-Talk-Federation-Invites'), "Should not contain 'X-Nextcloud-Talk-Federation-Invites' header\n" . json_encode($this->response->getHeaders(), JSON_PRETTY_PRINT));
-		} else {
-			Assert::assertTrue($this->response->hasHeader('X-Nextcloud-Talk-Federation-Invites'), "Should contain 'X-Nextcloud-Talk-Federation-Invites' header\n" . json_encode($this->response->getHeaders(), JSON_PRETTY_PRINT));
-			Assert::assertEquals($count, $this->response->getHeader('X-Nextcloud-Talk-Federation-Invites')[0]);
-		}
+		Assert::assertTrue($this->response->hasHeader('X-Nextcloud-Talk-Federation-Invites'), "Should contain 'X-Nextcloud-Talk-Federation-Invites' header\n" . json_encode($this->response->getHeaders(), JSON_PRETTY_PRINT));
+		Assert::assertEquals($count, $this->response->getHeader('X-Nextcloud-Talk-Federation-Invites')[0]);
 	}
 
 	/**

--- a/tests/integration/features/federation/invite.feature
+++ b/tests/integration/features/federation/invite.feature
@@ -70,7 +70,7 @@ Feature: federation/invite
     Then user "participant2" is participant of the following rooms (v4)
       | id          | name | type | remoteServer | remoteToken |
       | LOCAL::room | room | 3    | LOCAL        | room        |
-    Then last response has federation invites header set to "NULL"
+    Then last response has federation invites header set to "0"
     And user "participant2" accepts invite to room "room" of server "LOCAL" with 400 (v1)
       | error | state |
     And user "participant2" declines invite to room "room" of server "LOCAL" with 400 (v1)


### PR DESCRIPTION
## 🛠️ API Checklist

We should also return the invitation header, when there are no invitations, to allow for quick removal of "Pending Invitations" message.

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [ ] 🔖 Capability is added or not needed 
