### PR TITLE
fix(call): Simplify wording for one-to-one calls

### DIFF
--- a/tests/integration/features/command/user-remove.feature
+++ b/tests/integration/features/command/user-remove.feature
@@ -74,9 +74,9 @@ Feature: command/user-remove
     And user "participant1" leaves room "room" with 200 (v4)
     Then user "participant1" sees the following system messages in room "room" with 200
       | room | actorType     | actorId      | systemMessage        | message                      | messageParameters |
-      | room | users         | participant1 | call_tried           | You tried to call {user}     | {"user":{"type":"user","id":"participant2","name":"participant2-displayname","mention-id":"participant2"}} |
+      | room | users         | participant1 | call_tried           | Missed call                  | {"user":{"type":"user","id":"participant2","name":"participant2-displayname","mention-id":"participant2"}} |
       | room | users         | participant1 | call_left            | You left the call            | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname","mention-id":"participant1"}} |
-      | room | users         | participant1 | call_started         | You started a call           | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname","mention-id":"participant1"}} |
+      | room | users         | participant1 | call_started         | Outgoing call                | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname","mention-id":"participant1"}} |
       | room | users         | participant1 | conversation_created | You created the conversation | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname","mention-id":"participant1"}} |
     When reset signaling server requests
     And invoking occ with "talk:user:remove --user participant2"
@@ -99,7 +99,7 @@ Feature: command/user-remove
     Then user "participant1" sees the following system messages in room "room" with 200
       | room | actorType     | actorId      | systemMessage        | message                      | messageParameters |
       | room | guests        | cli          | read_only            | An administrator locked the conversation | {"actor":{"type":"guest","id":"guest\/cli","name":"Guest","mention-id":"guest\/cli"}} |
-      | room | users         | participant1 | call_tried           | You tried to call {user}     | {"user":{"type":"highlight","id":"deleted_users","name":"participant2-displayname"}} |
+      | room | users         | participant1 | call_tried           | Missed call                  | {"user":{"type":"highlight","id":"deleted_users","name":"participant2-displayname"}} |
       | room | users         | participant1 | call_left            | You left the call            | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname","mention-id":"participant1"}} |
-      | room | users         | participant1 | call_started         | You started a call           | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname","mention-id":"participant1"}} |
+      | room | users         | participant1 | call_started         | Outgoing call                | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname","mention-id":"participant1"}} |
       | room | users         | participant1 | conversation_created | You created the conversation | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname","mention-id":"participant1"}} |

--- a/tests/integration/features/command/user-transfer-ownership.feature
+++ b/tests/integration/features/command/user-transfer-ownership.feature
@@ -1,4 +1,4 @@
-Feature: command/user-remove
+Feature: command/user-transfer-ownership
 
   Background:
     Given user "participant1" exists


### PR DESCRIPTION
### ☑️ Resolves

* Fix #14056 
* Further simplification can be considered when the behaviour of 1-1 calls is (ever) changed to end the call if one person hangs up, or declines.

🏚️ Before | 🏡 After
-- | --
![Bildschirmfoto vom 2025-02-20 15-38-23](https://github.com/user-attachments/assets/a815404d-11fa-4e91-b217-bb69d9355d3a) | ![Bildschirmfoto vom 2025-02-20 15-37-12](https://github.com/user-attachments/assets/e9132d77-c5ad-4a9a-9021-55983c82d710) 
![Bildschirmfoto vom 2025-02-20 15-38-17](https://github.com/user-attachments/assets/40ed461f-4dd4-4b8e-b0ee-db5b205d30c2) | ![Bildschirmfoto vom 2025-02-20 15-37-22](https://github.com/user-attachments/assets/f2fc0823-095a-4b59-8bb1-ff30e066f781)

## 🛠️ API Checklist

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not possible
- [ ] 📘 API documentation in `docs/` has been updated or is not required
- [ ] 🔖 Capability is added or not needed 
