### PR TITLE
Release 21.0.0 rc.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 21.0.0-rc.3 – 2025-02-07
+### Added
+- feat(bots): Let bots know when a message was a reply
+  [#14310](https://github.com/nextcloud/spreed/issues/14310)
+
+### Changed
+- Update translations
+- Update dependencies
+- fix(calls): Adjust double-click behaviour when zooming screenshares
+  [#14284](https://github.com/nextcloud/spreed/issues/14284)
+
+### Fixed
+- fix(chat): Fix double scroll bar
+  [#14265](https://github.com/nextcloud/spreed/issues/14265)
+- fix(chat): Keep chat position at the bottom when the chat list height expends
+  [#14268](https://github.com/nextcloud/spreed/issues/14268)
+- fix(chat): Fix missing "Copy code" in some cases
+  [#14308](https://github.com/nextcloud/spreed/issues/14308)
+- fix(archive): Hide archived conversations from dashboard unless mentioned
+  [#14299](https://github.com/nextcloud/spreed/issues/14299)
+- fix(chat): Add mention-id to simplify editing messages with mentions
+  [#14311](https://github.com/nextcloud/spreed/issues/14311)
+
 ## 21.0.0-rc.2 – 2025-01-30
 ### Added
 - feat(chat): Support mentioning teams

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -18,7 +18,7 @@
 * 🌉 **Sync with other chat solutions** With [Matterbridge](https://github.com/42wim/matterbridge/) being integrated in Talk, you can easily sync a lot of other chat solutions to Nextcloud Talk and vice-versa.
 ]]></description>
 
-	<version>21.0.0-rc.2</version>
+	<version>21.0.0-rc.3</version>
 	<licence>agpl</licence>
 
 	<author>Anna Larch</author>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "talk",
-  "version": "21.0.0-rc.2",
+  "version": "21.0.0-rc.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "talk",
-      "version": "21.0.0-rc.2",
+      "version": "21.0.0-rc.3",
       "license": "agpl",
       "dependencies": {
         "@linusborg/vue-simple-portal": "^0.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "talk",
-  "version": "21.0.0-rc.2",
+  "version": "21.0.0-rc.3",
   "private": true,
   "description": "",
   "author": "Joas Schilling <coding@schilljs.com>",


### PR DESCRIPTION
## Added
- feat(bots): Let bots know when a message was a reply [#14310](https://github.com/nextcloud/spreed/issues/14310)

## Changed
- Update translations
- Update dependencies
- fix(calls): Adjust double-click behaviour when zooming screenshares [#14284](https://github.com/nextcloud/spreed/issues/14284)

## Fixed
- fix(chat): Fix double scroll bar [#14265](https://github.com/nextcloud/spreed/issues/14265)
- fix(chat): Keep chat position at the bottom when the chat list height expends [#14268](https://github.com/nextcloud/spreed/issues/14268)
- fix(chat): Fix missing "Copy code" in some cases [#14308](https://github.com/nextcloud/spreed/issues/14308)
- fix(archive): Hide archived conversations from dashboard unless mentioned [#14299](https://github.com/nextcloud/spreed/issues/14299)
- fix(chat): Add mention-id to simplify editing messages with mentions [#14311](https://github.com/nextcloud/spreed/issues/14311)
