### PR TITLE
Release 20.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 20.1.4 – 2025-02-13
+### Changed
+- Update translations
+- Update dependencies
+
+### Fixed
+- fix(bots): Allow users to edit messages of bots in one-to-one conversations
+  [#14352](https://github.com/nextcloud/spreed/issues/14352)
+- fix(calls): Address some false positives when showing the connection warning
+  [#14251](https://github.com/nextcloud/spreed/issues/14251)
+- fix(dashboard): Hide archived conversations from dashboard unless mentioned
+  [#14298](https://github.com/nextcloud/spreed/issues/14298)
+- fix(conversation): Don't suggest teams that are already added to the conversation
+  [#14348](https://github.com/nextcloud/spreed/issues/14348)
+- fix(chat): Fix missing "Copy code" button when syntax is used
+  [#14309](https://github.com/nextcloud/spreed/issues/14309)
+
+## 19.0.13 – 2025-02-13
+### Changed
+- Update translations
+- Update dependencies
+
+### Fixed
+- fix(bots): Allow users to edit messages of bots in one-to-one conversations
+  [#14360](https://github.com/nextcloud/spreed/issues/14360)
+- fix(calls): Address some false positives when showing the connection warning
+  [#14250](https://github.com/nextcloud/spreed/issues/14250)
+- fix(conversation): Don't suggest teams that are already added to the conversation
+  [#14347](https://github.com/nextcloud/spreed/issues/14347)
+
 ## 20.1.3 – 2025-01-17
 ### Changed
 - Update translations

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -18,7 +18,7 @@
 * 🌉 **Sync with other chat solutions** With [Matterbridge](https://github.com/42wim/matterbridge/) being integrated in Talk, you can easily sync a lot of other chat solutions to Nextcloud Talk and vice-versa.
 ]]></description>
 
-	<version>20.1.3</version>
+	<version>20.1.4</version>
 	<licence>agpl</licence>
 
 	<author>Anna Larch</author>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "talk",
-  "version": "20.1.3",
+  "version": "20.1.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "talk",
-      "version": "20.1.3",
+      "version": "20.1.4",
       "license": "agpl",
       "dependencies": {
         "@linusborg/vue-simple-portal": "^0.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "talk",
-  "version": "20.1.3",
+  "version": "20.1.4",
   "private": true,
   "description": "",
   "author": "Joas Schilling <coding@schilljs.com>",


### PR DESCRIPTION
## Changed
- Update translations
- Update dependencies

## Fixed
- fix(bots): Allow users to edit messages of bots in one-to-one conversations [#14352](https://github.com/nextcloud/spreed/issues/14352)
- fix(calls): Address some false positives when showing the connection warning [#14251](https://github.com/nextcloud/spreed/issues/14251)
- fix(dashboard): Hide archived conversations from dashboard unless mentioned [#14298](https://github.com/nextcloud/spreed/issues/14298)
- fix(conversation): Don't suggest teams that are already added to the conversation [#14348](https://github.com/nextcloud/spreed/issues/14348)
- fix(chat): Fix missing "Copy code" button when syntax is used [#14309](https://github.com/nextcloud/spreed/issues/14309)