### PR TITLE
feat(conversations): do not request last message when in compact mode

### DIFF
--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -461,6 +461,14 @@ export default {
 				this.isNavigating = true
 			}
 		},
+		isCompact(value) {
+			if (!value) {
+				// Last messages are likely missing from the store, need to fetch with modifiedSince=0
+				this.roomListModifiedBefore = 0
+				this.forceFullRoomListRefreshAfterXLoops = 10
+				this.fetchConversations()
+			}
+		}
 	},
 
 	beforeMount() {
@@ -759,6 +767,7 @@ export default {
 			try {
 				const response = await this.$store.dispatch('fetchConversations', {
 					modifiedSince: this.roomListModifiedBefore,
+					includeLastMessage: this.isCompact ? 0 : 1,
 				})
 
 				// We can only support this with the HPB as otherwise rooms,

--- a/src/store/conversationsStore.js
+++ b/src/store/conversationsStore.js
@@ -914,7 +914,7 @@ const actions = {
 		}
 	},
 
-	async fetchConversations({ dispatch }, { modifiedSince }) {
+	async fetchConversations({ dispatch }, { modifiedSince, includeLastMessage = 1 }) {
 		const talkHashStore = useTalkHashStore()
 		const federationStore = useFederationStore()
 		try {
@@ -923,6 +923,7 @@ const actions = {
 			const response = await fetchConversations({
 				modifiedSince,
 				includeStatus: 1,
+				includeLastMessage,
 			})
 			talkHashStore.updateTalkVersionHash(response)
 			federationStore.updatePendingSharesCount(response.headers['x-nextcloud-talk-federation-invites'])

--- a/src/store/conversationsStore.spec.js
+++ b/src/store/conversationsStore.spec.js
@@ -285,7 +285,7 @@ describe('conversationsStore', () => {
 
 			await store.dispatch('fetchConversations', {})
 
-			expect(fetchConversations).toHaveBeenCalledWith({ modifiedSince: 0, includeStatus: 1 })
+			expect(fetchConversations).toHaveBeenCalledWith({ modifiedSince: 0, includeStatus: 1, includeLastMessage: 1 })
 			expect(store.getters.conversationsList).toStrictEqual(testConversations)
 		})
 
@@ -334,7 +334,7 @@ describe('conversationsStore', () => {
 
 			await store.dispatch('fetchConversations', { })
 
-			expect(fetchConversations).toHaveBeenCalledWith({ modifiedSince: 0, includeStatus: 1 })
+			expect(fetchConversations).toHaveBeenCalledWith({ modifiedSince: 0, includeStatus: 1, includeLastMessage: 1 })
 			// conversationsList is actual to the response
 			expect(store.getters.conversationsList).toEqual([newConversation, oldConversation])
 			// Only old conversation with new activity should be actually replaced with new objects
@@ -554,7 +554,7 @@ describe('conversationsStore', () => {
 			store.dispatch('fetchConversations', { })
 			await flushPromises()
 
-			expect(fetchConversations).toHaveBeenCalledWith({ modifiedSince: 0, includeStatus: 1 })
+			expect(fetchConversations).toHaveBeenCalledWith({ modifiedSince: 0, includeStatus: 1, includeLastMessage: 1 })
 			expect(store.getters.conversationsList).toStrictEqual(testConversations)
 		})
 
@@ -595,7 +595,7 @@ describe('conversationsStore', () => {
 
 			await store.dispatch('fetchConversations', { modifiedSince })
 
-			expect(fetchConversations).toHaveBeenCalledWith({ modifiedSince, includeStatus: 1 })
+			expect(fetchConversations).toHaveBeenCalledWith({ modifiedSince, includeStatus: 1, includeLastMessage: 1 })
 			// conversations are actual to the response
 			expect(store.state.conversationsStore.conversations).toEqual({
 				[newConversation1.token]: newConversation1,


### PR DESCRIPTION
### ☑️ Resolves

* Follow-up to #14772

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

https://github.com/user-attachments/assets/261dfd22-a199-4036-a909-6d492fa7d616

### 🚧 TODO
* Has no effect without backend, so should be safe for Desktop client?
* Shows a fallback for a moment when switching from 'compact-mode' - acceptable?


### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
