### PR TITLE
fix(ConversationIcon): get rid of grey hairline, provide a fallback icon

### DIFF
--- a/src/components/ConversationIcon.vue
+++ b/src/components/ConversationIcon.vue
@@ -18,7 +18,8 @@
 				:width="size"
 				:height="size"
 				:alt="item.displayName"
-				class="avatar icon">
+				class="avatar icon"
+				@error="onError">
 			<span v-if="!hideUserStatus && conversationType"
 				class="conversation-icon__type"
 				role="img"
@@ -52,6 +53,8 @@
 </template>
 
 <script>
+import { ref } from 'vue'
+
 import IconLink from 'vue-material-design-icons/Link.vue'
 import IconStar from 'vue-material-design-icons/Star.vue'
 import IconVideo from 'vue-material-design-icons/Video.vue'
@@ -136,8 +139,19 @@ export default {
 	setup() {
 		const isDarkTheme = useIsDarkTheme()
 
+		const failed = ref(false)
+
+		/**
+		 * If avatar image failed to load, toggle value to provide a fallback
+		 */
+		function onError() {
+			failed.value = true
+		}
+
 		return {
 			isDarkTheme,
+			failed,
+			onError,
 		}
 	},
 
@@ -164,8 +178,9 @@ export default {
 				return this.item.type === CONVERSATION.TYPE.PUBLIC ? 'icon-public' : 'icon-contacts'
 			}
 
-			if (!supportsAvatar) {
-				if (this.item.objectType === CONVERSATION.OBJECT_TYPE.FILE) {
+			if (!supportsAvatar || this.failed) {
+				if (this.item.objectType === CONVERSATION.OBJECT_TYPE.FILE
+					|| this.item.type === CONVERSATION.TYPE.NOTE_TO_SELF) {
 					return 'icon-file'
 				} else if (this.item.objectType === CONVERSATION.OBJECT_TYPE.VIDEO_VERIFICATION) {
 					return 'icon-password'
@@ -255,6 +270,10 @@ export default {
 		&.icon-changelog {
 			background-size: cover !important;
 		}
+	}
+
+	img.avatar.icon {
+		background-color: transparent;
 	}
 
 	&--dark .avatar.icon {


### PR DESCRIPTION
### ☑️ Resolves

* Fix #13324
  * See icon in TopBar for better reference
  * Also add failed state and fallback in case avatar wasn't loaded

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/user-attachments/assets/9f3f1cfd-a713-4ae6-bef0-90bf28aa5079) | ![image](https://github.com/user-attachments/assets/7285599c-c18c-427f-9005-d0a0d8edbd8a)
Failed state | --
![image](https://github.com/user-attachments/assets/afb2e18d-090c-41c4-8990-86bc7387f7b3) | ![image](https://github.com/user-attachments/assets/08670329-f303-4ff9-ac20-d24804745e8b)

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required