### PR TITLE
fix(chat): Fix preloading the last chat message with the room query

### DIFF
--- a/lib/Manager.php
+++ b/lib/Manager.php
@@ -1440,7 +1440,7 @@ class Manager {
 	protected function loadLastMessageInfo(IQueryBuilder $query): void {
 		$query->leftJoin('r', 'comments', 'c', $query->expr()->andX(
 			$query->expr()->eq('r.last_message', 'c.id'),
-			$query->expr()->emptyString('r.remote_server'),
+			$query->expr()->isNull('r.remote_server'),
 		));
 		$query->selectAlias('c.id', 'comment_id');
 		$query->selectAlias('c.parent_id', 'comment_parent_id');


### PR DESCRIPTION
### ☑️ Resolves

* Ref #14807

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
