### PR TITLE
fix(search): Include captions in message search

### DIFF
--- a/lib/Chat/ChatManager.php
+++ b/lib/Chat/ChatManager.php
@@ -1003,11 +1003,11 @@ class ChatManager {
 	 *
 	 * @param string $search content to search for
 	 * @param string[] $objectIds Limit the search by object ids
-	 * @param string $verb Limit the verb of the comment
+	 * @param string[] $verbs Limit the verb of the comment
 	 * @return list<IComment>
 	 */
-	public function searchForObjectsWithFilters(string $search, array $objectIds, string $verb, ?\DateTimeImmutable $since, ?\DateTimeImmutable $until, ?string $actorType, ?string $actorId, int $offset, int $limit = 50): array {
-		return $this->commentsManager->searchForObjectsWithFilters($search, 'chat', $objectIds, $verb, $since, $until, $actorType, $actorId, $offset, $limit);
+	public function searchForObjectsWithFilters(string $search, array $objectIds, array $verbs, ?\DateTimeImmutable $since, ?\DateTimeImmutable $until, ?string $actorType, ?string $actorId, int $offset, int $limit = 50): array {
+		return $this->commentsManager->searchForObjectsWithFilters($search, 'chat', $objectIds, $verbs, $since, $until, $actorType, $actorId, $offset, $limit);
 	}
 
 	/**

--- a/lib/Chat/CommentsManager.php
+++ b/lib/Chat/CommentsManager.php
@@ -84,10 +84,10 @@ class CommentsManager extends Manager {
 	 * @param string $search content to search for
 	 * @param string $objectType Limit the search by object type
 	 * @param string[] $objectIds Limit the search by object ids
-	 * @param string $verb Limit the verb of the comment
+	 * @param string[] $verbs Limit the verb of the comment
 	 * @return list<IComment>
 	 */
-	public function searchForObjectsWithFilters(string $search, string $objectType, array $objectIds, string $verb, ?\DateTimeImmutable $since, ?\DateTimeImmutable $until, ?string $actorType, ?string $actorId, int $offset, int $limit = 50): array {
+	public function searchForObjectsWithFilters(string $search, string $objectType, array $objectIds, array $verbs, ?\DateTimeImmutable $since, ?\DateTimeImmutable $until, ?string $actorType, ?string $actorId, int $offset, int $limit = 50): array {
 		$query = $this->dbConn->getQueryBuilder();
 
 		$query->select('*')
@@ -121,8 +121,8 @@ class CommentsManager extends Manager {
 		if (!empty($objectIds)) {
 			$query->andWhere($query->expr()->in('object_id', $query->createNamedParameter($objectIds, IQueryBuilder::PARAM_STR_ARRAY)));
 		}
-		if ($verb !== '') {
-			$query->andWhere($query->expr()->eq('verb', $query->createNamedParameter($verb)));
+		if (!empty($verbs)) {
+			$query->andWhere($query->expr()->in('verb', $query->createNamedParameter($verbs, IQueryBuilder::PARAM_STR_ARRAY)));
 		}
 		if ($offset !== 0) {
 			$query->setFirstResult($offset);

--- a/lib/Search/MessageSearch.php
+++ b/lib/Search/MessageSearch.php
@@ -191,7 +191,7 @@ class MessageSearch implements IProvider, IFilteringProvider {
 		$comments = $this->chatManager->searchForObjectsWithFilters(
 			$query->getTerm(),
 			array_keys($roomMap),
-			ChatManager::VERB_MESSAGE,
+			[ChatManager::VERB_MESSAGE, ChatManager::VERB_OBJECT_SHARED],
 			$lowerTimeBoundary,
 			$upperTimeBoundary,
 			$actorType,

--- a/tests/integration/features/chat-4/search.feature
+++ b/tests/integration/features/chat-4/search.feature
@@ -21,19 +21,28 @@ Feature: chat-2/search
     And user "participant1" adds user "participant2" to room "room2" with 200 (v4)
     And user "participant1" sends message "Message 1" to room "room1" with 201
     And user "participant1" sends message "Message 2" to room "room2" with 201
+    When user "participant1" shares "welcome.txt" with room "room1"
+      | talkMetaData | {"caption":"Message 3"} |
+    Then user "participant1" sees the following messages in room "room1" with 200
+      | room  | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | room1 | users     | participant1 | participant1-displayname | Message 3 | "IGNORE"          |
+      | room1 | users     | participant1 | participant1-displayname | Message 1 | []                |
     When user "participant2" searches for messages with "essa" in room "room1" with 200
       | title                    | subline   | attributes.conversation | attributes.messageId |
+      | participant1-displayname | Message 3 | room1                   | Message 3            |
       | participant1-displayname | Message 1 | room1                   | Message 1            |
     When user "participant2" searches for messages with "essa" in room "room2" with 200
       | title                    | subline   | attributes.conversation | attributes.messageId |
       | participant1-displayname | Message 2 | room2                   | Message 2            |
     When user "participant2" searches for messages with "conversation:ROOM(room1) essa" in room "room1" with 200
       | title                    | subline   | attributes.conversation | attributes.messageId |
+      | participant1-displayname | Message 3 | room1                   | Message 3            |
       | participant1-displayname | Message 1 | room1                   | Message 1            |
     When user "participant2" searches for messages in other rooms with "conversation:ROOM(room1) essa" in room "room1" with 200
     When user "participant2" searches for messages with "conversation:ROOM(room1) essa" in room "room2" with 200
     When user "participant2" searches for messages in other rooms with "conversation:ROOM(room1) essa" in room "room2" with 200
       | title                    | subline   | attributes.conversation | attributes.messageId |
+      | participant1-displayname | Message 3 | room1                   | Message 3            |
       | participant1-displayname | Message 1 | room1                   | Message 1            |
 
   Scenario: Can not search when being blocked by the lobby


### PR DESCRIPTION
### ☑️ Resolves

* Fix #11281 

Before | After
---|---
![Bildschirmfoto vom 2025-03-03 15-45-21](https://github.com/user-attachments/assets/c49c3601-9d9b-4ebf-8985-55130e5c71e1) | ![Bildschirmfoto vom 2025-03-03 15-45-06](https://github.com/user-attachments/assets/0b93cc21-cb13-4a23-98a2-1fc7b49e6f2e)


### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
