### PR TITLE
fix(chat): Correctly limit editing to bots IN 1-1

### DIFF
--- a/src/composables/useMessageInfo.js
+++ b/src/composables/useMessageInfo.js
@@ -61,6 +61,8 @@ export function useMessageInfo(message = ref({})) {
 	const isBotInOneToOne = computed(() =>
 		message.value.actorId.startsWith(ATTENDEE.BOT_PREFIX)
 		&& message.value.actorType === ATTENDEE.ACTOR_TYPE.BOTS
+		&& (conversation.value.type === CONVERSATION.TYPE.ONE_TO_ONE
+			|| conversation.value.type === CONVERSATION.TYPE.ONE_TO_ONE_FORMER)
 	)
 
 	const isEditable = computed(() => {


### PR DESCRIPTION
- Regression from #14344 

Noticed on the backport to 29 that I forgot the "IN one-to-one" part.