### PR TITLE
fix(LeftSidebar): fetch room if user was in the lobby

### DIFF
--- a/lib/Service/RoomFormatter.php
+++ b/lib/Service/RoomFormatter.php
@@ -274,17 +274,6 @@ class RoomFormatter {
 			}
 		}
 
-		if ($room->getLobbyState() === Webinary::LOBBY_NON_MODERATORS &&
-			!$currentParticipant->hasModeratorPermissions() &&
-			!($currentParticipant->getPermissions() & Attendee::PERMISSIONS_LOBBY_IGNORE)) {
-			// No participants and chat messages for users in the lobby.
-			$roomData['hasCall'] = false;
-			$roomData['canLeaveConversation'] = true;
-			return $roomData;
-		}
-
-		$roomData['canStartCall'] = $currentParticipant->canStartCall($this->serverConfig);
-
 		$currentUser = null;
 		if ($attendee->getActorType() === Attendee::ACTOR_USERS) {
 			$currentUser = $this->userManager->get($attendee->getActorId());
@@ -355,6 +344,19 @@ class RoomFormatter {
 			$roomData['remoteServer'] = $room->getRemoteServer();
 			$roomData['remoteToken'] = $room->getRemoteToken();
 		}
+
+		if ($room->getLobbyState() === Webinary::LOBBY_NON_MODERATORS &&
+			!$currentParticipant->hasModeratorPermissions() &&
+			!($currentParticipant->getPermissions() & Attendee::PERMISSIONS_LOBBY_IGNORE)) {
+			// No participants and chat messages for users in the lobby.
+			$roomData['hasCall'] = false;
+			$roomData['unreadMessages'] = 0;
+			$roomData['unreadMention'] = false;
+			$roomData['unreadMentionDirect'] = false;
+			return $roomData;
+		}
+
+		$roomData['canStartCall'] = $currentParticipant->canStartCall($this->serverConfig);
 
 		// FIXME This should not be done, but currently all the clients use it to get the avatar of the user …
 		if ($room->getType() === Room::TYPE_ONE_TO_ONE) {

--- a/tests/integration/features/conversation-3/lobby.feature
+++ b/tests/integration/features/conversation-3/lobby.feature
@@ -241,25 +241,33 @@ Feature: conversation/lobby
     And user "guest2" joins room "room" with 200 (v4)
     When user "participant1" sets lobby state for room "room" to "non moderators" with 200 (v4)
     And user "participant1" sends message "Message 1" to room "room" with 201
+    And user "participant1" sees the following system messages in room "room" with 200
+      | room | actorType     | actorId      | systemMessage        |
+      | room | users         | participant1 | lobby_non_moderators |
+      | room | users         | participant1 | guest_moderator_promoted |
+      | room | users         | participant1 | user_added           |
+      | room | users         | participant1 | moderator_promoted   |
+      | room | users         | participant1 | user_added           |
+      | room | users         | participant1 | conversation_created |
     And user "participant1" sets description for room "room" to "the description" with 200 (v4)
     Then user "participant1" is participant of room "room" (v4)
-      | name | description     | type | participantType | lastMessage             |
-      | room | the description | 3    | 1               | You set the description |
+      | name | description     | type | participantType | lastMessage             | lastReadMessage |
+      | room | the description | 3    | 1               | You set the description | Message 1       |
     And user "participant2" is participant of room "room" (v4)
-      | name | description     | type | participantType | lastMessage                 |
-      | room | the description | 3    | 2               | {actor} set the description |
+      | name | description     | type | participantType | lastMessage                 | lastReadMessage      |
+      | room | the description | 3    | 2               | {actor} set the description | conversation_created |
     And user "participant3" is participant of room "room" (v4)
-      | name | description     | type | participantType | lastMessage |
-      | room | the description | 3    | 3               | UNSET       |
+      | name | description     | type | participantType | lastMessage | lastReadMessage    |
+      | room | the description | 3    | 3               | UNSET       | moderator_promoted |
     And user "participant4" is participant of room "room" (v4)
-      | name | description     | type | participantType | lastMessage |
-      | room | the description | 3    | 5               | UNSET       |
+      | name | description     | type | participantType | lastMessage | lastReadMessage |
+      | room | the description | 3    | 5               | UNSET       | user_added      |
     And user "guest" is participant of room "room" (v4)
-      | name | description     | type | participantType | lastMessage                 |
-      | room | the description | 3    | 6               | {actor} set the description |
+      | name | description     | type | participantType | lastMessage                 | lastReadMessage |
+      | room | the description | 3    | 6               | {actor} set the description | user_added      |
     And user "guest2" is participant of room "room" (v4)
-      | name | description     | type | participantType | lastMessage |
-      | room | the description | 3    | 4               | UNSET       |
+      | name | description     | type | participantType | lastMessage | lastReadMessage |
+      | room | the description | 3    | 4               | UNSET       | guest_moderator_promoted |
 
 
   # Not all the values are checked in the test, only the most relevant ones


### PR DESCRIPTION
### ☑️ Resolves

* Ref #14368 
* When moderator disables lobby, user receive updated common room properties via HPB signaling message. If lobbyState changes to 0, that unlocks chat messaging. But user-level parameters, like `lastReadMessage === 0`, and some other are not updated, thus blocking getting the message context

## 🖌️ API Checklist

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required