### PR TITLE
fix(a11y): provide missing aria-labels to buttons with no visible text

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/Reactions.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/Reactions.vue
@@ -44,6 +44,7 @@
 		<NcButton v-if="showControls"
 			size="small"
 			:title="t('spreed', 'Show all reactions')"
+			:aria-label="t('spreed', 'Show all reactions')"
 			@click="showAllReactions = true">
 			<HeartOutlineIcon :size="15" />
 		</NcButton>

--- a/src/components/NewMessage/NewMessageAbsenceInfo.vue
+++ b/src/components/NewMessage/NewMessageAbsenceInfo.vue
@@ -30,6 +30,8 @@
 		<NcButton v-if="userAbsenceMessage && isTextMoreThanOneLine"
 			class="absence-reminder__button"
 			type="tertiary"
+			:title="!collapsed ? t('spreed', 'Collapse') : t('spreed', 'Expand')"
+			:aria-label="!collapsed ? t('spreed', 'Collapse') : t('spreed', 'Expand')"
 			@click="toggleCollapsed">
 			<template #icon>
 				<ChevronUp class="icon" :class="{'icon--reverted': !collapsed}" :size="20" />

--- a/src/components/NewMessage/NewMessageChatSummary.vue
+++ b/src/components/NewMessage/NewMessageChatSummary.vue
@@ -13,6 +13,8 @@
 		<NcButton v-if="isTextMoreThanOneLine"
 			class="chat-summary__button"
 			type="tertiary"
+			:title="!collapsed ? t('spreed', 'Collapse') : t('spreed', 'Expand')"
+			:aria-label="!collapsed ? t('spreed', 'Collapse') : t('spreed', 'Expand')"
 			@click="toggleCollapsed">
 			<template #icon>
 				<IconChevronUp class="icon" :class="{'icon--reverted': !collapsed}" :size="20" />

--- a/src/components/RightSidebar/Participants/Participant.vue
+++ b/src/components/RightSidebar/Participants/Participant.vue
@@ -87,6 +87,7 @@
 				<NcButton v-if="canSkipLobby"
 					type="tertiary"
 					:title="t('spreed', 'Move back to lobby')"
+					:aria-label="t('spreed', 'Move back to lobby')"
 					@click="setLobbyPermission(false)">
 					<template #icon>
 						<AccountMinusIcon :size="20" />
@@ -95,6 +96,7 @@
 				<NcButton v-else
 					type="tertiary"
 					:title="t('spreed', 'Move to conversation')"
+					:aria-label="t('spreed', 'Move to conversation')"
 					@click="setLobbyPermission(true)">
 					<template #icon>
 						<AccountPlusIcon :size="20" />

--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -24,6 +24,7 @@
 		<template v-if="!showSearchMessagesTab && getUserId" #secondary-actions>
 			<NcActionButton type="tertiary"
 				:title="t('spreed', 'Search messages')"
+				:aria-label="t('spreed', 'Search messages')"
 				@click="handleShowSearch(true)">
 				<template #icon>
 					<IconMagnify :size="20" />
@@ -33,6 +34,7 @@
 		<template v-else-if="getUserId" #tertiary-actions>
 			<NcButton type="tertiary"
 				:title="t('spreed', 'Back')"
+				:aria-label="t('spreed', 'Back')"
 				@click="handleShowSearch(false)">
 				<template #icon>
 					<IconArrowLeft class="bidirectional-icon" :size="20" />

--- a/src/components/UIShared/DialpadPanel.vue
+++ b/src/components/UIShared/DialpadPanel.vue
@@ -56,6 +56,7 @@
 			<NcButton v-if="!dialing"
 				class="dial-panel__button"
 				type="tertiary"
+				:aria-label="t('spreed', 'Delete')"
 				@click="handleBackspace">
 				<template #icon>
 					<IconBackspaceOutline :size="20" />


### PR DESCRIPTION
### ☑️ Resolves

* Fix: missing aria-labels for button components
  * Actually fix: yellow warnings in console

## 🖌️ UI Checklist

No visual changes

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required