### PR TITLE
fix(i18n): align 'importListDescription' format and example in string

### DIFF
--- a/src/components/ImportEmailsDialog.vue
+++ b/src/components/ImportEmailsDialog.vue
@@ -37,7 +37,7 @@ const uploadResultCaption = computed(() => {
 		: { class: 'import-list__caption--success', label: t('spreed', 'Uploaded file is verified') }
 })
 
-const importListDescription = t('spreed', 'Content format is comma-separated values (CSV):<br/>- Header line is required and must match <samp>"email","name"</samp> or just <samp>"email"</samp><br/>- One entry per line (e.g. <samp>"John Doe","john@example.tld"</samp>)',
+const importListDescription = t('spreed', 'Content format is comma-separated values (CSV):<br/>- Header line is required and must match <samp>"name","email"</samp> or just <samp>"email"</samp><br/>- One entry per line (e.g. <samp>"John Doe","john@example.tld"</samp>)',
 	undefined,
 	undefined, {
 		escape: true,


### PR DESCRIPTION
### ☑️ Resolves

* Fix #14207


### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Not risky to browser differences / client