### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -307,12 +307,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "dc5473e3895d859535de45eab15d2095cb8eafe4"
+                "reference": "4f4564017c7a4e2c4da6cea1fc4b11c8afd8fe0d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/dc5473e3895d859535de45eab15d2095cb8eafe4",
-                "reference": "dc5473e3895d859535de45eab15d2095cb8eafe4",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/4f4564017c7a4e2c4da6cea1fc4b11c8afd8fe0d",
+                "reference": "4f4564017c7a4e2c4da6cea1fc4b11c8afd8fe0d",
                 "shasum": ""
             },
             "require": {
@@ -348,7 +348,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2025-03-11T00:46:19+00:00"
+            "time": "2025-03-21T00:47:07+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency