### PR TITLE
fix(MessagesList): keep chat at the bottom when list height is changing

### DIFF
--- a/src/components/CallView/shared/VideoVue.spec.js
+++ b/src/components/CallView/shared/VideoVue.spec.js
@@ -14,12 +14,6 @@ import storeConfig from '../../../store/storeConfig.js'
 import EmitterMixin from '../../../utils/EmitterMixin.js'
 import CallParticipantModel from '../../../utils/webrtc/models/CallParticipantModel.js'
 
-global.ResizeObserver = jest.fn().mockImplementation(() => ({
-	observe: jest.fn(),
-	unobserve: jest.fn(),
-	disconnect: jest.fn(),
-}))
-
 describe('VideoVue.vue', () => {
 	let localVue
 	let store

--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -341,6 +341,10 @@ export default {
 		subscribe('networkOnline', this.handleNetworkOnline)
 		window.addEventListener('focus', this.onWindowFocus)
 
+		window.addEventListener('resize', this.updateSize)
+		this.resizeObserver = new ResizeObserver(this.updateSize)
+		this.resizeObserver.observe(this.$refs.scroller)
+
 		/**
 		 * Every 30 seconds we remove expired messages from the store
 		 */
@@ -364,6 +368,11 @@ export default {
 		unsubscribe('networkOffline', this.handleNetworkOffline)
 		unsubscribe('networkOnline', this.handleNetworkOnline)
 
+		window.removeEventListener('resize', this.updateSize)
+		if (this.resizeObserver) {
+			this.resizeObserver.disconnect()
+		}
+
 		if (this.expirationInterval) {
 			clearInterval(this.expirationInterval)
 			this.expirationInterval = null
@@ -373,6 +382,14 @@ export default {
 	methods: {
 		t,
 		n,
+		updateSize() {
+			if (this.isChatScrolledToBottom) {
+				this.$refs.scroller.scrollTo({
+					top: this.$refs.scroller.scrollHeight,
+				})
+			}
+		},
+
 		prepareMessagesGroups(messages) {
 			let prevGroupMap = null
 			const groupsByDate = {}

--- a/src/test-setup.js
+++ b/src/test-setup.js
@@ -109,6 +109,12 @@ global.BroadcastChannel = jest.fn(() => ({
 	addEventListener: jest.fn(),
 }))
 
+global.ResizeObserver = jest.fn(() => ({
+	observe: jest.fn(),
+	unobserve: jest.fn(),
+	disconnect: jest.fn(),
+}))
+
 // Work around missing "URL.createObjectURL" (which is used in the code but not
 // relevant for the tests) in jsdom: https://github.com/jsdom/jsdom/issues/1721
 window.URL.createObjectURL = jest.fn()


### PR DESCRIPTION
### ☑️ Resolves

Fix breaking the list scrolling when input height changes from:
- multiline message
- reply to
- typing indicator
- e.t.c.


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before

https://github.com/user-attachments/assets/d567b660-f7bf-46d7-92eb-2c6216cdb8c0

🏡 After

https://github.com/user-attachments/assets/21236d4a-8e80-4d6d-8d68-8f0ca1ee600a


<!-- ☀️ Light theme | 🌑 Dark Theme -->

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
