### PR TITLE
fix: replace moment.js with Intl formatters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "@nextcloud/files": "^3.12.0",
         "@nextcloud/initial-state": "^3.0.0",
         "@nextcloud/l10n": "^3.4.0",
-        "@nextcloud/moment": "^1.3.5",
         "@nextcloud/paths": "^2.2.1",
         "@nextcloud/router": "^3.0.1",
         "@nextcloud/sharing": "^0.3.0",
@@ -1805,20 +1804,6 @@
       "integrity": "sha512-wByt0R0/6QC44RBpaJr1MWghjjOxk/pRbACHo/ZWWKht1qYbJRHB4GtEi+35KEIHY07ZpqxiDk6dIRuN7sXYWQ==",
       "dependencies": {
         "@nextcloud/auth": "^2.3.0"
-      },
-      "engines": {
-        "node": "^20.0.0",
-        "npm": "^10.0.0"
-      }
-    },
-    "node_modules/@nextcloud/moment": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@nextcloud/moment/-/moment-1.3.5.tgz",
-      "integrity": "sha512-sQjQ/D40sdedtq4ywuANSxqG0VhIB/i+QtZ6Voz3nyZWhkyyqGxdj9rQu9AyEvas3/Jlspdom5chc+a8jOmHxQ==",
-      "license": "GPL-3.0-or-later",
-      "dependencies": {
-        "@nextcloud/l10n": "^3.4.0",
-        "moment": "^2.30.1"
       },
       "engines": {
         "node": "^20.0.0",
@@ -10683,14 +10668,6 @@
       "resolved": "https://registry.npmjs.org/mockconsole/-/mockconsole-0.0.1.tgz",
       "integrity": "sha1-1ip+2FUwlkq80k7bnzD6WLvOVsY="
     },
-    "node_modules/moment": {
-      "version": "2.30.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
-      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/mrmime": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-1.0.1.tgz",
@@ -16903,15 +16880,6 @@
       "integrity": "sha512-wByt0R0/6QC44RBpaJr1MWghjjOxk/pRbACHo/ZWWKht1qYbJRHB4GtEi+35KEIHY07ZpqxiDk6dIRuN7sXYWQ==",
       "requires": {
         "@nextcloud/auth": "^2.3.0"
-      }
-    },
-    "@nextcloud/moment": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@nextcloud/moment/-/moment-1.3.5.tgz",
-      "integrity": "sha512-sQjQ/D40sdedtq4ywuANSxqG0VhIB/i+QtZ6Voz3nyZWhkyyqGxdj9rQu9AyEvas3/Jlspdom5chc+a8jOmHxQ==",
-      "requires": {
-        "@nextcloud/l10n": "^3.4.0",
-        "moment": "^2.30.1"
       }
     },
     "@nextcloud/paths": {
@@ -23210,11 +23178,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/mockconsole/-/mockconsole-0.0.1.tgz",
       "integrity": "sha1-1ip+2FUwlkq80k7bnzD6WLvOVsY="
-    },
-    "moment": {
-      "version": "2.30.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
-      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how=="
     },
     "mrmime": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "@nextcloud/files": "^3.12.0",
     "@nextcloud/initial-state": "^3.0.0",
     "@nextcloud/l10n": "^3.4.0",
-    "@nextcloud/moment": "^1.3.5",
     "@nextcloud/paths": "^2.2.1",
     "@nextcloud/router": "^3.0.1",
     "@nextcloud/sharing": "^0.3.0",

--- a/src/components/AdminSettings/BotsSettings.vue
+++ b/src/components/AdminSettings/BotsSettings.vue
@@ -84,7 +84,6 @@
 
 <script>
 import { t } from '@nextcloud/l10n'
-import moment from '@nextcloud/moment'
 import NcButton from '@nextcloud/vue/components/NcButton'
 import NcPopover from '@nextcloud/vue/components/NcPopover'
 import IconCancel from 'vue-material-design-icons/Cancel.vue'
@@ -92,6 +91,7 @@ import IconCheck from 'vue-material-design-icons/Check.vue'
 import IconLockOutline from 'vue-material-design-icons/LockOutline.vue'
 import { BOT } from '../../constants.ts'
 import { getAllBots } from '../../services/botsService.ts'
+import { formatDateTime } from '../../utils/formattedTime.ts'
 
 export default {
 	name: 'BotsSettings',
@@ -126,7 +126,7 @@ export default {
 				...bot,
 				...this.getStateIcon(bot.state),
 				description: bot.description ?? t('spreed', 'Description is not provided'),
-				last_error_date: bot.last_error_date ? moment(bot.last_error_date * 1000).format('ll LTS') : '---',
+				last_error_date: bot.last_error_date ? formatDateTime(bot.last_error_date * 1000, 'll LTS') : '---',
 			}))
 		},
 	},

--- a/src/components/AdminSettings/BotsSettings.vue
+++ b/src/components/AdminSettings/BotsSettings.vue
@@ -126,7 +126,7 @@ export default {
 				...bot,
 				...this.getStateIcon(bot.state),
 				description: bot.description ?? t('spreed', 'Description is not provided'),
-				last_error_date: bot.last_error_date ? formatDateTime(bot.last_error_date * 1000, 'll LTS') : '---',
+				last_error_date: bot.last_error_date ? formatDateTime(bot.last_error_date * 1000, 'shortDateWithTimeSeconds') : '---',
 			}))
 		},
 	},

--- a/src/components/AdminSettings/HostedSignalingServer.vue
+++ b/src/components/AdminSettings/HostedSignalingServer.vue
@@ -219,12 +219,12 @@ export default {
 
 		expiryDate() {
 			return this.trialAccount.expires
-				? formatDateTime(this.trialAccount.expires, 'L')
+				? formatDateTime(this.trialAccount.expires, 'shortDateNumeric')
 				: t('spreed', 'Never')
 		},
 
 		createdDate() {
-			return formatDateTime(this.trialAccount.created, 'L')
+			return formatDateTime(this.trialAccount.created, 'shortDateNumeric')
 		},
 	},
 

--- a/src/components/AdminSettings/HostedSignalingServer.vue
+++ b/src/components/AdminSettings/HostedSignalingServer.vue
@@ -146,12 +146,12 @@
 import axios from '@nextcloud/axios'
 import { loadState } from '@nextcloud/initial-state'
 import { n, t } from '@nextcloud/l10n'
-import moment from '@nextcloud/moment'
 import { generateOcsUrl } from '@nextcloud/router'
 import NcButton from '@nextcloud/vue/components/NcButton'
 import NcSelect from '@nextcloud/vue/components/NcSelect'
 import NcTextField from '@nextcloud/vue/components/NcTextField'
 import { EventBus } from '../../services/EventBus.ts'
+import { formatDateTime } from '../../utils/formattedTime.ts'
 
 export default {
 	name: 'HostedSignalingServer',
@@ -218,11 +218,13 @@ export default {
 		},
 
 		expiryDate() {
-			return this.trialAccount.expires ? moment(this.trialAccount.expires).format('L') : t('spreed', 'Never')
+			return this.trialAccount.expires
+				? formatDateTime(this.trialAccount.expires, 'L')
+				: t('spreed', 'Never')
 		},
 
 		createdDate() {
-			return moment(this.trialAccount.created).format('L')
+			return formatDateTime(this.trialAccount.created, 'L')
 		},
 	},
 

--- a/src/components/ConversationSettings/BanSettings/BannedItem.vue
+++ b/src/components/ConversationSettings/BanSettings/BannedItem.vue
@@ -27,8 +27,8 @@
 
 <script>
 import { t } from '@nextcloud/l10n'
-import moment from '@nextcloud/moment'
 import NcButton from '@nextcloud/vue/components/NcButton'
+import { formatDateTime } from '../../../utils/formattedTime.ts'
 
 export default {
 	name: 'BannedItem',
@@ -58,7 +58,7 @@ export default {
 				// TRANSLATORS name of a moderator who banned a participant
 				{ label: t('spreed', 'Banned by:'), value: this.ban.moderatorDisplayName },
 				// TRANSLATORS Date and time of ban creation
-				{ label: t('spreed', 'Date:'), value: moment(this.ban.bannedTime * 1000).format('lll') },
+				{ label: t('spreed', 'Date:'), value: formatDateTime(this.ban.bannedTime * 1000, 'lll') },
 				// TRANSLATORS Internal note for moderators, usually a reason for this ban
 				{ label: t('spreed', 'Note:'), value: this.ban.internalNote },
 			]

--- a/src/components/ConversationSettings/BanSettings/BannedItem.vue
+++ b/src/components/ConversationSettings/BanSettings/BannedItem.vue
@@ -58,7 +58,7 @@ export default {
 				// TRANSLATORS name of a moderator who banned a participant
 				{ label: t('spreed', 'Banned by:'), value: this.ban.moderatorDisplayName },
 				// TRANSLATORS Date and time of ban creation
-				{ label: t('spreed', 'Date:'), value: formatDateTime(this.ban.bannedTime * 1000, 'lll') },
+				{ label: t('spreed', 'Date:'), value: formatDateTime(this.ban.bannedTime * 1000, 'shortDateWithTime') },
 				// TRANSLATORS Internal note for moderators, usually a reason for this ban
 				{ label: t('spreed', 'Note:'), value: this.ban.internalNote },
 			]

--- a/src/components/LobbyScreen.vue
+++ b/src/components/LobbyScreen.vue
@@ -39,12 +39,11 @@
 
 <script>
 import { t } from '@nextcloud/l10n'
-import moment from '@nextcloud/moment'
 import NcRichText from '@nextcloud/vue/components/NcRichText'
 import IconRoomServiceOutline from 'vue-material-design-icons/RoomServiceOutline.vue'
 import MediaSettings from '../components/MediaSettings/MediaSettings.vue'
 import { useGetToken } from '../composables/useGetToken.ts'
-import { futureRelativeTime, ONE_DAY_IN_MS } from '../utils/formattedTime.ts'
+import { formatDateTime, futureRelativeTime, ONE_DAY_IN_MS } from '../utils/formattedTime.ts'
 
 export default {
 
@@ -87,7 +86,7 @@ export default {
 		},
 
 		startTime() {
-			return moment(this.lobbyTimer).format('LLL')
+			return formatDateTime(this.lobbyTimer, 'LLL')
 		},
 
 		message() {

--- a/src/components/LobbyScreen.vue
+++ b/src/components/LobbyScreen.vue
@@ -86,7 +86,7 @@ export default {
 		},
 
 		startTime() {
-			return formatDateTime(this.lobbyTimer, 'LLL')
+			return formatDateTime(this.lobbyTimer, 'longDateWithTime')
 		},
 
 		message() {

--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
@@ -326,7 +326,6 @@
 import { getCurrentUser } from '@nextcloud/auth'
 import { showError, showSuccess } from '@nextcloud/dialogs'
 import { t } from '@nextcloud/l10n'
-import moment from '@nextcloud/moment'
 import { emojiSearch } from '@nextcloud/vue/functions/emoji'
 import { vOnClickOutside as ClickOutside } from '@vueuse/components'
 import { toRefs } from 'vue'
@@ -373,7 +372,7 @@ import { useChatExtrasStore } from '../../../../../stores/chatExtras.ts'
 import { useIntegrationsStore } from '../../../../../stores/integrations.js'
 import { useReactionsStore } from '../../../../../stores/reactions.js'
 import { generatePublicShareDownloadUrl, generateUserFileUrl } from '../../../../../utils/davUtils.ts'
-import { convertToUnix } from '../../../../../utils/formattedTime.ts'
+import { convertToUnix, formatDateTime } from '../../../../../utils/formattedTime.ts'
 import { copyConversationLinkToClipboard } from '../../../../../utils/handleUrl.ts'
 import { parseMentions } from '../../../../../utils/textParse.ts'
 
@@ -575,11 +574,11 @@ export default {
 		},
 
 		messageDateTime() {
-			return moment(this.message.timestamp * 1000).format('lll')
+			return formatDateTime(this.message.timestamp * 1000, 'lll')
 		},
 
 		editedDateTime() {
-			return moment(this.message.lastEditTimestamp * 1000).format('lll')
+			return formatDateTime(this.message.lastEditTimestamp * 1000, 'lll')
 		},
 
 		customReminderDateTime: {
@@ -630,25 +629,25 @@ export default {
 				{
 					key: 'laterToday',
 					timestamp: laterTodayTime,
-					label: t('spreed', 'Later today – {timeLocale}', { timeLocale: moment(laterTodayTime).format('LT') }),
+					label: t('spreed', 'Later today – {timeLocale}', { timeLocale: formatDateTime(laterTodayTime, 'LT') }),
 					ariaLabel: t('spreed', 'Set reminder for later today'),
 				},
 				{
 					key: 'tomorrow',
 					timestamp: tomorrowTime,
-					label: t('spreed', 'Tomorrow – {timeLocale}', { timeLocale: moment(tomorrowTime).format('ddd LT') }),
+					label: t('spreed', 'Tomorrow – {timeLocale}', { timeLocale: formatDateTime(tomorrowTime, 'ddd LT') }),
 					ariaLabel: t('spreed', 'Set reminder for tomorrow'),
 				},
 				{
 					key: 'thisWeekend',
 					timestamp: thisWeekendTime,
-					label: t('spreed', 'This weekend – {timeLocale}', { timeLocale: moment(thisWeekendTime).format('ddd LT') }),
+					label: t('spreed', 'This weekend – {timeLocale}', { timeLocale: formatDateTime(thisWeekendTime, 'ddd LT') }),
 					ariaLabel: t('spreed', 'Set reminder for this weekend'),
 				},
 				{
 					key: 'nextWeek',
 					timestamp: nextWeekTime,
-					label: t('spreed', 'Next week – {timeLocale}', { timeLocale: moment(nextWeekTime).format('ddd LT') }),
+					label: t('spreed', 'Next week – {timeLocale}', { timeLocale: formatDateTime(nextWeekTime, 'ddd LT') }),
 					ariaLabel: t('spreed', 'Set reminder for next week'),
 				},
 			].filter((option) => option.timestamp !== null)
@@ -658,7 +657,7 @@ export default {
 			if (!this.currentReminder) {
 				return ''
 			}
-			return t('spreed', 'Clear reminder – {timeLocale}', { timeLocale: moment(this.currentReminder.timestamp * 1000).format('ddd LT') })
+			return t('spreed', 'Clear reminder – {timeLocale}', { timeLocale: formatDateTime(this.currentReminder.timestamp * 1000, 'ddd LT') })
 		},
 
 		lastEditActorLabel() {
@@ -840,7 +839,7 @@ export default {
 			try {
 				await setMessageReminder(this.message.token, this.message.id, convertToUnix(timestamp))
 				showSuccess(t('spreed', 'A reminder was successfully set at {datetime}', {
-					datetime: moment(timestamp).format('LLL'),
+					datetime: formatDateTime(timestamp, 'LLL'),
 				}))
 			} catch (error) {
 				console.error(error)

--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
@@ -574,11 +574,11 @@ export default {
 		},
 
 		messageDateTime() {
-			return formatDateTime(this.message.timestamp * 1000, 'lll')
+			return formatDateTime(this.message.timestamp * 1000, 'shortDateWithTime')
 		},
 
 		editedDateTime() {
-			return formatDateTime(this.message.lastEditTimestamp * 1000, 'lll')
+			return formatDateTime(this.message.lastEditTimestamp * 1000, 'shortDateWithTime')
 		},
 
 		customReminderDateTime: {
@@ -629,25 +629,25 @@ export default {
 				{
 					key: 'laterToday',
 					timestamp: laterTodayTime,
-					label: t('spreed', 'Later today – {timeLocale}', { timeLocale: formatDateTime(laterTodayTime, 'LT') }),
+					label: t('spreed', 'Later today – {timeLocale}', { timeLocale: formatDateTime(laterTodayTime, 'shortTime') }),
 					ariaLabel: t('spreed', 'Set reminder for later today'),
 				},
 				{
 					key: 'tomorrow',
 					timestamp: tomorrowTime,
-					label: t('spreed', 'Tomorrow – {timeLocale}', { timeLocale: formatDateTime(tomorrowTime, 'ddd LT') }),
+					label: t('spreed', 'Tomorrow – {timeLocale}', { timeLocale: formatDateTime(tomorrowTime, 'shortWeekdayWithTime') }),
 					ariaLabel: t('spreed', 'Set reminder for tomorrow'),
 				},
 				{
 					key: 'thisWeekend',
 					timestamp: thisWeekendTime,
-					label: t('spreed', 'This weekend – {timeLocale}', { timeLocale: formatDateTime(thisWeekendTime, 'ddd LT') }),
+					label: t('spreed', 'This weekend – {timeLocale}', { timeLocale: formatDateTime(thisWeekendTime, 'shortWeekdayWithTime') }),
 					ariaLabel: t('spreed', 'Set reminder for this weekend'),
 				},
 				{
 					key: 'nextWeek',
 					timestamp: nextWeekTime,
-					label: t('spreed', 'Next week – {timeLocale}', { timeLocale: formatDateTime(nextWeekTime, 'ddd LT') }),
+					label: t('spreed', 'Next week – {timeLocale}', { timeLocale: formatDateTime(nextWeekTime, 'shortWeekdayWithTime') }),
 					ariaLabel: t('spreed', 'Set reminder for next week'),
 				},
 			].filter((option) => option.timestamp !== null)
@@ -657,7 +657,7 @@ export default {
 			if (!this.currentReminder) {
 				return ''
 			}
-			return t('spreed', 'Clear reminder – {timeLocale}', { timeLocale: formatDateTime(this.currentReminder.timestamp * 1000, 'ddd LT') })
+			return t('spreed', 'Clear reminder – {timeLocale}', { timeLocale: formatDateTime(this.currentReminder.timestamp * 1000, 'shortWeekdayWithTime') })
 		},
 
 		lastEditActorLabel() {
@@ -839,7 +839,7 @@ export default {
 			try {
 				await setMessageReminder(this.message.token, this.message.id, convertToUnix(timestamp))
 				showSuccess(t('spreed', 'A reminder was successfully set at {datetime}', {
-					datetime: formatDateTime(timestamp, 'LLL'),
+					datetime: formatDateTime(timestamp, 'longDateWithTime'),
 				}))
 			} catch (error) {
 				console.error(error)

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/MessageBody.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/MessageBody.vue
@@ -365,11 +365,11 @@ export default {
 		},
 
 		messageTime() {
-			return formatDateTime(this.isTemporary ? Date.now() : this.message.timestamp * 1000, 'LT')
+			return formatDateTime(this.isTemporary ? Date.now() : this.message.timestamp * 1000, 'shortTime')
 		},
 
 		messageDate() {
-			return formatDateTime(this.isTemporary ? Date.now() : this.message.timestamp * 1000, 'LL')
+			return formatDateTime(this.isTemporary ? Date.now() : this.message.timestamp * 1000, 'longDate')
 		},
 
 		lastCallStartedMessageId() {

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/MessageBody.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/MessageBody.vue
@@ -160,7 +160,6 @@
 <script>
 import { showError, showSuccess } from '@nextcloud/dialogs'
 import { n, t } from '@nextcloud/l10n'
-import moment from '@nextcloud/moment'
 import emojiRegex from 'emoji-regex'
 import { inject, toRefs } from 'vue'
 import NcButton from '@nextcloud/vue/components/NcButton'
@@ -186,6 +185,7 @@ import { hasTalkFeature } from '../../../../../services/CapabilitiesManager.ts'
 import { EventBus } from '../../../../../services/EventBus.ts'
 import { useChatExtrasStore } from '../../../../../stores/chatExtras.ts'
 import { usePollsStore } from '../../../../../stores/polls.ts'
+import { formatDateTime } from '../../../../../utils/formattedTime.ts'
 import { parseMentions, parseSpecialSymbols } from '../../../../../utils/textParse.ts'
 
 // Regular expression to check for Unicode emojis in message text
@@ -365,11 +365,11 @@ export default {
 		},
 
 		messageTime() {
-			return moment(this.isTemporary ? undefined : this.message.timestamp * 1000).format('LT')
+			return formatDateTime(this.isTemporary ? Date.now() : this.message.timestamp * 1000, 'LT')
 		},
 
 		messageDate() {
-			return moment(this.isTemporary ? undefined : this.message.timestamp * 1000).format('LL')
+			return formatDateTime(this.isTemporary ? Date.now() : this.message.timestamp * 1000, 'LL')
 		},
 
 		lastCallStartedMessageId() {

--- a/src/components/NewMessage/NewMessageAbsenceInfo.vue
+++ b/src/components/NewMessage/NewMessageAbsenceInfo.vue
@@ -114,8 +114,8 @@ export default {
 				return ''
 			}
 			return t('spreed', 'Absence period: {startDate} - {endDate}', {
-				startDate: formatDateTime(this.userAbsence.startDate * 1000, 'll'),
-				endDate: formatDateTime(this.userAbsence.endDate * 1000, 'll'),
+				startDate: formatDateTime(this.userAbsence.startDate * 1000, 'shortDate'),
+				endDate: formatDateTime(this.userAbsence.endDate * 1000, 'shortDate'),
 			})
 		},
 	},

--- a/src/components/NewMessage/NewMessageAbsenceInfo.vue
+++ b/src/components/NewMessage/NewMessageAbsenceInfo.vue
@@ -47,7 +47,6 @@
 <script>
 import { getCurrentUser } from '@nextcloud/auth'
 import { t } from '@nextcloud/l10n'
-import moment from '@nextcloud/moment'
 import { useIsDarkTheme } from '@nextcloud/vue/composables/useIsDarkTheme'
 import NcButton from '@nextcloud/vue/components/NcButton'
 import NcNoteCard from '@nextcloud/vue/components/NcNoteCard'
@@ -56,6 +55,7 @@ import IconChevronUp from 'vue-material-design-icons/ChevronUp.vue'
 import AvatarWrapper from '../AvatarWrapper/AvatarWrapper.vue'
 import { useGetToken } from '../../composables/useGetToken.ts'
 import { AVATAR } from '../../constants.ts'
+import { formatDateTime } from '../../utils/formattedTime.ts'
 
 export default {
 	name: 'NewMessageAbsenceInfo',
@@ -114,8 +114,8 @@ export default {
 				return ''
 			}
 			return t('spreed', 'Absence period: {startDate} - {endDate}', {
-				startDate: moment(this.userAbsence.startDate * 1000).format('ll'),
-				endDate: moment(this.userAbsence.endDate * 1000).format('ll'),
+				startDate: formatDateTime(this.userAbsence.startDate * 1000, 'll'),
+				endDate: formatDateTime(this.userAbsence.endDate * 1000, 'll'),
 			})
 		},
 	},

--- a/src/components/RightSidebar/SearchMessages/SearchMessageItem.vue
+++ b/src/components/RightSidebar/SearchMessages/SearchMessageItem.vue
@@ -63,7 +63,7 @@ const clearReminderLabel = computed(() => {
 	if (!props.isReminder) {
 		return ''
 	}
-	return t('spreed', 'Clear reminder – {timeLocale}', { timeLocale: formatDateTime(props.timestamp * 1000, 'ddd LT') })
+	return t('spreed', 'Clear reminder – {timeLocale}', { timeLocale: formatDateTime(props.timestamp * 1000, 'shortWeekdayWithTime') })
 })
 
 const active = computed(() => {

--- a/src/components/RightSidebar/SearchMessages/SearchMessageItem.vue
+++ b/src/components/RightSidebar/SearchMessages/SearchMessageItem.vue
@@ -8,7 +8,6 @@ import type { RouteLocationAsRelative } from 'vue-router'
 import type { ChatMessage, Conversation } from '../../../types/index.ts'
 
 import { t } from '@nextcloud/l10n'
-import moment from '@nextcloud/moment'
 import { computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useStore } from 'vuex'
@@ -21,6 +20,7 @@ import ConversationIcon from '../../ConversationIcon.vue'
 import { CONVERSATION } from '../../../constants.ts'
 import { EventBus } from '../../../services/EventBus.ts'
 import { useDashboardStore } from '../../../stores/dashboard.ts'
+import { formatDateTime } from '../../../utils/formattedTime.ts'
 import { parseToSimpleMessage } from '../../../utils/textParse.ts'
 
 const props = withDefaults(defineProps<{
@@ -63,7 +63,7 @@ const clearReminderLabel = computed(() => {
 	if (!props.isReminder) {
 		return ''
 	}
-	return t('spreed', 'Clear reminder – {timeLocale}', { timeLocale: moment(props.timestamp * 1000).format('ddd LT') })
+	return t('spreed', 'Clear reminder – {timeLocale}', { timeLocale: formatDateTime(props.timestamp * 1000, 'ddd LT') })
 })
 
 const active = computed(() => {

--- a/src/store/fileUploadStore.js
+++ b/src/store/fileUploadStore.js
@@ -6,7 +6,6 @@
 import { showError } from '@nextcloud/dialogs'
 import { loadState } from '@nextcloud/initial-state'
 import { t } from '@nextcloud/l10n'
-import moment from '@nextcloud/moment'
 import { getUploader } from '@nextcloud/upload'
 import { useTemporaryMessage } from '../composables/useTemporaryMessage.ts'
 import { MESSAGE, SHARED_ITEM } from '../constants.ts'
@@ -242,7 +241,9 @@ const actions = {
 
 			if (rename) {
 				// note: can't overwrite the original read-only name attribute
-				file.newName = moment(file.lastModified || file.lastModifiedDate).format('YYYYMMDD_HHmmss')
+				// 'YYYY-MM-DDTHH:mm:ss.sssZ' -> 'YYYYMMDD_HHmmss.ext'
+				file.newName = new Date(file.lastModified ?? file.lastModifiedDate)
+					.toISOString().replace('T', '_').replace(/[:-]/g, '').split('.')[0]
 					+ getFileExtension(file.name)
 			}
 

--- a/src/utils/__tests__/formattedTime.spec.js
+++ b/src/utils/__tests__/formattedTime.spec.js
@@ -6,6 +6,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
 	convertToUnix,
+	formatDateTime,
 	formattedTime,
 	futureRelativeTime,
 	getRelativeDay,
@@ -98,4 +99,24 @@ describe('getRelativeDay', () => {
 			expect(result).toBe(output)
 		},
 	)
+})
+
+describe('formatDateTime', () => {
+	const TIME = new Date('2025-02-15T20:30:00Z')
+
+	const LOCALIZED_TEST_CASES = [
+		['LT', '8:30 PM'], // 'h:mm A'
+		['LL', 'February 15, 2025'], // 'MMMM D, YYYY'
+		['LLL', 'February 15, 2025 8:30 PM'], // 'MMMM D, YYYY h:mm A'
+		['ll', 'Feb 15, 2025'], // 'MMM D, YYYY'
+		['L', '02/15/2025'], // 'MM/DD/YYYY'
+		['lll', 'Feb 15, 2025 8:30 PM'], // 'MMM D, YYYY h:mm A'
+		['ll LTS', 'Feb 15, 2025 8:30:00 PM'], // 'MMM D, YYYY h:mm:ss A'
+		['ddd LT', 'Sat 8:30 PM'], // 'ddd h:mm A'
+	]
+
+	it.each(LOCALIZED_TEST_CASES)('should return datetime with specified format %s', (format, output) => {
+		const result = formatDateTime(TIME, format)
+		expect(result).toBe(output)
+	})
 })

--- a/src/utils/__tests__/formattedTime.spec.js
+++ b/src/utils/__tests__/formattedTime.spec.js
@@ -105,14 +105,14 @@ describe('formatDateTime', () => {
 	const TIME = new Date('2025-02-15T20:30:00Z')
 
 	const LOCALIZED_TEST_CASES = [
-		['LT', '8:30 PM'], // 'h:mm A'
-		['LL', 'February 15, 2025'], // 'MMMM D, YYYY'
-		['LLL', 'February 15, 2025 8:30 PM'], // 'MMMM D, YYYY h:mm A'
-		['ll', 'Feb 15, 2025'], // 'MMM D, YYYY'
-		['L', '02/15/2025'], // 'MM/DD/YYYY'
-		['lll', 'Feb 15, 2025 8:30 PM'], // 'MMM D, YYYY h:mm A'
-		['ll LTS', 'Feb 15, 2025 8:30:00 PM'], // 'MMM D, YYYY h:mm:ss A'
-		['ddd LT', 'Sat 8:30 PM'], // 'ddd h:mm A'
+		['shortTime', '8:30 PM'], // 'h:mm A'
+		['longDate', 'February 15, 2025'], // 'MMMM D, YYYY'
+		['longDateWithTime', 'February 15, 2025 at 8:30 PM'], // 'MMMM D, YYYY at h:mm A'
+		['shortDate', 'Feb 15, 2025'], // 'MMM D, YYYY'
+		['shortDateNumeric', '02/15/2025'], // 'MM/DD/YYYY'
+		['shortDateWithTime', 'Feb 15, 2025, 8:30 PM'], // 'MMM D, YYYY h:mm A'
+		['shortDateWithTimeSeconds', 'Feb 15, 2025, 8:30:00 PM'], // 'MMM D, YYYY h:mm:ss A'
+		['shortWeekdayWithTime', 'Sat 8:30 PM'], // 'ddd h:mm A'
 	]
 
 	it.each(LOCALIZED_TEST_CASES)('should return datetime with specified format %s', (format, output) => {

--- a/src/utils/formattedTime.ts
+++ b/src/utils/formattedTime.ts
@@ -3,11 +3,23 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { getLanguage, n, t } from '@nextcloud/l10n'
-import moment from '@nextcloud/moment'
+import { getCanonicalLocale, getLanguage, n, t } from '@nextcloud/l10n'
 
 const ONE_HOUR_IN_MS = 3600000
 const ONE_DAY_IN_MS = 86400000
+
+const locale = getCanonicalLocale()
+
+const absoluteTimeFormat = {
+	shortTime: new Intl.DateTimeFormat(locale, { hour: 'numeric', minute: 'numeric' }), // '8:30 PM'
+	longDate: new Intl.DateTimeFormat(locale, { year: 'numeric', month: 'long', day: 'numeric' }), // 'February 15, 2025'
+	longDateWithTime: new Intl.DateTimeFormat(locale, { year: 'numeric', month: 'long', day: 'numeric', hour: 'numeric', minute: 'numeric' }), // 'February 15, 2025 at 8:30 PM'
+	shortDate: new Intl.DateTimeFormat(locale, { year: 'numeric', month: 'short', day: 'numeric' }), // 'Feb 15, 2025'
+	shortDateNumeric: new Intl.DateTimeFormat(locale, { year: 'numeric', month: '2-digit', day: '2-digit' }), // '02/15/2025'
+	shortDateWithTime: new Intl.DateTimeFormat(locale, { year: 'numeric', month: 'short', day: 'numeric', hour: 'numeric', minute: 'numeric' }), // 'Feb 15, 2025, 8:30 PM'
+	shortDateWithTimeSeconds: new Intl.DateTimeFormat(locale, { year: 'numeric', month: 'short', day: 'numeric', hour: 'numeric', minute: 'numeric', second: 'numeric' }), // 'Feb 15, 2025, 8:30:00 PM'
+	shortWeekdayWithTime: new Intl.DateTimeFormat(locale, { weekday: 'short', hour: 'numeric', minute: 'numeric' }), // 'Sat 8:30 PM'
+} as const
 
 /** Formatters in user's language */
 
@@ -82,14 +94,13 @@ function futureRelativeTime(time: number): string {
 }
 
 /**
- * Converts the given time to human-readable formats. Supported formats:
- * - combination of datetime numeric representations, like 'YYYYMMDD_HHmmss'
- * - localized formats aligned with moment.js for easier migration: https://momentjs.com/docs/#/displaying/format/
+ * Converts the given time to human-readable formats
+ *
  * @param time time in ms or Date object
  * @param format format to use
  */
-function formatDateTime(time: Date | number, format: string): string {
-	return moment(time).format(format)
+function formatDateTime(time: Date | number, format: keyof typeof absoluteTimeFormat): string {
+	return absoluteTimeFormat[format].format(new Date(time))
 }
 
 /**

--- a/src/utils/formattedTime.ts
+++ b/src/utils/formattedTime.ts
@@ -2,7 +2,9 @@
  * SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+
 import { getLanguage, n, t } from '@nextcloud/l10n'
+import moment from '@nextcloud/moment'
 
 const ONE_HOUR_IN_MS = 3600000
 const ONE_DAY_IN_MS = 86400000
@@ -80,6 +82,17 @@ function futureRelativeTime(time: number): string {
 }
 
 /**
+ * Converts the given time to human-readable formats. Supported formats:
+ * - combination of datetime numeric representations, like 'YYYYMMDD_HHmmss'
+ * - localized formats aligned with moment.js for easier migration: https://momentjs.com/docs/#/displaying/format/
+ * @param time time in ms or Date object
+ * @param format format to use
+ */
+function formatDateTime(time: Date | number, format: string): string {
+	return moment(time).format(format)
+}
+
+/**
  * Calculates the difference (in days) from now (positive for future time, negative for the past)
  *
  * @param dateOrTimestamp Date object to calculate from (or timestamp in ms)
@@ -131,6 +144,7 @@ function getRelativeDay(
 
 export {
 	convertToUnix,
+	formatDateTime,
 	formattedTime,
 	futureRelativeTime,
 	getDiffInDays,


### PR DESCRIPTION
### ☑️ Resolves

* Fix #14434

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
Banned user date | -
'lll', `Feb 15, 2025 8:30 PM` | 'dateTimeShort', `Feb 15, 2025, 8:30 PM`
Bot last error | -
'll LTS', `Feb 15, 2025 8:30:00 PM` | 'dateTimeShortWithSeconds', `Feb 15, 2025, 8:30:00 PM`
Hosted HPB expiration dates | -
'L', `02/15/2025` | 'dateNumeric', `02/15/2025`
Lobby start time | -
'LLL', `February 15, 2025 8:30 PM` | 'dateTimeLong', `February 15, 2025 at 8:30 PM`
Message time and date | -
'LT', `8:30 PM` | 'timeShort', `8:30 PM`
'LL', `February 15, 2025` | 'dateLong', `February 15, 2025`
'lll', `Feb 15, 2025 8:30 PM` | 'dateTimeShort', `Feb 15, 2025, 8:30 PM`
Message reminders | -
'LT', `8:30 PM` | 'timeShort', `8:30 PM`
'ddd LT', `Sat 8:30 PM` | 'weekdayTimeShort', `Sat 8:30 PM`
'LLL', `February 15, 2025 8:30 PM` | 'dateTimeLong', `February 15, 2025 at 8:30 PM`
Absence period | -
'll', `Feb 15, 2025` | 'dateShort', `Feb 15, 2025`


### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required