### PR TITLE
fix(Grid): fix cropped videos in the last row

### DIFF
--- a/src/components/CallView/Grid/Grid.vue
+++ b/src/components/CallView/Grid/Grid.vue
@@ -447,11 +447,6 @@ export default {
 			}
 		},
 
-		// TODO: rebuild the grid to have optimal for last page
-		// isLastPage() {
-		// return !this.hasNextPage
-		// },
-
 		// Computed css to reactively style the grid
 		gridStyle() {
 			let columns = this.columns
@@ -566,22 +561,7 @@ export default {
 		'videos.length'() {
 			this.makeGrid()
 		},
-		// TODO: rebuild the grid to have optimal for last page
-		// Exception for when navigating in and away from the last page of the
-		// grid
-		/**
-		isLastPage(newValue, oldValue) {
-			 if (this.hasPagination) {
-				 // If navigating into last page, make grid for last page
-				if (newValue && this.currentPage !== 0) {
-					this.makeGridForLastPage()
-				} else if (!newValue) {
-				// TODO: make a proper grid for when navigating away from last page
-					this.makeGrid()
-				}
-			 }
-		 },
-		 */
+
 		isStripe() {
 			this.rebuildGrid()
 
@@ -619,11 +599,10 @@ export default {
 		},
 	},
 
-	// bind event handlers to the `handleResize` method
 	mounted() {
 		this.debounceMakeGrid = debounce(this.makeGrid, 200)
 		this.debounceHandleWheelEvent = debounce(this.handleWheelEvent, 50)
-		this.resizeObserver = new ResizeObserver(this.handleResize)
+		this.resizeObserver = new ResizeObserver(this.debounceMakeGrid)
 		this.resizeObserver.observe(this.$refs.gridWrapper)
 		this.makeGrid()
 
@@ -688,18 +667,17 @@ export default {
 			this.screenshotMode = false
 			this.devMode = false
 		},
-		// whenever the document is resized, re-set the 'clientWidth' variable
-		handleResize(event) {
+
+		// Find the right size if the grid in rows and columns (we already know the size in px).
+		makeGrid() {
 			// TODO: properly handle resizes when not on first page:
 			// currently if the user is not on the 'first page', upon resize the
 			// current position in the videos array is lost (first element
 			// in the grid goes back to be first video)
-			this.debounceMakeGrid()
-		},
-
-		// Find the right size if the grid in rows and columns (we already know
-		// the size in px).
-		makeGrid() {
+			// TODO: rebuild the grid to have optimal for last page:
+			// Exception for when navigating in and away from the last page of the grid
+			// The last grid page is very likely not to have the same number of elements
+			// as the previous pages so the grid needs to be tweaked accordingly
 			if (!this.$refs.grid) {
 				return
 			}
@@ -814,17 +792,6 @@ export default {
 			this.columns = currentColumns
 			this.rows = currentRows
 		},
-
-		// The last grid page is very likely not to have the same number of
-		// elements as the previous pages so the grid needs to be tweaked
-		// accordingly
-		// makeGridForLastPage() {
-		// this.columns = this.columnsMax
-		// this.rows = this.rowsMax
-		// // The displayed videos for the last page have already been set
-		// // in `handleClickNext`
-		// this.shrinkGrid(this.displayedVideos.length)
-		// },
 
 		handleWheelEvent(event) {
 			if (this.gridWidth <= 0) {

--- a/src/components/CallView/Grid/Grid.vue
+++ b/src/components/CallView/Grid/Grid.vue
@@ -172,6 +172,9 @@ import { useCallViewStore } from '../../../stores/callView.ts'
 const videosCap = parseInt(loadState('spreed', 'grid_videos_limit'), 10) || 0
 const videosCapEnforced = loadState('spreed', 'grid_videos_limit_enforced') || false
 
+// Align with var(--grid-gap) in CallView
+const GRID_GAP = 8
+
 export default {
 	name: 'Grid',
 
@@ -313,10 +316,10 @@ export default {
 			return this.videos.length
 		},
 		videoWidth() {
-			return this.gridWidth / this.columns
+			return (this.gridWidth - GRID_GAP * (this.columns - 1)) / this.columns
 		},
 		videoHeight() {
-			return this.gridHeight / this.rows
+			return (this.gridHeight - GRID_GAP * (this.rows - 1)) / this.rows
 		},
 
 		// Array of videos that are being displayed in the grid at any given
@@ -396,10 +399,10 @@ export default {
 
 		// Max number of columns possible
 		columnsMax() {
-			// Max amount of columns that fits on screen, including gaps and paddings (8px)
-			const calculatedApproxColumnsMax = Math.floor((this.gridWidth - 8 * this.columns) / this.dpiAwareMinWidth)
+			// Max amount of columns that fits on screen, including gaps (--grid-gap, 8px)
+			const calculatedApproxColumnsMax = Math.floor((this.gridWidth - GRID_GAP * (this.columns - 1)) / this.dpiAwareMinWidth)
 			// Max amount of columns that fits on screen (with one more gap, as if we try to fit one more column)
-			const calculatedHypotheticalColumnsMax = Math.floor((this.gridWidth - 8 * (this.columns + 1)) / this.dpiAwareMinWidth)
+			const calculatedHypotheticalColumnsMax = Math.floor((this.gridWidth - GRID_GAP * this.columns) / this.dpiAwareMinWidth)
 			// If we about to change current columns amount, check if one more column could fit the screen
 			// This helps to avoid flickering, when resize within 8px from minimal gridWidth for current amount of columns
 			const calculatedColumnsMax = calculatedApproxColumnsMax === this.columns ? calculatedApproxColumnsMax : calculatedHypotheticalColumnsMax
@@ -409,11 +412,11 @@ export default {
 
 		// Max number of rows possible
 		rowsMax() {
-			if (Math.floor(this.gridHeight / this.dpiAwareMinHeight) < 1) {
+			if (Math.floor((this.gridHeight - GRID_GAP * (this.rows - 1)) / this.dpiAwareMinHeight) < 1) {
 				// Return at least 1 row
 				return 1
 			} else {
-				return Math.floor(this.gridHeight / this.dpiAwareMinHeight)
+				return Math.floor((this.gridHeight - GRID_GAP * (this.rows - 1)) / this.dpiAwareMinHeight)
 			}
 		},
 
@@ -737,12 +740,12 @@ export default {
 				const previousRows = currentRows
 
 				// Current video dimensions
-				const videoWidth = this.gridWidth / currentColumns
-				const videoHeight = this.gridHeight / currentRows
+				const videoWidth = (this.gridWidth - GRID_GAP * (currentColumns - 1)) / currentColumns
+				const videoHeight = (this.gridHeight - GRID_GAP * (currentRows - 1)) / currentRows
 
 				// Hypothetical width/height with one column/row less than current
-				const videoWidthWithOneColumnLess = this.gridWidth / (currentColumns - 1)
-				const videoHeightWithOneRowLess = this.gridHeight / (currentRows - 1)
+				const videoWidthWithOneColumnLess = (this.gridWidth - GRID_GAP * (currentColumns - 2)) / (currentColumns - 1)
+				const videoHeightWithOneRowLess = (this.gridHeight - GRID_GAP * (currentRows - 2)) / (currentRows - 1)
 
 				// Hypothetical aspect ratio with one column/row less than current
 				const aspectRatioWithOneColumnLess = videoWidthWithOneColumnLess / videoHeight

--- a/src/components/CallView/Grid/gridPlaceholders.ts
+++ b/src/components/CallView/Grid/gridPlaceholders.ts
@@ -16,28 +16,29 @@ export function placeholderImage(i: number) {
 /**
  * Mock participant name for placeholders
  * @param i index
+ * @param showKey show key next to the name
  */
-export function placeholderName(i: number): string {
+export function placeholderName(i: number, showKey: boolean = false): string {
 	switch (i % 9) {
 	case 0:
-		return 'Sandra McKinney'
+		return 'Sandra McKinney' + (showKey ? ` | ${i}` : '')
 	case 1:
-		return 'Chris Wurst'
+		return 'Chris Wurst' + (showKey ? ` | ${i}` : '')
 	case 2:
-		return 'Edeltraut Bobb'
+		return 'Edeltraut Bobb' + (showKey ? ` | ${i}` : '')
 	case 3:
-		return 'Arthur Blitz'
+		return 'Arthur Blitz' + (showKey ? ` | ${i}` : '')
 	case 4:
-		return 'Roeland Douma'
+		return 'Roeland Douma' + (showKey ? ` | ${i}` : '')
 	case 5:
-		return 'Vanessa Steg'
+		return 'Vanessa Steg' + (showKey ? ` | ${i}` : '')
 	case 6:
-		return 'Emily Grant'
+		return 'Emily Grant' + (showKey ? ` | ${i}` : '')
 	case 7:
-		return 'Tobias Kaminsky'
+		return 'Tobias Kaminsky' + (showKey ? ` | ${i}` : '')
 	case 8:
 	default:
-		return 'Adrian Ada'
+		return 'Adrian Ada' + (showKey ? ` | ${i}` : '')
 	}
 }
 


### PR DESCRIPTION
### ☑️ Resolves

* replace `window.addEventListener('resize')` with `ResizeObserver`
  * `$refs.grid` is rendered conditionally, so we might lose a reference to it once mounted
  * 1 listener instead of 2, looks only for exact DOM element
* fix video cropping at the last row
* drop redundant method and store getter
* cleanup comments
* improve DX by exposing (in debug mode only):
  * `OCA.Talk.gridDebugInformation`
  * `OCA.Talk.gridDevModeEnable`

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="466" alt="image" src="https://github.com/user-attachments/assets/0fd54a11-749b-4b95-b424-540030bb4782" /> | <img width="466" alt="image" src="https://github.com/user-attachments/assets/8d4c0265-9f1e-4b96-82ef-917bae94b052" />

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Not risky to browser differences / client