### PR TITLE
fix(bots): Fix default and restrict features of app bots when install with event

### DIFF
--- a/lib/Command/Bot/Install.php
+++ b/lib/Command/Bot/Install.php
@@ -81,10 +81,10 @@ class Install extends Base {
 
 		if (!empty($input->getOption('feature'))) {
 			$featureFlags = Bot::featureLabelsToFlags($input->getOption('feature'));
-			if (str_starts_with($url, 'nextcloudapp://')) {
+			if (str_starts_with($url, Bot::URL_APP_PREFIX)) {
 				$featureFlags &= ~Bot::FEATURE_WEBHOOK;
 			}
-		} elseif (str_starts_with($url, 'nextcloudapp://')) {
+		} elseif (str_starts_with($url, Bot::URL_APP_PREFIX)) {
 			$featureFlags = Bot::FEATURE_EVENT;
 		} else {
 			$featureFlags = Bot::FEATURE_WEBHOOK + Bot::FEATURE_RESPONSE;

--- a/lib/Events/BotInstallEvent.php
+++ b/lib/Events/BotInstallEvent.php
@@ -17,7 +17,7 @@ class BotInstallEvent extends Event {
 		protected string $secret,
 		protected string $url,
 		protected string $description = '',
-		protected int $features = Bot::FEATURE_WEBHOOK | Bot::FEATURE_RESPONSE,
+		protected ?int $features = null,
 	) {
 		parent::__construct();
 	}
@@ -39,6 +39,12 @@ class BotInstallEvent extends Event {
 	}
 
 	public function getFeatures(): int {
-		return $this->features;
+		if ($this->features !== null) {
+			return $this->features;
+		}
+		if (str_starts_with($this->url, Bot::URL_APP_PREFIX)) {
+			return Bot::FEATURE_EVENT;
+		}
+		return Bot::FEATURE_WEBHOOK | Bot::FEATURE_RESPONSE;
 	}
 }

--- a/lib/Listener/BotListener.php
+++ b/lib/Listener/BotListener.php
@@ -93,6 +93,11 @@ class BotListener implements IEventListener {
 			} catch (DoesNotExistException) {
 			}
 
+			$features = $event->getFeatures();
+			if (str_starts_with($event->getUrl(), Bot::URL_APP_PREFIX)) {
+				$features &= ~Bot::FEATURE_WEBHOOK;
+			}
+
 			$bot = new BotServer();
 			$bot->setName($event->getName());
 			$bot->setDescription($event->getDescription());
@@ -100,7 +105,7 @@ class BotListener implements IEventListener {
 			$bot->setUrl($event->getUrl());
 			$bot->setUrlHash(sha1($event->getUrl()));
 			$bot->setState(Bot::STATE_ENABLED);
-			$bot->setFeatures($event->getFeatures());
+			$bot->setFeatures($features);
 			$this->botServerMapper->insert($bot);
 		}
 	}

--- a/lib/Model/Bot.php
+++ b/lib/Model/Bot.php
@@ -23,6 +23,7 @@ class Bot {
 	public const FEATURE_LABEL_WEBHOOK = 'webhook';
 	public const FEATURE_LABEL_RESPONSE = 'response';
 	public const FEATURE_LABEL_EVENT = 'event';
+	public const URL_APP_PREFIX = 'nextcloudapp://';
 
 	public const FEATURE_MAP = [
 		self::FEATURE_NONE => self::FEATURE_LABEL_NONE,

--- a/lib/Service/BotService.php
+++ b/lib/Service/BotService.php
@@ -406,7 +406,7 @@ class BotService {
 			throw new \InvalidArgumentException('The provided secret is too short (min. 40 chars, max. 128 chars)');
 		}
 
-		if (!$url || strlen($url) > 4000 || !(str_starts_with($url, 'http://') || str_starts_with($url, 'https://') || str_starts_with($url, 'nextcloudapp://'))) {
+		if (!$url || strlen($url) > 4000 || !(str_starts_with($url, 'http://') || str_starts_with($url, 'https://') || str_starts_with($url, Bot::URL_APP_PREFIX))) {
 			throw new \InvalidArgumentException('The provided URL is not a valid URL');
 		}
 


### PR DESCRIPTION
### ☑️ Resolves

* Noticed on prod when reinstalling call_summary_bot

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
