### PR TITLE
fix(breakout-rooms): Hide breakout-room config when already configured

### DIFF
--- a/src/components/TopBar/TopBarMenu.vue
+++ b/src/components/TopBar/TopBarMenu.vue
@@ -355,6 +355,11 @@ export default {
 				return false
 			}
 
+			if (this.conversation.objectType === CONVERSATION.OBJECT_TYPE.BREAKOUT_ROOM
+				|| this.conversation.breakoutRoomMode !== CONVERSATION.BREAKOUT_ROOM_MODE.NOT_CONFIGURED) {
+				return false
+			}
+
 			return !!getTalkConfig(this.token, 'call', 'breakout-rooms')
 		},
 


### PR DESCRIPTION
### ☑️ Resolves

🏚️ Before | 🏡 After
-- | --
![Bildschirmfoto vom 2025-03-03 16-19-56](https://github.com/user-attachments/assets/4739692c-9188-4491-86bf-f25796687afb)
 | ![grafik](https://github.com/user-attachments/assets/77cd94b8-8468-40a8-b057-ec5e751cd47f)

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Not risky to browser differences / client
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
