### PR TITLE
fix: do not add organizer as attendee and set status

### DIFF
--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -76,6 +76,7 @@ use OCP\AppFramework\Http\Attribute\PublicPage;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Services\IAppConfig;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Calendar\CalendarEventStatus;
 use OCP\Calendar\Exceptions\CalendarException;
 use OCP\Calendar\ICreateFromString;
 use OCP\Calendar\IManager as ICalendarManager;
@@ -2650,6 +2651,7 @@ class RoomController extends AEnvironmentAwareOCSController {
 		$eventBuilder->setOrganizer($user->getEMailAddress(), $user->getDisplayName() ?: $this->userId);
 		$eventBuilder->setStartDate($startDate);
 		$eventBuilder->setEndDate($endDate);
+		$eventBuilder->setStatus(CalendarEventStatus::CONFIRMED);
 
 		$userAttendees = $this->participantService->getParticipantsByActorType($this->room, Attendee::ACTOR_USERS);
 		foreach ($userAttendees as $userAttendee) {
@@ -2662,6 +2664,10 @@ class RoomController extends AEnvironmentAwareOCSController {
 				continue;
 			}
 			if ($targetUser->getEMailAddress() === null) {
+				continue;
+			}
+			// Do not add the organizer as an attendee
+			if ($targetUser->getEMailAddress() === $user->getEMailAddress()) {
 				continue;
 			}
 


### PR DESCRIPTION
### ☑️ Resolves

- Requires: https://github.com/nextcloud/server/pull/51501
- Resolves: https://github.com/nextcloud/calendar/issues/6819

Event status should be set on new events, the organizer should also not be added as a participant.

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not possible
- [ ] 📘 API documentation in `docs/` has been updated or is not required
- [ ] 🔖 Capability is added or not needed 
