### PR TITLE
fix(test): replace jest.spyOn with jest.useFakeTimers

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/Message.spec.js
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.spec.js
@@ -658,9 +658,7 @@ describe('Message.vue', () => {
 			store = new Store(testStoreConfig)
 
 			// need to mock the date to be within 6h
-			const mockDate = new Date('2020-05-07 10:00:00')
-			jest.spyOn(global.Date, 'now')
-				.mockImplementation(() => mockDate)
+			jest.useFakeTimers().setSystemTime(new Date('2020-05-07T10:00:00'))
 
 			const wrapper = shallowMount(Message, {
 				localVue,
@@ -694,6 +692,8 @@ describe('Message.vue', () => {
 
 			expect(wrapper.vm.isDeleting).toBe(false)
 			expect(wrapper.find('.icon-loading-small').exists()).toBe(false)
+
+			jest.useRealTimers()
 		})
 	})
 

--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.spec.js
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.spec.js
@@ -267,9 +267,8 @@ describe('MessageButtonsBar.vue', () => {
 		describe('delete action', () => {
 			test('emits delete event', async () => {
 				// need to mock the date to be within 6h
-				const mockDate = new Date('2020-05-07 10:00:00')
-				jest.spyOn(global.Date, 'now')
-					.mockImplementation(() => mockDate)
+				jest.useFakeTimers().setSystemTime(new Date('2020-05-07T10:00:00'))
+
 				useMessageInfoSpy.mockReturnValue({
 					isDeleteable: computed(() => true),
 				})
@@ -289,6 +288,8 @@ describe('MessageButtonsBar.vue', () => {
 				await actionButton.find('button').trigger('click')
 
 				expect(wrapper.emitted().delete).toBeTruthy()
+
+				jest.useRealTimers()
 			})
 
 			/**

--- a/src/store/conversationsStore.spec.js
+++ b/src/store/conversationsStore.spec.js
@@ -975,9 +975,7 @@ describe('conversationsStore', () => {
 
 		test('updates last activity', () => {
 			const mockDate = new Date('2020-01-01')
-
-			jest.spyOn(global, 'Date')
-				.mockImplementation(() => mockDate)
+			jest.useFakeTimers().setSystemTime(mockDate)
 
 			testConversation.lastActivity = 1200300
 

--- a/src/store/messagesStore.spec.js
+++ b/src/store/messagesStore.spec.js
@@ -560,12 +560,12 @@ describe('messagesStore', () => {
 	})
 
 	describe('temporary messages', () => {
-		let mockDate
-
 		beforeEach(() => {
-			mockDate = new Date('2020-01-01 20:00:00')
-			jest.spyOn(global, 'Date')
-				.mockImplementation(() => mockDate)
+			jest.useFakeTimers().setSystemTime(new Date('2020-01-01T20:00:00'))
+		})
+
+		afterEach(() => {
+			jest.useRealTimers()
 		})
 
 		test('adds temporary message to the list', () => {

--- a/src/store/participantsStore.spec.js
+++ b/src/store/participantsStore.spec.js
@@ -866,6 +866,8 @@ describe('participantsStore', () => {
 				restoreConsole = mockConsole(['error', 'debug'])
 			})
 			afterEach(() => {
+				jest.useRealTimers()
+
 				expect(testStoreConfig.actions.setCurrentParticipant).not.toHaveBeenCalled()
 				expect(testStoreConfig.actions.addConversation).not.toHaveBeenCalled()
 				expect(sessionStorage.setItem).not.toHaveBeenCalled()
@@ -883,8 +885,7 @@ describe('participantsStore', () => {
 				participantData.lastPing = mockDate.getTime() / 1000 - lastPingAge
 				participantData.inCall = inCall
 
-				jest.spyOn(global, 'Date')
-					.mockImplementation(() => mockDate)
+				jest.useFakeTimers().setSystemTime(mockDate)
 
 				const error = generateOCSErrorResponse({ payload: participantData, status: 409 })
 				joinConversation.mockRejectedValue(error)

--- a/src/utils/__tests__/formattedTime.spec.js
+++ b/src/utils/__tests__/formattedTime.spec.js
@@ -23,8 +23,13 @@ describe('formattedTime', () => {
 })
 
 describe('futureRelativeTime', () => {
-	const fixedDate = new Date('2024-01-01T00:00:00Z')
-	jest.spyOn(Date, 'now').mockImplementation(() => fixedDate.getTime())
+	beforeEach(() => {
+		jest.useFakeTimers().setSystemTime(new Date('2024-01-01T00:00:00Z'))
+	})
+
+	afterEach(() => {
+		jest.useRealTimers()
+	})
 
 	it('should return the correct string for time in hours', () => {
 		const timeInFuture = Date.now() + (2 * 60 * 60 * 1000) // 2 hours from now

--- a/src/utils/__tests__/prepareTemporaryMessage.spec.js
+++ b/src/utils/__tests__/prepareTemporaryMessage.spec.js
@@ -7,12 +7,13 @@ import { prepareTemporaryMessage } from '../prepareTemporaryMessage.ts'
 
 describe('prepareTemporaryMessage', () => {
 	const TOKEN = 'XXTOKENXX'
-	let mockDate
 
 	beforeEach(() => {
-		mockDate = new Date('2020-01-01 20:00:00')
-		jest.spyOn(global, 'Date')
-			.mockImplementation(() => mockDate)
+		jest.useFakeTimers().setSystemTime(new Date('2020-01-01T20:00:00'))
+	})
+
+	afterEach(() => {
+		jest.useRealTimers()
 	})
 
 	const defaultPayload = {


### PR DESCRIPTION
### ☑️ Resolves

* Fix `Error: Uncaught [TypeError: Date.now is not a function]` (I hope 🤞🏽)


### 🏁 Checklist

- [x] ⛑️ Tests are included or not possible