### PR TITLE
refactor: remove `IS_DESKTOP` flag check on `generateAbsoluteUrl`

### DIFF
--- a/src/utils/__tests__/handleUrl.spec.js
+++ b/src/utils/__tests__/handleUrl.spec.js
@@ -17,19 +17,14 @@ jest.mock('@nextcloud/dialogs', () => ({
 
 describe('handleUrl', () => {
 	describe('generateAbsoluteUrl', () => {
-		it('should generate url with IS_DESKTOP=false correctly', () => {
-			const output = generateAbsoluteUrl('/path')
-			expect(output).toBe('http://localhost/nc-webroot/path')
+		it('should generate absolute url', () => {
+			const output = generateAbsoluteUrl('/path/{foo}', { foo: 'bar' })
+			expect(output).toBe('http://localhost/nc-webroot/path/bar')
 		})
 
-		it('should generate url with IS_DESKTOP=true correctly', () => {
-			const originalIsDesktop = global.IS_DESKTOP
-			global.IS_DESKTOP = true
-
-			const output = generateAbsoluteUrl('/path')
-			expect(output).toBe('/nc-webroot/path')
-
-			global.IS_DESKTOP = originalIsDesktop
+		it('should generate absolute url with specified base', () => {
+			const output = generateAbsoluteUrl('/path/{foo}', { foo: 'bar' }, { baseURL: 'https://external.ltd/root' })
+			expect(output).toBe('https://external.ltd/root/path/bar')
 		})
 	})
 

--- a/src/utils/handleUrl.ts
+++ b/src/utils/handleUrl.ts
@@ -5,25 +5,22 @@
 
 import { showError, showSuccess } from '@nextcloud/dialogs'
 import { t } from '@nextcloud/l10n'
-import { generateUrl } from '@nextcloud/router'
+import { generateUrl, getBaseUrl } from '@nextcloud/router'
 import type { UrlOptions } from '@nextcloud/router'
 
 /**
  * Generate a full absolute link with @nextcloud/router.generateUrl
  *
  * @param url - path
- * @param [params] parameters to be replaced into the address
- * @param [options] options for the parameter replacement
+ * @param params - parameters to be replaced into the address
+ * @param options - options for the parameter replacement
  */
-export function generateAbsoluteUrl(url: string, params?: object, options?: UrlOptions): string {
+export function generateAbsoluteUrl(url: string, params?: object, options: UrlOptions = {}): string {
 	// TODO: add this function to @nextcloud/router?
-	const fullPath = generateUrl(url, params, options)
-	if (!IS_DESKTOP) {
-		return `${window.location.protocol}//${window.location.host}${fullPath}`
-	} else {
-		// On the Desktop generateUrl creates absolute url by default
-		return fullPath
-	}
+	return generateUrl(url, params, {
+		baseURL: getBaseUrl(),
+		...options,
+	})
 }
 
 /**


### PR DESCRIPTION
### ☑️ Resolves

* With new `getBaseUrl` there is no need for compile time checking for `IS_DESKTOP` when generating URL

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [x] Talk Desktop
  - [ ] Not risky to browser differences / client
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
