### PR TITLE
fix(MessagesList): adjust route params check

### DIFF
--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -1225,9 +1225,8 @@ export default {
 		},
 
 		async onRouteChange({ from, to }) {
-			if (from.name === 'conversation'
-				&& to.name === 'conversation'
-				&& from.token === to.token
+			if (from.name === 'conversation' && to.name === 'conversation'
+				&& from.params.token === to.params.token
 				&& from.hash !== to.hash) {
 
 				// the hash changed, need to focus/highlight another message


### PR DESCRIPTION
### ☑️ Resolves

* Fix using of `from.params.token`
  * 'params' is always an object including 'token'
  * rest places are fine
  * should only affect cases like 'open another conversation on another message_id', so not critical

## 🖌️ UI Checklist


### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required