### PR TITLE
fix: expose 'createConversation' method

### DIFF
--- a/src/__mocks__/capabilities.ts
+++ b/src/__mocks__/capabilities.ts
@@ -91,6 +91,8 @@ export const mockedCapabilities: Capabilities = {
 			'conversation-creation-password',
 			'call-notification-state-api',
 			'schedule-meeting',
+			'edit-draft-poll',
+			'conversation-creation-all',
 			// Conditional features
 			'message-expiration',
 			'reactions',

--- a/src/components/ConversationSettings/ConversationAvatarEditor.vue
+++ b/src/components/ConversationSettings/ConversationAvatarEditor.vue
@@ -315,8 +315,7 @@ export default {
 			this.backgroundColor = ''
 		},
 
-		async savePictureAvatar() {
-			this.showCropper = false
+		async getPictureFormData() {
 			const canvasData = this.$refs.cropper.getCroppedCanvas()
 			const scaleFactor = canvasData.width > 512 ? 512 / canvasData.width : 1
 
@@ -328,10 +327,16 @@ export default {
 			})
 			const formData = new FormData()
 			formData.append('file', blob)
+			return formData
+		},
+
+		async savePictureAvatar() {
+			this.showCropper = false
+			const file = await this.getPictureFormData()
 
 			await this.$store.dispatch('setConversationAvatarAction', {
 				token: this.conversation.token,
-				file: formData,
+				file,
 			})
 		},
 

--- a/src/components/NewConversationDialog/NewConversationDialog.vue
+++ b/src/components/NewConversationDialog/NewConversationDialog.vue
@@ -303,8 +303,8 @@ export default {
 				}
 
 				const conversation = await this.$store.dispatch('createGroupConversation', {
-					conversationName: this.conversationName,
-					isPublic: this.isPublic,
+					roomName: this.conversationName,
+					roomType: this.isPublic ? CONVERSATION.TYPE.PUBLIC : CONVERSATION.TYPE.GROUP,
 					password: this.password,
 					description: this.newConversation.description,
 					listable: this.listable,

--- a/src/components/NewConversationDialog/NewConversationDialog.vue
+++ b/src/components/NewConversationDialog/NewConversationDialog.vue
@@ -125,7 +125,6 @@ import { useId } from '../../composables/useId.ts'
 import { useIsInCall } from '../../composables/useIsInCall.js'
 import { CONVERSATION } from '../../constants.ts'
 import { getTalkConfig } from '../../services/CapabilitiesManager.ts'
-import { addParticipant } from '../../services/participantsService.js'
 import { copyConversationLinkToClipboard } from '../../utils/handleUrl.ts'
 
 const NEW_CONVERSATION = {
@@ -291,38 +290,28 @@ export default {
 			this.page = 2
 
 			try {
-				this.newConversation.token = await this.$store.dispatch('createGroupConversation', {
+				const avatar = {}
+				if (this.isAvatarEdited) {
+					if (this.$refs.setupPage.$refs.conversationAvatar.emojiAvatar) {
+						avatar.emoji = this.$refs.setupPage.$refs.conversationAvatar.emojiAvatar
+						avatar.color = this.$refs.setupPage.$refs.conversationAvatar.backgroundColor
+							? this.$refs.setupPage.$refs.conversationAvatar.backgroundColor.slice(1)
+							: null
+					} else {
+						avatar.file = await this.$refs.setupPage.$refs.conversationAvatar.getPictureFormData()
+					}
+				}
+
+				const conversation = await this.$store.dispatch('createGroupConversation', {
 					conversationName: this.conversationName,
 					isPublic: this.isPublic,
 					password: this.password,
+					description: this.newConversation.description,
+					listable: this.listable,
+					participants: this.selectedParticipants,
+					avatar,
 				})
-
-				// Gather all secondary requests to run in parallel
-				const promises = []
-
-				if (this.isAvatarEdited) {
-					promises.push(this.$refs.setupPage.$refs.conversationAvatar.saveAvatar())
-				}
-
-				if (this.newConversation.description) {
-					promises.push(this.$store.dispatch('setConversationDescription', {
-						token: this.newConversation.token,
-						description: this.newConversation.description,
-					}))
-				}
-
-				if (this.listable !== CONVERSATION.LISTABLE.NONE) {
-					promises.push(this.$store.dispatch('setListable', {
-						token: this.newConversation.token,
-						listable: this.listable,
-					}))
-				}
-
-				for (const participant of this.selectedParticipants) {
-					promises.push(addParticipant(this.newConversation.token, participant.id, participant.source))
-				}
-
-				await Promise.all(promises)
+				this.newConversation.token = conversation.token
 			} catch (exception) {
 				console.error('Error creating new conversation: ', exception)
 				this.isLoading = false

--- a/src/services/conversationsService.ts
+++ b/src/services/conversationsService.ts
@@ -15,6 +15,7 @@ import type {
 	getNoteToSelfConversationResponse,
 	getListedConversationsParams,
 	getListedConversationsResponse,
+	createConversationParams,
 	createConversationResponse,
 	legacyCreateConversationParams,
 	deleteConversationResponse,
@@ -115,6 +116,14 @@ async function createLegacyConversation({ roomType, roomName, password, objectTy
 		invite,
 		source,
 	} as legacyCreateConversationParams)
+}
+
+/**
+ * Create a new conversation (with params available with 'conversation-creation-all' capability)
+ * @param params API params
+ */
+const createConversation = async function(params: createConversationParams): createConversationResponse {
+	return axios.post(generateOcsUrl('apps/spreed/api/v4/room'), params)
 }
 
 /**
@@ -340,6 +349,7 @@ export {
 	fetchNoteToSelfConversation,
 	searchListedConversations,
 	createLegacyConversation,
+	createConversation,
 	deleteConversation,
 	addToFavorites,
 	removeFromFavorites,

--- a/src/store/conversationsStore.js
+++ b/src/store/conversationsStore.js
@@ -32,6 +32,7 @@ import {
 	changeReadOnlyState,
 	changeListable,
 	createLegacyConversation,
+	createConversation,
 	addToFavorites,
 	removeFromFavorites,
 	archiveConversation,
@@ -68,6 +69,7 @@ import { convertToUnix } from '../utils/formattedTime.ts'
 
 const forcePasswordProtection = getTalkConfig('local', 'conversations', 'force-passwords')
 const supportConversationCreationPassword = hasTalkFeature('local', 'conversation-creation-password')
+const supportConversationCreationAll = hasTalkFeature('local', 'conversation-creation-all')
 
 const DUMMY_CONVERSATION = {
 	token: '',
@@ -974,10 +976,15 @@ const actions = {
 	 */
 	async createOneToOneConversation(context, actorId) {
 		try {
-			const response = await createLegacyConversation({
-				roomType: CONVERSATION.TYPE.ONE_TO_ONE,
-				invite: actorId,
-			})
+			const response = supportConversationCreationAll
+				? await createConversation({
+					roomType: CONVERSATION.TYPE.ONE_TO_ONE,
+					participants: { users: [actorId] },
+				})
+				: await createLegacyConversation({
+					roomType: CONVERSATION.TYPE.ONE_TO_ONE,
+					invite: actorId,
+				})
 			await context.dispatch('addConversation', response.data.ocs.data)
 			return response.data.ocs.data
 		} catch (error) {

--- a/src/store/conversationsStore.spec.js
+++ b/src/store/conversationsStore.spec.js
@@ -26,7 +26,7 @@ import {
 	changeLobbyState,
 	changeReadOnlyState,
 	changeListable,
-	createLegacyConversation,
+	createConversation,
 	setConversationName,
 	setConversationDescription,
 	setNotificationLevel,
@@ -50,6 +50,7 @@ jest.mock('../services/conversationsService', () => ({
 	changeReadOnlyState: jest.fn(),
 	changeListable: jest.fn(),
 	createLegacyConversation: jest.fn(),
+	createConversation: jest.fn(),
 	setConversationName: jest.fn(),
 	setConversationDescription: jest.fn(),
 	setNotificationLevel: jest.fn(),
@@ -1203,13 +1204,13 @@ describe('conversationsStore', () => {
 			}
 
 			const response = generateOCSResponse({ payload: newConversation })
-			createLegacyConversation.mockResolvedValueOnce(response)
+			createConversation.mockResolvedValueOnce(response)
 
 			await store.dispatch('createOneToOneConversation', 'target-actor-id')
 
-			expect(createLegacyConversation).toHaveBeenCalledWith({
+			expect(createConversation).toHaveBeenCalledWith({
 				roomType: CONVERSATION.TYPE.ONE_TO_ONE,
-				invite: 'target-actor-id',
+				participants: { users: ['target-actor-id'] },
 			})
 
 			const addedConversation = store.getters.conversation('new-token')


### PR DESCRIPTION
## ☑️ Resolves

* Follow up to #14579
* Prerequisite to #14399

Advanced creation reduces amount of server requests:
 - Before: `1..5` requests for setup + `N` for participants
 - After: `1` request only (+`1` if avatar is picture - not supported by API)

## 🖌️ UI Checklist

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [x] ⛑️ Tests are included or not possible