### PR TITLE
fix: allow to create public room without password if password_policy enabled

### DIFF
--- a/lib/Service/RoomService.php
+++ b/lib/Service/RoomService.php
@@ -169,7 +169,7 @@ class RoomService {
 			throw new PasswordException(PasswordException::REASON_VALUE, $this->l10n->t('Password needs to be set'));
 		}
 
-		if ($type !== Room::TYPE_PUBLIC) {
+		if ($type !== Room::TYPE_PUBLIC || $password === '') {
 			$room = $this->manager->createRoom($type, $name, $objectType, $objectId);
 		} else {
 			$event = new ValidatePasswordPolicyEvent($password);


### PR DESCRIPTION
### ☑️ Resolves

* Follow-up to #13944


## 🛠️ API Checklist

### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not possible
- [ ] 📘 API documentation in `docs/` has been updated or is not required
- [ ] 🔖 Capability is added or not needed 
