### PR TITLE
Release 20.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,46 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 20.1.5 – 2025-03-12
+### Changed
+- Update translations
+- Update dependencies
+
+### Fixed
+- fix(calls): Improve call related system messages in one-to-one conversations
+  [#14468](https://github.com/nextcloud/spreed/issues/14468)
+- fix(search): Include caption messages in search results
+  [#14552](https://github.com/nextcloud/spreed/issues/14552)
+- fix(conversation): Stay in chat when removing a group or team the moderator is a member of
+  [#14396](https://github.com/nextcloud/spreed/issues/14396)
+- fix(chat): Correctly start loading the chat when the lobby is removed
+  [#14518](https://github.com/nextcloud/spreed/issues/14518)
+- fix(dashboard): Hide lobbied conversations from the dashboard
+  [#14611](https://github.com/nextcloud/spreed/issues/14611)
+- fix(calls): Further improve false positives when showing the connection warning
+  [#14449](https://github.com/nextcloud/spreed/issues/14449)
+- fix(calls): Fix guest displayname when exporting call participants
+  [#14631](https://github.com/nextcloud/spreed/issues/14631)
+- fix(reminder): Log when generating a reminder failed
+  [#14617](https://github.com/nextcloud/spreed/issues/14617)
+
+## 19.0.14 – 2025-03-12
+### Changed
+- Update translations
+- Update dependencies
+
+### Fixed
+- fix(search): Include caption messages in search results
+  [#14551](https://github.com/nextcloud/spreed/issues/14551)
+- fix(conversation): Stay in chat when removing a group or team the moderator is a member of
+  [#14395](https://github.com/nextcloud/spreed/issues/14395)
+- fix(dashboard): Hide lobbied conversations from the dashboard
+  [#14610](https://github.com/nextcloud/spreed/issues/14610)
+- fix(calls): Further improve false positives when showing the connection warning
+  [#14448](https://github.com/nextcloud/spreed/issues/14448)
+- fix(reminder): Log when generating a reminder failed
+  [#14616](https://github.com/nextcloud/spreed/issues/14616)
+
 ## 20.1.4 – 2025-02-13
 ### Changed
 - Update translations

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -18,7 +18,7 @@
 * 🌉 **Sync with other chat solutions** With [Matterbridge](https://github.com/42wim/matterbridge/) being integrated in Talk, you can easily sync a lot of other chat solutions to Nextcloud Talk and vice-versa.
 ]]></description>
 
-	<version>20.1.4</version>
+	<version>20.1.5</version>
 	<licence>agpl</licence>
 
 	<author>Anna Larch</author>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "talk",
-  "version": "20.1.4",
+  "version": "20.1.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "talk",
-      "version": "20.1.4",
+      "version": "20.1.5",
       "license": "agpl",
       "dependencies": {
         "@linusborg/vue-simple-portal": "^0.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "talk",
-  "version": "20.1.4",
+  "version": "20.1.5",
   "private": true,
   "description": "",
   "author": "Joas Schilling <coding@schilljs.com>",


### PR DESCRIPTION
## Changed
- Update translations
- Update dependencies

## Fixed
- fix(calls): Improve call related system messages in one-to-one conversations [#14468](https://github.com/nextcloud/spreed/issues/14468)
- fix(search): Include caption messages in search results [#14552](https://github.com/nextcloud/spreed/issues/14552)
- fix(conversation): Stay in chat when removing a group or team the moderator is a member of [#14396](https://github.com/nextcloud/spreed/issues/14396)
- fix(chat): Correctly start loading the chat when the lobby is removed [#14518](https://github.com/nextcloud/spreed/issues/14518)
- fix(dashboard): Hide lobbied conversations from the dashboard [#14611](https://github.com/nextcloud/spreed/issues/14611)
- fix(calls): Further improve false positives when showing the connection warning [#14449](https://github.com/nextcloud/spreed/issues/14449)
- fix(calls): Fix guest displayname when exporting call participants [#14631](https://github.com/nextcloud/spreed/issues/14631)
- fix(reminder): Log when generating a reminder failed [#14617](https://github.com/nextcloud/spreed/issues/14617)