### PR TITLE
fix: focus issue and minor enhancements

### DIFF
--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -286,7 +286,7 @@
 
 		<template #footer>
 			<div class="left-sidebar__settings-button-container">
-				<template v-if="supportsArchive">
+				<template v-if="!isSearching && supportsArchive">
 					<NcButton v-if="showArchived"
 						type="tertiary"
 						wide
@@ -558,7 +558,7 @@ export default {
 
 		filteredConversationsList() {
 			if (this.isFocused) {
-				return this.conversationsList
+				return this.conversationsList.filter((conversation) => shouldIncludeArchived(conversation, this.showArchived))
 			}
 
 			let validConversationsCount = 0

--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -24,7 +24,7 @@
 		<template v-if="!showSearchMessagesTab && getUserId" #secondary-actions>
 			<NcActionButton type="tertiary"
 				:title="t('spreed', 'Search messages')"
-				@click="showSearchMessagesTab = true">
+				@click="handleShowSearch(true)">
 				<template #icon>
 					<IconMagnify :size="20" />
 				</template>
@@ -33,7 +33,7 @@
 		<template v-else-if="getUserId" #tertiary-actions>
 			<NcButton type="tertiary"
 				:title="t('spreed', 'Back')"
-				@click="showSearchMessagesTab = false">
+				@click="handleShowSearch(false)">
 				<template #icon>
 					<IconArrowLeft class="bidirectional-icon" :size="20" />
 				</template>
@@ -48,7 +48,8 @@
 			key="search-messages"
 			:order="0"
 			:name="t('spreed', 'Search messages')">
-			<SearchMessagesTab @close="showSearchMessagesTab = false" />
+			<SearchMessagesTab :is-active="activeTab === 'search-messages'"
+				@close="handleShowSearch(false)" />
 		</NcAppSidebarTab>
 		<template v-else>
 			<NcAppSidebarTab v-if="isInCall"
@@ -461,6 +462,16 @@ export default {
 
 		handleUpdateActive(active) {
 			this.activeTab = active
+		},
+
+		handleShowSearch(value) {
+			this.showSearchMessagesTab = value
+			// FIXME upstream: NcAppSidebar should emit update:active
+			if (value) {
+				this.activeTab = 'search-messages'
+			} else {
+				this.activeTab = this.isInCall ? 'chat' : 'participants'
+			}
 		},
 
 		showSettings() {

--- a/src/components/RightSidebar/SearchMessages/SearchMessagesTab.vue
+++ b/src/components/RightSidebar/SearchMessages/SearchMessagesTab.vue
@@ -5,7 +5,7 @@
 
 <script setup lang="ts">
 import debounce from 'debounce'
-import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import type { Route } from 'vue-router'
 
 import IconCalendarRange from 'vue-material-design-icons/CalendarRange.vue'
@@ -42,6 +42,9 @@ import {
 } from '../../../types/index.ts'
 import CancelableRequest from '../../../utils/cancelableRequest.js'
 
+const props = defineProps<{
+	isActive: boolean,
+}>()
 const emit = defineEmits<{
 	(event: 'close'): void
 }>()
@@ -88,6 +91,13 @@ const participants = computed<UserFilterObject>(() => {
 })
 const canLoadMore = computed(() => !isSearchExhausted.value && !isFetchingResults.value && searchCursor.value !== 0)
 const hasFilter = computed(() => fromUser.value || sinceDate.value || untilDate.value)
+
+watch(() => props.isActive, (isActive) => {
+	if (isActive) {
+		// NcAppSidebarTabs renders tabs in 2 ticks, so need to wait here
+		nextTick(() => searchBox.value!.focus())
+	}
+}, { immediate: true })
 
 onMounted(() => {
 	EventBus.on('route-change', onRouteChange)


### PR DESCRIPTION
### ☑️ Resolves

* Fix sudden appearing of archived conversations when searchbox is focused
  * Focus should only disable filtering, but 'archived' is not a filter category, therefore should be hidden unless searched by name or in specific view
  * Focus trap is always triggered when toggle navigation
  * 'Archived conversation' does nothing when search, so should be hidden
* Focus search input on opening SearchMessagesTab

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before (Note to self 📥)   | 🏡 After
-- | --
<img width="259" alt="image" src="https://github.com/user-attachments/assets/d6bb5607-3795-482e-9451-a5b79b2ff224" /> | <img width="266" alt="image" src="https://github.com/user-attachments/assets/91966a8f-4492-43a2-9e80-eab9fe319da8" /> 
<img width="238" alt="image" src="https://github.com/user-attachments/assets/ad4c623d-cdad-4718-a981-f1637453f1c5" /> | <img width="239" alt="image" src="https://github.com/user-attachments/assets/c5a262f8-d6de-4ea4-ac9d-1156303f315c" />


### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
