### PR TITLE
ci: Generate authoritative classmap again

### DIFF
--- a/.github/workflows/appstore-build-publish.yml
+++ b/.github/workflows/appstore-build-publish.yml
@@ -104,7 +104,7 @@ jobs:
         if: steps.check_composer.outputs.files_exists == 'true'
         run: |
           cd ${{ env.APP_NAME }}
-          composer install --no-dev
+          composer install --no-dev --classmap-authoritative
 
       - name: Build ${{ env.APP_NAME }}
         # Skip if no package.json


### PR DESCRIPTION
- Restoring https://github.com/nextcloud/spreed/pull/8765
- Which got accidentally reverted by https://github.com/nextcloud/spreed/pull/9629