### PR TITLE
[stable30] style: drop redundant overrides for public shares

### DIFF
--- a/css/publicshare.css
+++ b/css/publicshare.css
@@ -5,19 +5,6 @@
 
 /* Special layout to include the Talk sidebar */
 
-/* The standard layout defined in the server includes a fixed header with a
- * sticky sidebar. This causes the scroll bar for the main area to appear to the
- * right of the sidebar, which looks confusing for the chat. Thus that layout is
- * overridden with a static header and a content with full height without header
- * to limit the vertical scroll bar only to it.
- * Note that the flex layout can not be cascaded from the body element, as a
- * flex display is not compatible with the absolute position set for the
- * autocompletion panel, which is reparented to the body when shown. */
-#body-user #header,
-#body-public #header {
-	/* Override fixed position from server to include it in the body layout */
-	position: static;
-}
 
 /* Overwrites styles from public.scss in public share after re-parenting footer */
 #body-public {
@@ -41,10 +28,6 @@
 	 * available for the content. */
 	min-height: 0;
 	padding-top: 0;
-
-	/* Override margin used in server, as the header is part of the flex layout
-	 * and thus the content does not need to be pushed down. */
-	margin-top: 0;
 }
 
 #app-content {


### PR DESCRIPTION
### ☑️ Resolves

* Fix #8561

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

No visual changes

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required