### PR TITLE
fix(MessagesList): fix resizeObserver and scrolledToBottom state update

### DIFF
--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -300,11 +300,14 @@ export default {
 				// scroll to bottom if needed
 				this.scrollToBottom({ smooth: false })
 
-				if (this.conversation?.type === CONVERSATION.TYPE.NOTE_TO_SELF) {
-					this.$nextTick(() => {
+				this.$nextTick(() => {
+					this.checkChatNotScrollable()
+
+					if (this.conversation?.type === CONVERSATION.TYPE.NOTE_TO_SELF) {
 						this.updateTasksCount()
-					})
-				}
+					}
+				})
+
 			},
 		},
 
@@ -320,8 +323,7 @@ export default {
 				this.$nextTick(() => {
 					this.checkSticky()
 					// setting wheel event for non-scrollable chat
-					const isScrollable = this.$refs.scroller.scrollHeight > this.$refs.scroller.clientHeight
-					if (!this.isChatBeginningReached && !isScrollable) {
+					if (!this.isChatBeginningReached && this.checkChatNotScrollable()) {
 						this.$refs.scroller.addEventListener('wheel', this.handleWheelEvent, { passive: true })
 					}
 				})
@@ -385,6 +387,8 @@ export default {
 				this.$refs.scroller.scrollTo({
 					top: this.$refs.scroller.scrollHeight,
 				})
+			} else {
+				this.checkChatNotScrollable()
 			}
 		},
 
@@ -1161,10 +1165,7 @@ export default {
 				this.$refs.scroller.scrollTop += this.$refs.scroller.offsetHeight / 4
 			}
 
-			if (this.$refs.scroller && this.$refs.scroller.clientHeight === this.$refs.scroller.scrollHeight) {
-				// chat is not scrollable
-				this.setChatScrolledToBottom(true)
-			}
+			this.checkChatNotScrollable()
 
 			if (highlightAnimation && scrollElement === element) {
 				// element is visible, highlight it
@@ -1284,6 +1285,18 @@ export default {
 			const tasksDoneCount = this.$refs.scroller.querySelectorAll('.checkbox-content__icon--checked')?.length
 			const tasksCount = this.$refs.scroller.querySelectorAll('.task-list-item')?.length
 			this.chatExtrasStore.setTasksCounters({ tasksCount, tasksDoneCount })
+		},
+
+		checkChatNotScrollable() {
+			const isNotScrollable = this.$refs.scroller
+				? this.$refs.scroller.clientHeight === this.$refs.scroller.scrollHeight
+				: false
+
+			if (isNotScrollable && !this.isChatScrolledToBottom) {
+				this.setChatScrolledToBottom(true)
+			}
+
+			return isNotScrollable
 		},
 
 		handleWheelEvent(event) {

--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -7,7 +7,6 @@
 	<!-- size and remain refer to the amount and initial height of the items that
 	are outside of the viewport -->
 	<div ref="scroller"
-		:key="token"
 		class="scroller messages-list__scroller"
 		:class="{'scroller--chatScrolledToBottom': isChatScrolledToBottom,
 			'scroller--isScrolling': isScrolling}"

--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -898,17 +898,20 @@ export default {
 			}
 
 			const { scrollHeight, scrollTop, clientHeight } = this.$refs.scroller
-			const scrollOffset = scrollHeight - scrollTop
+			const scrollOffsetFromTop = scrollHeight - scrollTop
+			const scrollOffsetFromBottom = Math.abs(scrollOffsetFromTop - clientHeight)
 
 			// For chats that are scrolled to bottom and not fitted in one screen
-			if (Math.abs(scrollOffset - clientHeight) < SCROLL_TOLERANCE && !this.hasMoreMessagesToLoad && scrollTop > 0) {
+			if (scrollOffsetFromBottom < SCROLL_TOLERANCE && !this.hasMoreMessagesToLoad && scrollTop > 0) {
 				this.setChatScrolledToBottom(true)
 				this.displayMessagesLoader = false
 				this.debounceUpdateReadMarkerPosition()
 				return
 			}
 
-			this.setChatScrolledToBottom(false)
+			if (scrollOffsetFromBottom >= SCROLL_TOLERANCE) {
+				this.setChatScrolledToBottom(false)
+			}
 
 			if ((scrollHeight > clientHeight && scrollTop < 800 && this.isScrolling === 'up')
 				|| skipHeightCheck) {
@@ -1309,6 +1312,7 @@ export default {
 					return
 				}
 
+				this.isScrolling = 'up'
 				this.debounceHandleScroll({ skipHeightCheck: true })
 			}
 		},


### PR DESCRIPTION
### ☑️ Resolves

* Follow-up to #14266
  * Keeps node reference for ResizeObserver after switching conversations
  * Ensure non-scrollable chat doesn't have 'scroll to bottom' button
* Fix #14392 🚧
  * `setChatScrolledToBottom(false)` should be only set on scroll up (if we're scrolling down. it should be already set)

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏡 After

https://github.com/user-attachments/assets/0cdcac86-e967-43e4-a894-94f5b5861c86

### 🔬  Test
- [x] removing `:key`:
  - [x] ResizeObserver works after conversation switch
  - [x] nothing is broken, if we get rid of 'force-refresh' of whole component
- [x] non-scrollable chats do not have 🔽 button:
  - [x] on open (on open with focusing message)
  - [x] on resize
  - [x] on messages list (height) change
- [x] scrollable chats do not have 🔽 button:
  - [x] when scrolling down
  - [x] when nothing to scroll
  - [x] when new message arrives, and there's a mismatch of last read (follow-up from above)

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required