### PR TITLE
fix: migrate from deprecated OC.dialogs.confirmDestructive

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -31,6 +31,7 @@ import NcAppContent from '@nextcloud/vue/components/NcAppContent'
 import NcContent from '@nextcloud/vue/components/NcContent'
 import { useHotKey } from '@nextcloud/vue/composables/useHotKey'
 import { useIsMobile } from '@nextcloud/vue/composables/useIsMobile'
+import { spawnDialog } from '@nextcloud/vue/functions/dialog'
 
 import ConversationSettingsDialog from './components/ConversationSettings/ConversationSettingsDialog.vue'
 import LeftSidebar from './components/LeftSidebar/LeftSidebar.vue'
@@ -38,6 +39,7 @@ import MediaSettings from './components/MediaSettings/MediaSettings.vue'
 import PollManager from './components/PollViewer/PollManager.vue'
 import RightSidebar from './components/RightSidebar/RightSidebar.vue'
 import SettingsDialog from './components/SettingsDialog/SettingsDialog.vue'
+import ConfirmDialog from './components/UIShared/ConfirmDialog.vue'
 
 import { useActiveSession } from './composables/useActiveSession.js'
 import { useDocumentTitle } from './composables/useDocumentTitle.ts'
@@ -368,25 +370,24 @@ export default {
 				// Safe to navigate
 				beforeRouteChangeListener(to, from, next)
 			} else {
-				OC.dialogs.confirmDestructive(
-					t('spreed', 'Navigating away from the page will leave the call in {conversation}', {
+				spawnDialog(ConfirmDialog, {
+					name: t('spreed', 'Leave call'),
+					message: t('spreed', 'Navigating away from the page will leave the call in {conversation}', {
 						conversation: this.currentConversation?.displayName ?? '',
 					}),
-					t('spreed', 'Leave call'),
-					{
-						type: OC.dialogs.YES_NO_BUTTONS,
-						confirm: t('spreed', 'Leave call'),
-						confirmClasses: 'error',
-						cancel: t('spreed', 'Stay in call'),
-					},
-					(decision) => {
-						if (!decision) {
-							return
+					buttons: [
+						{
+							label: t('spreed', 'Stay in call'),
+						},
+						{
+							label: t('spreed', 'Leave call'),
+							type: 'primary',
+							callback: () => {
+								beforeRouteChangeListener(to, from, next)
+							},
 						}
-
-						beforeRouteChangeListener(to, from, next)
-					}
-				)
+					],
+				})
 			}
 		})
 

--- a/src/components/UIShared/ConfirmDialog.vue
+++ b/src/components/UIShared/ConfirmDialog.vue
@@ -1,0 +1,50 @@
+<!--
+  - SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<script setup lang="ts">
+import NcDialog from '@nextcloud/vue/components/NcDialog'
+
+type NcDialogButtonProps = {
+	label: string,
+	callback?: () => unknown | false | Promise<unknown | false>,
+	disabled?: boolean,
+	icon?: string,
+	// FIXME deprecated, use type since 8.24.0
+	nativeType?: string,
+	// FIXME deprecated, use variant since 8.24.0
+	type?: string,
+	variant?: string,
+}
+type NcDialogProps = {
+	name: string,
+	buttons: NcDialogButtonProps[],
+	container?: string,
+	message?: string,
+	size?: string,
+}
+
+const props = defineProps<NcDialogProps>()
+
+const emit = defineEmits<{
+	(event: 'close', value?: unknown): void,
+}>()
+
+/**
+ * Emit result, if any (for spawnDialog callback)
+ * @param result callback result
+ */
+function onClosing(result: unknown) {
+	emit('close', result)
+}
+</script>
+
+<template>
+	<NcDialog :name="name"
+		:message="message"
+		:container="container"
+		:size="size"
+		:buttons="buttons"
+		@closing="onClosing" />
+</template>


### PR DESCRIPTION
### ☑️ Resolves

* Fix deprecated syntax, replacing with custom component
  * since Nc 30 `OC.dialogs.confirmDestructive` uses the same Dialog constructor

To test: modify store action with following:
```js
	async joinConversation(context, { token }) {
		const forceJoin = SessionStorage.getItem('joined_conversation') === token

		if (!forceJoin) {
			await context.dispatch('confirmForceJoinConversation', { token })
			return
		}

		try {		
			...
```

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
oc-dialog-dim is deprecated, reloads after 3 seconds | works as expected
![image](https://github.com/user-attachments/assets/06d3342e-127f-4109-89b9-9818dfb273f0) | ![image](https://github.com/user-attachments/assets/557a2d54-5287-4a93-b568-02c3247f6146)
![image](https://github.com/user-attachments/assets/78d82238-38d3-47ca-917e-370604d9b9ff) | ![image](https://github.com/user-attachments/assets/d66a2421-15fa-46a6-aa92-63a5afb7bb9b)

### 🚧 Tasks

- [ ] Follow-up: migrate another confirmation dialogs to `spawnDialog()`

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required