### PR TITLE
feat(conversations): handle event conversation rooms

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -18,7 +18,7 @@
 * 🌉 **Sync with other chat solutions** With [Matterbridge](https://github.com/42wim/matterbridge/) being integrated in Talk, you can easily sync a lot of other chat solutions to Nextcloud Talk and vice-versa.
 ]]></description>
 
-	<version>22.0.0-dev.0</version>
+	<version>22.0.0-dev.1</version>
 	<licence>agpl</licence>
 
 	<author>Anna Larch</author>

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -83,6 +83,7 @@ use OCA\Talk\Files\TemplateLoader as FilesTemplateLoader;
 use OCA\Talk\Flow\RegisterOperationsListener;
 use OCA\Talk\Listener\BeforeUserLoggedOutListener;
 use OCA\Talk\Listener\BotListener;
+use OCA\Talk\Listener\CalDavEventListener;
 use OCA\Talk\Listener\CircleDeletedListener;
 use OCA\Talk\Listener\CircleEditedListener;
 use OCA\Talk\Listener\CircleMembershipListener;
@@ -130,6 +131,8 @@ use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
+use OCP\Calendar\Events\CalendarObjectCreatedEvent;
+use OCP\Calendar\Events\CalendarObjectUpdatedEvent;
 use OCP\Collaboration\AutoComplete\AutoCompleteFilterEvent;
 use OCP\Collaboration\Resources\IProviderManager;
 use OCP\Collaboration\Resources\LoadAdditionalScriptsEvent;
@@ -227,6 +230,10 @@ class Application extends App implements IBootstrap {
 		$context->registerEventListener(MessageParseEvent::class, SystemMessage::class);
 		$context->registerEventListener(MessageParseEvent::class, SystemMessage::class, 9999);
 		$context->registerEventListener(MessageParseEvent::class, UserMention::class, -100);
+
+		// Calendar listeners
+		$context->registerEventListener(CalendarObjectCreatedEvent::class, CalDavEventListener::class);
+		$context->registerEventListener(CalendarObjectUpdatedEvent::class, CalDavEventListener::class);
 
 		// Files integration listeners
 		$context->registerEventListener(BeforeGuestJoinedRoomEvent::class, FilesListener::class);

--- a/lib/Listener/CalDavEventListener.php
+++ b/lib/Listener/CalDavEventListener.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OCA\Talk\Listener;
+
+use OCA\DAV\CalDAV\TimezoneService;
+use OCA\Talk\Exceptions\ParticipantNotFoundException;
+use OCA\Talk\Exceptions\RoomNotFoundException;
+use OCA\Talk\Manager;
+use OCA\Talk\Room;
+use OCA\Talk\Service\ParticipantService;
+use OCA\Talk\Service\RoomService;
+use OCP\Calendar\Events\CalendarObjectCreatedEvent;
+use OCP\Calendar\Events\CalendarObjectUpdatedEvent;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use Psr\Log\LoggerInterface;
+use Sabre\VObject\ParseException;
+use Sabre\VObject\Property\ICalendar\Date;
+use Sabre\VObject\Property\ICalendar\DateTime;
+use Sabre\VObject\Reader;
+
+/** @template-implements IEventListener<CalendarObjectCreatedEvent|CalendarObjectUpdatedEvent> */
+class CalDavEventListener implements IEventListener {
+
+	public function __construct(
+		private Manager $manager,
+		private RoomService $roomService,
+		private LoggerInterface $logger,
+		private TimezoneService $timezoneService,
+		private ParticipantService $participantService,
+		private string $userId,
+	) {
+
+	}
+
+	public function handle(Event $event): void {
+		if (!$event instanceof CalendarObjectCreatedEvent && !$event instanceof CalendarObjectUpdatedEvent) {
+			return;
+		}
+
+		$calData = $event->getObjectData()['calendardata'] ?? null;
+		if (!$calData) {
+			return;
+		}
+
+		if (!str_contains($calData, 'LOCATION:')) {
+			$this->logger->debug('No location for the even, skipping for calendar event integration');
+			return;
+		}
+
+		try {
+			$vobject = Reader::read($calData);
+		} catch (ParseException $e) { /** Undocumented in sabre code */
+			$this->logger->warning($e->getMessage());
+			return;
+		}
+
+		$vevent = $vobject->VEVENT;
+		// Check if the location is set and if the location string contains a call url
+		$location = $vevent->LOCATION->getValue();
+		if ($location === null || !str_contains($location, '/call/')) {
+			$this->logger->debug('No location for the event or event is not a call link, skipping for calendar event integration');
+			return;
+		}
+
+		// Check if room exists and check if user is part of room
+		$array = explode('/', $location);
+		$roomToken = end($array);
+		// Cut off any excess characters from the room token
+		if (str_contains($roomToken, '?')) {
+			$roomToken = substr($roomToken, 0, strpos($roomToken, '?'));
+		}
+		if (str_contains($roomToken, '#')) {
+			$roomToken = substr($roomToken, 0, strpos($roomToken, '#'));
+		}
+		try {
+			$room = $this->manager->getRoomForUserByToken($roomToken, $this->userId);
+		} catch (RoomNotFoundException) {
+			// Change log level if log is spammed too much
+			$this->logger->warning('Room with ' . $roomToken . ' not found for calendar event integration');
+			return;
+		}
+
+		try {
+			$participant = $this->participantService->getParticipant($room, $this->userId, false);
+		} catch (ParticipantNotFoundException) {
+			$this->logger->debug('Room with ' . $roomToken . ' not found for user ' . $this->userId . ' for calendar event integration');
+			return;
+		}
+
+		if (!$participant->hasModeratorPermissions()) {
+			$this->logger->debug('Participant ' . $this->userId . ' does not have moderator permissions for calendar event integration');
+			return;
+		}
+
+		// get room type and if it is not Room Object Event, return
+		if ($room->getObjectType() !== Room::OBJECT_TYPE_EVENT) {
+			$this->logger->debug("Room $roomToken not an event room for calendar event integration");
+			return;
+		}
+
+		$rrule = $vevent->RRULE;
+		// We don't handle events with RRULEs
+		if (!empty($rrule)) {
+			$this->roomService->setObject($room);
+			$this->logger->debug("Room $roomToken calendar event contains an RRULE, converting to regular room for calendar event integration");
+			return;
+		}
+
+		/** @var DateTime $start */
+		$start = $vevent->DTSTART;
+		if ($start instanceof Date) {
+			// Full day events don't have a timezone so we need to get the user's timezone
+			// If we don't have that we can use the default server timezone
+			$timezone = $this->timezoneService->getUserTimezone($this->userId) ?? $this->timezoneService->getDefaultTimezone();
+			try {
+				$start = $start->getDateTime(new \DateTimeZone($timezone))->getTimestamp();
+			} catch (\Exception $e) {
+				$this->logger->warning("Invalid date time zone for user for room $roomToken, continuing with UTC+0: " . $e->getMessage() . ' for calendar event integration');
+				// Since this is for a full day event, we set a timestamp with UTC+0 instead
+				$start = $start->getDateTime(new \DateTimeZone('UTC'))->getTimestamp();
+			}
+		} elseif ($start instanceof DateTime) {
+			// This already includes a TZ in the object
+			$start = $start->getDateTime()->getTimestamp();
+		}
+
+		$this->roomService->setObject($room, (string)$start, Room::OBJECT_TYPE_EVENT);
+	}
+}

--- a/lib/Room.php
+++ b/lib/Room.php
@@ -590,4 +590,12 @@ class Room {
 	public function setMentionPermissions(int $mentionPermissions): void {
 		$this->mentionPermissions = $mentionPermissions;
 	}
+
+	public function setObjectId(string $objectId): void {
+		$this->objectId = $objectId;
+	}
+
+	public function setObjectType(string $objectType): void {
+		$this->objectType = $objectType;
+	}
 }

--- a/lib/Service/RoomService.php
+++ b/lib/Service/RoomService.php
@@ -26,6 +26,7 @@ use OCA\Talk\Events\RoomDeletedEvent;
 use OCA\Talk\Events\RoomModifiedEvent;
 use OCA\Talk\Events\RoomPasswordVerifyEvent;
 use OCA\Talk\Events\RoomSyncedEvent;
+use OCA\Talk\Exceptions\InvalidRoomException;
 use OCA\Talk\Exceptions\RoomNotFoundException;
 use OCA\Talk\Exceptions\RoomProperty\AvatarException;
 use OCA\Talk\Exceptions\RoomProperty\BreakoutRoomModeException;
@@ -1428,5 +1429,32 @@ class RoomService {
 		if ($room->getObjectType() === BreakoutRoom::PARENT_OBJECT_TYPE) {
 			throw new TypeException(TypeException::REASON_BREAKOUT_ROOM);
 		}
+	}
+
+	public function resetObject(Room $room): void {
+		$update = $this->db->getQueryBuilder();
+		$update->update('talk_rooms')
+			->set('object_type', $update->createNamedParameter('', IQueryBuilder::PARAM_STR))
+			->set('object_id', $update->createNamedParameter('', IQueryBuilder::PARAM_STR))
+			->where($update->expr()->eq('id', $update->createNamedParameter($room->getId(), IQueryBuilder::PARAM_INT)));
+		$update->executeStatement();
+
+		$room->setObjectId('');
+		$room->setObjectType('');
+	}
+
+	public function setObject(Room $room, string $objectId = '', string $objectType = ''): void {
+		if (($objectId !== '' && $objectType === '') || ($objectId === '' && $objectType !== '')) {
+			throw new InvalidRoomException('Object ID and Object Type must both be empty or both have values');
+		}
+		$update = $this->db->getQueryBuilder();
+		$update->update('talk_rooms')
+			->set('object_id', $update->createNamedParameter($objectId, IQueryBuilder::PARAM_STR))
+			->set('object_type', $update->createNamedParameter($objectType, IQueryBuilder::PARAM_STR))
+			->where($update->expr()->eq('id', $update->createNamedParameter($room->getId(), IQueryBuilder::PARAM_INT)));
+		$update->executeStatement();
+
+		$room->setObjectId($objectId);
+		$room->setObjectType($objectType);
 	}
 }

--- a/psalm.xml
+++ b/psalm.xml
@@ -78,6 +78,7 @@
 		<file name="tests/stubs/oc_memcache.php" />
 		<file name="tests/stubs/oca_circles.php" />
 		<file name="tests/stubs/oca_federation_trustedservers.php" />
+		<file name="tests/stubs/oca_dav_caldav_timezoneservice.php" />
 		<file name="tests/stubs/oca_files_events.php" />
 		<file name="tests/stubs/GuzzleHttp_Exception_ClientException.php" />
 		<file name="tests/stubs/GuzzleHttp_Exception_ConnectException.php" />

--- a/tests/php/Listener/CalDavEventListenerTest.php
+++ b/tests/php/Listener/CalDavEventListenerTest.php
@@ -1,0 +1,579 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Talk\Tests\php\Listener;
+
+use OCA\DAV\CalDAV\TimezoneService;
+use OCA\Talk\Events\ACallEndedEvent;
+use OCA\Talk\Exceptions\ParticipantNotFoundException;
+use OCA\Talk\Exceptions\RoomNotFoundException;
+use OCA\Talk\Listener\CalDavEventListener;
+use OCA\Talk\Manager;
+use OCA\Talk\Participant;
+use OCA\Talk\Room;
+use OCA\Talk\Service\ParticipantService;
+use OCA\Talk\Service\RoomService;
+use OCP\Calendar\Events\CalendarObjectCreatedEvent;
+use OCP\Calendar\Events\CalendarObjectUpdatedEvent;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+use Test\TestCase;
+
+/**
+ * @group DB
+ */
+class CalDavEventListenerTest extends TestCase {
+	private Manager&MockObject $manager;
+	private RoomService&MockObject $roomService;
+	private LoggerInterface&MockObject $logger;
+	private TimezoneService&MockObject $timezoneService;
+	private ParticipantService&MockObject $participantService;
+	private string $calData;
+	private string $userId;
+	private CalDavEventListener $listener;
+
+	public static function roomUrl() {
+		return [
+			['http://talk.example.com/call/12345'],
+			['http://talk.example.com/call/12345#message_789456'],
+			['http://talk.example.com/call/12345#?message_789456'],
+			['http://talk.example.com/call/12345?email=test@example.tld'],
+			['http://talk.example.com/call/12345?email=test@example.tld#message_789456'],
+			['http://talk.example.com/call/12345?email=test@example.tld#message_789456?email=test@example.tld'],
+		];
+	}
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->manager = $this->createMock(Manager::class);
+		$this->roomService = $this->createMock(RoomService::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->timezoneService = $this->createMock(TimezoneService::class);
+		$this->participantService = $this->createMock(ParticipantService::class);
+		$this->userId = '123';
+		$this->calData = <<<EOD
+BEGIN:VCALENDAR
+PRODID:-//IDN nextcloud.com//Calendar app 5.2.0-dev.1//EN
+CALSCALE:GREGORIAN
+VERSION:2.0
+BEGIN:VEVENT
+CREATED:20250310T171800Z
+DTSTAMP:20250310T171819Z
+LAST-MODIFIED:20250310T171819Z
+SEQUENCE:2
+UID:4d336aa1-a29e-4015-b1dd-98e1dae802db
+DTSTART;TZID=Europe/Vienna:20250314T100000
+DTEND;TZID=Europe/Vienna:20250314T110000
+STATUS:CONFIRMED
+SUMMARY:Test
+LOCATION:{{{LOCATION}}}
+END:VEVENT
+BEGIN:VTIMEZONE
+TZID:Europe/Vienna
+BEGIN:DAYLIGHT
+TZOFFSETFROM:+0100
+TZOFFSETTO:+0200
+TZNAME:CEST
+DTSTART:19700329T020000
+RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU
+END:DAYLIGHT
+BEGIN:STANDARD
+TZOFFSETFROM:+0200
+TZOFFSETTO:+0100
+TZNAME:CET
+DTSTART:19701025T030000
+RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU
+END:STANDARD
+END:VTIMEZONE
+END:VCALENDAR
+EOD;
+
+		$this->listener = new CalDavEventListener(
+			$this->manager,
+			$this->roomService,
+			$this->logger,
+			$this->timezoneService,
+			$this->participantService,
+			$this->userId,
+		);
+	}
+
+	public function testIsNotCalendarEvent(): void {
+		$event = $this->createMock(ACallEndedEvent::class);
+		$this->manager->expects($this->never())
+			->method('getRoomForUserByToken');
+		$this->logger->expects($this->never())
+			->method('warning');
+		$this->logger->expects($this->never())
+			->method('debug');
+		$this->roomService->expects($this->never())
+			->method('setObject');
+		$this->participantService->expects($this->never())
+			->method('getParticipant');
+		$this->timezoneService->expects($this->never())
+			->method('getUserTimezone');
+		$this->timezoneService->expects($this->never())
+			->method('getDefaultTimezone');
+
+		$this->listener->handle($event);
+	}
+
+	public function testIsCalendarEventNoLocation(): void {
+		$event = new CalendarObjectCreatedEvent(1, [], [], ['calendardata' => 'justSomeData']);
+
+		$this->logger->expects($this->once())
+			->method('debug');
+		$this->manager->expects($this->never())
+			->method('getRoomForUserByToken');
+		$this->logger->expects($this->never())
+			->method('warning');
+		$this->roomService->expects($this->never())
+			->method('setObject');
+		$this->participantService->expects($this->never())
+			->method('getParticipant');
+		$this->timezoneService->expects($this->never())
+			->method('getUserTimezone');
+		$this->timezoneService->expects($this->never())
+			->method('getDefaultTimezone');
+
+		$this->listener->handle($event);
+	}
+
+	public function testIsCalendarEventInvalidCalendarData(): void {
+		$event = new CalendarObjectCreatedEvent(1, [], [], ['calendardata' => 'justSomeData\nLOCATION:']);
+
+		$this->logger->expects($this->once())
+			->method('warning');
+		$this->manager->expects($this->never())
+			->method('getRoomForUserByToken');
+		$this->logger->expects($this->never())
+			->method('debug');
+		$this->roomService->expects($this->never())
+			->method('setObject');
+		$this->participantService->expects($this->never())
+			->method('getParticipant');
+		$this->timezoneService->expects($this->never())
+			->method('getUserTimezone');
+		$this->timezoneService->expects($this->never())
+			->method('getDefaultTimezone');
+
+		$this->listener->handle($event);
+	}
+
+	public function testNoUrlInLocation(): void {
+		$calData = <<<EOD
+BEGIN:VCALENDAR
+PRODID:-//IDN nextcloud.com//Calendar app 5.2.0-dev.1//EN
+CALSCALE:GREGORIAN
+VERSION:2.0
+BEGIN:VEVENT
+CREATED:20250310T171800Z
+DTSTAMP:20250310T171819Z
+LAST-MODIFIED:20250310T171819Z
+SEQUENCE:2
+UID:4d336aa1-a29e-4015-b1dd-98e1dae802db
+DTSTART;TZID=Europe/Vienna:20250314T100000
+DTEND;TZID=Europe/Vienna:20250314T110000
+STATUS:CONFIRMED
+SUMMARY:Test
+LOCATION:Donde esta la biblioteca
+END:VEVENT
+BEGIN:VTIMEZONE
+TZID:Europe/Vienna
+BEGIN:DAYLIGHT
+TZOFFSETFROM:+0100
+TZOFFSETTO:+0200
+TZNAME:CEST
+DTSTART:19700329T020000
+RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU
+END:DAYLIGHT
+BEGIN:STANDARD
+TZOFFSETFROM:+0200
+TZOFFSETTO:+0100
+TZNAME:CET
+DTSTART:19701025T030000
+RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU
+END:STANDARD
+END:VTIMEZONE
+END:VCALENDAR
+EOD;
+		$event = new CalendarObjectUpdatedEvent(1, [], [], ['calendardata' => $calData]);
+
+		$this->logger->expects($this->once())
+			->method('debug');
+		$this->manager->expects($this->never())
+			->method('getRoomForUserByToken');
+		$this->logger->expects($this->never())
+			->method('warning');
+		$this->roomService->expects($this->never())
+			->method('setObject');
+		$this->participantService->expects($this->never())
+			->method('getParticipant');
+		$this->timezoneService->expects($this->never())
+			->method('getUserTimezone');
+		$this->timezoneService->expects($this->never())
+			->method('getDefaultTimezone');
+
+		$this->listener->handle($event);
+	}
+
+	/**
+	 * @dataProvider roomUrl
+	 */
+	public function testRoomNotFound(string $roomUrl): void {
+		$calData = str_replace('{{{LOCATION}}}', $roomUrl, $this->calData);
+		$event = new CalendarObjectUpdatedEvent(1, [], [], ['calendardata' => $calData]);
+
+		$this->manager->expects($this->once())
+			->method('getRoomForUserByToken')
+			->willThrowException(new RoomNotFoundException());
+		$this->logger->expects($this->once())
+			->method('warning');
+		$this->logger->expects($this->never())
+			->method('debug');
+		$this->roomService->expects($this->never())
+			->method('setObject');
+		$this->participantService->expects($this->never())
+			->method('getParticipant');
+		$this->timezoneService->expects($this->never())
+			->method('getUserTimezone');
+		$this->timezoneService->expects($this->never())
+			->method('getDefaultTimezone');
+
+		$this->listener->handle($event);
+	}
+
+	/**
+	 * @dataProvider roomUrl
+	 */
+	public function testUserNotParticipant(string $roomUrl): void {
+		$calData = str_replace('{{{LOCATION}}}', $roomUrl, $this->calData);
+		$event = new CalendarObjectUpdatedEvent(1, [], [], ['calendardata' => $calData]);
+
+		$this->manager->expects($this->once())
+			->method('getRoomForUserByToken');
+		$this->participantService->expects($this->once())
+			->method('getParticipant')
+			->willThrowException(new ParticipantNotFoundException());
+		$this->logger->expects($this->never())
+			->method('warning');
+		$this->logger->expects($this->once())
+			->method('debug');
+		$this->roomService->expects($this->never())
+			->method('setObject');
+		$this->timezoneService->expects($this->never())
+			->method('getUserTimezone');
+		$this->timezoneService->expects($this->never())
+			->method('getDefaultTimezone');
+
+		$this->listener->handle($event);
+	}
+
+	/**
+	 * @dataProvider roomUrl
+	 */
+	public function testUserNotModerator(string $roomUrl): void {
+		$calData = str_replace('{{{LOCATION}}}', $roomUrl, $this->calData);
+		$event = new CalendarObjectUpdatedEvent(1, [], [], ['calendardata' => $calData]);
+		$participant = $this->createMock(Participant::class);
+		$participant->method('hasModeratorPermissions')->willReturn(false);
+
+		$this->manager->expects($this->once())
+			->method('getRoomForUserByToken');
+		$this->participantService->expects($this->once())
+			->method('getParticipant')
+			->willReturn($participant);
+		$this->logger->expects($this->once())
+			->method('debug');
+		$this->logger->expects($this->never())
+			->method('warning');
+		$this->roomService->expects($this->never())
+			->method('setObject');
+		$this->timezoneService->expects($this->never())
+			->method('getUserTimezone');
+		$this->timezoneService->expects($this->never())
+			->method('getDefaultTimezone');
+
+		$this->listener->handle($event);
+	}
+
+	/**
+	 * @dataProvider roomUrl
+	 */
+	public function testRoomNotEventRoom(string $roomUrl): void {
+		$calData = str_replace('{{{LOCATION}}}', $roomUrl, $this->calData);
+		$event = new CalendarObjectUpdatedEvent(1, [], [], ['calendardata' => $calData]);
+		$room = $this->createMock(Room::class);
+		$room->method('getObjectType')->willReturn(Room::OBJECT_TYPE_PHONE);
+		$participant = $this->createMock(Participant::class);
+		$participant->method('hasModeratorPermissions')->willReturn(true);
+
+		$this->manager->expects($this->once())
+			->method('getRoomForUserByToken')
+			->willReturn($room);
+		$this->participantService->expects($this->once())
+			->method('getParticipant')
+			->willReturn($participant);
+		$this->logger->expects($this->once())
+			->method('debug');
+		$this->logger->expects($this->never())
+			->method('warning');
+		$this->roomService->expects($this->never())
+			->method('setObject');
+		$this->timezoneService->expects($this->never())
+			->method('getUserTimezone');
+		$this->timezoneService->expects($this->never())
+			->method('getDefaultTimezone');
+
+		$this->listener->handle($event);
+	}
+
+	public function testEventHasRRULE(): void {
+		$calData = <<<EOF
+BEGIN:VCALENDAR
+PRODID:-//IDN nextcloud.com//Calendar app 5.2.0-dev.1//EN
+CALSCALE:GREGORIAN
+VERSION:2.0
+BEGIN:VEVENT
+CREATED:20250310T175122Z
+DTSTAMP:20250310T175146Z
+LAST-MODIFIED:20250310T175146Z
+SEQUENCE:2
+UID:2fb2416e-13f3-4945-936e-28df560b00a2
+DTSTART;TZID=Europe/Vienna:20250315T100000
+DTEND;TZID=Europe/Vienna:20250315T110000
+STATUS:CONFIRMED
+LOCATION:https://nextcloud.local/index.php/call/44wd9tvp
+RRULE:FREQ=DAILY;UNTIL=20250322T090000Z
+END:VEVENT
+BEGIN:VTIMEZONE
+TZID:Europe/Vienna
+BEGIN:DAYLIGHT
+TZOFFSETFROM:+0100
+TZOFFSETTO:+0200
+TZNAME:CEST
+DTSTART:19700329T020000
+RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU
+END:DAYLIGHT
+BEGIN:STANDARD
+TZOFFSETFROM:+0200
+TZOFFSETTO:+0100
+TZNAME:CET
+DTSTART:19701025T030000
+RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU
+END:STANDARD
+END:VTIMEZONE
+END:VCALENDAR
+EOF;
+
+		$event = new CalendarObjectCreatedEvent(1, [], [], ['calendardata' => $calData]);
+		$room = $this->createMock(Room::class);
+		$room->method('getObjectType')->willReturn(Room::OBJECT_TYPE_EVENT);
+		$participant = $this->createMock(Participant::class);
+		$participant->method('hasModeratorPermissions')->willReturn(true);
+
+		$this->manager->expects($this->once())
+			->method('getRoomForUserByToken')
+			->willReturn($room);
+		$this->participantService->expects($this->once())
+			->method('getParticipant')
+			->willReturn($participant);
+		$this->roomService->expects($this->once())
+			->method('setObject')
+			->with($room, '', '');
+		$this->logger->expects($this->once())
+			->method('debug');
+		$this->logger->expects($this->never())
+			->method('warning');
+		$this->timezoneService->expects($this->never())
+			->method('getUserTimezone');
+		$this->timezoneService->expects($this->never())
+			->method('getDefaultTimezone');
+
+		$this->listener->handle($event);
+	}
+
+	/**
+	 * @dataProvider roomUrl
+	 */
+	public function testTime(string $roomUrl): void {
+		$calData = str_replace('{{{LOCATION}}}', $roomUrl, $this->calData);
+		$event = new CalendarObjectCreatedEvent(1, [], [], ['calendardata' => $calData]);
+		$room = $this->createMock(Room::class);
+		$room->method('getObjectType')->willReturn(Room::OBJECT_TYPE_EVENT);
+		$participant = $this->createMock(Participant::class);
+		$participant->method('hasModeratorPermissions')->willReturn(true);
+
+		$this->manager->expects($this->once())
+			->method('getRoomForUserByToken')
+			->willReturn($room);
+		$this->participantService->expects($this->once())
+			->method('getParticipant')
+			->willReturn($participant);
+		$this->roomService->expects($this->once())
+			->method('setObject')
+			->with($room, '1741942800', Room::OBJECT_TYPE_EVENT);
+		$this->timezoneService->expects($this->never())
+			->method('getUserTimezone');
+		$this->logger->expects($this->never())
+			->method('debug');
+		$this->logger->expects($this->never())
+			->method('warning');
+		$this->timezoneService->expects($this->never())
+			->method('getDefaultTimezone');
+
+		$this->listener->handle($event);
+	}
+
+	public function testTimezone(): void {
+		$calData = <<<EOF
+BEGIN:VCALENDAR
+PRODID:-//IDN nextcloud.com//Calendar app 5.2.0-dev.1//EN
+CALSCALE:GREGORIAN
+VERSION:2.0
+BEGIN:VEVENT
+CREATED:20250310T180746Z
+DTSTAMP:20250310T180758Z
+LAST-MODIFIED:20250310T180758Z
+SEQUENCE:2
+UID:75847de7-3754-4aae-87a4-f03755163b66
+DTSTART;VALUE=DATE:20250313
+DTEND;VALUE=DATE:20250314
+STATUS:CONFIRMED
+LOCATION:https://nextcloud.local/index.php/call/jpmrumps
+END:VEVENT
+END:VCALENDAR
+EOF;
+
+		$event = new CalendarObjectCreatedEvent(1, [], [], ['calendardata' => $calData]);
+		$room = $this->createMock(Room::class);
+		$room->method('getObjectType')->willReturn(Room::OBJECT_TYPE_EVENT);
+		$participant = $this->createMock(Participant::class);
+		$participant->method('hasModeratorPermissions')->willReturn(true);
+
+		$this->manager->expects($this->once())
+			->method('getRoomForUserByToken')
+			->willReturn($room);
+		$this->participantService->expects($this->once())
+			->method('getParticipant')
+			->willReturn($participant);
+		$this->roomService->expects($this->once())
+			->method('setObject')
+			->with($room, '1741820400', Room::OBJECT_TYPE_EVENT);
+		$this->timezoneService->expects($this->once())
+			->method('getUserTimezone')
+			->willReturn('Europe/Vienna');
+		$this->timezoneService->expects($this->never())
+			->method('getDefaultTimezone');
+		$this->logger->expects($this->never())
+			->method('debug');
+		$this->logger->expects($this->never())
+			->method('warning');
+
+		$this->listener->handle($event);
+	}
+
+	public function testTimezoneDefaultFallback(): void {
+		$calData = <<<EOF
+BEGIN:VCALENDAR
+PRODID:-//IDN nextcloud.com//Calendar app 5.2.0-dev.1//EN
+CALSCALE:GREGORIAN
+VERSION:2.0
+BEGIN:VEVENT
+CREATED:20250310T180746Z
+DTSTAMP:20250310T180758Z
+LAST-MODIFIED:20250310T180758Z
+SEQUENCE:2
+UID:75847de7-3754-4aae-87a4-f03755163b66
+DTSTART;VALUE=DATE:20250313
+DTEND;VALUE=DATE:20250314
+STATUS:CONFIRMED
+LOCATION:https://nextcloud.local/index.php/call/jpmrumps
+END:VEVENT
+END:VCALENDAR
+EOF;
+
+		$event = new CalendarObjectCreatedEvent(1, [], [], ['calendardata' => $calData]);
+		$room = $this->createMock(Room::class);
+		$room->method('getObjectType')->willReturn(Room::OBJECT_TYPE_EVENT);
+		$participant = $this->createMock(Participant::class);
+		$participant->method('hasModeratorPermissions')->willReturn(true);
+
+		$this->manager->expects($this->once())
+			->method('getRoomForUserByToken')
+			->willReturn($room);
+		$this->participantService->expects($this->once())
+			->method('getParticipant')
+			->willReturn($participant);
+		$this->roomService->expects($this->once())
+			->method('setObject')
+			->with($room, '1741820400', Room::OBJECT_TYPE_EVENT);
+		$this->timezoneService->expects($this->once())
+			->method('getUserTimezone')
+			->willReturn(null);
+		$this->timezoneService->expects($this->once())
+			->method('getDefaultTimezone')
+			->willReturn('Europe/Vienna');
+		$this->logger->expects($this->never())
+			->method('debug');
+		$this->logger->expects($this->never())
+			->method('warning');
+
+		$this->listener->handle($event);
+	}
+
+	public function testTimezoneUTC(): void {
+		$calData = <<<EOF
+BEGIN:VCALENDAR
+PRODID:-//IDN nextcloud.com//Calendar app 5.2.0-dev.1//EN
+CALSCALE:GREGORIAN
+VERSION:2.0
+BEGIN:VEVENT
+CREATED:20250310T180746Z
+DTSTAMP:20250310T180758Z
+LAST-MODIFIED:20250310T180758Z
+SEQUENCE:2
+UID:75847de7-3754-4aae-87a4-f03755163b66
+DTSTART;VALUE=DATE:20250313
+DTEND;VALUE=DATE:20250314
+STATUS:CONFIRMED
+LOCATION:https://nextcloud.local/index.php/call/jpmrumps
+END:VEVENT
+END:VCALENDAR
+EOF;
+
+		$event = new CalendarObjectCreatedEvent(1, [], [], ['calendardata' => $calData]);
+		$room = $this->createMock(Room::class);
+		$room->method('getObjectType')->willReturn(Room::OBJECT_TYPE_EVENT);
+		$participant = $this->createMock(Participant::class);
+		$participant->method('hasModeratorPermissions')->willReturn(true);
+
+		$this->manager->expects($this->once())
+			->method('getRoomForUserByToken')
+			->willReturn($room);
+		$this->participantService->expects($this->once())
+			->method('getParticipant')
+			->willReturn($participant);
+		$this->roomService->expects($this->once())
+			->method('setObject')
+			->with($room, '1741824000', Room::OBJECT_TYPE_EVENT);
+		$this->timezoneService->expects($this->once())
+			->method('getUserTimezone')
+			->willReturn(null);
+		$this->timezoneService->expects($this->once())
+			->method('getDefaultTimezone')
+			->willReturn('Garbage');
+		$this->logger->expects($this->never())
+			->method('debug');
+		$this->logger->expects($this->once())
+			->method('warning');
+
+		$this->listener->handle($event);
+	}
+}

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="6.2.0@814dfde37b43a1fe6d9b0996e08b19661af53bc5">
+<files psalm-version="6.5.0@38fc8444edf0cebc9205296ee6e30e906ade783b">
   <file src="lib/AppInfo/Application.php">
     <UndefinedClass>
       <code><![CDATA[BeforeTemplateRenderedEvent]]></code>
@@ -32,6 +32,11 @@
     <InvalidArgument>
       <code><![CDATA[$fileId]]></code>
     </InvalidArgument>
+  </file>
+  <file src="lib/Listener/CalDavEventListener.php">
+    <UndefinedClass>
+      <code><![CDATA[Reader]]></code>
+    </UndefinedClass>
   </file>
   <file src="lib/Listener/CircleEditedListener.php">
     <UndefinedClass>

--- a/tests/stubs/oca_dav_caldav_timezoneservice.php
+++ b/tests/stubs/oca_dav_caldav_timezoneservice.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OCA\DAV\CalDAV {
+
+	class TimezoneService {
+		public function getUserTimezone(string $userId): ?string {
+		}
+
+		public function getDefaultTimezone(): string {
+		}
+	}
+}


### PR DESCRIPTION
### ☑️ Resolves

* Needs https://github.com/nextcloud/calendar/pull/6768

* Fix #14402 

## 🛠️ API Checklist

### 🚧 Tasks

- [x] Listen to creation of VEVENTs on the DAV events and write start and end date to the DB (be careful of TZ)
- [x] ...

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [ ] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
