### PR TITLE
fix(AdminSettings): respect initial state of E2EE setting

### DIFF
--- a/src/components/AdminSettings/GeneralSettings.vue
+++ b/src/components/AdminSettings/GeneralSettings.vue
@@ -70,6 +70,7 @@ import NcCheckboxRadioSwitch from '@nextcloud/vue/components/NcCheckboxRadioSwit
 import NcNoteCard from '@nextcloud/vue/components/NcNoteCard'
 import NcSelect from '@nextcloud/vue/components/NcSelect'
 
+import { getTalkConfig } from '../../services/CapabilitiesManager.ts'
 import { EventBus } from '../../services/EventBus.ts'
 
 const defaultGroupNotificationOptions = [
@@ -106,7 +107,7 @@ export default {
 			conversationsFilesPublicShares: parseInt(loadState('spreed', 'conversations_files_public_shares')) === 1,
 
 			hasFeatureJoinFeatures: false,
-			isE2EECallsEnabled: false,
+			isE2EECallsEnabled: getTalkConfig('local', 'call', 'end-to-end-encryption'),
 			hasSIPBridge: !!loadState('spreed', 'sip_bridge_shared_secret'),
 		}
 	},


### PR DESCRIPTION
### ☑️ Resolves

* Fix #14672 
* Same check as used in encryption module:

https://github.com/nextcloud/spreed/blob/938cc9854f8127386b088c1a727c02551d194fce/src/utils/e2ee/encryption.js#L66

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

<img width="586" alt="image" src="https://github.com/user-attachments/assets/263de270-8aaf-439c-bed4-52c69eb64254" />


### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required