### PR TITLE
fix: replace moment objects comparison

### DIFF
--- a/src/components/CalendarEventsDialog.vue
+++ b/src/components/CalendarEventsDialog.vue
@@ -91,8 +91,8 @@ const canScheduleMeeting = computed(() => {
 })
 
 const selectedCalendar = ref<CalendarOption | null>(null)
-const selectedDateTimeStart = ref(new Date(moment().add(1, 'hours').startOf('hour')))
-const selectedDateTimeEnd = ref(new Date(moment().add(2, 'hours').startOf('hour')))
+const selectedDateTimeStart = ref(getCurrentDateInStartOfNthHour(1))
+const selectedDateTimeEnd = ref(getCurrentDateInStartOfNthHour(2))
 const newMeetingTitle = ref('')
 const newMeetingDescription = ref('')
 const invalid = ref<string | null>(null)
@@ -197,8 +197,8 @@ watch(isFormOpen, (value) => {
 
 	// Reset the default form values
 	selectedCalendar.value = calendarOptions.value.find(o => o.value === groupwareStore.defaultCalendarUri) ?? null
-	selectedDateTimeStart.value = new Date(moment().add(1, 'hours').startOf('hour'))
-	selectedDateTimeEnd.value = new Date(moment().add(2, 'hours').startOf('hour'))
+	selectedDateTimeStart.value = getCurrentDateInStartOfNthHour(1)
+	selectedDateTimeEnd.value = getCurrentDateInStartOfNthHour(2)
 	newMeetingTitle.value = ''
 	newMeetingDescription.value = ''
 	selectedAttendeeIds.value = participants.value.map((participant: Participant) => participant.attendeeId)
@@ -216,6 +216,16 @@ watch(participants, (value) => {
 		selectedAttendeeIds.value = value.map((participant: Participant) => participant.attendeeId)
 	}
 })
+
+/**
+ * Returns Date object with N hours from now at the start of hour
+ * @param hours amount of hours to add
+ */
+function getCurrentDateInStartOfNthHour(hours: number) {
+	const date = new Date()
+	date.setHours(date.getHours() + hours, 0, 0, 0)
+	return date
+}
 
 /**
  * Toggle selected attendees

--- a/src/components/ConversationSettings/LobbySettings.vue
+++ b/src/components/ConversationSettings/LobbySettings.vue
@@ -96,9 +96,7 @@ import ImportEmailsDialog from '../ImportEmailsDialog.vue'
 import { WEBINAR } from '../../constants.ts'
 import { hasTalkFeature } from '../../services/CapabilitiesManager.ts'
 import { EventBus } from '../../services/EventBus.ts'
-import { convertToUnix, futureRelativeTime } from '../../utils/formattedTime.ts'
-
-const ONE_DAY_IN_MS = 24 * 60 * 60 * 1000
+import { ONE_DAY_IN_MS, convertToUnix, futureRelativeTime } from '../../utils/formattedTime.ts'
 
 export default {
 	name: 'LobbySettings',

--- a/src/components/LobbyScreen.vue
+++ b/src/components/LobbyScreen.vue
@@ -14,7 +14,7 @@
 				{{ t('spreed', 'You are currently waiting in the lobby') }}
 			</p>
 
-			<p v-if="countdown"
+			<p v-if="lobbyTimer"
 				class="lobby__countdown">
 				{{ message }} -
 				<span class="lobby__countdown relative-timestamp"
@@ -72,24 +72,19 @@ export default {
 			return this.conversation ? this.conversation.displayName : ''
 		},
 
-		countdown() {
-			return this.conversation.lobbyTimer
+		lobbyTimer() {
+			return this.conversation.lobbyTimer * 1000
 		},
 
 		relativeDate() {
-			const diff = moment().diff(this.timerInMoment)
-			if (diff > -45000 && diff < 45000) {
+			if (Math.abs(Date.now() - this.lobbyTimer) < 45000) {
 				return t('spreed', 'The meeting will start soon')
 			}
-			return futureRelativeTime(this.timerInMoment.valueOf())
-		},
-
-		timerInMoment() {
-			return moment(this.countdown * 1000)
+			return futureRelativeTime(this.lobbyTimer)
 		},
 
 		startTime() {
-			return this.timerInMoment.format('LLL')
+			return moment(this.lobbyTimer).format('LLL')
 		},
 
 		message() {

--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -82,7 +82,7 @@ import { ATTENDEE, CHAT, CONVERSATION, MESSAGE } from '../../constants.ts'
 import { EventBus } from '../../services/EventBus.ts'
 import { useChatExtrasStore } from '../../stores/chatExtras.js'
 import { debugTimer } from '../../utils/debugTimer.ts'
-import { convertToUnix } from '../../utils/formattedTime.ts'
+import { ONE_DAY_IN_MS, convertToUnix } from '../../utils/formattedTime.ts'
 
 const SCROLL_TOLERANCE = 10
 
@@ -545,29 +545,16 @@ export default {
 				return false
 			}
 
-			if (this.messagesHaveDifferentDate(message1, message2)) {
+			const date1 = this.getDateOfMessage(message1)
+			const date2 = this.getDateOfMessage(message2)
+
+			if (date1.getFullYear() !== date2.getFullYear() || date1.getMonth() !== date2.getMonth() || date1.getDate() !== date2.getDate()) {
 				// Not posted on the same day
 				return false
 			}
 
 			// Only group messages within a short period of time (5 minutes), so unrelated messages are not grouped together
-			return this.getDateOfMessage(message1).diff(this.getDateOfMessage(message2)) < 300 * 1000
-		},
-
-		/**
-		 * Check if 2 messages are from the same date
-		 *
-		 * @param {object} message1 The new message
-		 * @param {string} message1.id The ID of the new message
-		 * @param {number} message1.timestamp Timestamp of the new message
-		 * @param {null|object} message2 The previous message
-		 * @param {string} message2.id The ID of the second message
-		 * @param {number} message2.timestamp Timestamp of the second message
-		 * @return {boolean} Boolean if the messages have the same date
-		 */
-		messagesHaveDifferentDate(message1, message2) {
-			return !message2 // There is no previous message
-				|| this.getDateOfMessage(message1).format('YYYY-MM-DD') !== this.getDateOfMessage(message2).format('YYYY-MM-DD')
+			return Math.abs(date1 - date2) < 300000
 		},
 
 		getRelativePrefix(diffDays) {
@@ -590,8 +577,8 @@ export default {
 		 * @return {string} Translated string of "<Today>, <November 11th, 2019>", "<3 days ago>, <November 8th, 2019>"
 		 */
 		generateDateSeparator(dateTimestamp) {
-			const date = moment(dateTimestamp * 1000).startOf('day')
-			const diffDays = moment().startOf('day').diff(date, 'days')
+			const startOfDay = new Date(dateTimestamp * 1000).setHours(0, 0, 0, 0)
+			const diffDays = Math.floor((Date.now() - startOfDay) / ONE_DAY_IN_MS)
 			// Relative date is only shown up to a week ago (inclusive)
 			if (diffDays <= 7) {
 				// TRANSLATORS: <Today>, <March 18th, 2024>
@@ -599,12 +586,12 @@ export default {
 					relativeDate: this.getRelativePrefix(diffDays),
 					// 'LL' formats a localized date including day of month, month
 					// name and year
-					absoluteDate: date.format('LL'),
+					absoluteDate: moment(startOfDay).format('LL'),
 				}, undefined, {
 					escape: false, // French "Today" has a ' in it
 				})
 			} else {
-				return date.format('LL')
+				return moment(startOfDay).format('LL')
 			}
 
 		},
@@ -615,13 +602,13 @@ export default {
 		 * @param {object} message The message object
 		 * @param {string} message.id The ID of the message
 		 * @param {number} message.timestamp Timestamp of the message (in UNIX format)
-		 * @return {object} MomentJS object
+		 * @return {object} Date object
 		 */
 		getDateOfMessage(message) {
 			if (message.id.toString().startsWith('temp-')) {
-				return moment()
+				return new Date()
 			}
-			return moment(message.timestamp * 1000)
+			return new Date(message.timestamp * 1000)
 		},
 
 		getMessageIdFromHash(hash = undefined) {

--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -570,7 +570,7 @@ export default {
 				|| this.getDateOfMessage(message1).format('YYYY-MM-DD') !== this.getDateOfMessage(message2).format('YYYY-MM-DD')
 		},
 
-		getRelativePrefix(date, diffDays) {
+		getRelativePrefix(diffDays) {
 			switch (diffDays) {
 			case 0:
 				return t('spreed', 'Today')
@@ -596,7 +596,7 @@ export default {
 			if (diffDays <= 7) {
 				// TRANSLATORS: <Today>, <March 18th, 2024>
 				return t('spreed', '{relativeDate}, {absoluteDate}', {
-					relativeDate: this.getRelativePrefix(date, diffDays),
+					relativeDate: this.getRelativePrefix(diffDays),
 					// 'LL' formats a localized date including day of month, month
 					// name and year
 					absoluteDate: date.format('LL'),

--- a/src/components/NewMessage/NewMessage.vue
+++ b/src/components/NewMessage/NewMessage.vue
@@ -181,7 +181,6 @@ import SendIcon from 'vue-material-design-icons/Send.vue'
 import { showError, showWarning } from '@nextcloud/dialogs'
 import { FilePickerVue } from '@nextcloud/dialogs/filepicker.js'
 import { t } from '@nextcloud/l10n'
-import moment from '@nextcloud/moment'
 
 import NcActionButton from '@nextcloud/vue/dist/Components/NcActionButton.js'
 import NcActions from '@nextcloud/vue/dist/Components/NcActions.js'
@@ -210,6 +209,7 @@ import { useChatExtrasStore } from '../../stores/chatExtras.js'
 import { useGroupwareStore } from '../../stores/groupware.ts'
 import { useSettingsStore } from '../../stores/settings.js'
 import { fetchClipboardContent } from '../../utils/clipboard.js'
+import { ONE_DAY_IN_MS } from '../../utils/formattedTime.ts'
 import { getCurrentSelectionRange, selectRange, insertTextInElement } from '../../utils/selectionRange.ts'
 import { parseSpecialSymbols } from '../../utils/textParse.ts'
 
@@ -901,7 +901,7 @@ export default {
 				return message.actorId === this.$store.getters.getUserId()
 					&& message.actorType === this.$store.getters.getActorType()
 					&& !message.isTemporary && !message.systemMessage
-					&& (moment(message.timestamp * 1000).add(1, 'd')) > moment()
+					&& (Date.now() - message.timestamp * 1000 < ONE_DAY_IN_MS)
 			})
 
 			if (!lastMessageByCurrentUser) {

--- a/src/composables/useMessageInfo.js
+++ b/src/composables/useMessageInfo.js
@@ -6,13 +6,13 @@
 import { computed, ref } from 'vue'
 
 import { t } from '@nextcloud/l10n'
-import moment from '@nextcloud/moment'
 
 import { useConversationInfo } from './useConversationInfo.js'
 import { useStore } from './useStore.js'
 import { ATTENDEE, CONVERSATION } from '../constants.ts'
 import { hasTalkFeature } from '../services/CapabilitiesManager.ts'
 import { useGuestNameStore } from '../stores/guestName.js'
+import { ONE_DAY_IN_MS, ONE_HOUR_IN_MS } from '../utils/formattedTime.ts'
 import { getDisplayNameWithFallback } from '../utils/getDisplayName.ts'
 
 /**
@@ -75,7 +75,7 @@ export function useMessageInfo(message = ref({})) {
 			return true
 		}
 
-		return (moment(message.value.timestamp * 1000).add(1, 'd')) > moment()
+		return (Date.now() - message.value.timestamp * 1000 < ONE_DAY_IN_MS)
 	})
 
 	const isFileShare = computed(() => Object.keys(Object(message.value.messageParameters)).some(key => key.startsWith('file')))
@@ -83,7 +83,7 @@ export function useMessageInfo(message = ref({})) {
 	const isFileShareWithoutCaption = computed(() => message.value.message === '{file}' && isFileShare.value)
 
 	const isDeleteable = computed(() =>
-		(hasTalkFeature(message.value.token, 'delete-messages-unlimited') || (moment(message.value.timestamp * 1000).add(6, 'h')) > moment())
+		(hasTalkFeature(message.value.token, 'delete-messages-unlimited') || (Date.now() - message.value.timestamp * 1000 < 6 * ONE_HOUR_IN_MS))
 		&& (message.value.messageType === 'comment' || message.value.messageType === 'voice-message')
 		&& (isCurrentUserOwnMessage.value || (!isOneToOneConversation.value && store.getters.isModerator))
 		&& isConversationModifiable.value)

--- a/src/utils/formattedTime.ts
+++ b/src/utils/formattedTime.ts
@@ -4,6 +4,9 @@
  */
 import { t, n } from '@nextcloud/l10n'
 
+const ONE_HOUR_IN_MS = 3600000
+const ONE_DAY_IN_MS = 86400000
+
 /**
  * Converts the given time to UNIX timestamp
  *
@@ -43,8 +46,8 @@ function formattedTime(time: number, condensed: boolean = false): string {
  */
 function futureRelativeTime(time: number): string {
 	const diff = time - Date.now()
-	const hours = Math.floor(diff / (60 * 60 * 1000))
-	const minutes = Math.floor((diff - hours * 60 * 60 * 1000) / (60 * 1000))
+	const hours = Math.floor(diff / ONE_HOUR_IN_MS)
+	const minutes = Math.floor((diff - hours * ONE_HOUR_IN_MS) / (60 * 1000))
 	if (hours >= 1) {
 		if (minutes === 0) {
 			// TRANSLATORS: hint for the time when the meeting starts (only hours)
@@ -63,6 +66,8 @@ function futureRelativeTime(time: number): string {
 }
 
 export {
+	ONE_HOUR_IN_MS,
+	ONE_DAY_IN_MS,
 	convertToUnix,
 	formattedTime,
 	futureRelativeTime,


### PR DESCRIPTION
### ☑️ Resolves

* Ref #14434 
* Now only `moment.format()` is left for human-readable string to be replaced

## 🖌️ UI Checklist

No visual changes

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] ⛑️ Tests are included or not possible