### PR TITLE
fix(federation): respect remote capabilities when show "Notify about calls"

### DIFF
--- a/src/components/ChatView.vue
+++ b/src/components/ChatView.vue
@@ -72,7 +72,7 @@ import NewMessageUploadEditor from './NewMessage/NewMessageUploadEditor.vue'
 import TransitionWrapper from './UIShared/TransitionWrapper.vue'
 
 import { CONVERSATION, PARTICIPANT } from '../constants.ts'
-import { getTalkConfig, hasTalkFeature } from '../services/CapabilitiesManager.ts'
+import { getTalkConfig } from '../services/CapabilitiesManager.ts'
 import { EventBus } from '../services/EventBus.ts'
 import { useChatExtrasStore } from '../stores/chatExtras.js'
 
@@ -134,7 +134,7 @@ export default {
 			return getTalkConfig(this.token, 'attachments', 'allowed') && this.$store.getters.getUserId()
 				&& this.$store.getters.getAttachmentFolderFreeSpace() !== 0
 				&& (this.conversation.permissions & PARTICIPANT.PERMISSIONS.CHAT)
-				&& (!hasTalkFeature(this.token, 'federation-v1') || !this.conversation.remoteServer)
+				&& !this.conversation.remoteServer // no attachments support in federated conversations
 		},
 
 		isDragAndDropBlocked() {

--- a/src/components/ConversationSettings/ConversationSettingsDialog.vue
+++ b/src/components/ConversationSettings/ConversationSettingsDialog.vue
@@ -205,7 +205,7 @@ export default {
 		},
 
 		showMediaSettingsToggle() {
-			return (hasTalkFeature(this.token, 'federation-v2') || !hasTalkFeature(this.token, 'federation-v1') || !this.conversation.remoteServer)
+			return !this.conversation.remoteServer || hasTalkFeature(this.token, 'federation-v2')
 		},
 
 		supportBanV1() {

--- a/src/components/ConversationSettings/NotificationsSettings.vue
+++ b/src/components/ConversationSettings/NotificationsSettings.vue
@@ -79,7 +79,7 @@ export default {
 
 	computed: {
 		showCallNotificationSettings() {
-			return (!hasTalkFeature(this.conversation.token, 'federation-v1') || !this.conversation.remoteServer)
+			return !this.conversation.remoteServer || hasTalkFeature(this.conversation.token, 'federation-v2')
 		}
 	},
 

--- a/src/components/LeftSidebar/ConversationsList/Conversation.vue
+++ b/src/components/LeftSidebar/ConversationsList/Conversation.vue
@@ -151,16 +151,18 @@
 					{{ level.label }}
 				</NcActionButton>
 
-				<NcActionSeparator />
+				<template v-if="showCallNotificationSettings">
+					<NcActionSeparator />
 
-				<NcActionButton type="checkbox"
-					:model-value="notificationCalls"
-					@click="setNotificationCalls(!notificationCalls)">
-					<template #icon>
-						<IconPhoneRing :size="16" />
-					</template>
-					{{ t('spreed', 'Notify about calls') }}
-				</NcActionButton>
+					<NcActionButton type="checkbox"
+						:model-value="notificationCalls"
+						@click="setNotificationCalls(!notificationCalls)">
+						<template #icon>
+							<IconPhoneRing :size="16" />
+						</template>
+						{{ t('spreed', 'Notify about calls') }}
+					</NcActionButton>
+				</template>
 			</template>
 		</template>
 
@@ -401,6 +403,10 @@ export default {
 
 		notificationCalls() {
 			return this.item.notificationCalls === PARTICIPANT.NOTIFY_CALLS.ON
+		},
+
+		showCallNotificationSettings() {
+			return !this.item.remoteServer || hasTalkFeature(this.item.token, 'federation-v2')
 		},
 
 		iconType() {

--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageForwarder.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageForwarder.vue
@@ -9,6 +9,7 @@
 		message to -->
 		<RoomSelector v-if="!showForwardedConfirmation"
 			show-postable-only
+			allow-federation
 			:dialog-title="dialogTitle"
 			:dialog-subtitle="dialogSubtitle"
 			@select="setSelectedConversationToken"

--- a/src/components/NewMessage/NewMessage.vue
+++ b/src/components/NewMessage/NewMessage.vue
@@ -388,7 +388,7 @@ export default {
 
 		canShareFiles() {
 			return !this.currentUserIsGuest
-				&& (!hasTalkFeature(this.token, 'federation-v1') || !this.conversation.remoteServer)
+				&& !this.conversation.remoteServer // no attachments support in federated conversations
 		},
 
 		canUploadFiles() {

--- a/src/components/RightSidebar/Participants/Participant.vue
+++ b/src/components/RightSidebar/Participants/Participant.vue
@@ -643,7 +643,7 @@ export default {
 		 */
 		isOffline() {
 			return !this.sessionIds.length && (this.isUserActor || this.isFederatedActor || this.isGuestActor)
-				&& (hasTalkFeature(this.token, 'federation-v2') || !hasTalkFeature(this.token, 'federation-v1') || (!this.conversation.remoteServer && !this.isFederatedActor))
+				&& (hasTalkFeature(this.token, 'federation-v2') || (!this.conversation.remoteServer && !this.isFederatedActor))
 		},
 
 		isModerator() {

--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -294,13 +294,9 @@ export default {
 			return this.conversation.breakoutRoomMode !== CONVERSATION.BREAKOUT_ROOM_MODE.NOT_CONFIGURED
 		},
 
-		supportFederationV1() {
-			return hasTalkFeature(this.token, 'federation-v1')
-		},
-
 		showBreakoutRoomsTab() {
 			return this.getUserId && !this.isOneToOne
-				&& (!this.supportFederationV1 || !this.conversation.remoteServer)
+				&& !this.conversation.remoteServer // no breakout rooms support in federated conversations
 				&& (this.breakoutRoomsConfigured || this.conversation.breakoutRoomMode === CONVERSATION.BREAKOUT_ROOM_MODE.FREE || this.conversation.objectType === CONVERSATION.OBJECT_TYPE.BREAKOUT_ROOM)
 		},
 
@@ -309,7 +305,7 @@ export default {
 		},
 
 		showSharedItemsTab() {
-			return this.getUserId && (!this.supportFederationV1 || !this.conversation.remoteServer)
+			return this.getUserId && !this.conversation.remoteServer // no attachments support in federated conversations
 		},
 
 		showDetailsTab() {

--- a/src/components/RoomSelector.vue
+++ b/src/components/RoomSelector.vue
@@ -63,7 +63,6 @@ import NcTextField from '@nextcloud/vue/components/NcTextField'
 import ConversationsSearchListVirtual from './LeftSidebar/ConversationsList/ConversationsSearchListVirtual.vue'
 
 import { CONVERSATION } from '../constants.ts'
-import { hasTalkFeature } from '../services/CapabilitiesManager.ts'
 import { searchListedConversations, fetchConversations } from '../services/conversationsService.ts'
 
 export default {
@@ -178,7 +177,8 @@ export default {
 				})
 
 			this.rooms = response.data.ocs.data.sort(this.sortConversations)
-				.filter(conversation => !hasTalkFeature(this.currentRoom, 'federation-v1') || !conversation.remoteServer)
+				// TODO MessageForwarder should work
+				.filter(conversation => !conversation.remoteServer) // no attachments support in federated conversations
 			this.loading = false
 		},
 

--- a/src/components/RoomSelector.vue
+++ b/src/components/RoomSelector.vue
@@ -99,6 +99,14 @@ export default {
 		},
 
 		/**
+		 * Whether interacting with federated conversations is allowed for this component.
+		 */
+		allowFederation: {
+			type: Boolean,
+			default: false,
+		},
+
+		/**
 		 * Whether to only show open conversations to which the user can join.
 		 */
 		listOpenConversations: {
@@ -177,8 +185,10 @@ export default {
 				})
 
 			this.rooms = response.data.ocs.data.sort(this.sortConversations)
-				// TODO MessageForwarder should work
-				.filter(conversation => !conversation.remoteServer) // no attachments support in federated conversations
+				// Federated conversations do not support:
+				// - open conversations
+				// - 3rd app integrations (e.g. Deck / Maps)
+				.filter(conversation => this.allowFederation || !conversation.remoteServer)
 			this.loading = false
 		},
 

--- a/src/components/TopBar/CallButton.vue
+++ b/src/components/TopBar/CallButton.vue
@@ -322,7 +322,7 @@ export default {
 			return this.callEnabled
 				&& this.conversation.type !== CONVERSATION.TYPE.NOTE_TO_SELF
 				&& this.conversation.readOnly === CONVERSATION.STATE.READ_WRITE
-				&& (hasTalkFeature(this.token, 'federation-v2') || !hasTalkFeature(this.token, 'federation-v1') || !this.conversation.remoteServer)
+				&& (!this.conversation.remoteServer || hasTalkFeature(this.token, 'federation-v2'))
 				&& !this.isInCall
 		},
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix regression after adding federated calls support


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

29 (no support) | 30 (support calls)
-- | --
<img width="243" alt="image" src="https://github.com/user-attachments/assets/f7f27ad5-2386-4fce-8226-5e7ebad437b8" /> | <img width="247" alt="image" src="https://github.com/user-attachments/assets/2748a38a-763b-431f-8e7e-f8fce0ea1434" />
<img width="477" alt="image" src="https://github.com/user-attachments/assets/174185ed-71ce-4ef7-bd61-e203b6454287" /> | <img width="547" alt="image" src="https://github.com/user-attachments/assets/3ccdeb55-2607-4672-8861-5e99a7a9fabd" />

All:
<img width="758" alt="image" src="https://github.com/user-attachments/assets/e3025fd6-d3b9-4330-8bbf-15e1934a08af" />


### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required