### PR TITLE
fix(teams): Track team name updates

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -10,6 +10,8 @@ namespace OCA\Talk\AppInfo;
 
 use OCA\Circles\Events\AddingCircleMemberEvent;
 use OCA\Circles\Events\CircleDestroyedEvent;
+use OCA\Circles\Events\CircleEditedEvent;
+use OCA\Circles\Events\EditingCircleEvent;
 use OCA\Circles\Events\RemovingCircleMemberEvent;
 use OCA\Files\Event\LoadSidebar;
 use OCA\Files_Sharing\Event\BeforeTemplateRenderedEvent;
@@ -82,6 +84,7 @@ use OCA\Talk\Flow\RegisterOperationsListener;
 use OCA\Talk\Listener\BeforeUserLoggedOutListener;
 use OCA\Talk\Listener\BotListener;
 use OCA\Talk\Listener\CircleDeletedListener;
+use OCA\Talk\Listener\CircleEditedListener;
 use OCA\Talk\Listener\CircleMembershipListener;
 use OCA\Talk\Listener\CSPListener;
 use OCA\Talk\Listener\DisplayNameListener;
@@ -258,6 +261,8 @@ class Application extends App implements IBootstrap {
 		$context->registerEventListener(UserAddedEvent::class, GroupMembershipListener::class);
 		$context->registerEventListener(UserRemovedEvent::class, GroupMembershipListener::class);
 		$context->registerEventListener(CircleDestroyedEvent::class, CircleDeletedListener::class);
+		$context->registerEventListener(EditingCircleEvent::class, CircleEditedListener::class);
+		$context->registerEventListener(CircleEditedEvent::class, CircleEditedListener::class);
 		$context->registerEventListener(AddingCircleMemberEvent::class, CircleMembershipListener::class);
 		$context->registerEventListener(RemovingCircleMemberEvent::class, CircleMembershipListener::class);
 

--- a/lib/Listener/CircleEditedListener.php
+++ b/lib/Listener/CircleEditedListener.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Talk\Listener;
+
+use OCA\Circles\Events\CircleEditedEvent;
+use OCA\Circles\Events\EditingCircleEvent;
+use OCA\Talk\Model\Attendee;
+use OCA\Talk\Service\ParticipantService;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+
+/**
+ * @template-implements IEventListener<Event>
+ */
+class CircleEditedListener implements IEventListener {
+
+	public function __construct(
+		readonly private ParticipantService $participantService,
+	) {
+	}
+
+	public function handle(Event $event): void {
+		if (!$event instanceof EditingCircleEvent && !$event instanceof CircleEditedEvent) {
+			// Unrelated
+			return;
+		}
+
+		$displayName = $event->getCircle()->getDisplayName();
+		if ($event instanceof EditingCircleEvent) {
+			// In the before event we need to cheat to get the name
+			if ($event->getFederatedEvent()?->getData()?->hasKey('name')) {
+				$displayName = $event->getFederatedEvent()->getData()->g('name');
+			}
+		}
+
+		$this->participantService->updateDisplayNameForActor(
+			Attendee::ACTOR_CIRCLES,
+			$event->getCircle()->getSingleId(),
+			$displayName,
+		);
+	}
+}

--- a/tests/integration/features/conversation-5/team-participants.feature
+++ b/tests/integration/features/conversation-5/team-participants.feature
@@ -1,0 +1,26 @@
+Feature: conversation-5/team-participants
+  Background:
+    Given user "participant1" exists
+    Given user "participant2" exists
+    And User "participant1" creates team "Team A"
+    And add user "participant2" to team "Team A"
+
+  Scenario: Owner invites a team
+    Given user "participant1" creates room "room" (v4)
+      | roomType | 3 |
+      | roomName | room |
+    And user "participant1" sees the following attendees in room "room" with 200 (v4)
+      | actorType  | actorId      | participantType |
+      | users      | participant1 | 1               |
+    And user "participant1" adds team "Team A" to room "room" with 200 (v4)
+    And user "participant1" sees the following attendees in room "room" with 200 (v4)
+      | actorType  | actorId         | participantType | displayName              |
+      | users      | participant1    | 1               | participant1-displayname |
+      | circles    | TEAM_ID(Team A) | 3               | Team A                   |
+      | users      | participant2    | 3               | participant2-displayname |
+    And team "Team A" is renamed to "Team Alpha"
+    And user "participant1" sees the following attendees in room "room" with 200 (v4)
+      | actorType  | actorId         | participantType | displayName              |
+      | users      | participant1    | 1               | participant1-displayname |
+      | circles    | TEAM_ID(Team A) | 3               | Team Alpha               |
+      | users      | participant2    | 3               | participant2-displayname |

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -4,6 +4,8 @@
     <UndefinedClass>
       <code><![CDATA[BeforeTemplateRenderedEvent]]></code>
       <code><![CDATA[BeforeTemplateRenderedEvent]]></code>
+      <code><![CDATA[CircleEditedEvent]]></code>
+      <code><![CDATA[EditingCircleEvent]]></code>
     </UndefinedClass>
   </file>
   <file src="lib/Chat/Parser/SystemMessage.php">
@@ -30,6 +32,11 @@
     <InvalidArgument>
       <code><![CDATA[$fileId]]></code>
     </InvalidArgument>
+  </file>
+  <file src="lib/Listener/CircleEditedListener.php">
+    <UndefinedClass>
+      <code><![CDATA[EditingCircleEvent]]></code>
+    </UndefinedClass>
   </file>
   <file src="lib/MatterbridgeManager.php">
     <UndefinedClass>


### PR DESCRIPTION
### ☑️ Resolves

* Add a team to a conversation
* Rename the team
* Check name in chat where it was added or mentioned :checkered_flag: 
* Check name in participant list, before :boom: after :checkered_flag: 

## 🛠️ API Checklist
### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
