### PR TITLE
fix(MessagesList): rename method to pollNewMessages

### DIFF
--- a/src/FilesSidebarTabApp.vue
+++ b/src/FilesSidebarTabApp.vue
@@ -73,7 +73,7 @@ export default {
 			Talk: OCA.Talk,
 			sidebarState: OCA.Files.Sidebar.state,
 			/**
-			 * Stores the cancel function returned by `cancelableLookForNewMessages`,
+			 * Stores the cancel function returned by `cancelablePollNewMessages`,
 			 */
 			cancelGetFileConversation: () => {},
 			isTalkSidebarSupportedForFile: undefined,

--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -273,7 +273,7 @@ export default {
 			immediate: true,
 			handler(newValue, oldValue) {
 				if (oldValue) {
-					this.$store.dispatch('cancelLookForNewMessages', { requestId: oldValue })
+					this.$store.dispatch('cancelPollNewMessages', { requestId: oldValue })
 				}
 				this.handleStartGettingMessagesPreconditions(this.token)
 
@@ -362,7 +362,7 @@ export default {
 		EventBus.off('focus-message', this.focusMessage)
 		EventBus.off('route-change', this.onRouteChange)
 		EventBus.off('message-height-changed', this.onMessageHeightChanged)
-		this.$store.dispatch('cancelLookForNewMessages', { requestId: this.chatIdentifier })
+		this.$store.dispatch('cancelPollNewMessages', { requestId: this.chatIdentifier })
 		this.destroying = true
 
 		unsubscribe('networkOffline', this.handleNetworkOffline)
@@ -695,27 +695,12 @@ export default {
 
 				this.isInitialisingMessages = false
 
-				// get new messages
-				await this.lookForNewMessages(token)
+				// Once the history is received, starts looking for new messages.
+				await this.pollNewMessages(token)
 
 			} else {
-				this.$store.dispatch('cancelLookForNewMessages', { requestId: this.chatIdentifier })
+				this.$store.dispatch('cancelPollNewMessages', { requestId: this.chatIdentifier })
 			}
-		},
-
-		/**
-		 * Fetches the messages of a conversation given the conversation token. Triggers
-		 * a long-polling request for new messages.
-		 * @param token token of conversation where a method was called
-		 */
-		async lookForNewMessages(token) {
-			// Once the history is received, starts looking for new messages.
-			if (this._isBeingDestroyed || this._isDestroyed) {
-				console.debug('Prevent getting new messages on a destroyed MessagesList')
-				return
-			}
-
-			await this.getNewMessages(token)
 		},
 
 		async getMessageContext(token, messageId) {
@@ -785,12 +770,13 @@ export default {
 		},
 
 		/**
-		 * Creates a long polling request for a new message.
-		 *
+		 * Fetches the messages of a conversation given the conversation token.
+		 * Creates a long polling request for new messages.
 		 * @param token token of conversation where a method was called
 		 */
-		async getNewMessages(token) {
+		async pollNewMessages(token) {
 			if (this.destroying) {
+				console.debug('Prevent polling new messages on MessagesList being destroyed')
 				return
 			}
 			// Check that the token has not changed
@@ -803,7 +789,7 @@ export default {
 				debugTimer.start(`${token} | long polling`)
 				// TODO: move polling logic to the store and also cancel timers on cancel
 				this.pollingErrorTimeout = 1
-				await this.$store.dispatch('lookForNewMessages', {
+				await this.$store.dispatch('pollNewMessages', {
 					token,
 					lastKnownMessageId: this.$store.getters.getLastKnownMessageId(token),
 					requestId: this.chatIdentifier,
@@ -822,7 +808,7 @@ export default {
 					// This is not an error, so reset error timeout and poll again
 					this.pollingErrorTimeout = 1
 					setTimeout(() => {
-						this.getNewMessages(token)
+						this.pollNewMessages(token)
 					}, 500)
 					return
 				}
@@ -836,13 +822,13 @@ export default {
 				console.debug('Error happened while getting chat messages. Trying again in ', this.pollingErrorTimeout, exception)
 
 				setTimeout(() => {
-					this.getNewMessages(token)
+					this.pollNewMessages(token)
 				}, this.pollingErrorTimeout * 1000)
 				return
 			}
 
 			setTimeout(() => {
-				this.getNewMessages(token)
+				this.pollNewMessages(token)
 			}, 500)
 		},
 
@@ -1217,14 +1203,12 @@ export default {
 
 		handleNetworkOffline() {
 			console.debug('Canceling message request as we are offline')
-			if (this.cancelLookForNewMessages) {
-				this.$store.dispatch('cancelLookForNewMessages', { requestId: this.chatIdentifier })
-			}
+			this.$store.dispatch('cancelPollNewMessages', { requestId: this.chatIdentifier })
 		},
 
 		handleNetworkOnline() {
 			console.debug('Restarting polling of new chat messages')
-			this.getNewMessages(this.token)
+			this.pollNewMessages(this.token)
 		},
 
 		async onRouteChange({ from, to }) {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -29,6 +29,8 @@ export const SESSION = {
 export const CHAT = {
 	FETCH_LIMIT: 100,
 	MINIMUM_VISIBLE: 5,
+	FETCH_OLD: 0,
+	FETCH_NEW: 1,
 } as const
 
 export const CALL = {

--- a/src/services/__tests__/messagesService.spec.js
+++ b/src/services/__tests__/messagesService.spec.js
@@ -9,7 +9,7 @@ import { CHAT } from '../../constants.ts'
 import {
 	fetchMessages,
 	getMessageContext,
-	lookForNewMessages,
+	pollNewMessages,
 	postNewMessage,
 	deleteMessage,
 	editMessage,
@@ -106,8 +106,8 @@ describe('messagesService', () => {
 		)
 	})
 
-	test('lookForNewMessages calls the chat API endpoint excluding last known', () => {
-		lookForNewMessages({
+	test('pollNewMessages calls the chat API endpoint excluding last known', () => {
+		pollNewMessages({
 			token: 'XXTOKENXX',
 			lastKnownMessageId: 1234,
 		}, {

--- a/src/services/messagesService.ts
+++ b/src/services/messagesService.ts
@@ -9,6 +9,7 @@ import SHA256 from 'crypto-js/sha256.js'
 import axios from '@nextcloud/axios'
 import { generateOcsUrl } from '@nextcloud/router'
 
+import { CHAT } from '../constants.ts'
 import type {
 	ChatMessage,
 	clearHistoryResponse,
@@ -45,15 +46,22 @@ type EditMessagePayload = { token: string, messageId: number, updatedMessage: ed
  * @param data.token the conversation token;
  * @param data.lastKnownMessageId last known message id;
  * @param data.includeLastKnown whether to include the last known message in the response;
+ * @param [data.lookIntoFuture=0] direction of message fetch
  * @param [data.limit=100] Number of messages to load
  * @param options options;
  */
-const fetchMessages = async function({ token, lastKnownMessageId, includeLastKnown, limit = 100 }: ReceiveMessagesPayload, options?: object): receiveMessagesResponse {
+const fetchMessages = async function({
+	token,
+	lastKnownMessageId,
+	includeLastKnown,
+	lookIntoFuture = CHAT.FETCH_OLD,
+	limit = 100,
+}: ReceiveMessagesPayload, options?: object): receiveMessagesResponse {
 	return axios.get(generateOcsUrl('apps/spreed/api/v1/chat/{token}', { token }, options), {
 		...options,
 		params: {
 			setReadMarker: 0,
-			lookIntoFuture: 0,
+			lookIntoFuture,
 			lastKnownMessageId,
 			limit,
 			includeLastKnown: includeLastKnown ? 1 : 0,
@@ -71,12 +79,16 @@ const fetchMessages = async function({ token, lastKnownMessageId, includeLastKno
  * @param [data.limit=100] Number of messages to load
  * @param options options
  */
-const pollNewMessages = async ({ token, lastKnownMessageId, limit = 100 }: ReceiveMessagesPayload, options?: object): receiveMessagesResponse => {
+const pollNewMessages = async ({
+	token,
+	lastKnownMessageId,
+	limit = 100,
+}: ReceiveMessagesPayload, options?: object): receiveMessagesResponse => {
 	return axios.get(generateOcsUrl('apps/spreed/api/v1/chat/{token}', { token }, options), {
 		...options,
 		params: {
 			setReadMarker: 0,
-			lookIntoFuture: 1,
+			lookIntoFuture: CHAT.FETCH_NEW,
 			lastKnownMessageId,
 			limit,
 			includeLastKnown: 0,

--- a/src/services/messagesService.ts
+++ b/src/services/messagesService.ts
@@ -71,7 +71,7 @@ const fetchMessages = async function({ token, lastKnownMessageId, includeLastKno
  * @param [data.limit=100] Number of messages to load
  * @param options options
  */
-const lookForNewMessages = async ({ token, lastKnownMessageId, limit = 100 }: ReceiveMessagesPayload, options?: object): receiveMessagesResponse => {
+const pollNewMessages = async ({ token, lastKnownMessageId, limit = 100 }: ReceiveMessagesPayload, options?: object): receiveMessagesResponse => {
 	return axios.get(generateOcsUrl('apps/spreed/api/v1/chat/{token}', { token }, options), {
 		...options,
 		params: {
@@ -226,7 +226,7 @@ const summarizeChat = async function(token: string, fromMessageId: summarizeChat
 
 export {
 	fetchMessages,
-	lookForNewMessages,
+	pollNewMessages,
 	getMessageContext,
 	postNewMessage,
 	clearConversationHistory,

--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -22,7 +22,7 @@ import {
 	editMessage,
 	updateLastReadMessage,
 	fetchMessages,
-	lookForNewMessages,
+	pollNewMessages,
 	getMessageContext,
 	postNewMessage,
 	postRichObjectToConversation,
@@ -125,11 +125,11 @@ const state = {
 	 */
 	cancelGetMessageContext: null,
 	/**
-	 * Stores the cancel function returned by `cancelableLookForNewMessages`,
+	 * Stores the cancel function returned by `cancelablePollNewMessages`,
 	 * which allows to cancel the previous long polling request for new
 	 * messages before making another one.
 	 */
-	cancelLookForNewMessages: {},
+	cancelPollNewMessages: {},
 	/**
 	 * Array of temporary message id to cancel function for the "postNewMessage" action
 	 */
@@ -140,7 +140,7 @@ const getters = {
 	/**
 	 * Returns whether more messages can be loaded, which means that the current
 	 * message list doesn't yet contain all future messages.
-	 * If false, the next call to "lookForNewMessages" will be blocking/long-polling.
+	 * If false, the next call to "pollNewMessages" will be blocking/long-polling.
 	 *
 	 * @param {object} state the state object.
 	 * @param {object} getters the getters object.
@@ -264,11 +264,11 @@ const mutations = {
 		state.cancelGetMessageContext = cancelFunction
 	},
 
-	setCancelLookForNewMessages(state, { requestId, cancelFunction }) {
+	setCancelPollNewMessages(state, { requestId, cancelFunction }) {
 		if (cancelFunction) {
-			Vue.set(state.cancelLookForNewMessages, requestId, cancelFunction)
+			Vue.set(state.cancelPollNewMessages, requestId, cancelFunction)
 		} else {
-			Vue.delete(state.cancelLookForNewMessages, requestId)
+			Vue.delete(state.cancelPollNewMessages, requestId)
 		}
 	},
 
@@ -1072,8 +1072,8 @@ const actions = {
 	 * @param {object} data.requestOptions request options;
 	 * @param {number} data.lastKnownMessageId The id of the last message in the store.
 	 */
-	async lookForNewMessages(context, { token, lastKnownMessageId, requestId, requestOptions }) {
-		context.dispatch('cancelLookForNewMessages', { requestId })
+	async pollNewMessages(context, { token, lastKnownMessageId, requestId, requestOptions }) {
+		context.dispatch('cancelPollNewMessages', { requestId })
 
 		if (!lastKnownMessageId) {
 			// if param is null | undefined, it won't be included in the request query
@@ -1082,17 +1082,17 @@ const actions = {
 		}
 
 		// Get a new cancelable request function and cancel function pair
-		const { request, cancel } = CancelableRequest(lookForNewMessages)
+		const { request, cancel } = CancelableRequest(pollNewMessages)
 
 		// Assign the new cancel function to our data value
-		context.commit('setCancelLookForNewMessages', { cancelFunction: cancel, requestId })
+		context.commit('setCancelPollNewMessages', { cancelFunction: cancel, requestId })
 
 		const response = await request({
 			token,
 			lastKnownMessageId,
 			limit: CHAT.FETCH_LIMIT,
 		}, requestOptions)
-		context.commit('setCancelLookForNewMessages', { requestId })
+		context.commit('setCancelPollNewMessages', { requestId })
 
 		if ('x-chat-last-common-read' in response.headers) {
 			const lastCommonReadMessage = parseInt(response.headers['x-chat-last-common-read'], 10)
@@ -1195,16 +1195,16 @@ const actions = {
 	},
 
 	/**
-	 * Cancels a previously running "lookForNewMessages" action if applicable.
+	 * Cancels a previously running "pollNewMessages" action if applicable.
 	 *
 	 * @param {object} context default store context;
 	 * @param {string} requestId request id
 	 * @return {boolean} true if a request got cancelled, false otherwise
 	 */
-	cancelLookForNewMessages(context, { requestId }) {
-		if (context.state.cancelLookForNewMessages[requestId]) {
-			context.state.cancelLookForNewMessages[requestId]('canceled')
-			context.commit('setCancelLookForNewMessages', { requestId })
+	cancelPollNewMessages(context, { requestId }) {
+		if (context.state.cancelPollNewMessages[requestId]) {
+			context.state.cancelPollNewMessages[requestId]('canceled')
+			context.commit('setCancelPollNewMessages', { requestId })
 			return true
 		}
 		return false

--- a/src/store/messagesStore.spec.js
+++ b/src/store/messagesStore.spec.js
@@ -25,7 +25,7 @@ import {
 	updateLastReadMessage,
 	fetchMessages,
 	getMessageContext,
-	lookForNewMessages,
+	pollNewMessages,
 	postNewMessage,
 	postRichObjectToConversation,
 } from '../services/messagesService.ts'
@@ -40,7 +40,7 @@ jest.mock('../services/messagesService', () => ({
 	updateLastReadMessage: jest.fn(),
 	fetchMessages: jest.fn(),
 	getMessageContext: jest.fn(),
-	lookForNewMessages: jest.fn(),
+	pollNewMessages: jest.fn(),
 	postNewMessage: jest.fn(),
 	postRichObjectToConversation: jest.fn(),
 }))
@@ -1199,14 +1199,14 @@ describe('messagesStore', () => {
 				},
 				payload: messages,
 			})
-			lookForNewMessages.mockResolvedValueOnce(response)
+			pollNewMessages.mockResolvedValueOnce(response)
 
 			// smaller number to make it update
 			conversationMock.mockReturnValue({
 				lastMessage: { id: 1 },
 			})
 
-			await store.dispatch('lookForNewMessages', {
+			await store.dispatch('pollNewMessages', {
 				token: TOKEN,
 				requestId: 'request1',
 				lastKnownMessageId: 100,
@@ -1215,7 +1215,7 @@ describe('messagesStore', () => {
 				},
 			})
 
-			expect(lookForNewMessages).toHaveBeenCalledWith({
+			expect(pollNewMessages).toHaveBeenCalledWith({
 				token: TOKEN,
 				lastKnownMessageId: 100,
 				limit: CHAT.FETCH_LIMIT,
@@ -1251,12 +1251,12 @@ describe('messagesStore', () => {
 			const response = generateOCSResponse({
 				payload: messages,
 			})
-			lookForNewMessages.mockResolvedValueOnce(response)
+			pollNewMessages.mockResolvedValueOnce(response)
 
 			// smaller number to make it update
 			conversationMock.mockReturnValue({ lastMessage: { id: 500 } })
 
-			await store.dispatch('lookForNewMessages', {
+			await store.dispatch('pollNewMessages', {
 				token: TOKEN,
 				requestId: 'request1',
 				lastKnownMessageId: 100,
@@ -1277,11 +1277,11 @@ describe('messagesStore', () => {
 			// Arrange: prepare cancelable request from previous call of the function
 			const cancelFunctionMock = jest.fn()
 			cancelFunctionMocks.push(cancelFunctionMock)
-			store.commit('setCancelLookForNewMessages', { cancelFunction: cancelFunctionMock, requestId: 'request1' })
+			store.commit('setCancelPollNewMessages', { cancelFunction: cancelFunctionMock, requestId: 'request1' })
 			console.warn = jest.fn()
 
 			// Act
-			store.dispatch('lookForNewMessages', {
+			store.dispatch('pollNewMessages', {
 				token: TOKEN,
 				requestId: 'request1',
 				lastKnownMessageId: null,
@@ -1289,11 +1289,11 @@ describe('messagesStore', () => {
 
 			// Assert
 			expect(cancelFunctionMocks[0]).toHaveBeenCalledWith('canceled')
-			expect(lookForNewMessages).not.toHaveBeenCalled()
+			expect(pollNewMessages).not.toHaveBeenCalled()
 		})
 
 		test('cancels look for new messages', async () => {
-			store.dispatch('lookForNewMessages', {
+			store.dispatch('pollNewMessages', {
 				token: TOKEN,
 				requestId: 'request1',
 				lastKnownMessageId: 100,
@@ -1301,19 +1301,19 @@ describe('messagesStore', () => {
 
 			expect(cancelFunctionMocks[0]).not.toHaveBeenCalled()
 
-			store.dispatch('cancelLookForNewMessages', { requestId: 'request1' })
+			store.dispatch('cancelPollNewMessages', { requestId: 'request1' })
 
 			expect(cancelFunctionMocks[0]).toHaveBeenCalledWith('canceled')
 		})
 
 		test('cancels look for new messages when called again', async () => {
-			store.dispatch('lookForNewMessages', {
+			store.dispatch('pollNewMessages', {
 				token: TOKEN,
 				requestId: 'request1',
 				lastKnownMessageId: 100,
 			}).catch(() => {})
 
-			store.dispatch('lookForNewMessages', {
+			store.dispatch('pollNewMessages', {
 				token: TOKEN,
 				requestId: 'request1',
 				lastKnownMessageId: 100,
@@ -1323,23 +1323,23 @@ describe('messagesStore', () => {
 		})
 
 		test('cancels look for new messages call individually', async () => {
-			store.dispatch('lookForNewMessages', {
+			store.dispatch('pollNewMessages', {
 				token: TOKEN,
 				requestId: 'request1',
 				lastKnownMessageId: 100,
 			}).catch(() => {})
 
-			store.dispatch('lookForNewMessages', {
+			store.dispatch('pollNewMessages', {
 				token: TOKEN,
 				requestId: 'request2',
 				lastKnownMessageId: 100,
 			}).catch(() => {})
 
-			store.dispatch('cancelLookForNewMessages', { requestId: 'request1' })
+			store.dispatch('cancelPollNewMessages', { requestId: 'request1' })
 			expect(cancelFunctionMocks[0]).toHaveBeenCalledWith('canceled')
 			expect(cancelFunctionMocks[1]).not.toHaveBeenCalled()
 
-			store.dispatch('cancelLookForNewMessages', { requestId: 'request2' })
+			store.dispatch('cancelPollNewMessages', { requestId: 'request2' })
 			expect(cancelFunctionMocks[1]).toHaveBeenCalledWith('canceled')
 		})
 
@@ -1367,12 +1367,12 @@ describe('messagesStore', () => {
 					},
 					payload: messages,
 				})
-				lookForNewMessages.mockResolvedValueOnce(response)
+				pollNewMessages.mockResolvedValueOnce(response)
 
 				// smaller number to make it update
 				conversationMock.mockReturnValue(testConversation)
 
-				await store.dispatch('lookForNewMessages', {
+				await store.dispatch('pollNewMessages', {
 					token: TOKEN,
 					requestId: 'request1',
 					lastKnownMessageId: 100,


### PR DESCRIPTION
### ☑️ Resolves

- Non-breaking pre-requisite to #10084
  - I'm giving up and will implement it by parts 👀 
- rename `getNewMessages` and `lookForNewMessages` to `pollNewMessages` (to avoid confusion - get*Messages should not poll)
- drop `lookForNewMessages` component method as redundant
  - `_isBeingDestroyed`, `_isDestroyed` are internal Vue flags, different in Vue3, and not needed here
- refactor `fetchMessages` to support both direction of `lookIntoFuture` (to make fetching the chunk of **new** messages possible)
- refactor tests

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

No visual changes

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Not risky to browser differences / client
- [x] ⛑️ Tests are included or not possible