### PR TITLE
fix(Participant): unexpected change of participant to be removed and users can ban themself

### DIFF
--- a/src/components/RightSidebar/Participants/Participant.spec.js
+++ b/src/components/RightSidebar/Participants/Participant.spec.js
@@ -66,8 +66,12 @@ describe('Participant.vue', () => {
 		}
 
 		const conversationGetterMock = jest.fn().mockReturnValue(conversation)
+		const actorIdMock = jest.fn().mockReturnValue('user-actor-id')
+		const actorTypeMock = jest.fn().mockReturnValue(ATTENDEE.ACTOR_TYPE.USERS)
 
 		testStoreConfig = cloneDeep(storeConfig)
+		testStoreConfig.modules.actorStore.getters.getActorId = () => () => actorIdMock()
+		testStoreConfig.modules.actorStore.getters.getActorType = () => () => actorTypeMock()
 		testStoreConfig.modules.tokenStore.getters.getToken = () => () => 'current-token'
 		testStoreConfig.modules.conversationsStore.getters.conversation = () => conversationGetterMock
 		store = new Vuex.Store(testStoreConfig)
@@ -401,17 +405,17 @@ describe('Participant.vue', () => {
 
 			test('does not allow demoting self', async () => {
 				conversation.participantType = PARTICIPANT.TYPE.MODERATOR
-				conversation.sessionId = 'current-session-id'
 				participant.participantType = PARTICIPANT.TYPE.MODERATOR
-				participant.sessionIds = ['current-session-id', 'another-session-id']
+				participant.actorId = 'user-actor-id'
+				participant.actorType = ATTENDEE.ACTOR_TYPE.USERS
 				await testCannotDemote()
 			})
 
 			test('does not allow demoting self as guest', async () => {
 				conversation.participantType = PARTICIPANT.TYPE.GUEST_MODERATOR
-				conversation.sessionId = 'current-session-id'
 				participant.participantType = PARTICIPANT.TYPE.GUEST_MODERATOR
-				participant.sessionIds = ['current-session-id']
+				participant.actorId = 'user-actor-id'
+				participant.actorType = ATTENDEE.ACTOR_TYPE.USERS
 				await testCannotDemote()
 			})
 
@@ -685,17 +689,17 @@ describe('Participant.vue', () => {
 
 			test('does not allow removing self', async () => {
 				conversation.participantType = PARTICIPANT.TYPE.MODERATOR
-				conversation.sessionId = 'current-session-id'
 				participant.participantType = PARTICIPANT.TYPE.MODERATOR
-				participant.sessionIds = ['current-session-id']
+				participant.actorId = 'user-actor-id'
+				participant.actorType = ATTENDEE.ACTOR_TYPE.USERS
 				await testCannotRemove()
 			})
 
 			test('does not allow removing self as guest', async () => {
 				conversation.participantType = PARTICIPANT.TYPE.GUEST_MODERATOR
-				conversation.sessionId = 'current-session-id'
 				participant.participantType = PARTICIPANT.TYPE.GUEST_MODERATOR
-				participant.sessionIds = ['current-session-id']
+				participant.actorId = 'user-actor-id'
+				participant.actorType = ATTENDEE.ACTOR_TYPE.USERS
 				await testCannotRemove()
 			})
 

--- a/src/components/RightSidebar/Participants/Participant.vue
+++ b/src/components/RightSidebar/Participants/Participant.vue
@@ -4,8 +4,7 @@
 -->
 
 <template>
-	<NcListItem :key="participantNavigationId"
-		:name="computedName"
+	<NcListItem :name="computedName"
 		:data-nav-id="participantNavigationId"
 		class="participant"
 		:class="{ 'participant--offline': isOffline }"
@@ -267,7 +266,7 @@
 		</template>
 
 		<template #extra>
-			<ParticipantPermissionsEditor v-if="permissionsEditor"
+			<ParticipantPermissionsEditor v-if="showPermissionsOptions && permissionsEditor"
 				:actor-id="participant.actorId"
 				close-after-click
 				:participant="participant"
@@ -275,7 +274,7 @@
 				@close="permissionsEditor = false" />
 
 			<!-- Confirmation required to remove participant -->
-			<NcDialog v-if="isRemoveDialogOpen"
+			<NcDialog v-if="canBeModerated && isRemoveDialogOpen"
 				:open.sync="isRemoveDialogOpen"
 				:name="removeParticipantLabel">
 				<p> {{ removeDialogMessage }} </p>

--- a/src/components/RightSidebar/Participants/Participant.vue
+++ b/src/components/RightSidebar/Participants/Participant.vue
@@ -628,7 +628,7 @@ export default {
 		},
 
 		isSelf() {
-			return this.sessionIds.length && this.sessionIds.includes(this.currentParticipant.sessionId)
+			return this.participant.actorType === this.$store.getters.getActorType() && this.participant.actorId === this.$store.getters.getActorId()
 		},
 
 		selfIsModerator() {

--- a/src/components/RightSidebar/Participants/ParticipantsListVirtual.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsListVirtual.vue
@@ -10,7 +10,7 @@
 		:item-size="PARTICIPANT_ITEM_SIZE"
 		key-field="attendeeId">
 		<template #default="{ item }">
-			<Participant :participant="item" />
+			<Participant :key="item.attendeeId" :participant="item" />
 		</template>
 		<template v-if="loading" #after>
 			<LoadingPlaceholder type="participants" :count="dummyParticipants" />

--- a/src/components/RightSidebar/Participants/ParticipantsTab.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsTab.vue
@@ -35,6 +35,7 @@
 			@select="addParticipants" />
 
 		<ParticipantsListVirtual v-if="!isSearching"
+			:key="token"
 			class="h-100"
 			:participants="participants"
 			:loading="!participantsInitialised" />


### PR DESCRIPTION
### ☑️ Resolves

fix multiple issues with participants virual list
- detect self with immediate data (do not rely on sessionId, as its update could be delayed, and client does not know if you is you)
- rerender virtual list when switch conversations (Recycle scroller is keeping items in the poll and reuse them, which may differ and interfere with actual list of participants from another conv)
- reset initial state of component if reused (same as above - Removed user from the list may be replaced by any other user from poll (usually first in the list) with open dialog and possibility to remove self)

To reproduce:
1. Open conversation 1
2. Switch to conversation 2
3. Open a dialog for deleting participant from conv2
4. Click 'Back' in browser, to return to previous route
-> dialog should dissapear if re-rendering the virtual list

To reproduce:
1. Open conversation 1
2. Open conversation 1 as a guest
3. Open a dialog for deleting guest from conv1
4. Reload (or leave) a page as a guest, to remove attendee from the list
-> dialog should dissapear if re-rendering the virtual item


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
fix(Participant): detect self with immediate data | --
![2025-02-25_11h07_34](https://github.com/user-attachments/assets/feaf017c-3110-4540-877b-6cef7bde3f72) | ![2025-02-25_11h09_41](https://github.com/user-attachments/assets/e14f0bfa-2654-4866-8c49-8c8cbf795c89)
fix(ParticipantsTab): rerender virtual list when switch conversations | --
![2025-02-25_11h13_53](https://github.com/user-attachments/assets/d8c220a3-3ec1-465f-9336-f569d261bcc0) | ![2025-02-25_11h15_19](https://github.com/user-attachments/assets/7435ca20-7e76-4002-b726-c12113b86a80)
fix(Participant): reset initial state of component if reused | --
![2025-02-25_11h12_35](https://github.com/user-attachments/assets/04355e86-3233-43a3-aa91-e4284ddffedb) | ![2025-02-25_11h11_04](https://github.com/user-attachments/assets/b9ce52b8-057a-49c7-a080-d0bb764ad1cd)

### 🚧 Tasks

- [ ] Possible drawbacks?
  - [ ] RecycleScroller doesn't work well with constantly changing lists. Maybe, go with own solution?

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required