### PR TITLE
fix(update/openapi): make PR from spreed Git repo

### DIFF
--- a/.github/workflows/update-nextcloud-openapi.yml
+++ b/.github/workflows/update-nextcloud-openapi.yml
@@ -74,6 +74,7 @@ jobs:
         if: steps.checkout.outcome == 'success'
         uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
         with:
+          path: apps/${{ env.APP_NAME }}
           token: ${{ secrets.COMMAND_BOT_PAT }}
           commit-message: 'chore(ts): update OpenAPI types from core'
           committer: GitHub <noreply@github.com>


### PR DESCRIPTION
### ☑️ Resolves

* Action was using server as repo: https://github.com/nextcloud/spreed/actions/runs/13612031198/job/38050450540

```sh
  /usr/bin/git config --local --get remote.origin.url
  https://github.com/nextcloud/server
```

Maybe this time it'll work 🤞🏽 