### PR TITLE
fix(dashboard): Hide archived conversations from dashboard unless mentioned

### DIFF
--- a/lib/Dashboard/TalkWidget.php
+++ b/lib/Dashboard/TalkWidget.php
@@ -142,12 +142,12 @@ class TalkWidget implements IAPIWidget, IIconWidget, IButtonWidget, IOptionWidge
 				return false;
 			}
 
-			if ($room->getCallFlag() !== Participant::FLAG_DISCONNECTED) {
-				return true;
-			}
-
 			$participant = $this->participantService->getParticipant($room, $userId);
 			$attendee = $participant->getAttendee();
+
+			if (!$attendee->isArchived() && $room->getCallFlag() !== Participant::FLAG_DISCONNECTED) {
+				return true;
+			}
 
 			if (($room->isFederatedConversation() && $attendee->getLastMentionMessage())
 				|| (!$room->isFederatedConversation() && $attendee->getLastMentionMessage() > $attendee->getLastReadMessage())) {
@@ -186,14 +186,18 @@ class TalkWidget implements IAPIWidget, IIconWidget, IButtonWidget, IOptionWidge
 			if ($room->getObjectType() === BreakoutRoom::PARENT_OBJECT_TYPE) {
 				continue;
 			}
-			$rooms[] = $room;
 
 			$participant = $this->participantService->getParticipant($room, $userId);
 			$attendee = $participant->getAttendee();
-			if ($room->getCallFlag() !== Participant::FLAG_DISCONNECTED) {
-				// Call in progress
-				$mentions[] = $room;
-				continue;
+
+			if (!$attendee->isArchived()) {
+				$rooms[] = $room;
+
+				if ($room->getCallFlag() !== Participant::FLAG_DISCONNECTED) {
+					// Call in progress
+					$mentions[] = $room;
+					continue;
+				}
 			}
 
 			if (($room->isFederatedConversation() && $attendee->getLastMentionMessage())

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -523,6 +523,9 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 			if (isset($expectedRoom['listable'])) {
 				$data['listable'] = (string)$room['listable'];
 			}
+			if (isset($expectedRoom['isArchived'])) {
+				$data['isArchived'] = (int)$room['isArchived'];
+			}
 			if (isset($expectedRoom['participantType'])) {
 				$data['participantType'] = (string)$room['participantType'];
 			}
@@ -5167,12 +5170,12 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 	 * @When /^user "([^"]*)" (unarchives|archives) room "([^"]*)" with (\d+) \((v4)\)$/
 	 *
 	 * @param string $user
-	 * @param string $identifier
 	 * @param string $action
+	 * @param string $identifier
 	 * @param int $statusCode
 	 * @param string $apiVersion
 	 */
-	public function userArchivesConversation(string $user, string $identifier, string $action, int $statusCode, string $apiVersion): void {
+	public function userArchivesConversation(string $user, string $action, string $identifier, int $statusCode, string $apiVersion): void {
 		$httpMethod = 'POST';
 
 		if ($action === 'unarchives') {
@@ -5182,22 +5185,6 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 		$this->setCurrentUser($user);
 		$this->sendRequest(
 			$httpMethod, '/apps/spreed/api/' . $apiVersion . '/room/' . self::$identifierToToken[$identifier] . '/archive',
-		);
-		$this->assertStatusCode($this->response, $statusCode);
-	}
-
-	/**
-	 * @When /^user "([^"]*)" unarchives room "([^"]*)" with (\d+) \((v4)\)$/
-	 *
-	 * @param string $user
-	 * @param string $identifier
-	 * @param int $statusCode
-	 * @param string $apiVersion
-	 */
-	public function userUnarchivesConversation(string $user, string $identifier, int $statusCode, string $apiVersion): void {
-		$this->setCurrentUser($user);
-		$this->sendRequest(
-			'DELETE', '/apps/spreed/api/' . $apiVersion . '/room/' . self::$identifierToToken[$identifier] . '/archive',
 		);
 		$this->assertStatusCode($this->response, $statusCode);
 	}

--- a/tests/integration/features/conversation-1/archive.feature
+++ b/tests/integration/features/conversation-1/archive.feature
@@ -1,0 +1,28 @@
+Feature: conversation-1/archive
+  Background:
+    Given user "participant1" exists
+    Given user "participant2" exists
+
+  Scenario: Archiving and unarchiving
+    Given user "participant1" creates room "group room" (v4)
+      | roomType | 3 |
+      | roomName | room |
+    When user "participant1" creates room "one-to-one room" (v4)
+      | roomType | 1 |
+      | invite   | participant2 |
+    And user "participant1" is participant of the following rooms (v4)
+      | id              | type | participantType | isArchived |
+      | group room      | 3    | 1               | 0          |
+      | one-to-one room | 1    | 1               | 0          |
+    And user "participant1" archives room "one-to-one room" with 200 (v4)
+    And user "participant1" archives room "group room" with 200 (v4)
+    And user "participant1" is participant of the following rooms (v4)
+      | id              | type | participantType | isArchived |
+      | group room      | 3    | 1               | 1          |
+      | one-to-one room | 1    | 1               | 1          |
+    And user "participant1" unarchives room "one-to-one room" with 200 (v4)
+    And user "participant1" unarchives room "group room" with 200 (v4)
+    And user "participant1" is participant of the following rooms (v4)
+      | id              | type | participantType | isArchived |
+      | group room      | 3    | 1               | 0          |
+      | one-to-one room | 1    | 1               | 0         |

--- a/tests/integration/features/integration/dashboard.feature
+++ b/tests/integration/features/integration/dashboard.feature
@@ -52,6 +52,20 @@ Feature: integration/dashboard
       | call room                | Call in progress   | call room       | {$BASE_URL}ocs/v2.php/apps/spreed/api/v1/room/{token}/avatar{version} |         |                |
       | group room               | You were mentioned | group room      | {$BASE_URL}ocs/v2.php/apps/spreed/api/v1/room/{token}/avatar{version} |         |                |
       | participant2-displayname | Hello              | one-to-one room | {$BASE_URL}ocs/v2.php/apps/spreed/api/v1/room/{token}/avatar{version} |         |                |
+    And user "participant1" archives room "one-to-one room" with 200 (v4)
+    And user "participant1" archives room "group room" with 200 (v4)
+    And user "participant1" archives room "call room" with 200 (v4)
+    Then user "participant1" sees the following entries for dashboard widgets "spreed" (v1)
+      | title                    | subtitle           | link            | iconUrl                                                               | sinceId | overlayIconUrl |
+      | group room               | You were mentioned | group room      | {$BASE_URL}ocs/v2.php/apps/spreed/api/v1/room/{token}/avatar{version} |         |                |
+      | participant2-displayname | Hello              | one-to-one room | {$BASE_URL}ocs/v2.php/apps/spreed/api/v1/room/{token}/avatar{version} |         |                |
+    Then user "participant1" sees the following entries for dashboard widgets "spreed" (v2)
+      | title                    | subtitle           | link            | iconUrl                                                               | sinceId | overlayIconUrl |
+      | group room               | You were mentioned | group room      | {$BASE_URL}ocs/v2.php/apps/spreed/api/v1/room/{token}/avatar{version} |         |                |
+      | participant2-displayname | Hello              | one-to-one room | {$BASE_URL}ocs/v2.php/apps/spreed/api/v1/room/{token}/avatar{version} |         |                |
+    And user "participant1" unarchives room "one-to-one room" with 200 (v4)
+    And user "participant1" unarchives room "group room" with 200 (v4)
+    And user "participant1" unarchives room "call room" with 200 (v4)
     And user "participant2" set the message expiration to 3 of room "one-to-one room" with 200 (v4)
     And user "participant2" sends message "Message 3" to room "one-to-one room" with 201
     And user "participant2" set the message expiration to 3 of room "group room" with 200 (v4)


### PR DESCRIPTION
## 🛠️ API Checklist
- Fix #13378 

### 🚧 Tasks

- [x] Archived calls are hidden
- [x] Archived conversations are hidden from "No mention, but here is the rest" list

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
