### PR TITLE
fix(conversations): remove Delete conversation from quick actions conversation menu

### DIFF
--- a/src/components/LeftSidebar/ConversationsList/Conversation.vue
+++ b/src/components/LeftSidebar/ConversationsList/Conversation.vue
@@ -105,17 +105,6 @@
 					</template>
 					{{ t('spreed', 'Leave conversation') }}
 				</NcActionButton>
-
-				<NcActionButton v-if="item.canDeleteConversation"
-					key="delete-conversation"
-					close-after-click
-					class="critical"
-					@click="isDeleteDialogOpen = true">
-					<template #icon>
-						<IconDelete :size="16" />
-					</template>
-					{{ t('spreed', 'Delete conversation') }}
-				</NcActionButton>
 			</template>
 			<template v-else-if="submenu === 'notifications'">
 				<NcActionButton :aria-label="t('spreed', 'Back')"
@@ -169,10 +158,9 @@
 			</NcActionButton>
 		</template>
 
-		<!-- confirmation required to leave / delete conversation -->
-		<template v-if="isLeaveDialogOpen || isDeleteDialogOpen" #extra>
-			<NcDialog v-if="isLeaveDialogOpen"
-				:open.sync="isLeaveDialogOpen"
+		<!-- confirmation required to leave conversation -->
+		<template v-if="isLeaveDialogOpen" #extra>
+			<NcDialog :open.sync="isLeaveDialogOpen"
 				:name="t('spreed', 'Leave conversation')">
 				<template #default>
 					<p>{{ dialogLeaveMessage }}</p>
@@ -188,19 +176,6 @@
 						{{ t('spreed', 'Archive conversation') }}
 					</NcButton>
 					<NcButton type="warning" @click="leaveConversation">
-						{{ t('spreed', 'Yes') }}
-					</NcButton>
-				</template>
-			</NcDialog>
-			<NcDialog v-if="isDeleteDialogOpen"
-				:open.sync="isDeleteDialogOpen"
-				:name="t('spreed','Delete conversation')"
-				:message="dialogDeleteMessage">
-				<template #actions>
-					<NcButton type="tertiary" @click="isDeleteDialogOpen = false">
-						{{ t('spreed', 'No') }}
-					</NcButton>
-					<NcButton type="error" @click="deleteConversation">
 						{{ t('spreed', 'Yes') }}
 					</NcButton>
 				</template>
@@ -222,7 +197,6 @@ import IconArrowRight from 'vue-material-design-icons/ArrowRight.vue'
 import IconBell from 'vue-material-design-icons/Bell.vue'
 import IconCog from 'vue-material-design-icons/Cog.vue'
 import IconContentCopy from 'vue-material-design-icons/ContentCopy.vue'
-import IconDelete from 'vue-material-design-icons/Delete.vue'
 import IconExitToApp from 'vue-material-design-icons/ExitToApp.vue'
 import IconEye from 'vue-material-design-icons/Eye.vue'
 import IconEyeOff from 'vue-material-design-icons/EyeOff.vue'
@@ -270,7 +244,6 @@ export default {
 		IconBell,
 		IconCog,
 		IconContentCopy,
-		IconDelete,
 		IconExitToApp,
 		IconEye,
 		IconEyeOff,
@@ -324,7 +297,6 @@ export default {
 	setup(props) {
 		const submenu = ref(null)
 		const isLeaveDialogOpen = ref(false)
-		const isDeleteDialogOpen = ref(false)
 		const { item, isSearchResult } = toRefs(props)
 		const { counterType, conversationInformation } = useConversationInfo({ item, isSearchResult })
 
@@ -333,7 +305,6 @@ export default {
 			supportsArchive,
 			submenu,
 			isLeaveDialogOpen,
-			isDeleteDialogOpen,
 			counterType,
 			conversationInformation,
 			notificationLevels,
@@ -362,13 +333,6 @@ export default {
 
 		dialogLeaveMessage() {
 			return t('spreed', 'Do you really want to leave "{displayName}"?', this.item, undefined, {
-				escape: false,
-				sanitize: false,
-			})
-		},
-
-		dialogDeleteMessage() {
-			return t('spreed', 'Do you really want to delete "{displayName}"?', this.item, undefined, {
 				escape: false,
 				sanitize: false,
 			})
@@ -426,24 +390,6 @@ export default {
 
 		showConversationSettings() {
 			emit('show-conversation-settings', { token: this.item.token })
-		},
-
-		/**
-		 * Deletes the conversation.
-		 */
-		async deleteConversation() {
-			try {
-				this.isDeleteDialogOpen = false
-				if (this.isActive) {
-					await this.$store.dispatch('leaveConversation', { token: this.item.token })
-					await this.$router.push({ name: 'root' })
-						.catch((failure) => !isNavigationFailure(failure, NavigationFailureType.duplicated) && Promise.reject(failure))
-				}
-				await this.$store.dispatch('deleteConversationFromServer', { token: this.item.token })
-			} catch (error) {
-				console.error(`Error while deleting conversation ${error}`)
-				showError(t('spreed', 'Error while deleting conversation'))
-			}
 		},
 
 		/**


### PR DESCRIPTION
### ☑️ Resolves

* There is a "Delete conversation" in the conversation list quick actions menu
* Unlike leaving, it is a very destructive operation
* IMO, it shouldn't be available in a conversation menu
* Even with the confirmation dialog, a user may just quickly click "Confirm" without reading
  * There is a similar dialog on leaving which is not so dangerous 
* To reduce the risk of accidental deletion, I'd propose removing it from the close menu
* A user can still remove conversation from the settings, where it is more obviously a destructive operation

Alternative - having double confirmation.

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/user-attachments/assets/4e6d9e94-bc6f-490b-93e7-1eac4a6fa0a1) | ![image](https://github.com/user-attachments/assets/43ea43f6-8d61-4ec8-a370-3efd604d6246)

<!-- ☀️ Light theme | 🌑 Dark Theme -->

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required

