### PR TITLE
Introduce unreadCount store

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -95,6 +95,33 @@ export default {
 	},
 
 	computed: {
+		unreadCountsMap() {
+			return this.$store.getters.conversationsList.reduce((acc, conversation) => {
+				if (conversation.isArchived) {
+					// Do not consider archived conversations in counting
+					return acc
+				}
+
+				if (conversation.unreadMessages > 0) {
+					acc.conversations++
+					acc.messages += conversation.unreadMessages
+				}
+
+				if (conversation.unreadMention) {
+					acc.mentions++
+				}
+
+				if (conversation.unreadMentionDirect) {
+					acc.mentionsDirect++
+				}
+				return acc
+			}, {
+				conversations: 0,
+				messages: 0,
+				mentions: 0,
+				mentionsDirect: 0,
+			})
+		},
 		getUserId() {
 			return this.$store.getters.getUserId()
 		},
@@ -163,6 +190,14 @@ export default {
 				}
 			}
 		},
+
+		unreadCountsMap: {
+			deep: true,
+			immediate: true,
+			handler(value) {
+				emit('talk:unread:updated', value)
+			},
+		}
 	},
 
 	beforeCreate() {


### PR DESCRIPTION
### ☑️ Implements issue https://github.com/nextcloud/spreed/issues/14667

* talk-desktop ref: https://github.com/nextcloud/talk-desktop/pull/1174

I had to introduce some changes to spreed that are described below to create a central unreadCountStore to have an even hook in talk-desktop to get updates of these unreadCounts and enable talk-desktop to set the correct badge count on the app icon.

### 1. New unreadCountStore
A new Vuex store module that serves as the single source of truth for all unread counters:

```javascript
state: {
    // Total counters
    totalUnreadMessages: 0,
    totalUnreadMentions: 0,
    totalUnreadMentionDirect: 0,

    // Per-conversation tracking
    unreadMessagesMap: {},
    unreadMentionsMap: {},
    unreadMentionDirectMap: {},
}
```

### 2. Integration Points

#### Conversations Store
- Enhanced `addConversation` mutation:
  - Automatically updates unread counters when adding new conversations
  - Handles initial state synchronization

- Improved `updateConversation` mutation:
  - Detects changes in unread counts
  - Dispatches updates to unreadCountStore
  - Maintains consistency across state changes

- Updated `deleteConversation` mutation:
  - Properly removes conversation counts from tracking
  - Updates total counters accordingly

#### Messages Store
- Enhanced `updateLastReadMessage` action:
  - Improved handling of "all messages read" scenarios
  - Proper counter reset when reaching conversation end
  - Better integration with chat-read-last feature

### 3. Event System
New event for badge updates:
```javascript
EVENTS.UNREAD_COUNT_UPDATED: 'talk:unread:updated'
```


### 🏁 Checklist

This issue is not browser depending.
But I added a matching change in talk-desktop and have a working application icon badge implementation.
This is already tested in Windows and MacOs builds of talk-desktop.

Pull request for talk-desktop is about to follow

## 🛠️ API Checklist

### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
