### PR TITLE
Changelog 21.0.0 rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 21.0.0-rc.1 – 2025-01-23
+### Added
+- feat(calls): Allow to zoom and pan screenshares in a call
+  [#14028](https://github.com/nextcloud/spreed/issues/14028)
+- feat(bots): Allow event based bots that don't require HTTP requests
+  [#14160](https://github.com/nextcloud/spreed/issues/14160)
+
+### Changed
+- Update translations
+- Update dependencies
+
+### Fixed
+- docs: Add quick install documentation for the High-performance backend
+  [#14165](https://github.com/nextcloud/spreed/issues/14165)
+
 ## 21.0.0-beta.2 – 2025-01-17
 ### Added
 - feat(search): Add message search to the right sidebar
@@ -27,7 +42,7 @@ All notable changes to this project will be documented in this file.
   [#13973](https://github.com/nextcloud/spreed/issues/13973)
 - fix(archive): Don't add asterix to title for unread messages in archived conversations
   [#14101](https://github.com/nextcloud/spreed/issues/14101)
-- 
+
 ## 20.1.2 – 2025-01-16
 ### Changed
 - Update translations

--- a/lib/Chat/Changelog/Manager.php
+++ b/lib/Chat/Changelog/Manager.php
@@ -140,6 +140,10 @@ class Manager {
 			. $this->l->t('- Summarize call recordings and unread messages in chats with the Nextcloud Assistant') . "\n"
 			. $this->l->t('- Improved meetings with recognizing guests invited via their email address, import of participant lists, drafts for polls and downloading call participant lists') . "\n"
 			. $this->l->t('- Archive conversations to stay focused'),
+			$this->l->t('## New in Talk %s', ['21']) . "\n"
+			. $this->l->t('- Schedule a meeting into your calendar from within a conversation') . "\n"
+			. $this->l->t('- Search for messages of the current conversation directly in the right sidebar') . "\n"
+			. $this->l->t('- See more conversations on a first glance with the new compact list (enable in the Talk settings)'),
 		];
 	}
 }


### PR DESCRIPTION
## 21.0.0-rc.1 – 2025-01-23
### Added
- feat(calls): Allow to zoom and pan screenshares in a call [#14028](https://github.com/nextcloud/spreed/issues/14028)
- feat(bots): Allow event based bots that don't require HTTP requests [#14160](https://github.com/nextcloud/spreed/issues/14160)

### Changed
- Update translations
- Update dependencies

### Fixed
- docs: Add quick install documentation for the High-performance backend [#14165](https://github.com/nextcloud/spreed/issues/14165)
