### PR TITLE
fix(openapi): Fix deprecation syntax after openapi-extractor change

### DIFF
--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -523,9 +523,9 @@ class RoomController extends AEnvironmentAwareOCSController {
 	 *
 	 * @param int $roomType Type of the room
 	 * @psalm-param Room::TYPE_* $roomType
-	 * @param string $invite User, group, … ID to invite **Deprecated** Use the `$participants` array instead
+	 * @param string $invite User, group, … ID to invite @deprecated Use the `$participants` array instead
 	 * @param string $roomName Name of the room, unless the legacy mode providing `$invite` and `$source` is used, the name must no longer be empty with the `conversation-creation-all` capability (Ignored if `$roomType` is {@see Room::TYPE_ONE_TO_ONE})
-	 * @param 'groups'|'circles'|'' $source Source of the invite ID ('circles' to create a room with a circle, etc.) **Deprecated** Use the `$participants` array instead
+	 * @param 'groups'|'circles'|'' $source Source of the invite ID ('circles' to create a room with a circle, etc.) @deprecated Use the `$participants` array instead
 	 * @param string $objectType Type of the object (Ignored if `$roomType` is {@see Room::TYPE_ONE_TO_ONE})
 	 * @param string $objectId ID of the object (Ignored if `$roomType` is {@see Room::TYPE_ONE_TO_ONE})
 	 * @param string $password The room password (only available with `conversation-creation-password` capability) (Ignored if `$roomType` is not {@see Room::TYPE_PUBLIC})

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -11963,8 +11963,9 @@
                                     },
                                     "invite": {
                                         "type": "string",
+                                        "deprecated": true,
                                         "default": "",
-                                        "description": "User, group, … ID to invite **Deprecated** Use the `$participants` array instead"
+                                        "description": "User, group, … ID to invite Deprecated: Use the `$participants` array instead"
                                     },
                                     "roomName": {
                                         "type": "string",
@@ -11973,8 +11974,9 @@
                                     },
                                     "source": {
                                         "type": "string",
+                                        "deprecated": true,
                                         "default": "",
-                                        "description": "Source of the invite ID ('circles' to create a room with a circle, etc.) **Deprecated** Use the `$participants` array instead"
+                                        "description": "Source of the invite ID ('circles' to create a room with a circle, etc.) Deprecated: Use the `$participants` array instead"
                                     },
                                     "objectType": {
                                         "type": "string",

--- a/openapi.json
+++ b/openapi.json
@@ -11868,8 +11868,9 @@
                                     },
                                     "invite": {
                                         "type": "string",
+                                        "deprecated": true,
                                         "default": "",
-                                        "description": "User, group, … ID to invite **Deprecated** Use the `$participants` array instead"
+                                        "description": "User, group, … ID to invite Deprecated: Use the `$participants` array instead"
                                     },
                                     "roomName": {
                                         "type": "string",
@@ -11878,8 +11879,9 @@
                                     },
                                     "source": {
                                         "type": "string",
+                                        "deprecated": true,
                                         "default": "",
-                                        "description": "Source of the invite ID ('circles' to create a room with a circle, etc.) **Deprecated** Use the `$participants` array instead"
+                                        "description": "Source of the invite ID ('circles' to create a room with a circle, etc.) Deprecated: Use the `$participants` array instead"
                                     },
                                     "objectType": {
                                         "type": "string",

--- a/src/types/openapi/openapi-full.ts
+++ b/src/types/openapi/openapi-full.ts
@@ -6490,7 +6490,8 @@ export interface operations {
                      */
                     roomType: number;
                     /**
-                     * @description User, group, … ID to invite **Deprecated** Use the `$participants` array instead
+                     * @deprecated
+                     * @description User, group, … ID to invite Deprecated: Use the `$participants` array instead
                      * @default
                      */
                     invite?: string;
@@ -6500,7 +6501,8 @@ export interface operations {
                      */
                     roomName?: string;
                     /**
-                     * @description Source of the invite ID ('circles' to create a room with a circle, etc.) **Deprecated** Use the `$participants` array instead
+                     * @deprecated
+                     * @description Source of the invite ID ('circles' to create a room with a circle, etc.) Deprecated: Use the `$participants` array instead
                      * @default
                      */
                     source?: string;

--- a/src/types/openapi/openapi.ts
+++ b/src/types/openapi/openapi.ts
@@ -5974,7 +5974,8 @@ export interface operations {
                      */
                     roomType: number;
                     /**
-                     * @description User, group, … ID to invite **Deprecated** Use the `$participants` array instead
+                     * @deprecated
+                     * @description User, group, … ID to invite Deprecated: Use the `$participants` array instead
                      * @default
                      */
                     invite?: string;
@@ -5984,7 +5985,8 @@ export interface operations {
                      */
                     roomName?: string;
                     /**
-                     * @description Source of the invite ID ('circles' to create a room with a circle, etc.) **Deprecated** Use the `$participants` array instead
+                     * @deprecated
+                     * @description Source of the invite ID ('circles' to create a room with a circle, etc.) Deprecated: Use the `$participants` array instead
                      * @default
                      */
                     source?: string;


### PR DESCRIPTION
### ☑️ Resolves

![image](https://github.com/user-attachments/assets/e2f2079e-5576-40e4-9618-8de2d5c356e5)

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
