### PR TITLE
fix(eventrooms): wrong parameter for string check

### DIFF
--- a/lib/Listener/CalDavEventListener.php
+++ b/lib/Listener/CalDavEventListener.php
@@ -154,7 +154,7 @@ class CalDavEventListener implements IEventListener {
 
 		$description = $vevent->DESCRIPTION?->getValue();
 		if ($description !== null) {
-			$description = strlen($name) > 1999 ? substr($description, 0, 1999) . "\u{2026}" : $description;
+			$description = strlen($description) > 1999 ? substr($description, 0, 1999) . "\u{2026}" : $description;
 			$this->roomService->setDescription($room, $description);
 		}
 	}


### PR DESCRIPTION
### ☑️ Resolves

* Fix https://github.com/nextcloud/spreed/issues/14885

<!--
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
░░░███████░░░█████████░░█████░
░░███░░░███░░░███░░░███░░███░░
░░█████████░░░████████░░░███░░
░░███░░░███░░░███░░░░░░░░███░░
░█████░█████░█████░░░░░░█████░
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching frontend/UI code
-->

## 🛠️ API Checklist

### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
