### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -307,12 +307,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "f5322bc3a4faaaa33a722cc22c8ee08f9da3e387"
+                "reference": "1abf593d27ecd373a9fcbbe87cfdd899ad3fee8b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/f5322bc3a4faaaa33a722cc22c8ee08f9da3e387",
-                "reference": "f5322bc3a4faaaa33a722cc22c8ee08f9da3e387",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/1abf593d27ecd373a9fcbbe87cfdd899ad3fee8b",
+                "reference": "1abf593d27ecd373a9fcbbe87cfdd899ad3fee8b",
                 "shasum": ""
             },
             "require": {
@@ -348,7 +348,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2025-02-28T00:44:44+00:00"
+            "time": "2025-03-08T00:36:29+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency