### PR TITLE
fix: replace moment.unix()

### DIFF
--- a/src/components/AdminSettings/TurnServer.vue
+++ b/src/components/AdminSettings/TurnServer.vue
@@ -90,6 +90,7 @@ import NcSelect from '@nextcloud/vue/dist/Components/NcSelect.js'
 import NcTextField from '@nextcloud/vue/dist/Components/NcTextField.js'
 
 import { isCertificateValid } from '../../services/certificateService.ts'
+import { convertToUnix } from '../../utils/formattedTime.ts'
 
 export default {
 	name: 'TurnServer',
@@ -259,7 +260,7 @@ export default {
 				}
 			}
 
-			const expires = Math.round((new Date()).getTime() / 1000) + (5 * 60)
+			const expires = convertToUnix(Date.now()) + 5 * 60
 			const username = expires + ':turn-test-user'
 			const password = Base64.stringify(hmacSHA1(username, this.secret))
 

--- a/src/components/CalendarEventsDialog.vue
+++ b/src/components/CalendarEventsDialog.vue
@@ -271,8 +271,8 @@ async function submitNewMeeting() {
 		submitting.value = true
 		await groupwareStore.scheduleMeeting(props.token, {
 			calendarUri: selectedCalendar.value.value,
-			start: selectedDateTimeStart.value.getTime() / 1000,
-			end: selectedDateTimeEnd.value.getTime() / 1000,
+			start: convertToUnix(selectedDateTimeStart.value),
+			end: convertToUnix(selectedDateTimeEnd.value),
 			title: newMeetingTitle.value || null,
 			description: newMeetingDescription.value || null,
 			attendeeIds: selectAll.value ? null : selectedAttendeeIds.value,

--- a/src/components/CalendarEventsDialog.vue
+++ b/src/components/CalendarEventsDialog.vue
@@ -40,6 +40,7 @@ import { ATTENDEE } from '../constants.ts'
 import { hasTalkFeature } from '../services/CapabilitiesManager.ts'
 import { useGroupwareStore } from '../stores/groupware.ts'
 import type { Conversation, Participant } from '../types/index.ts'
+import { convertToUnix } from '../utils/formattedTime.ts'
 import { getDisplayNameWithFallback } from '../utils/getDisplayName.ts'
 
 const props = defineProps<{
@@ -66,7 +67,7 @@ const submitting = ref(false)
 
 const calendars = computed(() => groupwareStore.calendars)
 const upcomingEvents = computed(() => {
-	const now = moment().unix()
+	const now = convertToUnix(Date.now())
 	return groupwareStore.getAllEvents(props.token)
 		.sort((a, b) => (a.start && b.start) ? (a.start - b.start) : 0)
 		.map(event => {

--- a/src/components/ConversationSettings/LobbySettings.vue
+++ b/src/components/ConversationSettings/LobbySettings.vue
@@ -96,7 +96,7 @@ import ImportEmailsDialog from '../ImportEmailsDialog.vue'
 import { WEBINAR } from '../../constants.ts'
 import { hasTalkFeature } from '../../services/CapabilitiesManager.ts'
 import { EventBus } from '../../services/EventBus.ts'
-import { futureRelativeTime } from '../../utils/formattedTime.ts'
+import { convertToUnix, futureRelativeTime } from '../../utils/formattedTime.ts'
 
 const ONE_DAY_IN_MS = 24 * 60 * 60 * 1000
 
@@ -240,7 +240,7 @@ export default {
 			try {
 				await this.$store.dispatch('setLobbyTimer', {
 					token: this.token,
-					timestamp: timestamp ? (timestamp / 1000) : 0,
+					timestamp: timestamp ? convertToUnix(timestamp) : 0,
 				})
 				showSuccess(t('spreed', 'Start time has been updated'))
 			} catch (e) {

--- a/src/components/LobbyScreen.vue
+++ b/src/components/LobbyScreen.vue
@@ -85,7 +85,7 @@ export default {
 		},
 
 		timerInMoment() {
-			return moment.unix(this.countdown)
+			return moment(this.countdown * 1000)
 		},
 
 		startTime() {

--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
@@ -309,6 +309,7 @@ import { getMessageReminder, removeMessageReminder, setMessageReminder } from '.
 import { useIntegrationsStore } from '../../../../../stores/integrations.js'
 import { useReactionsStore } from '../../../../../stores/reactions.js'
 import { generatePublicShareDownloadUrl, generateUserFileUrl } from '../../../../../utils/davUtils.ts'
+import { convertToUnix } from '../../../../../utils/formattedTime.ts'
 import { copyConversationLinkToClipboard } from '../../../../../utils/handleUrl.ts'
 import { parseMentions } from '../../../../../utils/textParse.ts'
 
@@ -734,7 +735,7 @@ export default {
 
 		async setReminder(timestamp) {
 			try {
-				await setMessageReminder(this.message.token, this.message.id, timestamp / 1000)
+				await setMessageReminder(this.message.token, this.message.id, convertToUnix(timestamp))
 				showSuccess(t('spreed', 'A reminder was successfully set at {datetime}', {
 					datetime: moment(timestamp).format('LLL'),
 				}))

--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -82,6 +82,7 @@ import { ATTENDEE, CHAT, CONVERSATION, MESSAGE } from '../../constants.ts'
 import { EventBus } from '../../services/EventBus.ts'
 import { useChatExtrasStore } from '../../stores/chatExtras.js'
 import { debugTimer } from '../../utils/debugTimer.ts'
+import { convertToUnix } from '../../utils/formattedTime.ts'
 
 const SCROLL_TOLERANCE = 10
 
@@ -253,7 +254,7 @@ export default {
 		},
 
 		currentDay() {
-			return moment().startOf('day').unix()
+			return convertToUnix(new Date().setHours(0, 0, 0, 0))
 		},
 
 		isChatBeginningReached() {
@@ -401,7 +402,7 @@ export default {
 						// This is a temporary message, the timestamp is today
 						dateTimestamp = this.currentDay
 					} else {
-						dateTimestamp = moment(message.timestamp * 1000).startOf('day').unix()
+						dateTimestamp = convertToUnix(new Date(message.timestamp * 1000).setHours(0, 0, 0, 0))
 					}
 
 					if (!this.dateSeparatorLabels[dateTimestamp]) {
@@ -585,11 +586,11 @@ export default {
 		/**
 		 * Generate the date header between the messages
 		 *
-		 * @param {number} dateTimestamp The day and year timestamp
+		 * @param {number} dateTimestamp The day and year timestamp (in UNIX format)
 		 * @return {string} Translated string of "<Today>, <November 11th, 2019>", "<3 days ago>, <November 8th, 2019>"
 		 */
 		generateDateSeparator(dateTimestamp) {
-			const date = moment.unix(dateTimestamp).startOf('day')
+			const date = moment(dateTimestamp * 1000).startOf('day')
 			const diffDays = moment().startOf('day').diff(date, 'days')
 			// Relative date is only shown up to a week ago (inclusive)
 			if (diffDays <= 7) {
@@ -613,14 +614,14 @@ export default {
 		 *
 		 * @param {object} message The message object
 		 * @param {string} message.id The ID of the message
-		 * @param {number} message.timestamp Timestamp of the message
+		 * @param {number} message.timestamp Timestamp of the message (in UNIX format)
 		 * @return {object} MomentJS object
 		 */
 		getDateOfMessage(message) {
 			if (message.id.toString().startsWith('temp-')) {
 				return moment()
 			}
-			return moment.unix(message.timestamp)
+			return moment(message.timestamp * 1000)
 		},
 
 		getMessageIdFromHash(hash = undefined) {

--- a/src/components/NewMessage/NewMessageAbsenceInfo.vue
+++ b/src/components/NewMessage/NewMessageAbsenceInfo.vue
@@ -114,8 +114,8 @@ export default {
 				return ''
 			}
 			return t('spreed', 'Absence period: {startDate} - {endDate}', {
-				startDate: moment.unix(this.userAbsence.startDate).format('ll'),
-				endDate: moment.unix(this.userAbsence.endDate).format('ll'),
+				startDate: moment(this.userAbsence.startDate * 1000).format('ll'),
+				endDate: moment(this.userAbsence.endDate * 1000).format('ll'),
 			})
 		},
 	},

--- a/src/store/conversationsStore.js
+++ b/src/store/conversationsStore.js
@@ -66,6 +66,7 @@ import { useFederationStore } from '../stores/federation.ts'
 import { useGroupwareStore } from '../stores/groupware.ts'
 import { useReactionsStore } from '../stores/reactions.js'
 import { useTalkHashStore } from '../stores/talkHash.js'
+import { convertToUnix } from '../utils/formattedTime.ts'
 
 const forcePasswordProtection = getTalkConfig('local', 'conversations', 'force-passwords')
 const supportConversationCreationPassword = hasTalkFeature('local', 'conversation-creation-password')
@@ -740,7 +741,7 @@ const actions = {
 		}
 
 		const conversation = Object.assign({}, getters.conversations[token], {
-			lastActivity: (new Date().getTime()) / 1000,
+			lastActivity: convertToUnix(Date.now()),
 		})
 
 		commit('addConversation', conversation)
@@ -775,7 +776,7 @@ const actions = {
 
 		const conversation = Object.assign({}, getters.conversations[token])
 		if (conversation.lastMessage?.id === parseInt(messageId, 10)
-			|| conversation.lastMessage?.timestamp >= Date.parse(notification.datetime) / 1000) {
+			|| conversation.lastMessage?.timestamp >= convertToUnix(new Date(notification.datetime))) {
 			// Already updated from other source, skipping
 			return
 		}
@@ -794,7 +795,7 @@ const actions = {
 			actorDisplayName: actor.name,
 			message: notification.messageRich,
 			messageParameters: notification.messageRichParameters,
-			timestamp: (new Date(notification.datetime)).getTime() / 1000,
+			timestamp: convertToUnix(new Date(notification.datetime)),
 
 			// Inaccurate but best effort from here on:
 			expirationTimestamp: 0,
@@ -843,7 +844,7 @@ const actions = {
 			return
 		}
 
-		const activeSince = (new Date(notification.datetime)).getTime() / 1000
+		const activeSince = convertToUnix(new Date(notification.datetime))
 
 		// Check if notification information is older than in known conversation object
 		if (activeSince < getters.conversations[token].lastActivity) {

--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -34,6 +34,7 @@ import { useReactionsStore } from '../stores/reactions.js'
 import { useSharedItemsStore } from '../stores/sharedItems.js'
 import CancelableRequest from '../utils/cancelableRequest.js'
 import { debugTimer } from '../utils/debugTimer.ts'
+import { convertToUnix } from '../utils/formattedTime.ts'
 
 /**
  * Returns whether the given message contains a mention to self, directly
@@ -480,7 +481,7 @@ const mutations = {
 			return
 		}
 
-		const timestamp = (new Date()) / 1000
+		const timestamp = convertToUnix(Date.now())
 		const messageIds = Object.keys(state.messages[token])
 		messageIds.forEach((messageId) => {
 			if (state.messages[token][messageId].expirationTimestamp

--- a/src/store/participantsStore.js
+++ b/src/store/participantsStore.js
@@ -39,6 +39,7 @@ import { talkBroadcastChannel } from '../services/talkBroadcastChannel.js'
 import { useCallViewStore } from '../stores/callView.ts'
 import { useGuestNameStore } from '../stores/guestName.js'
 import CancelableRequest from '../utils/cancelableRequest.js'
+import { convertToUnix } from '../utils/formattedTime.ts'
 import { messagePleaseTryToReload } from '../utils/talkDesktopUtils.ts'
 
 /**
@@ -1045,7 +1046,7 @@ const actions = {
 		} catch (error) {
 			if (error?.response?.status === 409 && error?.response?.data?.ocs?.data) {
 				const responseData = error.response.data.ocs.data
-				let maxLastPingAge = new Date().getTime() / 1000 - 40
+				let maxLastPingAge = convertToUnix(Date.now()) - 40
 				if (responseData.inCall !== PARTICIPANT.CALL_FLAG.DISCONNECTED) {
 					// When the user is/was in a call, we accept 20 seconds more delay
 					maxLastPingAge -= 20

--- a/src/utils/__tests__/formattedTime.spec.js
+++ b/src/utils/__tests__/formattedTime.spec.js
@@ -2,9 +2,22 @@
  * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-import { formattedTime, futureRelativeTime } from '../formattedTime.ts'
+import {
+	convertToUnix,
+	formattedTime,
+	futureRelativeTime,
+} from '../formattedTime.ts'
 
 const TIME = (61 * 60 + 5) * 1000 // 1 hour, 1 minute, 5 seconds in ms
+
+describe('convertToUnix', () => {
+	it('should return the correct UNIX timestamp for given time in ms', () => {
+		expect(convertToUnix(1704067200269)).toBe(1704067200)
+	})
+	it('should return the correct UNIX timestamp for given Date object', () => {
+		expect(convertToUnix(new Date('2024-01-01T00:00:00Z'))).toBe(1704067200)
+	})
+})
 
 describe('formattedTime', () => {
 	it('should return the formatted time with optional spacing and padded minutes / seconds', () => {

--- a/src/utils/formattedTime.ts
+++ b/src/utils/formattedTime.ts
@@ -5,6 +5,15 @@
 import { t, n } from '@nextcloud/l10n'
 
 /**
+ * Converts the given time to UNIX timestamp
+ *
+ * @param time given time in ms or Date object
+ */
+function convertToUnix(time: number | Date): number {
+	return Math.floor(+time / 1000)
+}
+
+/**
  * Calculates the stopwatch string given the time (ms)
  *
  * @param time the time in ms
@@ -53,6 +62,7 @@ function futureRelativeTime(time: number): string {
 }
 
 export {
+	convertToUnix,
 	formattedTime,
 	futureRelativeTime,
 }

--- a/src/utils/formattedTime.ts
+++ b/src/utils/formattedTime.ts
@@ -24,9 +24,10 @@ function formattedTime(time: number, condensed: boolean = false): string {
 		return condensed ? '--:--' : '-- : --'
 	}
 
-	const seconds = Math.floor((time / 1000) % 60)
-	const minutes = Math.floor((time / (1000 * 60)) % 60)
-	const hours = Math.floor((time / (1000 * 60 * 60)) % 24)
+	const timeInSec = convertToUnix(time)
+	const seconds = timeInSec % 60
+	const minutes = Math.floor(timeInSec / 60) % 60
+	const hours = Math.floor(timeInSec / 3600) % 24
 
 	return [
 		hours,

--- a/src/utils/signaling.js
+++ b/src/utils/signaling.js
@@ -16,6 +16,7 @@ import {
 
 import CancelableRequest from './cancelableRequest.js'
 import Encryption from './e2ee/encryption.js'
+import { convertToUnix } from './formattedTime.ts'
 import { messagePleaseTryToReload } from './talkDesktopUtils.ts'
 import { PARTICIPANT } from '../constants.ts'
 import { hasTalkFeature } from '../services/CapabilitiesManager.ts'
@@ -1279,7 +1280,7 @@ Signaling.Standalone.prototype.joinResponseReceived = function(data, token) {
 		// of joined room so it gets sorted to the top.
 		this.roomCollection.forEach(function(room) {
 			if (room.get('token') === token) {
-				room.set('lastPing', (new Date()).getTime() / 1000)
+				room.set('lastPing', convertToUnix(Date.now()))
 			}
 		})
 		this.roomCollection.sort()


### PR DESCRIPTION
### ☑️ Resolves

- Ref #14434
- Replace some of `@nextcloud/moment` functionality:
  - formatter `moment().unix()` replaced with `convertToUnix()` util
  - same done for all `timestamp / 1000`
  - constructor `moment.unix(arg)` returns the same result as `moment(arg * 1000)`

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

No visual change

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Not risky to browser differences / client
- [x] ⛑️ Tests are included or not possible