### PR TITLE
chore(stylelint): add `csstools/use-logical`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -86,6 +86,7 @@
         "jest-transform-stub": "^2.0.0",
         "openapi-typescript": "^7.5.2",
         "regenerator-runtime": "^0.14.1",
+        "stylelint-use-logical": "^2.1.2",
         "ts-jest": "^29.2.5",
         "vue-template-compiler": "^2.7.16",
         "wasm-check": "^2.1.2",
@@ -18855,6 +18856,19 @@
         "stylelint": "^16.0.2"
       }
     },
+    "node_modules/stylelint-use-logical": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/stylelint-use-logical/-/stylelint-use-logical-2.1.2.tgz",
+      "integrity": "sha512-4ffvPNk/swH4KS3izExWuzQOuzLmi0gb0uOhvxWJ20vDA5W5xKCjcHHtLoAj1kKvTIX6eGIN5xGtaVin9PD0wg==",
+      "dev": true,
+      "license": "CC0-1.0",
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "stylelint": ">= 11 < 17"
+      }
+    },
     "node_modules/stylelint/node_modules/ansi-regex": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
@@ -35416,6 +35430,13 @@
         "postcss-selector-parser": "^6.0.15",
         "postcss-value-parser": "^4.2.0"
       }
+    },
+    "stylelint-use-logical": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/stylelint-use-logical/-/stylelint-use-logical-2.1.2.tgz",
+      "integrity": "sha512-4ffvPNk/swH4KS3izExWuzQOuzLmi0gb0uOhvxWJ20vDA5W5xKCjcHHtLoAj1kKvTIX6eGIN5xGtaVin9PD0wg==",
+      "dev": true,
+      "requires": {}
     },
     "subscribable-things": {
       "version": "2.1.47",

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "jest-transform-stub": "^2.0.0",
     "openapi-typescript": "^7.5.2",
     "regenerator-runtime": "^0.14.1",
+    "stylelint-use-logical": "^2.1.2",
     "ts-jest": "^29.2.5",
     "vue-template-compiler": "^2.7.16",
     "wasm-check": "^2.1.2",

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -18,6 +18,7 @@ stylelintConfig.plugins.push('stylelint-use-logical')
 stylelintConfig.rules['csstools/use-logical'] = [
 	'always',
 	{
+		severity: 'warning',
 		// Only lint LTR-RTL properties for now
 		except: [
 			// Position properties

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -10,4 +10,31 @@ stylelintConfig.rules['at-rule-no-unknown'] = [
 	},
 ]
 
+if (!stylelintConfig.plugins) {
+	stylelintConfig.plugins = []
+}
+
+stylelintConfig.plugins.push('stylelint-use-logical')
+stylelintConfig.rules['csstools/use-logical'] = [
+	'always',
+	{
+		// Only lint LTR-RTL properties for now
+		except: [
+			// Position properties
+			'top',
+			'bottom',
+			// Position properties with directional suffixes
+			/-top$/,
+			/-bottom$/,
+			// Size properties
+			'width',
+			'max-width',
+			'min-width',
+			'height',
+			'max-height',
+			'min-height',
+		],
+	},
+]
+
 module.exports = stylelintConfig


### PR DESCRIPTION
### ☑️ Resolves

* Add `csstools/use-logical`

Note: no auto-fix was performed. Some non-logical properties must be checked, for example, when they redefine external styles.

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Not risky to browser differences / client
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
