### PR TITLE
chore(release): Prepare 19.0.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,24 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 19.0.15 – 2025-04-04
+### Changed
+- Update translations
+- Update dependencies
+
+### Fixed
+- fix(calls): Do not reset previous connected users after resuming in a call
+  [#14735](https://github.com/nextcloud/spreed/issues/14735)
+- fix(sidebar): Show tooltips when Talk is in the sidebar
+  [#14697](https://github.com/nextcloud/spreed/issues/14697)
+- fix(guests): Fix style and labels on public share page as a guest
+  [#14720](https://github.com/nextcloud/spreed/issues/14720)
+  [#14726](https://github.com/nextcloud/spreed/issues/14726)
+- fix(calls): Skip password verification for guests that are reconnecting to the call
+  [#14787](https://github.com/nextcloud/spreed/pull/14787)
+- fix(calls): Fix leaving call if a signaling message is received while reconnecting
+  [#14788](https://github.com/nextcloud/spreed/pull/14788)
+
 ## 19.0.14 – 2025-03-12
 ### Changed
 - Update translations

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -14,7 +14,7 @@
 * 🌉 **Sync with other chat solutions** With [Matterbridge](https://github.com/42wim/matterbridge/) being integrated in Talk, you can easily sync a lot of other chat solutions to Nextcloud Talk and vice-versa.
 ]]></description>
 
-	<version>19.0.14</version>
+	<version>19.0.15</version>
 	<licence>agpl</licence>
 
 	<author>Daniel Calviño Sánchez</author>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "talk",
-  "version": "19.0.14",
+  "version": "19.0.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "talk",
-      "version": "19.0.14",
+      "version": "19.0.15",
       "license": "agpl",
       "dependencies": {
         "@linusborg/vue-simple-portal": "^0.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "talk",
-  "version": "19.0.14",
+  "version": "19.0.15",
   "private": true,
   "description": "",
   "author": "Joas Schilling <coding@schilljs.com>",


### PR DESCRIPTION
## 19.0.15 – 2025-04-04
### Changed
- Update translations
- Update dependencies

### Fixed
- fix(calls): Do not reset previous connected users after resuming in a call [#14735](https://github.com/nextcloud/spreed/issues/14735)
- fix(sidebar): Show tooltips when Talk is in the sidebar [#14697](https://github.com/nextcloud/spreed/issues/14697)
- fix(guests): Fix style and labels on public share page as a guest [#14720](https://github.com/nextcloud/spreed/issues/14720) [#14726](https://github.com/nextcloud/spreed/issues/14726)
- fix(calls): Skip password verification for guests that are reconnecting to the call [#14787](https://github.com/nextcloud/spreed/pull/14787)
- fix(calls): Fix leaving call if a signaling message is received while reconnecting [#14788](https://github.com/nextcloud/spreed/pull/14788)
