### PR TITLE
fix(messages): fix missing instant reactions for own message

### DIFF
--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -1281,7 +1281,10 @@ const actions = {
 				})
 			}
 
-			context.dispatch('processMessage', { token, message: response.data.ocs.data })
+			// Own message might have been added already by polling, which is more up-to-date (e.g. reactions)
+			if (!context.state.messages[token]?.[response.data.ocs.data.id]) {
+				context.dispatch('processMessage', { token, message: response.data.ocs.data })
+			}
 
 			return response
 		} catch (error) {


### PR DESCRIPTION
### ☑️ Resolves

* Fix #14670

**Explanation:**
Own message can be added to polling response (1) before receiving the message creation response (2), the bot will thus react before (2) and another polling response will be received containing the bot reaction system message (3). 
The final order is: (1) -> (3) -> (2) 

We always update by the recent response, which is (2) in this case and it's outdated. 

**Workaround:**
As own message in polling is always up to date (e.g. contains reactions), we skip the update with (2) when (1) is already received.


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before 

https://github.com/user-attachments/assets/6ba4ac9e-eb16-41d6-b37c-a94d3d1ae302 

🏡 After

https://github.com/user-attachments/assets/a287769d-f81f-4210-bf4b-f4d8898348a9


<!-- ☀️ Light theme | 🌑 Dark Theme -->



### 🚧 Tasks

- [x] Test with bots

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
