### PR TITLE
fix(team): support team mentions on frontend

### DIFF
--- a/css/icons.css
+++ b/css/icons.css
@@ -106,12 +106,15 @@
  * "forced-white" needs to be included in the class name as the Avatar does
  * not accept several classes. */
 .user-bubble__avatar .icon-group-forced-white.avatar-class-icon,
+.user-bubble__avatar .icon-team-forced-white.avatar-class-icon,
 .user-bubble__avatar .icon-user-forced-white.avatar-class-icon,
 .user-bubble__avatar .icon-mail-forced-white.avatar-class-icon,
 .autocomplete-result .icon-group-forced-white.autocomplete-result__icon--,
+.autocomplete-result .icon-team-forced-white.autocomplete-result__icon--,
 .autocomplete-result .icon-user-forced-white.autocomplete-result__icon--,
 .autocomplete-result .icon-mail-forced-white.autocomplete-result__icon--,
 .mention-bubble .icon-group-forced-white.mention-bubble__icon--,
+.mention-bubble .icon-team-forced-white.mention-bubble__icon--,
 .mention-bubble .icon-user-forced-white.mention-bubble__icon--,
 .mention-bubble .icon-mail-forced-white.mention-bubble__icon-- {
 	background-color: #6B6B6B;
@@ -120,12 +123,15 @@
 /* System default: dark theme */
 @media (prefers-color-scheme: dark) {
 	body[data-theme-default] .user-bubble__avatar .icon-group-forced-white.avatar-class-icon,
+	body[data-theme-default] .user-bubble__avatar .icon-team-forced-white.avatar-class-icon,
 	body[data-theme-default] .user-bubble__avatar .icon-user-forced-white.avatar-class-icon,
 	body[data-theme-default] .user-bubble__avatar .icon-mail-forced-white.avatar-class-icon,
 	body[data-theme-default] .autocomplete-result .icon-group-forced-white.autocomplete-result__icon--,
+	body[data-theme-default] .autocomplete-result .icon-team-forced-white.autocomplete-result__icon--,
 	body[data-theme-default] .autocomplete-result .icon-user-forced-white.autocomplete-result__icon--,
 	body[data-theme-default] .autocomplete-result .icon-mail-forced-white.autocomplete-result__icon--,
 	body[data-theme-default] .mention-bubble .icon-group-forced-white.mention-bubble__icon--,
+	body[data-theme-default] .mention-bubble .icon-team-forced-white.mention-bubble__icon--,
 	body[data-theme-default] .mention-bubble .icon-user-forced-white.mention-bubble__icon--,
 	body[data-theme-default] .mention-bubble .icon-mail-forced-white.mention-bubble__icon-- {
 		background-color: #3B3B3B;
@@ -134,12 +140,15 @@
 
 /* Manually set dark theme */
 body[data-theme-dark] .user-bubble__avatar .icon-group-forced-white.avatar-class-icon,
+body[data-theme-dark] .user-bubble__avatar .icon-team-forced-white.avatar-class-icon,
 body[data-theme-dark] .user-bubble__avatar .icon-user-forced-white.avatar-class-icon,
 body[data-theme-dark] .user-bubble__avatar .icon-mail-forced-white.avatar-class-icon,
 body[data-theme-dark] .autocomplete-result .icon-group-forced-white.autocomplete-result__icon--,
+body[data-theme-dark] .autocomplete-result .icon-team-forced-white.autocomplete-result__icon--,
 body[data-theme-dark] .autocomplete-result .icon-user-forced-white.autocomplete-result__icon--,
 body[data-theme-dark] .autocomplete-result .icon-mail-forced-white.autocomplete-result__icon--,
 body[data-theme-dark] .mention-bubble .icon-group-forced-white.mention-bubble__icon--,
+body[data-theme-dark] .mention-bubble .icon-team-forced-white.mention-bubble__icon--,
 body[data-theme-dark] .mention-bubble .icon-user-forced-white.mention-bubble__icon--,
 body[data-theme-dark] .mention-bubble .icon-mail-forced-white.mention-bubble__icon-- {
 	background-color: #3B3B3B;
@@ -151,15 +160,18 @@ body[dir="rtl"] .bidirectional-icon {
 }
 
 .user-bubble__avatar .icon-group-forced-white.avatar-class-icon,
+.user-bubble__avatar .icon-team-forced-white.avatar-class-icon,
 .user-bubble__avatar .icon-user-forced-white.avatar-class-icon,
 .user-bubble__avatar .icon-mail-forced-white.avatar-class-icon,
 .mention-bubble .icon-group-forced-white.mention-bubble__icon--,
+.mention-bubble .icon-team-forced-white.mention-bubble__icon--,
 .mention-bubble .icon-user-forced-white.mention-bubble__icon--,
 .mention-bubble .icon-mail-forced-white.mention-bubble__icon-- {
 	background-size: 75%;
 }
 
 .autocomplete-result .icon-group-forced-white.autocomplete-result__icon--,
+.autocomplete-result .icon-team-forced-white.autocomplete-result__icon--,
 .autocomplete-result .icon-user-forced-white.autocomplete-result__icon--,
 .autocomplete-result .icon-mail-forced-white.autocomplete-result__icon-- {
 	background-size: 50% !important;
@@ -181,6 +193,12 @@ body[dir="rtl"] .bidirectional-icon {
 .autocomplete-result .icon-group-forced-white.autocomplete-result__icon--,
 .mention-bubble .icon-group-forced-white.mention-bubble__icon-- {
 	background-image: url(../img/icon-contacts-white.svg);
+}
+
+.user-bubble__avatar .icon-team-forced-white,
+.autocomplete-result .icon-team-forced-white.autocomplete-result__icon--,
+.mention-bubble .icon-team-forced-white.mention-bubble__icon-- {
+	background-image: url(../img/icon-team-white.svg);
 }
 
 /* Needed to use white color also in dark mode. */

--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -229,7 +229,7 @@
 							:compact="isCompact"
 							@click="createAndJoinConversation(item)">
 							<template #icon>
-								<ConversationIcon :item="iconData(item)" />
+								<ConversationIcon :item="iconData(item)" :size="isCompact ? AVATAR.SIZE.COMPACT: AVATAR.SIZE.DEFAULT" />
 							</template>
 							<template v-if="!isCompact" #subname>
 								{{ t('spreed', 'New group conversation') }}
@@ -247,7 +247,7 @@
 							:compact="isCompact"
 							@click="createAndJoinConversation(item)">
 							<template #icon>
-								<ConversationIcon :item="iconData(item)" />
+								<ConversationIcon :item="iconData(item)" :size="isCompact ? AVATAR.SIZE.COMPACT: AVATAR.SIZE.DEFAULT" />
 							</template>
 							<template v-if="!isCompact" #subname>
 								{{ t('spreed', 'New group conversation') }}

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/Mention.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/Mention.vue
@@ -75,6 +75,9 @@ export default {
 		isGroupMention() {
 			return [MENTION.TYPE.USERGROUP, MENTION.TYPE.GROUP].includes(this.type)
 		},
+		isTeamMention() {
+			return [MENTION.TYPE.CIRCLE, MENTION.TYPE.TEAM].includes(this.type)
+		},
 		isMentionToGuest() {
 			return this.type === MENTION.TYPE.GUEST || this.type === MENTION.TYPE.EMAIL
 		},
@@ -105,9 +108,15 @@ export default {
 			return this.isGroupMention
 				&& loadState('spreed', 'user_group_ids', []).includes(this.id)
 		},
+		isCurrentUserTeam() {
+			// FIXME need backend support here
+			return this.isTeamMention && false
+		},
 		primary() {
-			return this.isMentionToAll || this.isCurrentUser
-				|| (this.isGroupMention && this.isCurrentUserGroup)
+			return this.isMentionToAll
+				|| this.isCurrentUser
+				|| this.isCurrentUserGroup
+				|| this.isCurrentUserTeam
 				|| (this.isMentionToGuest && this.isCurrentGuest)
 		},
 		avatarUrl() {
@@ -117,6 +126,8 @@ export default {
 					: 'icon-user-forced-white'
 			} else if (this.isGroupMention) {
 				return 'icon-group-forced-white'
+			} else if (this.isTeamMention) {
+				return 'icon-team-forced-white'
 			} else if (this.isMentionToGuest) {
 				return 'icon-user-forced-white'
 			} else if (!this.isMentionToAll) {

--- a/src/composables/useChatMentions.ts
+++ b/src/composables/useChatMentions.ts
@@ -66,6 +66,10 @@ export function useChatMentions(token: Ref<string>): ReturnType {
 		} else if (possibleMention.source === ATTENDEE.ACTOR_TYPE.GROUPS) {
 			chatMention.icon = 'icon-group-forced-white'
 			chatMention.subline = t('spreed', 'Group')
+		} else if (possibleMention.source === ATTENDEE.ACTOR_TYPE.CIRCLES
+			|| possibleMention.source === ATTENDEE.ACTOR_TYPE.TEAMS) {
+			chatMention.icon = 'icon-team-forced-white'
+			chatMention.subline = t('spreed', 'Team')
 		} else if (possibleMention.source === ATTENDEE.ACTOR_TYPE.GUESTS) {
 			chatMention.icon = 'icon-user-forced-white'
 			chatMention.subline = t('spreed', 'Guest')

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -119,6 +119,7 @@ export const ATTENDEE = {
 		EMAILS: 'emails',
 		GROUPS: 'groups',
 		CIRCLES: 'circles',
+		TEAMS: 'teams',
 		BOTS: 'bots',
 		BRIDGED: 'bridged',
 		FEDERATED_USERS: 'federated_users',
@@ -325,9 +326,11 @@ export const MENTION = {
 		GUEST: 'guest',
 		EMAIL: 'email',
 		USERGROUP: 'user-group',
+		CIRCLE: 'circle',
 		// Parsed to another types
 		FEDERATED_USER: 'federated_user',
 		GROUP: 'group',
+		TEAM: 'team',
 	},
 }
 

--- a/src/utils/textParse.ts
+++ b/src/utils/textParse.ts
@@ -28,6 +28,9 @@ function parseMentions(text: string, parameters: ChatMessage['messageParameters'
 		} else if (key.startsWith('mention-group')
 			&& [MENTION.TYPE.USERGROUP, MENTION.TYPE.GROUP].includes(value.type)) {
 			mention = `@"group/${value.id}"`
+		} else if (key.startsWith('mention-team')
+			&& [MENTION.TYPE.CIRCLE, MENTION.TYPE.TEAM].includes(value.type)) {
+			mention = `@"team/${value.id}"`
 		} else if (key.startsWith('mention-guest') && value.type === MENTION.TYPE.GUEST) {
 			mention = `@"${value.id}"`
 		} else if (key.startsWith('mention-email') && value.type === MENTION.TYPE.EMAIL) {


### PR DESCRIPTION
### ☑️ Resolves

* Ref #12036 
* Relevant, but not required: #14204
* To test: uncomment `$mention['type'] === 'team' ||` and `&& !str_starts_with($search, 'team/')` in UserMention.php

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="409" alt="image" src="https://github.com/user-attachments/assets/55ca6ce1-711d-4e78-aa33-3ccfc6a39353" /> | <img width="407" alt="image" src="https://github.com/user-attachments/assets/b1197711-e7fd-44f9-9204-0752656e3f7c" />

### 🚧 Tasks

- [ ] `isCurrentUserTeam` requires to be handled somehow with backend
- [ ] displayName is supposed to be passed from backend

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Not risky to browser differences / client
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required