### PR TITLE
fix(teams): Filter out already added teams from invite suggestions

### DIFF
--- a/lib/Collaboration/Collaborators/Listener.php
+++ b/lib/Collaboration/Collaborators/Listener.php
@@ -134,6 +134,13 @@ class Listener implements IEventListener {
 			$results['exact']['users'] = array_filter($results['exact']['users'], [$this, 'filterParticipantUserResult']);
 		}
 
+		if (!empty($results['circles'])) {
+			$results['circles'] = array_filter($results['circles'], [$this, 'filterParticipantTeamResult']);
+		}
+		if (!empty($results['exact']['circles'])) {
+			$results['exact']['circles'] = array_filter($results['exact']['circles'], [$this, 'filterParticipantTeamResult']);
+		}
+
 		return $results;
 	}
 
@@ -161,6 +168,17 @@ class Listener implements IEventListener {
 
 		try {
 			$this->participantService->getParticipantByActor($this->room, Attendee::ACTOR_GROUPS, $groupId);
+			return false;
+		} catch (ParticipantNotFoundException $e) {
+			return true;
+		}
+	}
+
+	protected function filterParticipantTeamResult(array $result): bool {
+		$circleId = $result['value']['shareWith'];
+
+		try {
+			$this->participantService->getParticipantByActor($this->room, Attendee::ACTOR_CIRCLES, $circleId);
 			return false;
 		} catch (ParticipantNotFoundException $e) {
 			return true;

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -3540,12 +3540,18 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 	 * @param string $apiVersion
 	 * @param TableNode|null $formData
 	 */
-	public function userGetsTheFollowingCollaboratorSuggestions($user, $identifier, $search, $statusCode, $apiVersion = 'v1', ?TableNode $formData = null) {
+	public function userGetsTheFollowingCollaboratorSuggestions($user, $identifier, $search, $statusCode, ?TableNode $formData = null) {
 		$this->setCurrentUser($user);
 		$this->sendRequest('GET', '/core/autocomplete/get?search=' . $search . '&itemType=call&itemId=' . self::$identifierToToken[$identifier] . '&shareTypes[]=0&shareTypes[]=1&shareTypes[]=7&shareTypes[]=4');
 		$this->assertStatusCode($this->response, $statusCode);
 
-		$mentions = $this->getDataFromResponse($this->response);
+		$mentions = array_map(static function (array $mention): array {
+			unset($mention['icon']);
+			unset($mention['status']);
+			unset($mention['subline']);
+			unset($mention['shareWithDisplayNameUnique']);
+			return $mention;
+		}, $this->getDataFromResponse($this->response));
 
 		if ($formData === null) {
 			Assert::assertEmpty($mentions);
@@ -3561,7 +3567,14 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 			return $a['source'] <=> $b['source'];
 		});
 
-		$expected = $formData->getHash();
+		$expected = array_map(function (array $mention): array {
+			$result = preg_match('/TEAM_ID\(([^)]+)\)/', $mention['id'], $matches);
+			if ($result) {
+				$mention['id'] = self::$createdTeams[$this->currentServer][$matches[1]];
+			}
+			return $mention;
+		}, $formData->getHash());
+
 		usort($expected, function ($a, $b) {
 			if ($a['source'] === $b['source']) {
 				return $a['label'] <=> $b['label'];
@@ -3569,13 +3582,7 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 			return $a['source'] <=> $b['source'];
 		});
 
-		foreach ($expected as $key => $row) {
-			unset($mentions[$key]['icon']);
-			unset($mentions[$key]['status']);
-			unset($mentions[$key]['subline']);
-			unset($mentions[$key]['shareWithDisplayNameUnique']);
-			Assert::assertEquals($row, $mentions[$key]);
-		}
+		Assert::assertEquals($expected, $mentions);
 	}
 
 	/**

--- a/tests/integration/features/conversation-1/add-participant.feature
+++ b/tests/integration/features/conversation-1/add-participant.feature
@@ -160,6 +160,22 @@ Feature: conversation/add-participant
       | source | id           | label                    |
       | users  | participant2 | participant2-displayname |
 
+  Scenario: Filter out already added entries
+    Given user "participant1" creates room "room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    And group "Filtered group" exists
+    And team "Filtered team" exists
+    And add user "participant1" to team "Filtered team"
+    When user "participant1" gets the following collaborator suggestions in room "room" for "Filtered" with 200
+      | source  | id                     | label          |
+      | circles | TEAM_ID(Filtered team) | Filtered team  |
+      | groups  | Filtered group         | Filtered group |
+    And user "participant1" adds group "Filtered group" to room "room" with 200 (v4)
+    And user "participant1" adds team "Filtered team" to room "room" with 200 (v4)
+    When user "participant1" gets the following collaborator suggestions in room "room" for "Filtered" with 200
+      | source  | id           | label                    |
+
   Scenario: Getting participant suggestions in a public room
     Given user "participant1" creates room "room" (v4)
       | roomType | 3 |


### PR DESCRIPTION
## 🛠️ API Checklist

### 🚧 Tasks

- [x] Filter out teams when already invited

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
