### PR TITLE
feat(bots): Let bots know the parent message when it was a reply

### DIFF
--- a/lib/Events/BotInvokeEvent.php
+++ b/lib/Events/BotInvokeEvent.php
@@ -11,20 +11,36 @@ namespace OCA\Talk\Events;
 use OCP\EventDispatcher\Event;
 
 /**
+ * @psalm-type ChatMessageParentData = array{
+ *     type: 'Note',
+ *     actor: array{
+ *         type: 'Person',
+ *         id: non-empty-string,
+ *         name: non-empty-string,
+ *     },
+ *     object: array{
+ *         type: 'Note',
+ *         id: numeric-string,
+ *         name: string,
+ *         content: non-empty-string,
+ *         mediaType: 'text/markdown'|'text/plain',
+ *     },
+ * }
  * @psalm-type ChatMessageData = array{
  *     type: 'Activity'|'Create',
  *     actor: array{
  *         type: 'Person',
  *         id: non-empty-string,
  *         name: non-empty-string,
- *         talkParticipantType: non-empty-string,
+ *         talkParticipantType: numeric-string,
  *     },
  *     object: array{
  *         type: 'Note',
- *         id: non-empty-string,
+ *         id: numeric-string,
  *         name: string,
  *         content: non-empty-string,
  *         mediaType: 'text/markdown'|'text/plain',
+ *         inReplyTo?: ChatMessageParentData,
  *     },
  *     target: array{
  *         type: 'Collection',

--- a/lib/Service/ActivityPubHelper.php
+++ b/lib/Service/ActivityPubHelper.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Talk\Service;
+
+use OCA\Talk\Events\BotInvokeEvent;
+use OCA\Talk\Model\Attendee;
+use OCA\Talk\Model\BotServer;
+use OCA\Talk\Model\Message;
+use OCA\Talk\Room;
+use OCP\Comments\IComment;
+
+/**
+ * @psalm-import-type ChatMessageParentData from BotInvokeEvent
+ * @psalm-type NoteType = array{type: 'Note', id: numeric-string, name: string, content: string, mediaType: 'text/markdown'|'text/plain'}
+ */
+class ActivityPubHelper {
+	/**
+	 * @return array{type: 'Application', id: non-falsy-string, name: string}
+	 */
+	public function generateApplicationFromBot(BotServer $bot): array {
+		return [
+			'type' => 'Application',
+			'id' => Attendee::ACTOR_BOTS . '/' . Attendee::ACTOR_BOT_PREFIX . $bot->getUrlHash(),
+			'name' => $bot->getName(),
+		];
+	}
+
+	/**
+	 * @return array{type: 'Collection', id: non-empty-string, name: string}
+	 */
+	public function generateCollectionFromRoom(Room $room): array {
+		/** @var non-empty-string $token */
+		$token = $room->getToken();
+		return [
+			'type' => 'Collection',
+			'id' => $token,
+			'name' => $room->getName(),
+		];
+	}
+
+	/**
+	 * @psalm-param ?ChatMessageParentData $inReplyTo
+	 * @psalm-return NoteType&array{inReplyTo?: ChatMessageParentData}
+	 */
+	public function generateNote(IComment $comment, array $messageData, string $messageType, ?array $inReplyTo = null): array {
+		/** @var string $content */
+		$content = json_encode($messageData, JSON_THROW_ON_ERROR);
+		/** @var numeric-string $messageId */
+		$messageId = $comment->getId();
+		/** @var 'text/markdown'|'text/plain' $mediaType */
+		$mediaType = 'text/markdown';// FIXME or text/plain when markdown is disabled
+		$note = [
+			'type' => 'Note',
+			'id' => $messageId,
+			'name' => $messageType,
+			'content' => $content,
+			'mediaType' => $mediaType,
+		];
+		if ($inReplyTo !== null) {
+			$note['inReplyTo'] = $inReplyTo;
+		}
+		return $note;
+	}
+
+	/**
+	 * @return array{type: 'Person', id: non-falsy-string, name: string, talkParticipantType: numeric-string}
+	 */
+	public function generatePersonFromAttendee(Attendee $attendee): array {
+		return [
+			'type' => 'Person',
+			'id' => $attendee->getActorType() . '/' . $attendee->getActorId(),
+			'name' => $attendee->getDisplayName(),
+			'talkParticipantType' => (string)$attendee->getParticipantType(),
+		];
+	}
+
+	/**
+	 * @return array{type: 'Person', id: non-falsy-string, name: string}
+	 */
+	public function generatePersonFromMessageActor(Message $message): array {
+		return [
+			'type' => 'Person',
+			'id' => $message->getActorType() . '/' . $message->getActorId(),
+			'name' => $message->getActorDisplayName(),
+		];
+	}
+}

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -89,30 +89,6 @@
       <code><![CDATA[Filesystem]]></code>
     </UndefinedClass>
   </file>
-  <file src="lib/Service/BotService.php">
-    <InvalidArgument>
-      <code><![CDATA[[
-			'type' => 'Activity',
-			'actor' => [
-				'type' => 'Person',
-				'id' => $message->getActorType() . '/' . $message->getActorId(),
-				'name' => $message->getActorDisplayName(),
-			],
-			'object' => [
-				'type' => 'Note',
-				'id' => $event->getComment()->getId(),
-				'name' => $message->getMessageRaw(),
-				'content' => json_encode($messageData),
-				'mediaType' => 'text/markdown',
-			],
-			'target' => [
-				'type' => 'Collection',
-				'id' => $event->getRoom()->getToken(),
-				'name' => $event->getRoom()->getName(),
-			]
-		]]]></code>
-    </InvalidArgument>
-  </file>
   <file src="lib/Service/RecordingService.php">
     <LessSpecificReturnStatement>
       <code><![CDATA[$recordingFolder]]></code>


### PR DESCRIPTION
### ☑️ Resolves

* Fix #14285 

Allows bots to do things like:
Person using the bot | Original author being assisted
---|---
![grafik](https://github.com/user-attachments/assets/3e51c90f-4f0f-4d0b-a519-ebd915b8a2ca) | ![grafik](https://github.com/user-attachments/assets/41a0dbe9-8546-4f95-8bb5-1a7714743be1)



### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
