### PR TITLE
Release 21.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,71 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 21.0.1 – 2025-03-12
+### Changed
+- Update translations
+- Update dependencies
+
+### Fixed
+- fix(calls): Improve call related system messages in one-to-one conversations
+  [#14495](https://github.com/nextcloud/spreed/issues/14495)
+- fix(search): Include caption messages in search results
+  [#14553](https://github.com/nextcloud/spreed/issues/14553)
+- fix(chat): Show loading spinner when requesting AI chat summary
+  [#14625](https://github.com/nextcloud/spreed/issues/14625)
+- fix(chat): Correctly start loading the chat when the lobby is removed
+  [#14517](https://github.com/nextcloud/spreed/issues/14517)
+- fix(dashboard): Hide lobbied conversations from the dashboard
+  [#14612](https://github.com/nextcloud/spreed/issues/14612)
+- fix(federation): Fix broken participant avatar when federated instance is down
+  [#14573](https://github.com/nextcloud/spreed/issues/14573)
+- fix(conversation): Fix participant list change when the menu for a participant is open
+  [#14564](https://github.com/nextcloud/spreed/issues/14564)
+- fix(calls): Fix guest displayname when exporting call participants
+  [#14630](https://github.com/nextcloud/spreed/issues/14630)
+- fix(reminder): Log when generating a reminder failed
+  [#14618](https://github.com/nextcloud/spreed/issues/14618)
+
+## 20.1.5 – 2025-03-12
+### Changed
+- Update translations
+- Update dependencies
+
+### Fixed
+- fix(calls): Improve call related system messages in one-to-one conversations
+  [#14468](https://github.com/nextcloud/spreed/issues/14468)
+- fix(search): Include caption messages in search results
+  [#14552](https://github.com/nextcloud/spreed/issues/14552)
+- fix(conversation): Stay in chat when removing a group or team the moderator is a member of
+  [#14396](https://github.com/nextcloud/spreed/issues/14396)
+- fix(chat): Correctly start loading the chat when the lobby is removed
+  [#14518](https://github.com/nextcloud/spreed/issues/14518)
+- fix(dashboard): Hide lobbied conversations from the dashboard
+  [#14611](https://github.com/nextcloud/spreed/issues/14611)
+- fix(calls): Further improve false positives when showing the connection warning
+  [#14449](https://github.com/nextcloud/spreed/issues/14449)
+- fix(calls): Fix guest displayname when exporting call participants
+  [#14631](https://github.com/nextcloud/spreed/issues/14631)
+- fix(reminder): Log when generating a reminder failed
+  [#14617](https://github.com/nextcloud/spreed/issues/14617)
+
+## 19.0.14 – 2025-03-12
+### Changed
+- Update translations
+- Update dependencies
+
+### Fixed
+- fix(search): Include caption messages in search results
+  [#14551](https://github.com/nextcloud/spreed/issues/14551)
+- fix(conversation): Stay in chat when removing a group or team the moderator is a member of
+  [#14395](https://github.com/nextcloud/spreed/issues/14395)
+- fix(dashboard): Hide lobbied conversations from the dashboard
+  [#14610](https://github.com/nextcloud/spreed/issues/14610)
+- fix(calls): Further improve false positives when showing the connection warning
+  [#14448](https://github.com/nextcloud/spreed/issues/14448)
+- fix(reminder): Log when generating a reminder failed
+  [#14616](https://github.com/nextcloud/spreed/issues/14616)
+
 ## 21.0.0 – 2025-02-25
 ### Added
 - feat(meetings): Schedule a meeting directly from within the conversation

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -18,7 +18,7 @@
 * 🌉 **Sync with other chat solutions** With [Matterbridge](https://github.com/42wim/matterbridge/) being integrated in Talk, you can easily sync a lot of other chat solutions to Nextcloud Talk and vice-versa.
 ]]></description>
 
-	<version>21.0.0</version>
+	<version>21.0.1</version>
 	<licence>agpl</licence>
 
 	<author>Anna Larch</author>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "talk",
-  "version": "21.0.0",
+  "version": "21.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "talk",
-      "version": "21.0.0",
+      "version": "21.0.1",
       "license": "agpl",
       "dependencies": {
         "@linusborg/vue-simple-portal": "^0.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "talk",
-  "version": "21.0.0",
+  "version": "21.0.1",
   "private": true,
   "description": "",
   "author": "Joas Schilling <coding@schilljs.com>",


### PR DESCRIPTION
## Changed
- Update translations
- Update dependencies

## Fixed
- fix(calls): Improve call related system messages in one-to-one conversations [#14495](https://github.com/nextcloud/spreed/issues/14495)
- fix(search): Include caption messages in search results [#14553](https://github.com/nextcloud/spreed/issues/14553)
- fix(chat): Show loading spinner when requesting AI chat summary [#14625](https://github.com/nextcloud/spreed/issues/14625)
- fix(chat): Correctly start loading the chat when the lobby is removed [#14517](https://github.com/nextcloud/spreed/issues/14517)
- fix(dashboard): Hide lobbied conversations from the dashboard [#14612](https://github.com/nextcloud/spreed/issues/14612)
- fix(federation): Fix broken participant avatar when federated instance is down [#14573](https://github.com/nextcloud/spreed/issues/14573)
- fix(conversation): Fix participant list change when the menu for a participant is open [#14564](https://github.com/nextcloud/spreed/issues/14564)
- fix(calls): Fix guest displayname when exporting call participants [#14630](https://github.com/nextcloud/spreed/issues/14630)
- fix(reminder): Log when generating a reminder failed [#14618](https://github.com/nextcloud/spreed/issues/14618)