### PR TITLE
fix(call): do not show warning for the same conversation

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -361,7 +361,13 @@ export default {
 		 * Global before guard, this is called whenever a navigation is triggered.
 		 */
 		Router.beforeEach((to, from, next) => {
-			if (this.warnLeaving && !to.params?.skipLeaveWarning) {
+			if (from.name === 'conversation' && to.name === 'conversation' && from.params.token === to.params.token) {
+				// Navigating within the same conversation
+				beforeRouteChangeListener(to, from, next)
+			} else if (!this.warnLeaving || to.params?.skipLeaveWarning) {
+				// Safe to navigate
+				beforeRouteChangeListener(to, from, next)
+			} else {
 				OC.dialogs.confirmDestructive(
 					t('spreed', 'Navigating away from the page will leave the call in {conversation}', {
 						conversation: this.currentConversation?.displayName ?? '',
@@ -381,8 +387,6 @@ export default {
 						beforeRouteChangeListener(to, from, next)
 					}
 				)
-			} else {
-				beforeRouteChangeListener(to, from, next)
 			}
 		})
 

--- a/src/components/Quote.vue
+++ b/src/components/Quote.vue
@@ -135,7 +135,7 @@ export default {
 		component() {
 			return this.canCancel
 				? { tag: 'div', link: undefined }
-				: { tag: 'router-link', link: { hash: this.hash, params: { skipLeaveWarning: true } } }
+				: { tag: 'router-link', link: { hash: this.hash } }
 		},
 
 		isOwnMessageQuoted() {


### PR DESCRIPTION
### ☑️ Resolves

* Fix scrolling to another message in call, when navigating via quote or link
  * Quote was hard-fixed, reverted now


## 🖌️ UI Checklist

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
