### PR TITLE
Release 19.0.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 19.0.13 – 2025-02-13
+### Changed
+- Update translations
+- Update dependencies
+
+### Fixed
+- fix(bots): Allow users to edit messages of bots in one-to-one conversations
+  [#14360](https://github.com/nextcloud/spreed/issues/14360)
+- fix(calls): Address some false positives when showing the connection warning
+  [#14250](https://github.com/nextcloud/spreed/issues/14250)
+- fix(conversation): Don't suggest teams that are already added to the conversation
+  [#14347](https://github.com/nextcloud/spreed/issues/14347)
+
 ## 19.0.12 – 2025-01-16
 ### Changed
 - Update translations

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -14,7 +14,7 @@
 * 🌉 **Sync with other chat solutions** With [Matterbridge](https://github.com/42wim/matterbridge/) being integrated in Talk, you can easily sync a lot of other chat solutions to Nextcloud Talk and vice-versa.
 ]]></description>
 
-	<version>19.0.12</version>
+	<version>19.0.13</version>
 	<licence>agpl</licence>
 
 	<author>Daniel Calviño Sánchez</author>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "talk",
-  "version": "19.0.12",
+  "version": "19.0.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "talk",
-      "version": "19.0.12",
+      "version": "19.0.13",
       "license": "agpl",
       "dependencies": {
         "@linusborg/vue-simple-portal": "^0.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "talk",
-  "version": "19.0.12",
+  "version": "19.0.13",
   "private": true,
   "description": "",
   "author": "Joas Schilling <coding@schilljs.com>",


### PR DESCRIPTION
## Changed
- Update translations
- Update dependencies

## Fixed
- fix(bots): Allow users to edit messages of bots in one-to-one conversations [#14360](https://github.com/nextcloud/spreed/issues/14360)
- fix(calls): Address some false positives when showing the connection warning [#14250](https://github.com/nextcloud/spreed/issues/14250)
- fix(conversation): Don't suggest teams that are already added to the conversation [#14347](https://github.com/nextcloud/spreed/issues/14347)
