### PR TITLE
[stable29] fix: show tooltips in sidebar (from Vue directive)

### DIFF
--- a/src/components/AdminSettings/TurnServer.vue
+++ b/src/components/AdminSettings/TurnServer.vue
@@ -106,16 +106,11 @@ import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import NcPasswordField from '@nextcloud/vue/dist/Components/NcPasswordField.js'
 import NcSelect from '@nextcloud/vue/dist/Components/NcSelect.js'
 import NcTextField from '@nextcloud/vue/dist/Components/NcTextField.js'
-import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip.js'
 
 import { isCertificateValid } from '../../services/certificateService.js'
 
 export default {
 	name: 'TurnServer',
-
-	directives: {
-		tooltip: Tooltip,
-	},
 
 	components: {
 		AlertCircle,

--- a/src/components/AdminSettings/WebServerSetupChecks.vue
+++ b/src/components/AdminSettings/WebServerSetupChecks.vue
@@ -58,7 +58,6 @@ import { generateFilePath } from '@nextcloud/router'
 
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import NcNoteCard from '@nextcloud/vue/dist/Components/NcNoteCard.js'
-import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip.js'
 
 import { VIRTUAL_BACKGROUND } from '../../constants.js'
 import JitsiStreamBackgroundEffect from '../../utils/media/effects/virtual-background/JitsiStreamBackgroundEffect.js'
@@ -66,10 +65,6 @@ import VirtualBackground from '../../utils/media/pipeline/VirtualBackground.js'
 
 export default {
 	name: 'WebServerSetupChecks',
-
-	directives: {
-		tooltip: Tooltip,
-	},
 
 	components: {
 		AlertCircle,

--- a/src/components/CallView/Grid/Grid.vue
+++ b/src/components/CallView/Grid/Grid.vue
@@ -160,7 +160,6 @@ import { loadState } from '@nextcloud/initial-state'
 import { generateFilePath } from '@nextcloud/router'
 
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
-import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip.js'
 
 import TransitionWrapper from '../../UIShared/TransitionWrapper.vue'
 import EmptyCallView from '../shared/EmptyCallView.vue'
@@ -186,10 +185,6 @@ export default {
 		ChevronLeft,
 		ChevronUp,
 		ChevronDown,
-	},
-
-	directives: {
-		Tooltip,
 	},
 
 	props: {

--- a/src/components/CallView/shared/VideoBottomBar.vue
+++ b/src/components/CallView/shared/VideoBottomBar.vue
@@ -114,7 +114,6 @@ import VideoOff from 'vue-material-design-icons/VideoOff.vue'
 import { emit } from '@nextcloud/event-bus'
 
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
-import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip.js'
 
 import TransitionWrapper from '../../UIShared/TransitionWrapper.vue'
 
@@ -134,10 +133,6 @@ export default {
 		TransitionWrapper,
 		VideoIcon,
 		VideoOff,
-	},
-
-	directives: {
-		tooltip: Tooltip,
 	},
 
 	inheritAttrs: false,

--- a/src/components/CallView/shared/ViewerOverlayCallView.vue
+++ b/src/components/CallView/shared/ViewerOverlayCallView.vue
@@ -129,7 +129,7 @@ import ArrowExpand from 'vue-material-design-icons/ArrowExpand.vue'
 import ChevronDown from 'vue-material-design-icons/ChevronDown.vue'
 import ChevronUp from 'vue-material-design-icons/ChevronUp.vue'
 
-import { NcButton, Tooltip } from '@nextcloud/vue'
+import { NcButton } from '@nextcloud/vue'
 
 import EmptyCallView from './EmptyCallView.vue'
 import LocalAudioControlButton from './LocalAudioControlButton.vue'
@@ -157,10 +157,6 @@ export default {
 		TransitionWrapper,
 		VideoVue,
 		ArrowExpand,
-	},
-
-	directives: {
-		tooltip: Tooltip,
 	},
 
 	props: {

--- a/src/components/ConversationSettings/Matterbridge/MatterbridgeSettings.vue
+++ b/src/components/ConversationSettings/Matterbridge/MatterbridgeSettings.vue
@@ -111,7 +111,6 @@ import NcCheckboxRadioSwitch from '@nextcloud/vue/dist/Components/NcCheckboxRadi
 import NcModal from '@nextcloud/vue/dist/Components/NcModal.js'
 import NcSelect from '@nextcloud/vue/dist/Components/NcSelect.js'
 import NcTextArea from '@nextcloud/vue/dist/Components/NcTextArea.js'
-import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip.js'
 
 import BridgePart from './BridgePart.vue'
 
@@ -120,8 +119,6 @@ import {
 	getBridge,
 	getBridgeProcessState,
 } from '../../../services/matterbridgeService.js'
-
-Vue.directive('tooltip', Tooltip)
 
 export default {
 	name: 'MatterbridgeSettings',
@@ -134,12 +131,6 @@ export default {
 		NcModal,
 		NcTextArea,
 		Plus,
-	},
-
-	mixins: [
-	],
-
-	props: {
 	},
 
 	data() {

--- a/src/components/MediaSettings/MediaSettings.vue
+++ b/src/components/MediaSettings/MediaSettings.vue
@@ -227,7 +227,6 @@ import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import NcCheckboxRadioSwitch from '@nextcloud/vue/dist/Components/NcCheckboxRadioSwitch.js'
 import NcModal from '@nextcloud/vue/dist/Components/NcModal.js'
 import NcNoteCard from '@nextcloud/vue/dist/Components/NcNoteCard.js'
-import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip.js'
 
 import MediaDevicesSelector from './MediaDevicesSelector.vue'
 import MediaDevicesSpeakerTest from './MediaDevicesSpeakerTest.vue'
@@ -250,10 +249,6 @@ const recordingConsent = getCapabilities()?.spreed?.config?.call?.['recording-co
 
 export default {
 	name: 'MediaSettings',
-
-	directives: {
-		Tooltip,
-	},
 
 	components: {
 		AvatarWrapper,

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/Contact.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/Contact.vue
@@ -40,14 +40,8 @@
 </template>
 
 <script>
-import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip.js'
-
 export default {
 	name: 'Contact',
-
-	directives: {
-		tooltip: Tooltip,
-	},
 
 	props: {
 		name: {

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/DeckCard.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/DeckCard.vue
@@ -40,14 +40,8 @@
 </template>
 
 <script>
-import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip.js'
-
 export default {
 	name: 'DeckCard',
-
-	directives: {
-		tooltip: Tooltip,
-	},
 
 	props: {
 		type: {

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
@@ -86,7 +86,6 @@ import { getUploader } from '@nextcloud/upload'
 
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import NcProgressBar from '@nextcloud/vue/dist/Components/NcProgressBar.js'
-import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip.js'
 
 import AudioPlayer from './AudioPlayer.vue'
 
@@ -109,10 +108,6 @@ export default {
 		Close,
 		PlayCircleOutline,
 		NcButton,
-	},
-
-	directives: {
-		tooltip: Tooltip,
 	},
 
 	props: {

--- a/src/components/NewMessage/NewMessageAudioRecorder.vue
+++ b/src/components/NewMessage/NewMessageAudioRecorder.vue
@@ -77,7 +77,6 @@ import Microphone from 'vue-material-design-icons/Microphone.vue'
 import { showError } from '@nextcloud/dialogs'
 
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
-import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip.js'
 
 import { mediaDevicesManager } from '../../utils/webrtc/index.js'
 
@@ -89,10 +88,6 @@ export default {
 		Close,
 		Check,
 		NcButton,
-	},
-
-	directives: {
-		tooltip: Tooltip,
 	},
 
 	props: {

--- a/src/components/RightSidebar/Participants/Participant.vue
+++ b/src/components/RightSidebar/Participants/Participant.vue
@@ -362,7 +362,6 @@ import NcActions from '@nextcloud/vue/dist/Components/NcActions.js'
 import NcActionSeparator from '@nextcloud/vue/dist/Components/NcActionSeparator.js'
 import NcActionText from '@nextcloud/vue/dist/Components/NcActionText.js'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
-import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip.js'
 
 import ParticipantPermissionsEditor from './ParticipantPermissionsEditor.vue'
 import AvatarWrapper from '../../AvatarWrapper/AvatarWrapper.vue'
@@ -419,10 +418,6 @@ export default {
 		PhonePaused,
 		Tune,
 		VideoIcon,
-	},
-
-	directives: {
-		tooltip: Tooltip,
 	},
 
 	props: {

--- a/src/components/TopBar/CallButton.vue
+++ b/src/components/TopBar/CallButton.vue
@@ -121,7 +121,6 @@ import NcActionButton from '@nextcloud/vue/dist/Components/NcActionButton.js'
 import NcActions from '@nextcloud/vue/dist/Components/NcActions.js'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import { useIsMobile } from '@nextcloud/vue/dist/Composables/useIsMobile.js'
-import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip.js'
 
 import { useIsInCall } from '../../composables/useIsInCall.js'
 import { ATTENDEE, CALL, CONVERSATION, PARTICIPANT } from '../../constants.js'
@@ -136,10 +135,6 @@ const supportFederationV1 = getCapabilities()?.spreed?.features?.includes('feder
 
 export default {
 	name: 'CallButton',
-
-	directives: {
-		Tooltip,
-	},
 
 	components: {
 		NcActions,

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -113,7 +113,6 @@ import { getCapabilities } from '@nextcloud/capabilities'
 import { emit } from '@nextcloud/event-bus'
 
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
-import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip.js'
 import richEditor from '@nextcloud/vue/dist/Mixins/richEditor.js'
 
 import CallButton from './CallButton.vue'
@@ -132,10 +131,6 @@ import { localCallParticipantModel, localMediaModel } from '../../utils/webrtc/i
 
 export default {
 	name: 'TopBar',
-
-	directives: {
-		Tooltip,
-	},
 
 	components: {
 		// Components

--- a/src/components/TopBar/TopBarMediaControls.vue
+++ b/src/components/TopBar/TopBarMediaControls.vue
@@ -138,7 +138,6 @@ import NcActionButton from '@nextcloud/vue/dist/Components/NcActionButton.js'
 import NcActions from '@nextcloud/vue/dist/Components/NcActions.js'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import NcPopover from '@nextcloud/vue/dist/Components/NcPopover.js'
-import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip.js'
 
 import LocalAudioControlButton from '../CallView/shared/LocalAudioControlButton.vue'
 import LocalVideoControlButton from '../CallView/shared/LocalVideoControlButton.vue'
@@ -153,9 +152,6 @@ export default {
 
 	name: 'TopBarMediaControls',
 
-	directives: {
-		tooltip: Tooltip,
-	},
 	components: {
 		LocalAudioControlButton,
 		LocalVideoControlButton,

--- a/src/components/UIShared/EditableTextField.vue
+++ b/src/components/UIShared/EditableTextField.vue
@@ -85,7 +85,6 @@ import Pencil from 'vue-material-design-icons/Pencil.vue'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import NcRichContenteditable from '@nextcloud/vue/dist/Components/NcRichContenteditable.js'
 import NcRichText from '@nextcloud/vue/dist/Components/NcRichText.js'
-import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip.js'
 
 import { parseSpecialSymbols } from '../../utils/textParse.ts'
 
@@ -98,10 +97,6 @@ export default {
 		NcRichContenteditable,
 		NcRichText,
 		Pencil,
-	},
-
-	directives: {
-		Tooltip,
 	},
 
 	props: {

--- a/src/main.js
+++ b/src/main.js
@@ -37,7 +37,7 @@ import { emit } from '@nextcloud/event-bus'
 import { translate, translatePlural } from '@nextcloud/l10n'
 import { generateFilePath } from '@nextcloud/router'
 
-import { options as TooltipOptions } from '@nextcloud/vue/dist/Directives/Tooltip.js'
+import Tooltip, { options as TooltipOptions } from '@nextcloud/vue/dist/Directives/Tooltip.js'
 
 import App from './App.vue'
 
@@ -76,6 +76,7 @@ Vue.use(VueRouter)
 Vue.use(VueObserveVisibility)
 Vue.use(VueShortKey, { prevent: ['input', 'textarea', 'div'] })
 Vue.use(vOutsideEvents)
+Vue.directive('tooltip', Tooltip)
 
 const pinia = createPinia()
 

--- a/src/mainAdminSettings.js
+++ b/src/mainAdminSettings.js
@@ -22,6 +22,8 @@
 
 import Vue from 'vue'
 
+import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip.js'
+
 import AdminSettings from './views/AdminSettings.vue'
 
 import '@nextcloud/dialogs/style.css'
@@ -31,6 +33,7 @@ Vue.prototype.n = n
 Vue.prototype.OC = OC
 Vue.prototype.OCA = OCA
 Vue.prototype.OCP = OCP
+Vue.directive('tooltip', Tooltip)
 
 export default new Vue({
 	el: '#admin_settings',

--- a/src/mainFilesSidebar.js
+++ b/src/mainFilesSidebar.js
@@ -35,6 +35,8 @@ import { getRequestToken } from '@nextcloud/auth'
 import { translate, translatePlural } from '@nextcloud/l10n'
 import { generateFilePath } from '@nextcloud/router'
 
+import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip.js'
+
 import FilesSidebarCallViewApp from './FilesSidebarCallViewApp.vue'
 import FilesSidebarTabApp from './FilesSidebarTabApp.vue'
 
@@ -69,6 +71,7 @@ Vue.use(Vuex)
 Vue.use(VueShortKey, { prevent: ['input', 'textarea', 'div'] })
 Vue.use(vOutsideEvents)
 Vue.use(VueObserveVisibility)
+Vue.directive('tooltip', Tooltip)
 
 const pinia = createPinia()
 

--- a/src/mainPublicShareAuthSidebar.js
+++ b/src/mainPublicShareAuthSidebar.js
@@ -29,6 +29,8 @@ import { getRequestToken } from '@nextcloud/auth'
 import { translate, translatePlural } from '@nextcloud/l10n'
 import { generateFilePath } from '@nextcloud/router'
 
+import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip.js'
+
 import PublicShareAuthRequestPasswordButton from './PublicShareAuthRequestPasswordButton.vue'
 import PublicShareAuthSidebar from './PublicShareAuthSidebar.vue'
 
@@ -63,6 +65,7 @@ Vue.use(Vuex)
 Vue.use(VueShortKey, { prevent: ['input', 'textarea', 'div'] })
 Vue.use(vOutsideEvents)
 Vue.use(VueObserveVisibility)
+Vue.directive('tooltip', Tooltip)
 
 const pinia = createPinia()
 store.dispatch('setMainContainerSelector', '#talk-sidebar')

--- a/src/mainPublicShareSidebar.js
+++ b/src/mainPublicShareSidebar.js
@@ -29,6 +29,8 @@ import { getRequestToken } from '@nextcloud/auth'
 import { translate, translatePlural } from '@nextcloud/l10n'
 import { generateFilePath } from '@nextcloud/router'
 
+import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip.js'
+
 import PublicShareSidebar from './PublicShareSidebar.vue'
 import PublicShareSidebarTrigger from './PublicShareSidebarTrigger.vue'
 
@@ -63,6 +65,7 @@ Vue.use(Vuex)
 Vue.use(VueShortKey, { prevent: ['input', 'textarea', 'div'] })
 Vue.use(vOutsideEvents)
 Vue.use(VueObserveVisibility)
+Vue.directive('tooltip', Tooltip)
 
 const pinia = createPinia()
 

--- a/src/mainRecording.js
+++ b/src/mainRecording.js
@@ -37,7 +37,7 @@ import { getRequestToken } from '@nextcloud/auth'
 import { translate, translatePlural } from '@nextcloud/l10n'
 import { generateFilePath } from '@nextcloud/router'
 
-import { options as TooltipOptions } from '@nextcloud/vue/dist/Directives/Tooltip.js'
+import Tooltip, { options as TooltipOptions } from '@nextcloud/vue/dist/Directives/Tooltip.js'
 
 import Recording from './Recording.vue'
 
@@ -79,6 +79,7 @@ Vue.use(VueRouter)
 Vue.use(VueObserveVisibility)
 Vue.use(VueShortKey, { prevent: ['input', 'textarea', 'div'] })
 Vue.use(vOutsideEvents)
+Vue.directive('tooltip', Tooltip)
 
 const pinia = createPinia()
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix #12033
* Directive was only declared in MatterbridgeSettings.vue, which made it work in main app (without it nothing works 🙈)
* stable30+ are not affected, as we replaced tooltips with native titles or NcPopover

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
Files sidebars (3/3) | --
<img width="616" alt="image" src="https://github.com/user-attachments/assets/0a1b9477-ddfc-41af-95c8-1a7536a8988a" /> | <img width="613" alt="image" src="https://github.com/user-attachments/assets/b8f45578-f66d-454f-9b24-cb7d147f1664" />
Admin settings | --
<img width="350" alt="image" src="https://github.com/user-attachments/assets/06612110-cb88-4673-ae64-48f5b0ce0adb" />| <img width="354" alt="image" src="https://github.com/user-attachments/assets/731fed8a-7fd4-4fb0-8daf-7b558d92b362" />


### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required