### PR TITLE
build(webpack): reduce production source maps

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,6 +11,8 @@ const webpack = require('webpack')
 const { mergeWithRules } = require('webpack-merge')
 const commonWebpackConfig = require('./webpack.common.config.js')
 
+const IS_PROD = process.env.NODE_ENV === 'production'
+
 module.exports = mergeWithRules({
 	module: {
 		// Rules from @nextcloud/webpack-vue-config/rules already added by commonWebpackConfig
@@ -67,4 +69,11 @@ module.exports = mergeWithRules({
 	],
 
 	cache: true,
+
+	devtool: IS_PROD
+		// .js.map files with original file names and lines but without the source code
+		// Tradeoff choice between dist size and features
+		? 'nosources-source-map'
+		// Mid-quality (transformed) SourceMaps with ok/slow build/rebuild
+		: 'cheap-source-map',
 })


### PR DESCRIPTION
### ☑️ Resolves

Reduce `/js` directory size on production from 170 MB to 90 MB

- Application size in the `/apps/spreed` folder is about 210 MB, with 170 MB (80%) `js/` folder
- It includes `.map` files with 120 MB (70% of `js/`, 57% of `/apps/spreed`)
- Getting rid of SourceMaps completely would make bug reporting much more complicated
- However, we can use less expensive source maps with only original file names and lines, but not entire source content
- This makes `.map` 3 times smaller, or `/apps/spreed` 60% smaller

Stuff | 🏚️ Before | 🏡 After
-- | -- | --
App folder | 210 MB 🟦🟦🟦🟦🟦 | 130 MB 🟦🟦🟦
JS folder | 170 MB 🟦🟦🟦🟦 | 90 MB 🟦🟦🟦
.js.map | 120 MB 🟦🟦🟦 | 40 MB 🟦

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
