### PR TITLE
[stable29] style: make type icon in LeftSidebar blend with background

### DIFF
--- a/src/components/LeftSidebar/ConversationsList/Conversation.vue
+++ b/src/components/LeftSidebar/ConversationsList/Conversation.vue
@@ -25,6 +25,7 @@
 		:name="item.displayName"
 		:title="item.displayName"
 		:data-nav-id="`conversation_${item.token}`"
+		:class="['conversation', { 'conversation--active': isActive }]"
 		:actions-aria-label="t('spreed', 'Conversation actions')"
 		:to="to"
 		:bold="!!item.unreadMessages"
@@ -339,6 +340,28 @@ export default {
 <style lang="scss" scoped>
 .critical > :deep(.action-button) {
 	color: var(--color-error);
+}
+
+.conversation {
+	// Overwrite ConversationIcon styles to blend a type icon with NcListItem
+	& :deep(.list-item:hover .conversation-icon__type) {
+		background-color: var(--color-background-hover);
+		border-color: var(--color-background-hover);
+	}
+
+	&--active {
+		&:deep(.list-item .conversation-icon__type) {
+			color: var(--color-primary-element-text);
+			background-color: var(--color-primary-element);
+			border-color: var(--color-primary-element);
+		}
+
+		&:deep(.list-item:hover .conversation-icon__type) {
+			color: var(--color-primary-element-text);
+			background-color: var(--color-primary-element-hover);
+			border-color: var(--color-primary-element-hover);
+		}
+	}
 }
 
 :deep(.dialog) {

--- a/src/components/LeftSidebar/ConversationsList/Conversation.vue
+++ b/src/components/LeftSidebar/ConversationsList/Conversation.vue
@@ -343,6 +343,15 @@ export default {
 }
 
 .conversation {
+	// Overwrite NcListItem styles to reduce a component height
+	padding: 0 !important;
+	margin: var(--default-grid-baseline);
+	width: calc(100% - var(--default-grid-baseline) * 2);
+
+	:deep(.list-item) {
+		padding-block: var(--default-grid-baseline);
+	}
+
 	// Overwrite ConversationIcon styles to blend a type icon with NcListItem
 	& :deep(.list-item:hover .conversation-icon__type) {
 		background-color: var(--color-background-hover);

--- a/src/components/LeftSidebar/ConversationsList/ConversationsListVirtual.vue
+++ b/src/components/LeftSidebar/ConversationsList/ConversationsListVirtual.vue
@@ -42,7 +42,12 @@ import LoadingPlaceholder from '../../UIShared/LoadingPlaceholder.vue'
 
 import 'vue-virtual-scroller/dist/vue-virtual-scroller.css'
 
-const CONVERSATION_ITEM_SIZE = 66
+/* Consider:
+ * 48 = 2 * var(--default-line-height) - 2 lines of text
+ * 8 = 2 * var(--default-grid-baseline) - item padding
+ * 4 = var(--default-grid-baseline) - item margin (collapsed)
+ */
+const CONVERSATION_ITEM_SIZE = 60
 
 export default {
 	name: 'ConversationsListVirtual',

--- a/src/components/NewConversationDialog/NewConversationSetupPage.vue
+++ b/src/components/NewConversationDialog/NewConversationSetupPage.vue
@@ -36,6 +36,7 @@
 			:placeholder="t('spreed', 'Enter a description for this conversation')"
 			:label="t('spreed', 'Description')"
 			:error="!!descriptionErrorLabel"
+			resize="vertical"
 			label-visible />
 		<span v-if="descriptionErrorLabel" class="new-group-conversation__error">
 			{{ descriptionErrorLabel }}


### PR DESCRIPTION
### ☑️ Resolves

* Partial backport of #12767 
* Includes 8e5a9d1, 073a9b0, cb3a7fa

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/user-attachments/assets/b256d714-42ab-4a89-af69-1b505db54e99) | ![image](https://github.com/user-attachments/assets/6cbb50a1-f7eb-4a3f-8d6f-405d333322f5)
![image](https://github.com/user-attachments/assets/e12035fd-548f-49ca-ae7b-77fb2bb476a0) | ![image](https://github.com/user-attachments/assets/ece13e81-2edc-4972-9ab4-0920f4359a8b)

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client