### PR TITLE
fix(MessagesList): ease list around lastReadMessage

### DIFF
--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -621,7 +621,7 @@ export default {
 			let isFocused = null
 			if (focusMessageId) {
 				// scroll to message in URL anchor
-				this.focusMessage(focusMessageId)
+				this.focusMessage(focusMessageId, false)
 				return
 			}
 

--- a/src/store/messagesStore.spec.js
+++ b/src/store/messagesStore.spec.js
@@ -291,13 +291,28 @@ describe('messagesStore', () => {
 		})
 
 		const testCases = [
-			[1, 200, 1, 200],
-			[1, 400, 201, 400],
+			// Default
+			[1, 200, 1, 200, 200, undefined],
+			[1, 400, 201, 400, 200, undefined],
+			// with lastReadMessage
+			[201, 600, 401, 600, 200, 200],
+			[1, 400, 101, 300, 200, 200],
+			[1, 400, 201, 400, 200, 300],
+			// Border values
+			[1, 400, 1, 101, 101, 1],
+			[1, 400, 301, 400, 100, 400],
+			[1, 400, 1, 199, 199, 99],
+			[1, 400, 1, 200, 200, 100],
+			[1, 400, 2, 201, 200, 101],
+			[1, 400, 202, 400, 199, 301],
+			[1, 400, 201, 400, 200, 300],
+			[1, 400, 200, 399, 200, 299],
 		]
 
-		it.each(testCases)('eases messages list from %s - %s to %s - %s',
-			(oldFirst, oldLast, newFirst, newLast) => {
+		it.each(testCases)('eases list from [%s - %s] to [%s - %s] (length: %s) with lastReadMessage %s',
+			(oldFirst, oldLast, newFirst, newLast, length, lastReadMessage) => {
 			// Arrange
+				conversationMock.mockReturnValue({ lastReadMessage })
 				for (let id = oldFirst; id <= oldLast; id++) {
 					store.dispatch('processMessage', { token: TOKEN, message: { token: TOKEN, id } })
 				}
@@ -308,7 +323,7 @@ describe('messagesStore', () => {
 				store.dispatch('easeMessageList', { token: TOKEN })
 
 				// Assert
-				expect(store.getters.messagesList(TOKEN)).toHaveLength(200)
+				expect(store.getters.messagesList(TOKEN)).toHaveLength(length)
 				expect(store.getters.messagesList(TOKEN).at(0)).toStrictEqual({ token: TOKEN, id: newFirst })
 				expect(store.getters.messagesList(TOKEN).at(-1)).toStrictEqual({ token: TOKEN, id: newLast })
 				expect(store.getters.getFirstKnownMessageId(TOKEN)).toStrictEqual(newFirst)


### PR DESCRIPTION
### ☑️ Resolves

* Fix following case:
  * Open chat with 300+ unread messages, poll them all, switch to another chat, switch back - last read is no longer found, user is at the bottom of the chat, need to load old messages again
* Drawbacks:
  * Need to poll all new messages again
    * [ ] should be fixed with message history (follow-up)
* Known issues:
  * after page reload first rich text will be re-rendered again (async lib load)
    * [ ] drop async load or make workaround (follow-up)

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before 

https://github.com/user-attachments/assets/e13caf39-a8d6-4835-8ced-bbd967dea5c5

🏡 After

https://github.com/user-attachments/assets/b70f1722-9c4f-4b8b-8a25-026d9e0d7238


### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible