### PR TITLE
fix(capabilities): make a deep comparison

### DIFF
--- a/src/components/TopBar/CallButton.vue
+++ b/src/components/TopBar/CallButton.vue
@@ -353,8 +353,9 @@ export default {
 	},
 
 	watch: {
-		token() {
+		token(newValue, oldValue) {
 			this.callViewStore.resetCallHasJustEnded()
+			this.talkHashStore.resetTalkProxyHashDirty(oldValue)
 		}
 	},
 

--- a/src/services/__tests__/CapabilitiesManager.spec.js
+++ b/src/services/__tests__/CapabilitiesManager.spec.js
@@ -177,5 +177,36 @@ describe('CapabilitiesManager', () => {
 			expect(talkHashStore.isNextcloudTalkProxyHashDirty[token]).toBeTruthy()
 			expect(BrowserStorage.setItem).toHaveBeenCalledTimes(1)
 		})
+
+		it('should reset dirty proxy hash after second fetch and negative check for changes', async () => {
+			const joinRoomResponseMock = generateOCSResponse({
+				headers: { 'x-nextcloud-talk-proxy-hash': `${remoteCapabilities.hash}003` },
+				payload: { token, remoteServer }
+			})
+			const joinRoomResponseMock2 = generateOCSResponse({
+				headers: { 'x-nextcloud-talk-proxy-hash': `${remoteCapabilities.hash}004` },
+				payload: { token, remoteServer }
+			})
+			const responseMock = generateOCSResponse({
+				payload: {
+					...mockedCapabilities.spreed,
+					features: [...mockedCapabilities.spreed.features, 'new-feature', 'new-feature-2'],
+				}
+			})
+			const responseMock2 = generateOCSResponse({
+				payload: {
+					...mockedCapabilities.spreed,
+					features: [...mockedCapabilities.spreed.features, 'new-feature', 'new-feature-2'],
+				}
+			})
+			getRemoteCapabilities.mockReturnValueOnce(responseMock).mockReturnValueOnce(responseMock2)
+			await setRemoteCapabilities(joinRoomResponseMock)
+			expect(talkHashStore.isNextcloudTalkProxyHashDirty[token]).toBeTruthy()
+			expect(BrowserStorage.setItem).toHaveBeenCalledTimes(1)
+
+			await setRemoteCapabilities(joinRoomResponseMock2)
+			expect(talkHashStore.isNextcloudTalkProxyHashDirty[token]).not.toBeDefined()
+			expect(BrowserStorage.setItem).toHaveBeenCalledTimes(2)
+		})
 	})
 })

--- a/src/services/__tests__/CapabilitiesManager.spec.js
+++ b/src/services/__tests__/CapabilitiesManager.spec.js
@@ -146,12 +146,32 @@ describe('CapabilitiesManager', () => {
 			expect(BrowserStorage.setItem).toHaveBeenCalledTimes(0)
 		})
 
+		it('should set capabilities for new server and mark talk proxy hash as dirty', async () => {
+			const token = 'TOKEN7FED3'
+			const remoteServer = 'https://nextcloud3.local'
+			const remoteHash = 'abc123'
+			const joinRoomResponseMock = generateOCSResponse({
+				headers: { 'x-nextcloud-talk-proxy-hash': remoteHash },
+				payload: { token, remoteServer }
+			})
+			const responseMock = generateOCSResponse({ payload: mockedCapabilities.spreed })
+			getRemoteCapabilities.mockReturnValue(responseMock)
+			await setRemoteCapabilities(joinRoomResponseMock)
+			expect(talkHashStore.isNextcloudTalkProxyHashDirty[token]).toBeTruthy()
+			expect(BrowserStorage.setItem).toHaveBeenCalledTimes(1)
+		})
+
 		it('should update capabilities from server response and mark talk proxy hash as dirty', async () => {
 			const joinRoomResponseMock = generateOCSResponse({
 				headers: { 'x-nextcloud-talk-proxy-hash': `${remoteCapabilities.hash}002` },
 				payload: { token, remoteServer }
 			})
-			const responseMock = generateOCSResponse({ payload: mockedCapabilities.spreed })
+			const responseMock = generateOCSResponse({
+				payload: {
+					...mockedCapabilities.spreed,
+					features: [...mockedCapabilities.spreed.features, 'new-feature'],
+				}
+			})
 			getRemoteCapabilities.mockReturnValue(responseMock)
 			await setRemoteCapabilities(joinRoomResponseMock)
 			expect(talkHashStore.isNextcloudTalkProxyHashDirty[token]).toBeTruthy()

--- a/src/stores/__tests__/federation.spec.js
+++ b/src/stores/__tests__/federation.spec.js
@@ -4,7 +4,8 @@
  */
 import { setActivePinia, createPinia } from 'pinia'
 
-import { getShares, acceptShare, rejectShare } from '../../services/federationService.ts'
+import { mockedCapabilities } from '../../__mocks__/capabilities.ts'
+import { getShares, acceptShare, rejectShare, getRemoteCapabilities } from '../../services/federationService.ts'
 import { generateOCSErrorResponse, generateOCSResponse } from '../../test-helpers.js'
 import { useFederationStore } from '../federation.ts'
 
@@ -12,6 +13,7 @@ jest.mock('../../services/federationService', () => ({
 	getShares: jest.fn(),
 	acceptShare: jest.fn(),
 	rejectShare: jest.fn(),
+	getRemoteCapabilities: jest.fn(),
 }))
 
 describe('federationStore', () => {
@@ -186,6 +188,9 @@ describe('federationStore', () => {
 		}
 		const acceptResponse = generateOCSResponse({ payload: room })
 		acceptShare.mockResolvedValueOnce(acceptResponse)
+
+		const responseMock = generateOCSResponse({ payload: mockedCapabilities.spreed })
+		getRemoteCapabilities.mockReturnValue(responseMock)
 
 		// Act: accept invite
 		const conversation = await federationStore.acceptShare(invites[0].id)

--- a/src/stores/federation.ts
+++ b/src/stores/federation.ts
@@ -11,6 +11,7 @@ import { t } from '@nextcloud/l10n'
 import { getBaseUrl } from '@nextcloud/router'
 
 import { FEDERATION } from '../constants.ts'
+import { setRemoteCapabilitiesIfEmpty } from '../services/CapabilitiesManager.ts'
 import { getShares, acceptShare, rejectShare } from '../services/federationService.ts'
 import type { Conversation, FederationInvite, NotificationInvite } from '../types/index.ts'
 
@@ -109,6 +110,7 @@ export const useFederationStore = defineStore('federation', {
 			try {
 				Vue.set(this.pendingShares[id], 'loading', 'accept')
 				const response = await acceptShare(id)
+				await setRemoteCapabilitiesIfEmpty(response)
 				this.markInvitationAccepted(id, response.data.ocs.data)
 				this.updatePendingSharesCount(Object.keys(this.pendingShares).length)
 				return response.data.ocs.data

--- a/src/stores/talkHash.js
+++ b/src/stores/talkHash.js
@@ -32,6 +32,7 @@ export const useTalkHashStore = defineStore('talkHash', {
 		isNextcloudTalkHashDirty: false,
 		isNextcloudTalkProxyHashDirty: {},
 		maintenanceWarningToast: null,
+		proxyHashDirtyToast: null,
 	}),
 
 	actions: {
@@ -58,6 +59,20 @@ export const useTalkHashStore = defineStore('talkHash', {
 		setTalkProxyHashDirty(token) {
 			console.debug('X-Nextcloud-Talk-Proxy-Hash marked dirty: ', token)
 			Vue.set(this.isNextcloudTalkProxyHashDirty, token, true)
+		},
+
+		/**
+		 * Clear the current Talk Federation dirty hash marker (as it is irrelevant after reload or leaving)
+		 *
+		 * @param {string} token federated conversation token
+		 */
+		resetTalkProxyHashDirty(token) {
+			Vue.delete(this.isNextcloudTalkProxyHashDirty, token)
+
+			if (this.proxyHashDirtyToast) {
+				this.proxyHashDirtyToast.hideToast()
+				this.proxyHashDirtyToast = null
+			}
 		},
 
 		/**
@@ -103,6 +118,15 @@ export const useTalkHashStore = defineStore('talkHash', {
 				this.maintenanceWarningToast.hideToast()
 				this.maintenanceWarningToast = null
 			}
+		},
+
+		/**
+		 * Show a toast message when Talk Federation requires rejoining
+		 */
+		showTalkProxyHashDirtyToast() {
+			this.proxyHashDirtyToast = showError(t('spreed', 'Nextcloud Talk Federation was updated.') + '\n' + messagePleaseReload, {
+				timeout: TOAST_PERMANENT_TIMEOUT,
+			})
 		},
 	}
 })

--- a/src/test-setup.js
+++ b/src/test-setup.js
@@ -115,6 +115,8 @@ global.ResizeObserver = jest.fn(() => ({
 	disconnect: jest.fn(),
 }))
 
+global.structuredClone = jest.fn((val) => JSON.parse(JSON.stringify(val)))
+
 // Work around missing "URL.createObjectURL" (which is used in the code but not
 // relevant for the tests) in jsdom: https://github.com/jsdom/jsdom/issues/1721
 window.URL.createObjectURL = jest.fn()


### PR DESCRIPTION
### ☑️ Resolves

* Ref #14201
* Ref #12885
  * make a deep comparison of old and new remote capabilities (omitting local ones), to see if there are actual changes that might require a reload of page or rejoining
  * move toast message handling to the store, reset on leaving conversation and on following checks (next join)
  * when accepting an invitation from federated server, immediately fetch remote capabilities for it, so we know them  before joining. 

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
Toast message | Less of it

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required