### PR TITLE
feat(conversations): Allow to not request the last message when getting rooms

### DIFF
--- a/lib/Service/RoomFormatter.php
+++ b/lib/Service/RoomFormatter.php
@@ -65,6 +65,7 @@ class RoomFormatter {
 		?array $statuses = null,
 		bool $isSIPBridgeRequest = false,
 		bool $isListingBreakoutRooms = false,
+		bool $skipLastMessage = false,
 	): array {
 		return $this->formatRoomV4(
 			$responseFormat,
@@ -74,6 +75,7 @@ class RoomFormatter {
 			$statuses,
 			$isSIPBridgeRequest,
 			$isListingBreakoutRooms,
+			$skipLastMessage,
 		);
 	}
 
@@ -89,6 +91,7 @@ class RoomFormatter {
 		?array $statuses,
 		bool $isSIPBridgeRequest,
 		bool $isListingBreakoutRooms,
+		bool $skipLastMessage,
 	): array {
 		$roomData = [
 			'id' => $room->getId(),
@@ -386,7 +389,7 @@ class RoomFormatter {
 			}
 		}
 
-		$lastMessage = $room->getLastMessage();
+		$lastMessage = $skipLastMessage ? null : $room->getLastMessage();
 		if (!$room->isFederatedConversation() && $lastMessage instanceof IComment) {
 			$lastMessageData = $this->formatLastMessage(
 				$responseFormat,

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -11854,6 +11854,19 @@
                         }
                     },
                     {
+                        "name": "includeLastMessage",
+                        "in": "query",
+                        "description": "Include the last message, clients should opt-out when only rendering a compact list",
+                        "schema": {
+                            "type": "integer",
+                            "default": 1,
+                            "enum": [
+                                0,
+                                1
+                            ]
+                        }
+                    },
+                    {
                         "name": "OCS-APIRequest",
                         "in": "header",
                         "description": "Required to be true for the API request to pass",

--- a/openapi.json
+++ b/openapi.json
@@ -11759,6 +11759,19 @@
                         }
                     },
                     {
+                        "name": "includeLastMessage",
+                        "in": "query",
+                        "description": "Include the last message, clients should opt-out when only rendering a compact list",
+                        "schema": {
+                            "type": "integer",
+                            "default": 1,
+                            "enum": [
+                                0,
+                                1
+                            ]
+                        }
+                    },
+                    {
                         "name": "OCS-APIRequest",
                         "in": "header",
                         "description": "Required to be true for the API request to pass",

--- a/src/types/openapi/openapi-full.ts
+++ b/src/types/openapi/openapi-full.ts
@@ -6439,6 +6439,8 @@ export interface operations {
                 includeStatus?: 0 | 1;
                 /** @description Filter rooms modified after a timestamp */
                 modifiedSince?: number;
+                /** @description Include the last message, clients should opt-out when only rendering a compact list */
+                includeLastMessage?: 0 | 1;
             };
             header: {
                 /** @description Required to be true for the API request to pass */

--- a/src/types/openapi/openapi.ts
+++ b/src/types/openapi/openapi.ts
@@ -5921,6 +5921,8 @@ export interface operations {
                 includeStatus?: 0 | 1;
                 /** @description Filter rooms modified after a timestamp */
                 modifiedSince?: number;
+                /** @description Include the last message, clients should opt-out when only rendering a compact list */
+                includeLastMessage?: 0 | 1;
             };
             header: {
                 /** @description Required to be true for the API request to pass */


### PR DESCRIPTION
This is useful e.g. when only showing a compact list

## 🛠️ API Checklist

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [X] 🔖 Capability is added or not needed 
