### PR TITLE
fix(CalendarEventsDialog): adjust UI based on conversation type

### DIFF
--- a/src/components/CalendarEventsDialog.vue
+++ b/src/components/CalendarEventsDialog.vue
@@ -36,7 +36,7 @@ import SearchBox from './UIShared/SearchBox.vue'
 import TransitionWrapper from './UIShared/TransitionWrapper.vue'
 
 import { useStore } from '../composables/useStore.js'
-import { ATTENDEE } from '../constants.ts'
+import { ATTENDEE, CONVERSATION } from '../constants.ts'
 import { hasTalkFeature } from '../services/CapabilitiesManager.ts'
 import { useGroupwareStore } from '../stores/groupware.ts'
 import type { Conversation, Participant } from '../types/index.ts'
@@ -158,11 +158,11 @@ const attendeeHint = computed(() => {
 const searchText = ref('')
 const isMatch = (string: string = '') => string.toLowerCase().includes(searchText.value.toLowerCase())
 
+const conversation = computed<Conversation>(() => store.getters.conversation(props.token))
 const participants = computed(() => {
-	const conversation: Conversation = store.getters.conversation(props.token)
 	return store.getters.participantsList(props.token).filter((participant: Participant) => {
 		return [ATTENDEE.ACTOR_TYPE.USERS, ATTENDEE.ACTOR_TYPE.EMAILS].includes(participant.actorType)
-			&& participant.attendeeId !== conversation.attendeeId
+			&& participant.attendeeId !== conversation.value.attendeeId
 	})
 })
 const participantsInitialised = computed(() => store.getters.participantsInitialised(props.token))
@@ -185,6 +185,17 @@ const selectedParticipants = computed(() => participants.value
 		return 0
 	})
 )
+
+const isOneToOneConversation = computed(() => {
+	return conversation.value.type === CONVERSATION.TYPE.ONE_TO_ONE
+		|| conversation.value.type === CONVERSATION.TYPE.ONE_TO_ONE_FORMER
+})
+
+const inviteLabel = computed(() => {
+	return isOneToOneConversation.value
+		? t('spreed', 'Invite {user}', { user: conversation.value.displayName })
+		: t('spreed', 'Invite all users and emails in this conversation')
+})
 
 onBeforeMount(() => {
 	getCalendars()
@@ -407,13 +418,13 @@ async function submitNewMeeting() {
 						{{ option.label }}
 					</template>
 				</NcSelect>
-				<h5 class="calendar-meeting__header">
+				<h5 v-if="!isOneToOneConversation" class="calendar-meeting__header">
 					{{ t('spreed', 'Attendees') }}
 				</h5>
 				<NcCheckboxRadioSwitch v-model="selectAll" @update:modelValue="toggleAll">
-					{{ t('spreed', 'Invite all users and emails') }}
+					{{ inviteLabel }}
 				</NcCheckboxRadioSwitch>
-				<NcButton type="tertiary" @click="isSelectorOpen = true">
+				<NcButton v-if="!isOneToOneConversation && !selectAll" type="tertiary" @click="isSelectorOpen = true">
 					<template #icon>
 						<IconAccountPlus :size="20" />
 					</template>

--- a/src/components/CalendarEventsDialog.vue
+++ b/src/components/CalendarEventsDialog.vue
@@ -421,16 +421,26 @@ async function submitNewMeeting() {
 				<h5 v-if="!isOneToOneConversation" class="calendar-meeting__header">
 					{{ t('spreed', 'Attendees') }}
 				</h5>
-				<NcCheckboxRadioSwitch v-model="selectAll" @update:modelValue="toggleAll">
-					{{ inviteLabel }}
-				</NcCheckboxRadioSwitch>
-				<NcButton v-if="!isOneToOneConversation && !selectAll" type="tertiary" @click="isSelectorOpen = true">
-					<template #icon>
-						<IconAccountPlus :size="20" />
-					</template>
-					{{ t('spreed', 'Add attendees') }}
-				</NcButton>
-				<p>{{ attendeeHint }}</p>
+				<div v-if="!participantsInitialised"
+					class="calendar-meeting--loading">
+					<NcLoadingIcon />
+					{{ t('spreed', 'Loading …') }}
+				</div>
+				<p v-else-if="participants.length === 0">
+					{{ t('spreed', 'No other participants to send invitations to.') }}
+				</p>
+				<template v-else>
+					<NcCheckboxRadioSwitch v-model="selectAll" @update:modelValue="toggleAll">
+						{{ inviteLabel }}
+					</NcCheckboxRadioSwitch>
+					<NcButton v-if="!isOneToOneConversation && !selectAll" type="tertiary" @click="isSelectorOpen = true">
+						<template #icon>
+							<IconAccountPlus :size="20" />
+						</template>
+						{{ t('spreed', 'Add attendees') }}
+					</NcButton>
+					<p>{{ attendeeHint }}</p>
+				</template>
 
 				<template #actions>
 					<p v-if="invalidHint" class="calendar-meeting__invalid-hint">
@@ -627,6 +637,13 @@ async function submitNewMeeting() {
 	&__empty-content {
 		height: calc(5.5 * var(--item-height));
 		margin-block: auto !important;
+	}
+
+	&--loading {
+		display: flex;
+		align-items: center;
+		gap: var(--default-grid-baseline);
+		height: 32px;
 	}
 
 	// Overwrite default NcDateTimePickerNative styles

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -283,6 +283,7 @@ export default {
 		showCalendarEvents() {
 			return this.getUserId && !this.isInCall && !this.isSidebar
 				&& this.conversation.type !== CONVERSATION.TYPE.NOTE_TO_SELF
+				&& this.conversation.type !== CONVERSATION.TYPE.CHANGELOG
 		},
 
 		getUserId() {


### PR DESCRIPTION
### ☑️ Resolves

- Ref: https://github.com/nextcloud/spreed/issues/14802
  - [x] Considered closed? Button is not shown by default in group and 1-1 conversation; only shown when unselect all, then you need to "add attendees" to the meeting, so they receive invites

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![calendar-dialog-before](https://github.com/user-attachments/assets/08804e92-3be4-465e-b2d8-64b252f4bae2) | ![image](https://github.com/user-attachments/assets/a81d452c-e9b3-4919-83db-16f91df12c0e)

<!-- ☀️ Light theme | 🌑 Dark Theme -->


### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required

