### PR TITLE
fix(chat): Fix end-of-call showing "missed call" sometimes in one-to-one

### DIFF
--- a/lib/Controller/CallController.php
+++ b/lib/Controller/CallController.php
@@ -240,6 +240,7 @@ class CallController extends AEnvironmentAwareOCSController {
 			// Default flags: user is in room with audio/video.
 			$flags = Participant::FLAG_IN_CALL | Participant::FLAG_WITH_AUDIO | Participant::FLAG_WITH_VIDEO;
 		}
+		$lastJoinedCall = $this->timeFactory->getDateTime();
 
 		if ($this->room->isFederatedConversation()) {
 			/** @var \OCA\Talk\Federation\Proxy\TalkV1\Controller\CallController $proxy */
@@ -247,15 +248,15 @@ class CallController extends AEnvironmentAwareOCSController {
 			$response = $proxy->joinFederatedCall($this->room, $this->participant, $flags, $silent, $recordingConsent);
 
 			if ($response->getStatus() === Http::STATUS_OK) {
-				$this->participantService->changeInCall($this->room, $this->participant, $flags, false, $silent);
+				$this->participantService->changeInCall($this->room, $this->participant, $flags, silent: $silent, lastJoinedCall: $lastJoinedCall->getTimestamp());
 			}
 
 			return $response;
 		}
 
 		try {
-			$this->participantService->changeInCall($this->room, $this->participant, $flags, silent: $silent);
-			$this->roomService->setActiveSince($this->room, $this->participant, $this->timeFactory->getDateTime(), $flags, silent: $silent);
+			$this->participantService->changeInCall($this->room, $this->participant, $flags, silent: $silent, lastJoinedCall: $lastJoinedCall->getTimestamp());
+			$this->roomService->setActiveSince($this->room, $this->participant, $lastJoinedCall, $flags, silent: $silent);
 		} catch (\InvalidArgumentException $e) {
 			return new DataResponse(['error' => $e->getMessage()], Http::STATUS_BAD_REQUEST);
 		}

--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -1289,7 +1289,7 @@ class ParticipantService {
 	 * @psalm-param int-mask-of<Participant::FLAG_*> $flags
 	 * @throws \InvalidArgumentException
 	 */
-	public function changeInCall(Room $room, Participant $participant, int $flags, bool $endCallForEveryone = false, bool $silent = false): void {
+	public function changeInCall(Room $room, Participant $participant, int $flags, bool $endCallForEveryone = false, bool $silent = false, int $lastJoinedCall = 0): void {
 		if ($room->getType() === Room::TYPE_CHANGELOG
 			|| $room->getType() === Room::TYPE_ONE_TO_ONE_FORMER
 			|| $room->getType() === Room::TYPE_NOTE_TO_SELF) {
@@ -1328,7 +1328,7 @@ class ParticipantService {
 
 		$attendee = $participant->getAttendee();
 		if ($flags !== Participant::FLAG_DISCONNECTED) {
-			$attendee->setLastJoinedCall($this->timeFactory->getTime());
+			$attendee->setLastJoinedCall($lastJoinedCall ?: $this->timeFactory->getTime());
 			$this->attendeeMapper->update($attendee);
 		} elseif ($attendee->getActorType() === Attendee::ACTOR_PHONES) {
 			$attendee->setCallId('');


### PR DESCRIPTION
We called getTime() twice and if by chance the time bit flipped between the call for the attendee last_joined_call and the room last_activity, the chat would show a "Missed call" for the starter when they also finished the call.

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
