### PR TITLE
fix(PresenterOverlay): do not move component to negative values

### DIFF
--- a/src/components/CallView/shared/PresenterOverlay.vue
+++ b/src/components/CallView/shared/PresenterOverlay.vue
@@ -146,10 +146,10 @@ export default {
 			this.$refs.presenterOverlay.checkParentSize()
 			// FIXME: if it stays out of bounds (right and bottom), bring it back
 			// FIXME: should consider RTL
-			if (this.$refs.presenterOverlay.right < 0) {
+			if (this.$refs.presenterOverlay.right < 0 && this.$refs.presenterOverlay.parentWidth > this.presenterOverlaySize) {
 				this.$refs.presenterOverlay.moveHorizontally(this.$refs.presenterOverlay.parentWidth - this.presenterOverlaySize)
 			}
-			if (this.$refs.presenterOverlay.bottom < 0) {
+			if (this.$refs.presenterOverlay.bottom < 0 && this.$refs.presenterOverlay.parentHeight > this.presenterOverlaySize) {
 				this.$refs.presenterOverlay.moveVertically(this.$refs.presenterOverlay.parentHeight - this.presenterOverlaySize)
 			}
 		},


### PR DESCRIPTION
### ☑️ Resolves

* Fix placing presenter video out of visible bounds while screensharing
* Parent size is recalculated after mounting, which results in smaller parentHeight than actual -> moveVertically pushes it behind the CallView

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before 

https://github.com/user-attachments/assets/4af0ca81-f779-424e-8d06-2aaf7cfa16df

🏡 After

https://github.com/user-attachments/assets/d1e54469-94d5-4f63-8a89-1db9800c59eb


### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required