### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -306,12 +306,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "05ab90026400b8ce3343765177988a1bda1e2cb8"
+                "reference": "6e597101481226c5d2518d98596301f2efc692d1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/05ab90026400b8ce3343765177988a1bda1e2cb8",
-                "reference": "05ab90026400b8ce3343765177988a1bda1e2cb8",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/6e597101481226c5d2518d98596301f2efc692d1",
+                "reference": "6e597101481226c5d2518d98596301f2efc692d1",
                 "shasum": ""
             },
             "require": {
@@ -347,7 +347,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2025-02-07T00:43:35+00:00"
+            "time": "2025-02-14T00:43:30+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency