### PR TITLE
feat(one-to-one): Don't invite one-to-one participant before sending …

### DIFF
--- a/lib/Chat/SystemMessage/Listener.php
+++ b/lib/Chat/SystemMessage/Listener.php
@@ -366,6 +366,7 @@ class Listener implements IEventListener {
 			return;
 		}
 		$room = $this->manager->getRoomByToken($share->getSharedWith());
+		$this->participantService->ensureOneToOneRoomIsFilled($room);
 
 		$metaData = $this->request->getParam('talkMetaData') ?? '';
 		$metaData = json_decode($metaData, true);

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -749,7 +749,7 @@ class RoomController extends AEnvironmentAwareOCSController {
 			// We are only doing this manually here to be able to return different status codes
 			// Actually createOneToOneConversation also checks it.
 			$room = $this->manager->getOne2OneRoom($currentUser->getUID(), $targetUser->getUID());
-			$this->participantService->ensureOneToOneRoomIsFilled($room);
+			$this->participantService->ensureOneToOneRoomIsFilled($room, $currentUser->getUID());
 			return new DataResponse(
 				$this->formatRoom($room, $this->participantService->getParticipant($room, $currentUser->getUID(), false)),
 				Http::STATUS_OK

--- a/lib/Notification/Listener.php
+++ b/lib/Notification/Listener.php
@@ -74,6 +74,10 @@ class Listener implements IEventListener {
 	 * @param Attendee[] $attendees
 	 */
 	protected function generateInvitation(Room $room, array $attendees): void {
+		if ($room->getType() === Room::TYPE_ONE_TO_ONE) {
+			return;
+		}
+
 		if ($room->getObjectType() === Room::OBJECT_TYPE_FILE) {
 			return;
 		}
@@ -135,6 +139,12 @@ class Listener implements IEventListener {
 	 * Room invitation: "{actor} invited you to {call}"
 	 */
 	protected function markInvitationRead(Room $room, IUser $user): void {
+		if ($room->getType() === Room::TYPE_ONE_TO_ONE
+			|| $room->getType() === Room::TYPE_ONE_TO_ONE_FORMER) {
+			// No notifications for one-to-one, save a query
+			return;
+		}
+
 		$notification = $this->notificationManager->createNotification();
 		try {
 			$notification->setApp(Application::APP_ID)

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -966,33 +966,7 @@ class Notifier implements INotifier {
 		}
 
 		$roomName = $room->getDisplayName($notification->getUser());
-		if ($room->getType() === Room::TYPE_ONE_TO_ONE || $room->getType() === Room::TYPE_ONE_TO_ONE_FORMER) {
-			$subject = $l->t('{user} invited you to a private conversation');
-			if ($this->participantService->hasActiveSessionsInCall($room)) {
-				$notification = $this->addActionButton($notification, 'call_view', $l->t('Join call'), true, true);
-			} else {
-				$notification = $this->addActionButton($notification, 'chat_view', $l->t('View chat'), false);
-			}
-
-			$notification
-				->setParsedSubject(str_replace('{user}', $userDisplayName, $subject))
-				->setRichSubject(
-					$subject, [
-						'user' => [
-							'type' => 'user',
-							'id' => $uid,
-							'name' => $userDisplayName,
-						],
-						'call' => [
-							'type' => 'call',
-							'id' => (string)$room->getId(),
-							'name' => $roomName,
-							'call-type' => $this->getRoomType($room),
-							'icon-url' => $this->avatarService->getAvatarUrl($room),
-						],
-					]
-				);
-		} elseif (\in_array($room->getType(), [Room::TYPE_GROUP, Room::TYPE_PUBLIC], true)) {
+		if (\in_array($room->getType(), [Room::TYPE_GROUP, Room::TYPE_PUBLIC], true)) {
 			$subject = $l->t('{user} invited you to a group conversation: {call}');
 			if ($this->participantService->hasActiveSessionsInCall($room)) {
 				$notification = $this->addActionButton($notification, 'call_view', $l->t('Join call'), true, true);

--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -952,14 +952,18 @@ class ParticipantService {
 		}
 	}
 
-	public function ensureOneToOneRoomIsFilled(Room $room): void {
+	public function ensureOneToOneRoomIsFilled(Room $room, ?string $enforceUserId = null): void {
 		if ($room->getType() !== Room::TYPE_ONE_TO_ONE) {
 			return;
 		}
 
 		$users = json_decode($room->getName(), true);
 		$participants = $this->getParticipantUserIds($room);
-		$missingUsers = array_diff($users, $participants);
+		if ($enforceUserId !== null) {
+			$missingUsers = !in_array($enforceUserId, $participants) ? [$enforceUserId] : [];
+		} else {
+			$missingUsers = array_diff($users, $participants);
+		}
 
 		foreach ($missingUsers as $userId) {
 			$userDisplayName = $this->userManager->getDisplayName($userId);

--- a/lib/Service/RoomService.php
+++ b/lib/Service/RoomService.php
@@ -105,7 +105,7 @@ class RoomService {
 		try {
 			// If room exists: Reuse that one, otherwise create a new one.
 			$room = $this->manager->getOne2OneRoom($actor->getUID(), $targetUser->getUID());
-			$this->participantService->ensureOneToOneRoomIsFilled($room);
+			$this->participantService->ensureOneToOneRoomIsFilled($room, $actor->getUID());
 		} catch (RoomNotFoundException) {
 			if (!$this->shareManager->currentUserCanEnumerateTargetUser($actor, $targetUser)) {
 				throw new RoomNotFoundException();
@@ -120,12 +120,6 @@ class RoomService {
 					'actorType' => Attendee::ACTOR_USERS,
 					'actorId' => $actor->getUID(),
 					'displayName' => $actor->getDisplayName(),
-					'participantType' => Participant::OWNER,
-				],
-				[
-					'actorType' => Attendee::ACTOR_USERS,
-					'actorId' => $targetUser->getUID(),
-					'displayName' => $targetUser->getDisplayName(),
 					'participantType' => Participant::OWNER,
 				],
 			], $actor);

--- a/tests/integration/features/callapi/one-to-one.feature
+++ b/tests/integration/features/callapi/one-to-one.feature
@@ -14,14 +14,13 @@ Feature: callapi/one-to-one
       | roomType | 1 |
       | invite   | participant2 |
     Then user "participant1" is participant of room "room" (v4)
-    And user "participant2" is participant of room "room" (v4)
+    And user "participant2" is not participant of room "room" (v4)
     Then user "participant1" sees 0 peers in call "room" with 200 (v4)
-    And user "participant2" sees 0 peers in call "room" with 200 (v4)
     Then user "participant1" joins room "room" with 200 (v4)
     Then user "participant1" sees 0 peers in call "room" with 200 (v4)
-    And user "participant2" sees 0 peers in call "room" with 200 (v4)
     Then user "participant1" joins call "room" with 200 (v4)
     Then user "participant1" sees 1 peers in call "room" with 200 (v4)
+    And user "participant2" is participant of room "room" (v4)
     And user "participant2" sees 1 peers in call "room" with 200 (v4)
     And user "participant2" joins room "room" with 200 (v4)
     Then user "participant1" sees 1 peers in call "room" with 200 (v4)
@@ -105,10 +104,13 @@ Feature: callapi/one-to-one
     Then user "participant1" sees 0 peers in call "room" with 200 (v4)
     And user "guest" sees 0 peers in call "room" with 404 (v4)
 
-  Scenario: Sending a message into a one-to-one chat re-adds the participants
+  Scenario: Starting a call in a one-to-one re-adds the participants
     Given user "participant1" creates room "room" (v4)
       | roomType | 1 |
       | invite   | participant2 |
+    Given user "participant2" creates room "room" with 200 (v4)
+      | roomType | 1 |
+      | invite   | participant1 |
     And user "participant1" is participant of room "room" (v4)
     And user "participant2" is participant of room "room" (v4)
     When user "participant1" removes themselves from room "room" with 200 (v4)
@@ -126,6 +128,9 @@ Feature: callapi/one-to-one
     Given user "participant1" creates room "room" (v4)
       | roomType | 1 |
       | invite   | participant2 |
+    Given user "participant2" creates room "room" with 200 (v4)
+      | roomType | 1 |
+      | invite   | participant1 |
     And user "participant1" is participant of room "room" (v4)
     And user "participant2" is participant of room "room" (v4)
     Then user "participant1" is participant of the following rooms (v4)

--- a/tests/integration/features/chat-1/message-expiration.feature
+++ b/tests/integration/features/chat-1/message-expiration.feature
@@ -65,7 +65,6 @@ Feature: chat/message-expiration
       | roomType | 1 |
       | invite   | participant2 |
     And user "participant1" is participant of room "room" (v4)
-    And user "participant2" is participant of room "room" (v4)
     Then user "participant1" is participant of the following rooms (v4)
       | id   | type | participantType |
       | room | 1    | 1               |

--- a/tests/integration/features/chat-1/notifications.feature
+++ b/tests/integration/features/chat-1/notifications.feature
@@ -10,6 +10,9 @@ Feature: chat/notifications
     When user "participant1" creates room "one-to-one room" (v4)
       | roomType | 1 |
       | invite   | participant2 |
+    When user "participant2" creates room "one-to-one room" with 200 (v4)
+      | roomType | 1 |
+      | invite   | participant1 |
     Given user "participant1" sets session state to 2 in room "one-to-one room" with 404 (v4)
     Given user "participant2" joins room "one-to-one room" with 200 (v4)
     When user "participant1" sends message "Message 1" to room "one-to-one room" with 201
@@ -20,7 +23,9 @@ Feature: chat/notifications
     When user "participant1" creates room "one-to-one room" (v4)
       | roomType | 1 |
       | invite   | participant2 |
-    # Join and leave to clear the invite notification
+    When user "participant2" creates room "one-to-one room" with 200 (v4)
+      | roomType | 1 |
+      | invite   | participant1 |
     Given user "participant2" joins room "one-to-one room" with 200 (v4)
     Given user "participant2" sets session state to 2 in room "one-to-one room" with 400 (v4)
     When user "participant1" sends message "Message 1" to room "one-to-one room" with 201
@@ -36,9 +41,6 @@ Feature: chat/notifications
     When user "participant1" creates room "one-to-one room" (v4)
       | roomType | 1 |
       | invite   | participant2 |
-    # Join and leave to clear the invite notification
-    Given user "participant2" joins room "one-to-one room" with 200 (v4)
-    Given user "participant2" leaves room "one-to-one room" with 200 (v4)
     When user "participant1" sends message "Message 1" to room "one-to-one room" with 201
     Then user "participant2" has the following notifications
       | app    | object_type | object_id                 | subject                                             |
@@ -51,9 +53,6 @@ Feature: chat/notifications
     When user "participant1" creates room "one-to-one room" (v4)
       | roomType | 1 |
       | invite   | participant2 |
-    # Join and leave to clear the invite notification
-    Given user "participant2" joins room "one-to-one room" with 200 (v4)
-    Given user "participant2" leaves room "one-to-one room" with 200 (v4)
     When user "participant1" silent sends message "Message 1" to room "one-to-one room" with 201
     Then user "participant2" has the following notifications
       | app | object_type | object_id | subject |
@@ -65,9 +64,9 @@ Feature: chat/notifications
     When user "participant1" creates room "one-to-one room" (v4)
       | roomType | 1 |
       | invite   | participant2 |
-    # Join and leave to clear the invite notification
-    Given user "participant2" joins room "one-to-one room" with 200 (v4)
-    Given user "participant2" leaves room "one-to-one room" with 200 (v4)
+    When user "participant2" creates room "one-to-one room" with 200 (v4)
+      | roomType | 1 |
+      | invite   | participant1 |
     And user "participant2" sets notifications to disabled for room "one-to-one room" (v4)
     When user "participant1" sends message "Message 1" to room "one-to-one room" with 201
     Then user "participant2" has the following notifications
@@ -77,6 +76,9 @@ Feature: chat/notifications
     When user "participant1" creates room "one-to-one room" (v4)
       | roomType | 1 |
       | invite   | participant2 |
+    When user "participant2" creates room "one-to-one room" with 200 (v4)
+      | roomType | 1 |
+      | invite   | participant1 |
     Given user "participant2" joins room "one-to-one room" with 200 (v4)
     When user "participant1" sends message "Hi @participant2 bye" to room "one-to-one room" with 201
     Then user "participant2" has the following notifications
@@ -87,9 +89,6 @@ Feature: chat/notifications
     When user "participant1" creates room "one-to-one room" (v4)
       | roomType | 1 |
       | invite   | participant2 |
-    # Join and leave to clear the invite notification
-    Given user "participant2" joins room "one-to-one room" with 200 (v4)
-    Given user "participant2" leaves room "one-to-one room" with 200 (v4)
     When user "participant1" sends message "Hi @participant2 bye" to room "one-to-one room" with 201
     Then user "participant2" has the following notifications
       | app    | object_type | object_id                            | subject                                                          |
@@ -99,9 +98,9 @@ Feature: chat/notifications
     When user "participant1" creates room "one-to-one room" (v4)
       | roomType | 1 |
       | invite   | participant2 |
-    # Join and leave to clear the invite notification
-    Given user "participant2" joins room "one-to-one room" with 200 (v4)
-    Given user "participant2" leaves room "one-to-one room" with 200 (v4)
+    When user "participant2" creates room "one-to-one room" with 200 (v4)
+      | roomType | 1 |
+      | invite   | participant1 |
     And user "participant2" sets notifications to disabled for room "one-to-one room" (v4)
     When user "participant1" sends message "Hi @participant2 bye" to room "one-to-one room" with 201
     Then user "participant2" has the following notifications
@@ -111,9 +110,9 @@ Feature: chat/notifications
     When user "participant1" creates room "one-to-one room" (v4)
       | roomType | 1 |
       | invite   | participant2 |
-    # Join and leave to clear the invite notification
-    Given user "participant2" joins room "one-to-one room" with 200 (v4)
-    Given user "participant2" leaves room "one-to-one room" with 200 (v4)
+    When user "participant2" creates room "one-to-one room" with 200 (v4)
+      | roomType | 1 |
+      | invite   | participant1 |
     When user "participant2" sends message "Message 1" to room "one-to-one room" with 201
     And user "participant1" react with "🚀" on message "Message 1" to room "one-to-one room" with 201
     Then user "participant2" has the following notifications
@@ -124,9 +123,9 @@ Feature: chat/notifications
     When user "participant1" creates room "one-to-one room" (v4)
       | roomType | 1 |
       | invite   | participant2 |
-    # Join and leave to clear the invite notification
-    Given user "participant2" joins room "one-to-one room" with 200 (v4)
-    Given user "participant2" leaves room "one-to-one room" with 200 (v4)
+    When user "participant2" creates room "one-to-one room" with 200 (v4)
+      | roomType | 1 |
+      | invite   | participant1 |
     When user "participant2" sends message "Message 1" to room "one-to-one room" with 201
     And user "participant2" sets notifications to disabled for room "one-to-one room" (v4)
     And user "participant1" react with "🚀" on message "Message 1" to room "one-to-one room" with 201
@@ -137,6 +136,9 @@ Feature: chat/notifications
     When user "participant1" creates room "one-to-one room" (v4)
       | roomType | 1 |
       | invite   | participant2 |
+    When user "participant2" creates room "one-to-one room" with 200 (v4)
+      | roomType | 1 |
+      | invite   | participant1 |
     Given user "participant2" joins room "one-to-one room" with 200 (v4)
     When user "participant1" sends message "Hi @all bye" to room "one-to-one room" with 201
     Then user "participant2" has the following notifications
@@ -147,9 +149,6 @@ Feature: chat/notifications
     When user "participant1" creates room "one-to-one room" (v4)
       | roomType | 1 |
       | invite   | participant2 |
-    # Join and leave to clear the invite notification
-    Given user "participant2" joins room "one-to-one room" with 200 (v4)
-    Given user "participant2" leaves room "one-to-one room" with 200 (v4)
     When user "participant1" sends message "Hi @all bye" to room "one-to-one room" with 201
     Then user "participant2" has the following notifications
       | app    | object_type | object_id                   | subject                                                          |
@@ -159,9 +158,9 @@ Feature: chat/notifications
     When user "participant1" creates room "one-to-one room" (v4)
       | roomType | 1 |
       | invite   | participant2 |
-    # Join and leave to clear the invite notification
-    Given user "participant2" joins room "one-to-one room" with 200 (v4)
-    Given user "participant2" leaves room "one-to-one room" with 200 (v4)
+    When user "participant2" creates room "one-to-one room" with 200 (v4)
+      | roomType | 1 |
+      | invite   | participant1 |
     And user "participant2" sets notifications to disabled for room "one-to-one room" (v4)
     When user "participant1" sends message "Hi @all bye" to room "one-to-one room" with 201
     Then user "participant2" has the following notifications
@@ -502,8 +501,6 @@ Feature: chat/notifications
       | roomType | 1 |
       | invite   | participant2 |
     # Join and leave to clear the invite notification
-    Given user "participant2" joins room "one-to-one room" with 200 (v4)
-    And user "participant2" leaves room "one-to-one room" with 200 (v4)
     And user "participant1" sends message "Message 1" to room "one-to-one room" with 201
     Then user "participant2" has the following notifications
       | app    | object_type | object_id                 | subject                                             |

--- a/tests/integration/features/chat-1/one-to-one.feature
+++ b/tests/integration/features/chat-1/one-to-one.feature
@@ -17,6 +17,9 @@ Feature: chat/one-to-one
     Given user "participant1" creates room "one-to-one room" (v4)
       | roomType | 1 |
       | invite   | participant2 |
+    Given user "participant2" creates room "one-to-one room" with 200 (v4)
+      | roomType | 1 |
+      | invite   | participant1 |
     When user "participant2" sends message "Message 1" to room "one-to-one room" with 201
     Then user "participant2" sees the following messages in room "one-to-one room" with 200
       | room            | actorType | actorId      | actorDisplayName         | message   | messageParameters |
@@ -58,6 +61,9 @@ Feature: chat/one-to-one
     Given user "participant1" creates room "one-to-one room" (v4)
       | roomType | 1 |
       | invite   | participant2 |
+    Given user "participant2" creates room "one-to-one room" with 200 (v4)
+      | roomType | 1 |
+      | invite   | participant1 |
     And user "participant1" is participant of room "one-to-one room" (v4)
     And user "participant2" is participant of room "one-to-one room" (v4)
     When user "participant1" removes themselves from room "one-to-one room" with 200 (v4)

--- a/tests/integration/features/chat-2/bots.feature
+++ b/tests/integration/features/chat-2/bots.feature
@@ -366,7 +366,6 @@ Feature: chat/bots
       | roomType | 1 |
       | invite   | participant2 |
     And user "participant1" is participant of room "room" (v4)
-    And user "participant2" is participant of room "room" (v4)
     When user "participant2" is deleted
     Then user "participant1" is participant of the following rooms (v4)
       | id   | type | participantType |
@@ -376,6 +375,7 @@ Feature: chat/bots
     And invoking occ with "talk:bot:list room-name:room"
     Then the command was successful
     And the command output is empty
+    And read bot ids from OCC
     And user "participant1" sets up bot "Webhook Demo" for room "room" with 400 (v1)
     Given invoking occ with "talk:bot:list room-name:room"
     And the command was successful

--- a/tests/integration/features/chat-2/mentions.feature
+++ b/tests/integration/features/chat-2/mentions.feature
@@ -13,6 +13,10 @@ Feature: chat/mentions
     Then user "participant1" gets the following candidate mentions in room "one-to-one room" for "" with 200
       | id           | label                    | source | mentionId    |
       | participant2 | participant2-displayname | users  | participant2 |
+    And user "participant2" gets the following candidate mentions in room "one-to-one room" for "" with 404
+    When user "participant2" creates room "one-to-one room" with 200 (v4)
+      | roomType | 1 |
+      | invite   | participant1 |
     And user "participant2" gets the following candidate mentions in room "one-to-one room" for "" with 200
       | id           | label                    | source | mentionId    |
       | participant1 | participant1-displayname | users  | participant1 |
@@ -24,6 +28,10 @@ Feature: chat/mentions
     Then user "participant1" gets the following candidate mentions in room "one-to-one room" for "part" with 200
       | id           | label                    | source | mentionId    |
       | participant2 | participant2-displayname | users  | participant2 |
+    And user "participant2" gets the following candidate mentions in room "one-to-one room" for "part" with 404
+    When user "participant2" creates room "one-to-one room" with 200 (v4)
+      | roomType | 1 |
+      | invite   | participant1 |
     And user "participant2" gets the following candidate mentions in room "one-to-one room" for "part" with 200
       | id           | label                    | source | mentionId    |
       | participant1 | participant1-displayname | users  | participant1 |
@@ -33,6 +41,10 @@ Feature: chat/mentions
       | roomType | 1 |
       | invite   | participant2 |
     Then user "participant1" gets the following candidate mentions in room "one-to-one room" for "unknown" with 200
+    And user "participant2" gets the following candidate mentions in room "one-to-one room" for "unknown" with 404
+    When user "participant2" creates room "one-to-one room" with 200 (v4)
+      | roomType | 1 |
+      | invite   | participant1 |
     And user "participant2" gets the following candidate mentions in room "one-to-one room" for "unknown" with 200
 
   Scenario: get mentions in a one-to-one room with a participant not in the room

--- a/tests/integration/features/chat-3/reminder.feature
+++ b/tests/integration/features/chat-3/reminder.feature
@@ -8,6 +8,9 @@ Feature: chat-2/reminder
     Given user "participant1" creates room "room" (v4)
       | roomType | 1 |
       | invite   | participant2 |
+    Given user "participant2" creates room "room" with 200 (v4)
+      | roomType | 1 |
+      | invite   | participant1 |
     And user "participant2" joins room "room" with 200 (v4)
     And user "participant1" sends message "Message 1" to room "room" with 201
     When user "participant1" sets reminder for message "Message 1" in room "room" for time 1234567 with 201 (v1)
@@ -35,6 +38,9 @@ Feature: chat-2/reminder
     Given user "participant1" creates room "room" (v4)
       | roomType | 1 |
       | invite   | participant2 |
+    Given user "participant2" creates room "room" with 200 (v4)
+      | roomType | 1 |
+      | invite   | participant1 |
     And user "participant2" joins room "room" with 200 (v4)
     And user "participant1" sends message "Message 1" to room "room" with 201
     When user "participant1" sets reminder for message "Message 1" in room "room" for time 1234567 with 201 (v1)

--- a/tests/integration/features/command/monitor-calls.feature
+++ b/tests/integration/features/command/monitor-calls.feature
@@ -39,6 +39,9 @@ Feature: command/monitor-calls
     When user "participant3" creates room "room2" (v4)
       | roomType | 1 |
       | invite | participant2 |
+    Given user "participant2" creates room "room2" with 200 (v4)
+      | roomType | 1 |
+      | invite   | participant3 |
     And user "participant2" gets room "room2" with 200 (v4)
 
     And user "participant2" joins room "room2" with 200 (v4)

--- a/tests/integration/features/command/user-remove.feature
+++ b/tests/integration/features/command/user-remove.feature
@@ -8,6 +8,9 @@ Feature: command/user-remove
     Given user "participant1" creates room "one-to-one" (v4)
       | roomType | 1 |
       | invite   | participant2 |
+    Given user "participant2" creates room "one-to-one" with 200 (v4)
+      | roomType | 1 |
+      | invite   | participant1 |
     Given user "participant1" creates room "public room" (v4)
       | roomType | 3 |
       | roomName | public room |

--- a/tests/integration/features/command/user-transfer-ownership.feature
+++ b/tests/integration/features/command/user-transfer-ownership.feature
@@ -10,9 +10,15 @@ Feature: command/user-transfer-ownership
     Given user "participant1" creates room "one-to-one" (v4)
       | roomType | 1 |
       | invite   | participant2 |
+    Given user "participant2" creates room "one-to-one" with 200 (v4)
+      | roomType | 1 |
+      | invite   | participant1 |
     Given user "participant4" creates room "one-to-one former" (v4)
       | roomType | 1 |
       | invite   | participant2 |
+    Given user "participant2" creates room "one-to-one former" with 200 (v4)
+      | roomType | 1 |
+      | invite   | participant4 |
     Given user "participant1" creates room "user" (v4)
       | roomType | 3 |
       | roomName | user |
@@ -50,9 +56,15 @@ Feature: command/user-transfer-ownership
     Given user "participant1" creates room "one-to-one" (v4)
       | roomType | 1 |
       | invite   | participant2 |
+    Given user "participant2" creates room "one-to-one" with 200 (v4)
+      | roomType | 1 |
+      | invite   | participant1 |
     Given user "participant4" creates room "one-to-one former" (v4)
       | roomType | 1 |
       | invite   | participant2 |
+    Given user "participant2" creates room "one-to-one former" with 200 (v4)
+      | roomType | 1 |
+      | invite   | participant4 |
     Given user "participant1" creates room "user" (v4)
       | roomType | 3 |
       | roomName | user |
@@ -91,9 +103,15 @@ Feature: command/user-transfer-ownership
     Given user "participant1" creates room "one-to-one" (v4)
       | roomType | 1 |
       | invite   | participant2 |
+    Given user "participant2" creates room "one-to-one" with 200 (v4)
+      | roomType | 1 |
+      | invite   | participant1 |
     Given user "participant4" creates room "one-to-one former" (v4)
       | roomType | 1 |
       | invite   | participant2 |
+    Given user "participant2" creates room "one-to-one former" with 200 (v4)
+      | roomType | 1 |
+      | invite   | participant4 |
     Given user "participant1" creates room "user" (v4)
       | roomType | 3 |
       | roomName | user |

--- a/tests/integration/features/conversation-3/join-leave.feature
+++ b/tests/integration/features/conversation-3/join-leave.feature
@@ -9,6 +9,9 @@ Feature: conversation/join-leave
     Given user "participant1" creates room "room" (v4)
       | roomType | 1 |
       | invite   | participant2 |
+    Given user "participant2" creates room "room" with 200 (v4)
+      | roomType | 1 |
+      | invite   | participant1 |
     When user "participant1" joins room "room" with 200 (v4)
     And user "participant2" joins room "room" with 200 (v4)
     And user "participant3" joins room "room" with 404 (v4)
@@ -22,6 +25,9 @@ Feature: conversation/join-leave
     Given user "participant1" creates room "room" (v4)
       | roomType | 1 |
       | invite   | participant2 |
+    Given user "participant2" creates room "room" with 200 (v4)
+      | roomType | 1 |
+      | invite   | participant1 |
     And user "participant1" joins room "room" with 200 (v4)
     And user "participant2" joins room "room" with 200 (v4)
     When user "participant1" leaves room "room" with 200 (v4)

--- a/tests/integration/features/conversation-3/lobby.feature
+++ b/tests/integration/features/conversation-3/lobby.feature
@@ -61,6 +61,9 @@ Feature: conversation/lobby
       | invite   | participant2 |
     When user "participant1" sets lobby state for room "room" to "non moderators" with 400 (v4)
     And user "participant1" sets lobby state for room "room" to "no lobby" with 400 (v4)
+    Given user "participant2" creates room "room" with 200 (v4)
+      | roomType | 1 |
+      | invite   | participant1 |
     And user "participant2" sets lobby state for room "room" to "non moderators" with 400 (v4)
     And user "participant2" sets lobby state for room "room" to "no lobby" with 400 (v4)
 

--- a/tests/integration/features/conversation-3/one-to-one.feature
+++ b/tests/integration/features/conversation-3/one-to-one.feature
@@ -22,44 +22,50 @@ Feature: conversation-2/one-to-one
       | id    | type | participantType |
       | room1 | 1    | 1               |
     And user "participant2" is participant of the following rooms (v4)
-      | id    | type | participantType |
-      | room1 | 1    | 1               |
     And user "participant3" is participant of the following rooms (v4)
     And user "participant1" is participant of room "room1" (v4)
-    And user "participant2" is participant of room "room1" (v4)
+    And user "participant2" is not participant of room "room1" (v4)
     And user "participant3" is not participant of room "room1" (v4)
+    Given user "participant2" creates room "room1" with 200 (v4)
+      | roomType | 1 |
+      | invite   | participant1 |
+    And user "participant2" is participant of room "room1" (v4)
+    Then user "participant1" is participant of the following rooms (v4)
+      | id    | type | participantType |
+      | room1 | 1    | 1               |
+    And user "participant2" is participant of the following rooms (v4)
+      | id    | type | participantType |
+      | room1 | 1    | 1               |
 
   Scenario: User1 invites user2 to a one2one room and leaves it
     Given user "participant1" creates room "room2" (v4)
       | roomType | 1 |
       | invite   | participant2 |
     And user "participant1" is participant of room "room2" (v4)
-    And user "participant2" is participant of room "room2" (v4)
+    And user "participant2" is not participant of room "room2" (v4)
     When user "participant1" removes themselves from room "room2" with 200 (v4)
     Then user "participant1" is not participant of room "room2" (v4)
     And user "participant1" is participant of the following rooms (v4)
-    And user "participant2" is participant of room "room2" (v4)
+    And user "participant2" is not participant of room "room2" (v4)
     And user "participant2" is participant of the following rooms (v4)
-      | id    | type | participantType |
-      | room2 | 1    | 1               |
-    And user "participant2" sees the following attendees in room "room2" with 200 (v4)
-      | actorType  | actorId      | participantType |
-      | users      | participant2 | 1               |
 
   Scenario: User1 invites user2 to a one2one room and tries to delete it
     Given user "participant1" creates room "room3" (v4)
       | roomType | 1 |
       | invite   | participant2 |
     Then user "participant1" is participant of room "room3" (v4)
-    And user "participant2" is participant of room "room3" (v4)
+    And user "participant2" is not participant of room "room3" (v4)
     When user "participant1" deletes room "room3" with 400 (v4)
     Then user "participant1" is participant of room "room3" (v4)
-    And user "participant2" is participant of room "room3" (v4)
+    And user "participant2" is not participant of room "room3" (v4)
 
   Scenario: User1 invites user2 to a one2one room and tries to remove user2
     Given user "participant1" creates room "room4" (v4)
       | roomType | 1 |
       | invite   | participant2 |
+    Given user "participant2" creates room "room4" with 200 (v4)
+      | roomType | 1 |
+      | invite   | participant1 |
     Then user "participant1" is participant of room "room4" (v4)
     And user "participant2" is participant of room "room4" (v4)
     And user "participant1" loads attendees attendee ids in room "room4" (v4)
@@ -72,7 +78,6 @@ Feature: conversation-2/one-to-one
       | roomType | 1 |
       | invite   | participant2 |
     And user "participant1" is participant of room "room5" (v4)
-    And user "participant2" is participant of room "room5" (v4)
     When user "participant1" renames room "room5" to "new name" with 400 (v4)
 
   Scenario: User1 invites user2 to a one2one room and tries to make it public
@@ -80,7 +85,6 @@ Feature: conversation-2/one-to-one
       | roomType | 1 |
       | invite   | participant2 |
     And user "participant1" is participant of room "room6" (v4)
-    And user "participant2" is participant of room "room6" (v4)
     When user "participant1" makes room "room6" public with 400 (v4)
     Then user "participant1" is participant of the following rooms (v4)
       | id    | type | participantType |
@@ -90,6 +94,9 @@ Feature: conversation-2/one-to-one
     Given user "participant1" creates room "room7" (v4)
       | roomType | 1 |
       | invite   | participant2 |
+    Given user "participant2" creates room "room7" with 200 (v4)
+      | roomType | 1 |
+      | invite   | participant1 |
     And user "participant1" is participant of room "room7" (v4)
     And user "participant2" is participant of room "room7" (v4)
     And user "participant3" is not participant of room "room7" (v4)
@@ -104,6 +111,9 @@ Feature: conversation-2/one-to-one
     Given user "participant1" creates room "room8" (v4)
       | roomType | 1 |
       | invite   | participant2 |
+    Given user "participant2" creates room "room8" with 200 (v4)
+      | roomType | 1 |
+      | invite   | participant1 |
     And user "participant1" is participant of room "room8" (v4)
     And user "participant2" is participant of room "room8" (v4)
     And user "participant1" loads attendees attendee ids in room "room8" (v4)
@@ -113,6 +123,9 @@ Feature: conversation-2/one-to-one
     Given user "participant1" creates room "room9" (v4)
       | roomType | 1 |
       | invite   | participant2 |
+    Given user "participant2" creates room "room9" with 200 (v4)
+      | roomType | 1 |
+      | invite   | participant1 |
     And user "participant1" is participant of room "room9" (v4)
     And user "participant2" is participant of room "room9" (v4)
     And user "participant1" loads attendees attendee ids in room "room9" (v4)
@@ -141,29 +154,28 @@ Feature: conversation-2/one-to-one
       | roomType | 1 |
       | invite   | participant2 |
     And user "participant1" is participant of room "room12" (v4)
-    And user "participant2" is participant of room "room12" (v4)
+    And user "participant2" is not participant of room "room12" (v4)
     And user "participant1" is participant of the following rooms (v4)
       | id     | type | participantType |
       | room12 | 1    | 1               |
     And user "participant2" is participant of the following rooms (v4)
-      | id     | type | participantType |
-      | room12 | 1    | 1               |
     When user "participant1" creates room "room13" with 200 (v4)
       | roomType | 1 |
       | invite   | participant2 |
     And user "participant1" is participant of room "room12" (v4)
-    And user "participant2" is participant of room "room12" (v4)
+    And user "participant2" is not participant of room "room12" (v4)
     And user "participant1" is participant of the following rooms (v4)
       | id     | type | participantType |
       | room12 | 1    | 1               |
     And user "participant2" is participant of the following rooms (v4)
-      | id     | type | participantType |
-      | room12 | 1    | 1               |
 
   Scenario: User1 invites user2 to a one2one room, leaves and does it again, it's the same room
     Given user "participant1" creates room "room14" (v4)
       | roomType | 1 |
       | invite   | participant2 |
+    Given user "participant2" creates room "room14" with 200 (v4)
+      | roomType | 1 |
+      | invite   | participant1 |
     And user "participant1" is participant of room "room14" (v4)
     And user "participant2" is participant of room "room14" (v4)
     And user "participant1" is participant of the following rooms (v4)
@@ -212,6 +224,9 @@ Feature: conversation-2/one-to-one
     Given user "participant1" creates room "room" with 201 (v4)
       | roomType | 1 |
       | invite   | participant2 |
+    Given user "participant2" creates room "room" with 200 (v4)
+      | roomType | 1 |
+      | invite   | participant1 |
     Then user "participant1" removes themselves from room "room" with 200 (v4)
     And user "participant1" is participant of the following rooms (v4)
     And user "participant2" is participant of the following rooms (v4)

--- a/tests/integration/features/conversation-5/delete-user.feature
+++ b/tests/integration/features/conversation-5/delete-user.feature
@@ -11,6 +11,9 @@ Feature: conversation/delete-user
     Given user "participant1" creates room "one-to-one room" (v4)
       | roomType | 1 |
       | invite   | participant2 |
+    Given user "participant2" creates room "one-to-one room" with 200 (v4)
+      | roomType | 1 |
+      | invite   | participant1 |
     And user "participant2" sends message "Message 1" to room "one-to-one room" with 201
     Then user "participant1" is participant of the following rooms (v4)
       | name         | type     | readOnly |
@@ -27,6 +30,9 @@ Feature: conversation/delete-user
     Given user "participant1" creates room "one-to-one room" (v4)
       | roomType | 1 |
       | invite   | participant2 |
+    Given user "participant2" creates room "one-to-one room" with 200 (v4)
+      | roomType | 1 |
+      | invite   | participant1 |
     And user "participant2" sends message "Message 1" to room "one-to-one room" with 201
     Then user "participant1" is participant of the following rooms (v4)
       | name         | type     | readOnly |

--- a/tests/integration/features/conversation-5/set-description.feature
+++ b/tests/integration/features/conversation-5/set-description.feature
@@ -57,6 +57,9 @@ Feature: conversation-2/set-description
     Given user "owner" creates room "one-to-one room" (v4)
       | roomType | 1 |
       | invite   | moderator |
+    Given user "moderator" creates room "one-to-one room" with 200 (v4)
+      | roomType | 1 |
+      | invite   | owner |
     When user "owner" sets description for room "one-to-one room" to "the description" with 400 (v4)
     And user "moderator" sets description for room "one-to-one room" to "the description" with 400 (v4)
     Then user "owner" is participant of room "one-to-one room" (v4)

--- a/tests/integration/features/conversation-5/set-listable.feature
+++ b/tests/integration/features/conversation-5/set-listable.feature
@@ -56,6 +56,9 @@ Feature: conversation-2/set-listable
     Given user "creator" creates room "room" (v4)
       | roomType | 1            |
       | invite   | regular-user |
+    Given user "regular-user" creates room "room" with 200 (v4)
+      | roomType | 1            |
+      | invite   | creator |
     Then user "creator" allows listing room "room" for "all" with 400 (v4)
     And user "regular-user" allows listing room "room" for "all" with 400 (v4)
 

--- a/tests/integration/features/conversation-5/set-participant-permissions.feature
+++ b/tests/integration/features/conversation-5/set-participant-permissions.feature
@@ -9,6 +9,9 @@ Feature: conversation-2/set-publishing-permissions
     Given user "owner" creates room "one-to-one room" (v4)
       | roomType | 1 |
       | invite   | moderator |
+    Given user "moderator" creates room "one-to-one room" with 200 (v4)
+      | roomType | 1 |
+      | invite   | owner |
     And user "owner" loads attendees attendee ids in room "one-to-one room" (v4)
     When user "owner" sets permissions for "owner" in room "one-to-one room" to "S" with 400 (v4)
     And user "owner" sets permissions for "moderator" in room "one-to-one room" to "S" with 400 (v4)

--- a/tests/integration/features/sharing-1/create.feature
+++ b/tests/integration/features/sharing-1/create.feature
@@ -36,6 +36,7 @@ Feature: create
     Given user "participant2" creates room "one-to-one room invited to" (v4)
       | roomType | 1 |
       | invite   | participant1 |
+    And user "participant2" sends message "Message 1" to room "one-to-one room invited to" with 201
     When user "participant1" shares "welcome.txt" with room "one-to-one room invited to"
     Then share is returned with
       | uid_owner              | participant1 |

--- a/tests/integration/features/sharing-1/delete.feature
+++ b/tests/integration/features/sharing-1/delete.feature
@@ -22,6 +22,7 @@ Feature: delete
     Given user "participant2" creates room "one-to-one room invited to" (v4)
       | roomType | 1 |
       | invite   | participant1 |
+    And user "participant2" sends message "Message 1" to room "one-to-one room invited to" with 201
     And user "participant1" shares "welcome.txt" with room "one-to-one room invited to" with OCS 100
     When user "participant1" deletes last share
     Then the OCS status code should be "100"

--- a/tests/integration/features/sharing-2/get.feature
+++ b/tests/integration/features/sharing-2/get.feature
@@ -375,6 +375,7 @@ Feature: get
     Given user "participant2" creates room "one-to-one room not invited to" (v4)
       | roomType | 1 |
       | invite   | participant3 |
+    And user "participant2" sends message "Message 1" to room "one-to-one room not invited to" with 201
     And user "participant1" shares "welcome.txt" with user "participant3" with OCS 100
     And user "participant3" accepts last share
     And user "participant3" shares "welcome (2).txt" with room "one-to-one room not invited to" with OCS 100
@@ -593,6 +594,7 @@ Feature: get
     Given user "participant2" creates room "one-to-one room not invited to" (v4)
       | roomType | 1 |
       | invite   | participant3 |
+    And user "participant2" sends message "Message 1" to room "one-to-one room not invited to" with 201
     And user "participant1" shares "welcome.txt" with user "participant3" with OCS 100
     And user "participant3" accepts last share
     And user "participant3" shares "welcome (2).txt" with room "one-to-one room not invited to" with OCS 100
@@ -945,6 +947,7 @@ Feature: get
     And user "participant1" creates room "own one-to-one room" (v4)
       | roomType | 1 |
       | invite   | participant3 |
+    And user "participant1" sends message "Message 1" to room "own one-to-one room" with 201
     And user "participant3" creates folder "/test"
     And user "participant2" shares "welcome.txt" with room "own group room" with OCS 100
     And user "participant3" shares "test" with room "group room invited to" with OCS 100
@@ -1013,6 +1016,7 @@ Feature: get
     And user "participant1" creates room "own one-to-one room" (v4)
       | roomType | 1 |
       | invite   | participant3 |
+    And user "participant1" sends message "Message 1" to room "own one-to-one room" with 201
     And user "participant3" creates folder "/test"
     And user "participant2" shares "welcome.txt" with room "own group room" with OCS 100
     And user "participant3" shares "test" with room "group room invited to" with OCS 100
@@ -1056,6 +1060,7 @@ Feature: get
     And user "participant1" creates room "own one-to-one room" (v4)
       | roomType | 1 |
       | invite   | participant3 |
+    And user "participant1" sends message "Message 1" to room "own one-to-one room" with 201
     And user "participant3" creates folder "/test"
     And user "participant2" shares "welcome.txt" with room "own group room" with OCS 100
     And user "participant3" shares "test" with room "group room invited to" with OCS 100

--- a/tests/integration/features/sharing-4/update.feature
+++ b/tests/integration/features/sharing-4/update.feature
@@ -56,6 +56,7 @@ Feature: update
     Given user "participant2" creates room "one-to-one room invited to" (v4)
       | roomType | 1 |
       | invite   | participant1 |
+    And user "participant2" sends message "Message 1" to room "one-to-one room invited to" with 201
     And user "participant1" shares "welcome.txt" with room "one-to-one room invited to" with OCS 100
     When user "participant1" updates last share with
       | permissions            | 1 |
@@ -511,6 +512,7 @@ Feature: update
     Given user "participant2" creates room "own one-to-one room" (v4)
       | roomType | 1 |
       | invite   | participant1 |
+    And user "participant2" sends message "Message 1" to room "own one-to-one room" with 201
     And user "participant1" shares "welcome.txt" with room "own one-to-one room" with OCS 100
     When user "participant2" updates last share with
       | permissions            | 1 |

--- a/tests/php/Service/RoomServiceTest.php
+++ b/tests/php/Service/RoomServiceTest.php
@@ -162,11 +162,6 @@ class RoomServiceTest extends TestCase {
 				'actorId' => 'uid1',
 				'displayName' => 'display-1',
 				'participantType' => Participant::OWNER,
-			], [
-				'actorType' => 'users',
-				'actorId' => 'uid2',
-				'displayName' => 'display-2',
-				'participantType' => Participant::OWNER,
 			]]);
 
 		$this->participantService->expects($this->never())


### PR DESCRIPTION
…message

Not adding the other participant any more directly, but instead only when calling or writing a message, so users are not notified while the actor is still typing the initial message.


### ☑️ Resolves

* Ref #13403 
* Fix #14848

## 🛠️ API Checklist

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
