### PR TITLE
fix: do not fail to filter if invitedActorId is not provided

### DIFF
--- a/src/components/BreakoutRoomsEditor/SelectableParticipant.vue
+++ b/src/components/BreakoutRoomsEditor/SelectableParticipant.vue
@@ -120,7 +120,7 @@ export default {
 
 		participantStatus() {
 			if (this.actorType === ATTENDEE.ACTOR_TYPE.EMAILS) {
-				return this.participant.invitedActorId
+				return this.participant.invitedActorId ?? ''
 			}
 			return this.participant.shareWithDisplayNameUnique
 				?? getStatusMessage(this.participant)

--- a/src/components/CalendarEventsDialog.vue
+++ b/src/components/CalendarEventsDialog.vue
@@ -168,7 +168,7 @@ const participantsInitialised = computed(() => store.getters.participantsInitial
 const filteredParticipants = computed(() => participants.value.filter((participant: Participant) => {
 	return isMatch(participant.displayName)
 		|| (participant.actorType === ATTENDEE.ACTOR_TYPE.USERS && isMatch(participant.actorId))
-		|| (participant.actorType === ATTENDEE.ACTOR_TYPE.EMAILS && isMatch(participant.invitedActorId))
+		|| (participant.actorType === ATTENDEE.ACTOR_TYPE.EMAILS && participant.invitedActorId && isMatch(participant.invitedActorId))
 }))
 const selectedParticipants = computed(() => participants.value
 	.filter((participant: Participant) => selectedAttendeeIds.value.includes(participant.attendeeId))

--- a/src/components/RightSidebar/Participants/ParticipantsTab.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsTab.vue
@@ -177,7 +177,7 @@ export default {
 			return this.participants.filter(participant => {
 				return isMatch(participant.displayName)
 					|| (![ATTENDEE.ACTOR_TYPE.GUESTS, ATTENDEE.ACTOR_TYPE.EMAILS].includes(participant.actorType) && isMatch(participant.actorId))
-					|| (participant.actorType === ATTENDEE.ACTOR_TYPE.EMAILS && isMatch(participant.invitedActorId))
+					|| (participant.actorType === ATTENDEE.ACTOR_TYPE.EMAILS && participant.invitedActorId && isMatch(participant.invitedActorId))
 			})
 		},
 


### PR DESCRIPTION
### ☑️ Resolves

* Regresion from #14097
* Fix search in participants list for user with no moderator permissions
  * `invitedActorId` is not provided to them

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Not risky to browser differences / client
- [ ] ⛑️ Tests are included or not possible