### PR TITLE
fix(desktop): change "reload page" messages to "restart app"

### DIFF
--- a/src/components/CallView/CallFailedDialog.vue
+++ b/src/components/CallView/CallFailedDialog.vue
@@ -14,6 +14,7 @@ import NcEmptyContent from '@nextcloud/vue/dist/Components/NcEmptyContent.js'
 import NcModal from '@nextcloud/vue/dist/Components/NcModal.js'
 
 import { useStore } from '../../composables/useStore.js'
+import { messagePleaseTryToReload } from '../../utils/talkDesktopUtils.ts'
 
 const store = useStore()
 
@@ -45,7 +46,7 @@ const message = computed(() => {
 		return connectionFailed.value.data.error
 	}
 
-	return t('spreed', 'Please try to reload the page')
+	return messagePleaseTryToReload
 })
 
 /**

--- a/src/components/TopBar/CallButton.vue
+++ b/src/components/TopBar/CallButton.vue
@@ -115,6 +115,7 @@ import { useSettingsStore } from '../../stores/settings.js'
 import { useSoundsStore } from '../../stores/sounds.js'
 import { useTalkHashStore } from '../../stores/talkHash.js'
 import { blockCalls, unsupportedWarning } from '../../utils/browserCheck.ts'
+import { messagePleaseReload } from '../../utils/talkDesktopUtils.ts'
 
 export default {
 	name: 'CallButton',
@@ -288,7 +289,7 @@ export default {
 
 		startCallTitle() {
 			if (this.isNextcloudTalkHashDirty) {
-				return t('spreed', 'Nextcloud Talk was updated, you need to reload the page before you can start or join a call.')
+				return t('spreed', 'Nextcloud Talk was updated, you cannot start or join a call.') + ' ' + messagePleaseReload
 			}
 
 			if (this.callViewStore.callHasJustEnded) {

--- a/src/composables/useHashCheck.js
+++ b/src/composables/useHashCheck.js
@@ -9,6 +9,7 @@ import { showError, TOAST_PERMANENT_TIMEOUT } from '@nextcloud/dialogs'
 import { t } from '@nextcloud/l10n'
 
 import { useTalkHashStore } from '../stores/talkHash.js'
+import { messagePleaseReload } from '../utils/talkDesktopUtils.ts'
 
 /**
  * Check whether the conflicting session detected or not, and navigate to another page
@@ -31,7 +32,7 @@ export function useHashCheck() {
 	const showReloadWarning = () => {
 		reloadWarningShown = true
 
-		showError(t('spreed', 'Nextcloud Talk was updated, please reload the page'), {
+		showError(t('spreed', 'Nextcloud Talk was updated.') + '\n' + messagePleaseReload, {
 			timeout: TOAST_PERMANENT_TIMEOUT,
 		})
 	}

--- a/src/services/CapabilitiesManager.ts
+++ b/src/services/CapabilitiesManager.ts
@@ -11,6 +11,7 @@ import { getRemoteCapabilities } from './federationService.ts'
 import BrowserStorage from '../services/BrowserStorage.js'
 import { useTalkHashStore } from '../stores/talkHash.js'
 import type { Capabilities, Conversation, JoinRoomFullResponse } from '../types/index.ts'
+import { messagePleaseReload } from '../utils/talkDesktopUtils.ts'
 
 type Config = Capabilities['spreed']['config']
 type RemoteCapability = Capabilities & Partial<{ hash: string }>
@@ -136,7 +137,7 @@ export async function setRemoteCapabilities(joinRoomResponse: JoinRoomFullRespon
 	patchTokenMap(joinRoomResponse.data.ocs.data)
 
 	// As normal capabilities update, requires a reload to take effect
-	showError(t('spreed', 'Nextcloud Talk Federation was updated, please reload the page'), {
+	showError(t('spreed', 'Nextcloud Talk Federation was updated.') + '\n' + messagePleaseReload, {
 		timeout: TOAST_PERMANENT_TIMEOUT,
 	})
 }

--- a/src/store/participantsStore.js
+++ b/src/store/participantsStore.js
@@ -39,6 +39,7 @@ import { talkBroadcastChannel } from '../services/talkBroadcastChannel.js'
 import { useCallViewStore } from '../stores/callView.js'
 import { useGuestNameStore } from '../stores/guestName.js'
 import CancelableRequest from '../utils/cancelableRequest.js'
+import { messagePleaseTryToReload } from '../utils/talkDesktopUtils.ts'
 
 /**
  * Emit global event for user status update with the status from a participant
@@ -1059,7 +1060,7 @@ const actions = {
 				EventBus.emit('forbidden-route', error.response.data.ocs.data)
 			} else {
 				console.error(error)
-				showError(t('spreed', 'Failed to join the conversation. Try to reload the page.'))
+				showError(t('spreed', 'Failed to join the conversation.') + '\n' + messagePleaseTryToReload)
 			}
 		}
 	},

--- a/src/stores/talkHash.js
+++ b/src/stores/talkHash.js
@@ -10,6 +10,7 @@ import { showError, TOAST_PERMANENT_TIMEOUT } from '@nextcloud/dialogs'
 import { t } from '@nextcloud/l10n'
 
 import { talkBroadcastChannel } from '../services/talkBroadcastChannel.js'
+import { messagePleaseReload } from '../utils/talkDesktopUtils.ts'
 
 /**
  * @typedef {object} State
@@ -87,7 +88,7 @@ export const useTalkHashStore = defineStore('talkHash', {
 		checkMaintenanceMode(response) {
 			if (response?.status === 503 && !this.maintenanceWarningToast) {
 				this.maintenanceWarningToast = showError(
-					t('spreed', 'Nextcloud is in maintenance mode, please reload the page'),
+					t('spreed', 'Nextcloud is in maintenance mode.') + '\n' + messagePleaseReload,
 					{ timeout: TOAST_PERMANENT_TIMEOUT }
 				)
 			}

--- a/src/utils/signaling.js
+++ b/src/utils/signaling.js
@@ -16,6 +16,7 @@ import {
 
 import CancelableRequest from './cancelableRequest.js'
 import Encryption from './e2ee/encryption.js'
+import { messagePleaseTryToReload } from './talkDesktopUtils.ts'
 import { PARTICIPANT } from '../constants.js'
 import { hasTalkFeature } from '../services/CapabilitiesManager.ts'
 import { EventBus } from '../services/EventBus.ts'
@@ -543,7 +544,7 @@ Signaling.Internal.prototype._startPullingMessages = function() {
 					}
 
 					// Giving up after 5 minutes
-					this.pullMessageErrorToast = showError(t('spreed', 'Lost connection to signaling server. Try to reload the page manually.'), {
+					this.pullMessageErrorToast = showError(t('spreed', 'Lost connection to signaling server.') + '\n' + messagePleaseTryToReload, {
 						timeout: TOAST_PERMANENT_TIMEOUT,
 					})
 					return

--- a/src/utils/talkDesktopUtils.ts
+++ b/src/utils/talkDesktopUtils.ts
@@ -1,0 +1,14 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { t } from '@nextcloud/l10n'
+
+export const messagePleaseReload = IS_DESKTOP
+	? t('spreed', 'Please restart the app.')
+	: t('spreed', 'Please reload the page.')
+
+export const messagePleaseTryToReload = IS_DESKTOP
+	? t('spreed', 'Please try to restart the app.')
+	: t('spreed', 'Please try to reload the page.')


### PR DESCRIPTION
### ☑️ Resolves

* On Talk Desktop it shouldn't say, "Reload the page". Instead, it must be "Restart the app".
* Module name might not be the best, but rushing before the string freeze to have the strings. Module/structure can be refactored afterwards.

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

![image](https://github.com/user-attachments/assets/9d25d869-9d92-4927-8614-9637810ce4dc)

![image](https://github.com/user-attachments/assets/14e9dbc4-a043-490f-91f6-3552ff28a095)

![image](https://github.com/user-attachments/assets/0a6219f5-4307-4df7-ba21-43bc6222d6c8)

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required