### PR TITLE
fix(LeftSidebar): do not expand empty search bar when focused

### DIFF
--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -8,7 +8,7 @@
 		<template #search>
 			<div class="new-conversation">
 				<div class="conversations-search"
-					:class="{'conversations-search--expanded': isFocused}">
+					:class="{'conversations-search--expanded': isSearching}">
 					<SearchBox ref="searchBox"
 						:value.sync="searchText"
 						:is-focused.sync="isFocused"
@@ -22,7 +22,7 @@
 					<NcActions v-show="searchText === ''"
 						:primary="isFiltered !== null"
 						class="filters"
-						:class="{'hidden-visually': isFocused}">
+						:class="{'hidden-visually': isSearching}">
 						<template #icon>
 							<FilterIcon :size="15" />
 						</template>
@@ -60,7 +60,7 @@
 				<TransitionWrapper name="radial-reveal">
 					<NcActions v-show="searchText === ''"
 						class="actions"
-						:class="{'hidden-visually': isFocused}">
+						:class="{'hidden-visually': isSearching}">
 						<template #icon>
 							<ChatPlus :size="20" />
 						</template>
@@ -505,7 +505,7 @@ export default {
 		},
 
 		searchResultsConversationList() {
-			if (this.searchText !== '' || this.isFocused) {
+			if (this.isSearching) {
 				const lowerSearchText = this.searchText.toLowerCase()
 				return this.conversationsList.filter(conversation =>
 					conversation.displayName.toLowerCase().includes(lowerSearchText)


### PR DESCRIPTION
### ☑️ Resolves

* Fix expanding the searchbar and covering focus buttons on any focus (any sidebar open)
* Now it's expanded only when there's an actual search query
  * searchResultsConversationList is used only when `isSearching` is true, so there's no need for a focus check


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="209" alt="image" src="https://github.com/user-attachments/assets/3fce9ae2-48e5-429f-873e-8fb02b2889c2" /> | <img width="227" alt="image" src="https://github.com/user-attachments/assets/390dc830-ba14-4ded-bdf6-045270a2bccb" />

### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
