### PR TITLE
fix: Do not reset previous users after a resume

### DIFF
--- a/src/utils/signaling.js
+++ b/src/utils/signaling.js
@@ -636,7 +636,6 @@ Signaling.Standalone.prototype.reconnect = function() {
 	// simultaneously in case the server connection is interrupted.
 	const interval = this.reconnectIntervalMs - (this.reconnectIntervalMs / 2) + (this.reconnectIntervalMs * Math.random())
 	console.info('Reconnect in', interval)
-	this.reconnected = true
 	this.reconnectTimer = window.setTimeout(function() {
 		this.reconnectTimer = null
 		this.connect()
@@ -1361,18 +1360,10 @@ Signaling.Standalone.prototype.processRoomEvent = function(data) {
 		joinedUsers = data.event.join || []
 		if (joinedUsers.length) {
 			console.debug('Users joined', joinedUsers)
-			let leftUsers = {}
-			if (this.reconnected) {
-				this.reconnected = false
-				// The browser reconnected, some of the previous sessions
-				// may now no longer exist.
-				leftUsers = Object.assign({}, this.joinedUsers)
-			}
 
 			let userListIsDirty = false
 			for (i = 0; i < joinedUsers.length; i++) {
 				this.joinedUsers[joinedUsers[i].sessionid] = joinedUsers[i]
-				delete leftUsers[joinedUsers[i].sessionid]
 
 				if (this.settings.userId && joinedUsers[i].userid === this.settings.userId) {
 					if (joinedUsers[i].sessionid === this.sessionId) {
@@ -1382,18 +1373,6 @@ Signaling.Standalone.prototype.processRoomEvent = function(data) {
 					}
 				} else {
 					userListIsDirty = true
-				}
-			}
-			leftUsers = Object.keys(leftUsers)
-			if (leftUsers.length) {
-				this._trigger('usersLeft', [leftUsers])
-
-				for (i = 0; i < leftUsers.length; i++) {
-					delete this.joinedUsers[leftUsers[i]]
-
-					if (!this.settings.userId || leftUsers[i].userid !== this.settings.userId) {
-						userListIsDirty = true
-					}
 				}
 			}
 			this._trigger('usersJoined', [joinedUsers])


### PR DESCRIPTION
After the signaling session was resumed the list of known participants was reset to the next received list of joined users, as it was expected that the `join` event included the full list of participants currently in the room. This was introduced when support for the external signaling server was added in Talk, and back then it may have worked as expected. However, in current signaling server versions when a `join` event is received after the session was resumed it only includes the participant that was just added, rather than the full list (like any other `join` event except the first one received after joining a room). Therefore all the previous participants in the room are seen as leaving the room, which would cause, for example, that they are removed from the call view. Due to that now the list of participants is no longer reset to the next received list of joined users.

Moreover, the signaling server also resends any pending message that would have been received between the session disconnected and resumed, so the list of known participants will be updated as expected without that code.

## How to test (scenario 1)

- Setup the HPB
- Create three users in Nextcloud
- Login as user A
- Create a group conversation with users B and C
- Start a call
- In a private window, login as user B
- Join the call
- In another browser, login as user C
- Open Talk
- In the original window, close the signaling connection with `OCA.Talk.SimpleWebRTC.connection.socket.close()`
- Wait until the WebSocket connection is established again
- In the other browser, join the conversation as user C

### Result with this pull request

User A and B are in the call and can see each other

### Result without this pull request

User A and B are in the call, but user A sees `Waiting for others to join the call` and user B sees a static image of user A



## How to test (scenario 2)

- (Steps from scenario 1)
- Join the call

### Result with this pull request

User A, B and C are in the call and can see each other

### Result without this pull request

User A, B and C are in the call, users A and C can see each other and user B, but user B sees a static image of user A
