### PR TITLE
feat: allow to create new conversation from one-to-one

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -232,7 +232,7 @@ export default {
 			}
 		})
 
-		EventBus.on('switch-to-conversation', (params) => {
+		EventBus.on('switch-to-conversation', async (params) => {
 			if (this.isInCall) {
 				this.callViewStore.setForceCallView(true)
 
@@ -242,6 +242,11 @@ export default {
 				const virtualBackgroundType = BrowserStorage.getItem('virtualBackgroundType_' + this.token)
 				const virtualBackgroundBlurStrength = BrowserStorage.getItem('virtualBackgroundBlurStrength_' + this.token)
 				const virtualBackgroundUrl = BrowserStorage.getItem('virtualBackgroundUrl_' + this.token)
+
+				// Fetch conversation object, if it's not known yet to the client
+				if (!this.$store.getters.conversation(params.token)) {
+					await this.fetchSingleConversation(params.token)
+				}
 
 				EventBus.once('joined-conversation', async ({ token }) => {
 					if (params.token !== token) {

--- a/src/components/BreakoutRoomsEditor/SelectableParticipant.vue
+++ b/src/components/BreakoutRoomsEditor/SelectableParticipant.vue
@@ -8,6 +8,7 @@
 		<input v-model="modelProxy"
 			:value="value"
 			:aria-label="participantAriaLabel"
+			:disabled="isLocked"
 			type="checkbox"
 			class="selectable-participant__checkbox"
 			@keydown.enter.stop.prevent="handleEnter">
@@ -36,7 +37,7 @@
 </template>
 
 <script>
-import { inject } from 'vue'
+import { computed, inject, ref } from 'vue'
 
 import IconCheck from 'vue-material-design-icons/Check.vue'
 
@@ -77,12 +78,20 @@ export default {
 
 	emits: ['update:checked', 'click-participant'],
 
-	setup() {
+	setup(props) {
 		// Toggles the bulk selection state of this component
 		const isBulkSelection = inject('bulkParticipantsSelection', false)
 
+		// Defines list of locked participants (can not be removed manually
+		const lockedParticipants = inject('lockedParticipants', ref([]))
+
+		const isLocked = computed(() => lockedParticipants.value.some(item => {
+			return item.id === props.participant.id && item.source === props.participant.source
+		}))
+
 		return {
 			isBulkSelection,
+			isLocked,
 		}
 	},
 
@@ -92,6 +101,9 @@ export default {
 				return this.checked
 			},
 			set(value) {
+				if (this.isLocked) {
+					return
+				}
 				this.isBulkSelection
 					? this.$emit('update:checked', value)
 					: this.$emit('click-participant', this.participant)

--- a/src/components/ExtendOneToOneDialog.vue
+++ b/src/components/ExtendOneToOneDialog.vue
@@ -1,0 +1,126 @@
+<!--
+  - SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<script setup lang="ts">
+import { provide, ref, watch } from 'vue'
+import { useRouter } from 'vue-router/composables'
+
+import IconAccountMultiplePlus from 'vue-material-design-icons/AccountMultiplePlus.vue'
+
+import { showError } from '@nextcloud/dialogs'
+import { t } from '@nextcloud/l10n'
+
+import NcButton from '@nextcloud/vue/components/NcButton'
+import NcPopover from '@nextcloud/vue/components/NcPopover'
+
+import NewConversationContactsPage from './NewConversationDialog/NewConversationContactsPage.vue'
+
+import { useStore } from '../composables/useStore.js'
+
+const props = defineProps<{
+  token: string,
+  container?: string,
+}>()
+
+const store = useStore()
+const router = useRouter()
+
+const selectedParticipants = ref([])
+provide('selectedParticipants', selectedParticipants)
+
+// Add a visual bulk selection state for SelectableParticipant component
+provide('bulkParticipantsSelection', true)
+
+watch(() => props.token, () => {
+	selectedParticipants.value = []
+})
+/**
+ * Add current participants and selected ones to the new conversation
+ */
+async function extendOneToOneConversation() {
+	try {
+		const newConversation = await store.dispatch('extendOneToOneConversation', {
+			token: props.token,
+			newParticipants: selectedParticipants.value,
+		})
+		if (newConversation) {
+			await router.push({ name: 'conversation', params: { token: newConversation.token } })
+		}
+	} catch (error) {
+		console.error('Error creating new conversation: ', error)
+		showError(t('spreed', 'Error while creating the conversation'))
+	}
+}
+</script>
+
+<template>
+	<NcPopover :container="container"
+		popup-role="dialog">
+		<template #trigger>
+			<NcButton type="tertiary"
+				:title="t('spreed', 'Start a group conversation')"
+				:aria-label="t('spreed', 'Start a group conversation')">
+				<template #icon>
+					<IconAccountMultiplePlus :size="20" />
+				</template>
+			</NcButton>
+		</template>
+		<template #default>
+			<div class="start-group__content">
+				<h5 class="start-group__header">
+					{{ t('spreed', 'Start a group conversation') }}
+				</h5>
+				<NewConversationContactsPage class="start-group__contacts"
+					:token="token"
+					:selected-participants.sync="selectedParticipants"
+					only-users />
+				<NcButton class="start-group__action"
+					type="primary"
+					:disabled="!selectedParticipants.length"
+					@click="extendOneToOneConversation">
+					{{ t('spreed', 'Create conversation') }}
+				</NcButton>
+			</div>
+		</template>
+	</NcPopover>
+</template>
+
+<style lang="scss" scoped>
+.start-group {
+	&__content {
+		display: flex;
+		flex-direction: column;
+		gap: calc(2 * var(--default-grid-baseline));
+		width: 350px;
+		padding: calc(2 * var(--default-grid-baseline));
+
+		/* FIXME: remove after https://github.com/nextcloud-libraries/nextcloud-vue/pull/4959 is released */
+		&,
+		& :deep(*) {
+			box-sizing: border-box;
+		}
+		/* FIXME: remove after https://github.com/nextcloud-libraries/nextcloud-vue/pull/6669 is released */
+		& :deep(.avatardiv:has(img)) {
+			line-height: 0 !important;
+		}
+	}
+
+	&__header {
+		margin-block: 0 var(--default-grid-baseline);
+		text-align: center;
+	}
+
+	&__contacts {
+		display: flex;
+		flex-direction: column;
+		max-height: 50vh;
+	}
+
+	&__action {
+		justify-self: flex-end;
+		align-self: flex-end;
+	}
+}
+</style>

--- a/src/components/NewConversationDialog/NewConversationContactsPage.vue
+++ b/src/components/NewConversationDialog/NewConversationContactsPage.vue
@@ -52,8 +52,9 @@
 			:contacts-loading="contactsLoading"
 			:no-results="noResults"
 			scrollable
-			show-search-hints
+			:show-search-hints="!onlyUsers"
 			:token="token"
+			:only-users="onlyUsers"
 			@click="updateSelectedParticipants"
 			@click-search-hint="focusInput" />
 	</div>
@@ -116,6 +117,11 @@ export default {
 		canModerateSipDialOut: {
 			type: Boolean,
 			default: false,
+		},
+
+		onlyUsers: {
+			type: Boolean,
+			required: false,
 		},
 	},
 
@@ -302,9 +308,9 @@ export default {
 	gap: var(--default-grid-baseline);
 	border-bottom: 1px solid var(--color-background-darker);
 	padding: var(--default-grid-baseline) 0;
+	min-height: min-content;
 	max-height: 97px;
 	overflow-y: auto;
-	flex: 1 0 auto;
 	align-content: flex-start;
 }
 </style>

--- a/src/components/NewConversationDialog/NewConversationContactsPage.vue
+++ b/src/components/NewConversationDialog/NewConversationContactsPage.vue
@@ -53,6 +53,7 @@
 			:no-results="noResults"
 			scrollable
 			show-search-hints
+			:token="token"
 			@click="updateSelectedParticipants"
 			@click-search-hint="focusInput" />
 	</div>
@@ -102,9 +103,9 @@ export default {
 	},
 
 	props: {
-		conversationName: {
+		token: {
 			type: String,
-			required: true,
+			default: '',
 		},
 
 		selectedParticipants: {
@@ -213,7 +214,7 @@ export default {
 
 				const response = await request({
 					searchText: this.searchText,
-					token: 'new',
+					token: this.token || 'new',
 					forceTypes: [SHARE.TYPE.EMAIL], // email guests are allowed directly after conversation creation
 				})
 

--- a/src/components/NewConversationDialog/NewConversationDialog.vue
+++ b/src/components/NewConversationDialog/NewConversationDialog.vue
@@ -31,8 +31,7 @@
 				<NewConversationContactsPage v-if="page === 1"
 					class="new-group-conversation__content"
 					:selected-participants.sync="selectedParticipants"
-					:can-moderate-sip-dial-out="canModerateSipDialOut"
-					:conversation-name="conversationName" />
+					:can-moderate-sip-dial-out="canModerateSipDialOut" />
 			</div>
 
 			<!-- Navigation: different buttons with different actions and

--- a/src/components/NewConversationDialog/NewConversationDialog.vue
+++ b/src/components/NewConversationDialog/NewConversationDialog.vue
@@ -160,6 +160,8 @@ export default {
 		const isInCall = useIsInCall()
 		const selectedParticipants = ref([])
 		provide('selectedParticipants', selectedParticipants)
+		const lockedParticipants = ref([])
+		provide('lockedParticipants', lockedParticipants)
 
 		// Add a visual bulk selection state for SelectableParticipant component
 		provide('bulkParticipantsSelection', true)
@@ -170,6 +172,7 @@ export default {
 		return {
 			isInCall,
 			selectedParticipants,
+			lockedParticipants,
 			dialogHeaderPrepId,
 			dialogHeaderResId,
 		}
@@ -255,6 +258,7 @@ export default {
 				// Preload the conversation name from group selection
 				this.newConversation.displayName = item.label
 				this.selectedParticipants.push(item)
+				this.lockedParticipants.push(item)
 			}
 
 			this.showModal()
@@ -275,6 +279,7 @@ export default {
 			this.listable = CONVERSATION.LISTABLE.NONE
 			this.isAvatarEdited = false
 			this.selectedParticipants = []
+			this.lockedParticipants = []
 		},
 
 		switchToPage(value) {

--- a/src/components/RightSidebar/Participants/ParticipantsSearchResults.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsSearchResults.vue
@@ -6,58 +6,60 @@
 <template>
 	<div class="participants-search-results" :class="{'scrollable': scrollable }">
 		<template v-if="addableUsers.length !== 0">
-			<NcAppNavigationCaption :name="t('spreed', 'Add users')" />
+			<NcAppNavigationCaption v-if="!onlyUsers" :name="t('spreed', 'Add users')" />
 			<ParticipantsList :items="addableUsers"
 				is-search-result
 				@click="handleClickParticipant" />
 		</template>
 
-		<template v-if="addableGroups.length !== 0">
-			<NcAppNavigationCaption :name="t('spreed', 'Add groups')" />
-			<ParticipantsList :items="addableGroups"
-				is-search-result
-				@click="handleClickParticipant" />
+		<template v-if="!onlyUsers">
+			<template v-if="addableGroups.length !== 0">
+				<NcAppNavigationCaption :name="t('spreed', 'Add groups')" />
+				<ParticipantsList :items="addableGroups"
+					is-search-result
+					@click="handleClickParticipant" />
+			</template>
+
+			<template v-if="addableEmails.length !== 0">
+				<NcAppNavigationCaption :name="t('spreed', 'Add emails')" />
+				<ParticipantsList :items="addableEmails"
+					is-search-result
+					@click="handleClickParticipant" />
+			</template>
+
+			<template v-if="addableCircles.length !== 0">
+				<NcAppNavigationCaption :name="t('spreed', 'Add teams')" />
+				<ParticipantsList :items="addableCircles"
+					is-search-result
+					@click="handleClickParticipant" />
+			</template>
+
+			<!-- integrations -->
+			<template v-if="integrations.length !== 0">
+				<NcAppNavigationCaption :name="t('spreed', 'Integrations')" />
+				<ul>
+					<NcButton v-for="(integration, index) in integrations"
+						:key="'integration' + index"
+						type="tertiary-no-background"
+						@click="runIntegration(integration)">
+						<!-- FIXME: dynamically change the material design icon -->
+						<template #icon>
+							<AccountPlus :size="20" />
+						</template>
+						{{ integration.label }}
+					</NcButton>
+				</ul>
+			</template>
+
+			<template v-if="addableRemotes.length !== 0">
+				<NcAppNavigationCaption :name="t('spreed', 'Add federated users')" />
+				<ParticipantsList :items="addableRemotes"
+					is-search-result
+					@click="handleClickParticipant" />
+			</template>
 		</template>
 
-		<template v-if="addableEmails.length !== 0">
-			<NcAppNavigationCaption :name="t('spreed', 'Add emails')" />
-			<ParticipantsList :items="addableEmails"
-				is-search-result
-				@click="handleClickParticipant" />
-		</template>
-
-		<template v-if="addableCircles.length !== 0">
-			<NcAppNavigationCaption :name="t('spreed', 'Add teams')" />
-			<ParticipantsList :items="addableCircles"
-				is-search-result
-				@click="handleClickParticipant" />
-		</template>
-
-		<!-- integrations -->
-		<template v-if="integrations.length !== 0">
-			<NcAppNavigationCaption :name="t('spreed', 'Integrations')" />
-			<ul>
-				<NcButton v-for="(integration, index) in integrations"
-					:key="'integration' + index"
-					type="tertiary-no-background"
-					@click="runIntegration(integration)">
-					<!-- FIXME: dynamically change the material design icon -->
-					<template #icon>
-						<AccountPlus :size="20" />
-					</template>
-					{{ integration.label }}
-				</NcButton>
-			</ul>
-		</template>
-
-		<template v-if="addableRemotes.length !== 0">
-			<NcAppNavigationCaption :name="t('spreed', 'Add federated users')" />
-			<ParticipantsList :items="addableRemotes"
-				is-search-result
-				@click="handleClickParticipant" />
-		</template>
-
-		<NcAppNavigationCaption v-if="sourcesWithoutResults" :name="sourcesWithoutResultsList" />
+		<NcAppNavigationCaption v-if="sourcesWithoutResults && !onlyUsers" :name="sourcesWithoutResultsList" />
 		<Hint v-if="contactsLoading" :hint="t('spreed', 'Searching …')" />
 		<Hint v-else-if="sourcesWithoutResults" :hint="t('spreed', 'No search results')" />
 
@@ -136,6 +138,13 @@ export default {
 			default: false,
 		},
 		/**
+		 * Display only results from internal users.
+		 */
+		onlyUsers: {
+			type: Boolean,
+			default: false,
+		},
+		/**
 		 * Display loading state instead of list.
 		 */
 		loading: {
@@ -173,7 +182,11 @@ export default {
 		},
 
 		sourcesWithoutResults() {
-			return !this.addableUsers.length || !this.addableGroups.length || this.circlesWithoutResults
+			if (this.onlyUsers) {
+				return !this.addableUsers.length
+			} else {
+				return !this.addableUsers.length || !this.addableGroups.length || this.circlesWithoutResults
+			}
 		},
 
 		integrations() {
@@ -272,6 +285,10 @@ export default {
 
 	&__hint {
 		margin: 20px auto 0;
+	}
+
+	:deep(.app-navigation-hint):first-child {
+		margin-top: var(--default-grid-baseline) !important;
 	}
 }
 

--- a/src/components/RightSidebar/Participants/ParticipantsSearchResults.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsSearchResults.vue
@@ -122,6 +122,13 @@ export default {
 			required: true,
 		},
 		/**
+		 * Token of current conversation (if provided).
+		 */
+		token: {
+			type: String,
+			default: '',
+		},
+		/**
 		 * Display no-results state instead of list.
 		 */
 		noResults: {

--- a/src/components/RightSidebar/Participants/ParticipantsTab.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsTab.vue
@@ -51,6 +51,7 @@
 
 			<ParticipantsSearchResults v-if="canAdd"
 				class="search-results"
+				:token="token"
 				:search-results="searchResults"
 				:contacts-loading="contactsLoading"
 				:no-results="noResults"

--- a/src/components/RightSidebar/Participants/ParticipantsTab.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsTab.vue
@@ -41,18 +41,25 @@
 			:loading="!participantsInitialised" />
 
 		<div v-else class="scroller h-100">
-			<NcAppNavigationCaption v-if="canAdd" :name="t('spreed', 'Participants')" />
+			<template v-if="isOneToOneConversation">
+				<NcNoteCard type="info"
+					:text="t('spreed', 'A new group conversation with selected participant will be created')" />
+			</template>
+			<template v-else>
+				<NcAppNavigationCaption v-if="canAdd" :name="t('spreed', 'Participants')" />
 
-			<ParticipantsList v-if="filteredParticipants.length"
-				class="known-results"
-				:items="filteredParticipants"
-				:loading="!participantsInitialised" />
-			<Hint v-else :hint="t('spreed', 'No search results')" />
+				<ParticipantsList v-if="filteredParticipants.length"
+					class="known-results"
+					:items="filteredParticipants"
+					:loading="!participantsInitialised" />
+				<Hint v-else :hint="t('spreed', 'No search results')" />
+			</template>
 
 			<ParticipantsSearchResults v-if="canAdd"
 				class="search-results"
 				:token="token"
 				:search-results="searchResults"
+				:only-users="isOneToOneConversation"
 				:contacts-loading="contactsLoading"
 				:no-results="noResults"
 				:search-text="searchText"
@@ -72,6 +79,7 @@ import { subscribe, unsubscribe } from '@nextcloud/event-bus'
 import { t } from '@nextcloud/l10n'
 
 import NcAppNavigationCaption from '@nextcloud/vue/components/NcAppNavigationCaption'
+import NcNoteCard from '@nextcloud/vue/components/NcNoteCard'
 
 import ParticipantsList from './ParticipantsList.vue'
 import ParticipantsListVirtual from './ParticipantsListVirtual.vue'
@@ -86,7 +94,7 @@ import { useGetParticipants } from '../../../composables/useGetParticipants.js'
 import { useId } from '../../../composables/useId.ts'
 import { useIsInCall } from '../../../composables/useIsInCall.js'
 import { useSortParticipants } from '../../../composables/useSortParticipants.js'
-import { ATTENDEE } from '../../../constants.ts'
+import { ATTENDEE, CONVERSATION } from '../../../constants.ts'
 import { getTalkConfig, hasTalkFeature } from '../../../services/CapabilitiesManager.ts'
 import { autocompleteQuery } from '../../../services/coreService.ts'
 import { EventBus } from '../../../services/EventBus.ts'
@@ -99,6 +107,7 @@ const isFederationEnabled = getTalkConfig('local', 'federation', 'enabled')
 export default {
 	name: 'ParticipantsTab',
 	components: {
+		NcNoteCard,
 		DialpadPanel,
 		Hint,
 		NcAppNavigationCaption,
@@ -205,6 +214,9 @@ export default {
 		conversation() {
 			return this.$store.getters.conversation(this.token) || this.$store.getters.dummyConversation
 		},
+		isOneToOneConversation() {
+			return [CONVERSATION.TYPE.ONE_TO_ONE, CONVERSATION.TYPE.ONE_TO_ONE_FORMER].includes(this.conversation.type)
+		},
 		userId() {
 			return this.$store.getters.getUserId()
 		},
@@ -291,6 +303,7 @@ export default {
 				const response = await request({
 					searchText: this.searchText,
 					token: this.token,
+					onlyUsers: this.isOneToOneConversation,
 				})
 
 				this.searchResults = response?.data?.ocs?.data || []
@@ -310,18 +323,25 @@ export default {
 		/**
 		 * Add the selected group/user/circle to the conversation
 		 *
-		 * @param {object} item The autocomplete suggestion to start a conversation with
-		 * @param {string} item.id The ID of the target
-		 * @param {string} item.source The source of the target
+		 * @param {object} participant The autocomplete suggestion to start a conversation with
+		 * @param {string} participant.id The ID of the target
+		 * @param {string} participant.source The source of the target
 		 */
-		async addParticipants(item) {
+		async addParticipants(participant) {
 			try {
-				await addParticipant(this.token, item.id, item.source)
-				if (item.source === ATTENDEE.ACTOR_TYPE.EMAILS) {
-					showSuccess(t('spreed', 'Invitation was sent to {actorId}', { actorId: item.id }))
+				if (this.isOneToOneConversation) {
+					await this.$store.dispatch('extendOneToOneConversation', {
+						token: this.token,
+						newParticipants: [participant],
+					})
+				} else {
+					await addParticipant(this.token, participant.id, participant.source)
+					this.cancelableGetParticipants()
+				}
+				if (participant.source === ATTENDEE.ACTOR_TYPE.EMAILS) {
+					showSuccess(t('spreed', 'Invitation was sent to {actorId}', { actorId: participant.id }))
 				}
 				this.abortSearch()
-				this.cancelableGetParticipants()
 			} catch (exception) {
 				console.debug(exception)
 				showError(t('spreed', 'An error occurred while adding the participants'))

--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -160,6 +160,8 @@ import { CONVERSATION, WEBINAR, PARTICIPANT } from '../../constants.ts'
 import { hasTalkFeature } from '../../services/CapabilitiesManager.ts'
 import { useSidebarStore } from '../../stores/sidebar.ts'
 
+const supportConversationCreationAll = hasTalkFeature('local', 'conversation-creation-all')
+
 export default {
 	name: 'RightSidebar',
 	components: {
@@ -248,8 +250,9 @@ export default {
 		},
 
 		canSearchParticipants() {
-			return (this.conversation.type === CONVERSATION.TYPE.GROUP
-				|| (this.conversation.type === CONVERSATION.TYPE.PUBLIC && this.conversation.objectType !== CONVERSATION.OBJECT_TYPE.VIDEO_VERIFICATION))
+			return this.conversation.type === CONVERSATION.TYPE.GROUP
+				|| (this.conversation.type === CONVERSATION.TYPE.PUBLIC && this.conversation.objectType !== CONVERSATION.OBJECT_TYPE.VIDEO_VERIFICATION)
+				|| (this.conversation.type === CONVERSATION.TYPE.ONE_TO_ONE && supportConversationCreationAll)
 		},
 
 		participantType() {

--- a/src/components/UIShared/ContactSelectionBubble.vue
+++ b/src/components/UIShared/ContactSelectionBubble.vue
@@ -4,7 +4,8 @@
 -->
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, inject, ref } from 'vue'
+import type { Ref } from 'vue'
 
 import { t } from '@nextcloud/l10n'
 
@@ -19,6 +20,21 @@ const props = defineProps<{
 	participant: Participant | ParticipantSearchResult,
 }>()
 const emit = defineEmits(['update'])
+
+// Defines list of locked participants (can not be removed manually
+const lockedParticipants = inject<Ref<(Participant | ParticipantSearchResult)[]>>('lockedParticipants', ref([]))
+
+const isLocked = computed(() => lockedParticipants.value.some(item => {
+	if ('actorId' in props.participant) {
+		return ('actorId' in item)
+			? item.actorId === props.participant.actorId && item.actorType === props.participant.actorType
+			: item.id === props.participant.actorId && item.source === props.participant.actorType
+	} else {
+		return ('actorId' in item)
+			? item.actorId === props.participant.id && item.actorType === props.participant.source
+			: item.id === props.participant.id && item.source === props.participant.source
+	}
+}))
 
 const actorId = computed(() => {
 	return ('actorId' in props.participant) ? props.participant.actorId : props.participant.id
@@ -38,6 +54,7 @@ const removeLabel = computed(() => t('spreed', 'Remove participant {name}', { na
 <template>
 	<NcChip :text="computedName"
 		:aria-label-close="removeLabel"
+		:no-close="isLocked"
 		@close="emit('update', participant)">
 		<template #icon>
 			<AvatarWrapper :id="actorId"

--- a/src/components/UIShared/SearchBox.vue
+++ b/src/components/UIShared/SearchBox.vue
@@ -165,7 +165,7 @@ export default {
 			}
 
 			// Blur triggered by clicking on a conversation item
-			if (this.listRef.length && this.listRef.some(list => list?.$el?.contains(event.relatedTarget))) {
+			if (this.listRef?.length && this.listRef.some(list => list?.$el?.contains(event.relatedTarget))) {
 				return
 			}
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -103,6 +103,7 @@ export const CONVERSATION = {
 		CIRCLES: 'circles',
 		VIDEO_VERIFICATION: 'share:password',
 		BREAKOUT_ROOM: 'room',
+		EXTENDED: 'extended_conversation',
 		DEFAULT: '',
 	},
 

--- a/src/store/conversationsStore.js
+++ b/src/store/conversationsStore.js
@@ -1001,16 +1001,20 @@ const actions = {
 	 * @param {object} payload action payload;
 	 * @param {string} payload.roomName displayed name for a new conversation
 	 * @param {number} payload.roomType whether a conversation is public or private
-	 * @param {string} payload.password password for a public conversation
-	 * @param {string} payload.description description for a new conversation
-	 * @param {number} payload.listable whether a conversation is opened to registered users
-	 * @param {Array} payload.participants list of participants
-	 * @param {object} payload.avatar avatar object: { emoji, color } | { file }
+	 * @param {string} [payload.objectType] object type of new conversation, if applicable
+	 * @param {string} [payload.objectId] reference to initial conversation, if applicable
+	 * @param {string} [payload.password] password for a public conversation
+	 * @param {string} [payload.description] description for a new conversation
+	 * @param {number} [payload.listable] whether a conversation is opened to registered users
+	 * @param {Array} [payload.participants] list of participants
+	 * @param {object} [payload.avatar] avatar object: { emoji, color } | { file }
 	 * @return {object} new conversation object
 	 */
 	async createGroupConversation(context, {
 		roomName,
 		roomType,
+		objectType,
+		objectId,
 		password,
 		description,
 		listable,
@@ -1041,11 +1045,13 @@ const actions = {
 				response = await createConversation({
 					roomType,
 					roomName,
+					objectType,
+					objectId,
 					password,
 					description,
 					listable,
-					emoji: avatar.emoji,
-					avatarColor: avatar.color,
+					emoji: avatar?.emoji,
+					avatarColor: avatar?.color,
 					participants: participantsMap,
 				})
 			} else {
@@ -1062,12 +1068,12 @@ const actions = {
 			const promises = []
 
 			// FIXME Both advanced and legacy API do not support picture avatar upload on creation
-			if (avatar.file) {
+			if (avatar?.file) {
 				promises.push(context.dispatch('setConversationAvatarAction', { token, file: avatar.file }))
 			}
 
 			if (!supportConversationCreationAll) {
-				if (avatar.emoji) {
+				if (avatar?.emoji) {
 					promises.push(context.dispatch('setConversationEmojiAvatarAction', { token, emoji: avatar.emoji, color: avatar.color }))
 				}
 

--- a/src/utils/getDisplayName.ts
+++ b/src/utils/getDisplayName.ts
@@ -2,11 +2,16 @@
  * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-import { t } from '@nextcloud/l10n'
+import { getLanguage, t } from '@nextcloud/l10n'
 
 import { ATTENDEE } from '../constants.ts'
 
-export const getDisplayNameWithFallback = function(displayName: string, source: string): string {
+/**
+ * Returns display name with 'Guest' or 'Deleted user' fallback if not provided
+ * @param displayName possible name of participant
+ * @param source actor type of participant
+ */
+export function getDisplayNameWithFallback(displayName: string, source: string): string {
 	if (displayName?.trim()) {
 		return displayName.trim()
 	}
@@ -19,4 +24,27 @@ export const getDisplayNameWithFallback = function(displayName: string, source: 
 	// - for matching type: `source === ATTENDEE.ACTOR_TYPE.DELETED_USERS`
 	// - in other cases: should not happen, but can not be empty either
 	return t('spreed', 'Deleted user')
+}
+
+/**
+ * Returns concatenated display names with comma divider
+ * @param {Array} displayNames list of display name
+ * @param {number} [maxLength] max allowed length
+ */
+export function getDisplayNamesList(displayNames: string[], maxLength?: number): string {
+	const sanitizedList = displayNames.map((name) => name.trim()).filter(Boolean)
+
+	if (!sanitizedList.length) {
+		return ''
+	}
+
+	const joinedDisplayNames = new Intl.ListFormat(getLanguage(), {
+		style: 'narrow',
+		type: 'conjunction',
+	}).format(sanitizedList)
+
+	if (maxLength && joinedDisplayNames.length > maxLength) {
+		return joinedDisplayNames.substring(0, maxLength - 1) + '…'
+	}
+	return joinedDisplayNames
 }


### PR DESCRIPTION
### ☑️ Resolves

* Fix #14399
	* New util "getDisplayNamesList" to format display name lists with length constraints.
	* Introduce the "extendOneToOneConversation" store action
	* Show the "Participants" button in one-to-one
	* Allow to search for user participant only in the one-to-one call
	* Allow to lock pre-selected participant when creating a new group conversation
	* New popover to extend one-to-one conversations in the TopBar.


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

From LeftSidebar (locking group/team)
![image](https://github.com/user-attachments/assets/0b8ed7c9-1007-4958-b692-d372eec29df4)


From TopBar (in chat)
![image](https://github.com/user-attachments/assets/c428c2fb-2f5f-4318-88a4-c4f4a30e9e0f)

From RightSidebar (in call)
![image](https://github.com/user-attachments/assets/f5b9bfb3-dbab-482e-a1f4-53ec7ff0dd68)
![image](https://github.com/user-attachments/assets/52e3e3a8-d854-4ba0-9ae3-2be2c6366f36)
![image](https://github.com/user-attachments/assets/3330e668-8fee-4554-9fe3-e4e432cb65e6)


### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
