### PR TITLE
Empty iceServers.urls handling fix (reloaded)

### DIFF
--- a/lib/Controller/SignalingController.php
+++ b/lib/Controller/SignalingController.php
@@ -164,15 +164,25 @@ class SignalingController extends OCSController {
 		$stunUrls = [];
 		$stunServers = $this->talkConfig->getStunServers();
 		foreach ($stunServers as $stunServer) {
+			if (empty($stunServer)) {
+				continue;
+			}
+
 			$stunUrls[] = 'stun:' . $stunServer;
 		}
-		$stun[] = [
-			'urls' => $stunUrls
-		];
+		if (!empty($stunUrls)) {
+			$stun[] = [
+				'urls' => $stunUrls
+			];
+		}
 
 		$turn = [];
 		$turnSettings = $this->talkConfig->getTurnSettings();
 		foreach ($turnSettings as $turnServer) {
+			if (empty($turnServer['schemes']) || empty($turnServer['server']) || empty($turnServer['protocols'])) {
+				continue;
+			}
+
 			$turnUrls = [];
 			$schemes = explode(',', $turnServer['schemes']);
 			$protocols = explode(',', $turnServer['protocols']);


### PR DESCRIPTION
This pull request addresses the review comments from https://github.com/nextcloud/spreed/pull/8020 (the original branch could not be pushed to, so I had to create a new branch).

[As explained in the review](https://github.com/nextcloud/spreed/pull/8020#discussion_r984577745) I have adjusted the signaling settings returned by the server so the STUN and TURN servers do not contain empty or invalid `urls`. With that change it is no longer needed to guard setting `iceServers` in the frontend, so I reverted those changes. I have squashed everything into the first commit, slightly adjusted its message to reflect the changes done to the code and pushed the branch again after rebasing. @pboguslawski I hope that is fine :-)

Now `stunservers` and `turnservers` will be an empty array if the URL is empty or invalid in the STUN or TURN settings, and from a quick look to the mobile clients code the filtered STUN and TURN servers should work as expected in them:
- In iOS [`stunservers` and `turnservers` are treated as an array of dictionaries](https://github.com/nextcloud/talk-ios/blob/adcf6c9bdd1518cc6619915604509e01c012fe89/NextcloudTalk/SignalingSettings.swift#L31-L41). Then the STUN and TURN server arrays will be traversed and [the elements added to `iceServers`](https://github.com/nextcloud/talk-ios/blob/f333a1253fbd80c48c0f89e057f4eb455fa8dacb/NextcloudTalk/NCSignalingController.m#L71-L84), so `iceServers` would be an empty array if `stunservers` and `turnservers` were empty, which [should be a valid value](https://w3c.github.io/webrtc-pc/#dom-rtcconfiguration-iceservers).
- In Android [`stunservers` and `turnservers` are treated as a list of data parsable as an `IceServer` object](https://github.com/nextcloud/talk-android/blob/6706bc2790fb11b1f3c8d9dfd42e5f587d49b4e9/app/src/main/java/com/nextcloud/talk/models/json/signaling/settings/SignalingSettings.kt#L20-L23). Then the STUN and TURN server list will be traversed if not null and [the elements added to `iceServers` (if they contain a URL)](https://github.com/nextcloud/talk-android/blob/ea2bebe3b0f91b61147822e51cfecbf7baa0bc51/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt#L1535-L1568), so `iceServers` would be an empty array if `stunservers` and `turnservers` were empty, which [should be a valid value](https://w3c.github.io/webrtc-pc/#dom-rtcconfiguration-iceservers).

Finally, and independently of the signaling settings, the mentioned approach about [resetting the loading spinner in _TurnServer.vue_](https://github.com/nextcloud/spreed/pull/8020#discussion_r984575430) was fixed in the meantime (in a slightly different way) in https://github.com/nextcloud/spreed/commit/ac4a76a627c1d1fad2a353bf63ad5d4c638bf4d1

## How to test (scenario 1)

- Open Talk settings
- Setup the HPB
- Empty the STUN server (do not remove it, as that sets again the default STUN server)
- Open Talk
- Start a call

### Result with this pull request

The participant can establish a connection with the HPB (if the HPB is local or there is also a working TURN server configured)

### Result without this pull request

`Error while accessing microphone and camera` will be shown in the UI and no connection is established with the HPB; an error is shown in the browser console with a call to `createPeer` in the stack


## How to test (scenario 2)

- Open Talk settings
- Setup the HPB
- Add a new TURN server and set a secret, but not a server
- Open Talk
- Start a call

### Result with this pull request

The participant can establish a connection with the HPB (if a direct connection with the HPB is possible without needing a TURN server)

### Result without this pull request

`Error while accessing microphone and camera` will be shown in the UI and no connection is established with the HPB; an error is shown in the browser console with a call to `createPeer` in the stack
