### PR TITLE
fix(conversations): do not add second participant to extended 1-1 twice

### DIFF
--- a/src/components/RightSidebar/Participants/ParticipantsTab.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsTab.vue
@@ -332,7 +332,10 @@ export default {
 				if (this.isOneToOneConversation) {
 					await this.$store.dispatch('extendOneToOneConversation', {
 						token: this.token,
-						newParticipants: [participant],
+						newParticipants: [
+							{ id: this.conversation.name, source: ATTENDEE.ACTOR_TYPE.USERS, label: this.conversation.displayName },
+							participant,
+						],
 					})
 				} else {
 					await addParticipant(this.token, participant.id, participant.source)

--- a/src/store/conversationsStore.js
+++ b/src/store/conversationsStore.js
@@ -1003,13 +1003,12 @@ const actions = {
 	 * @param {object} context default store context
 	 * @param {object} payload action payload
 	 * @param {string} payload.token one-to-one conversation token
-	 * @param {Array} payload.newParticipants selected participants to be added
+	 * @param {Array} payload.newParticipants selected participants to be added (should include second participant form original conversation)
 	 */
 	async extendOneToOneConversation(context, { token, newParticipants }) {
 		const conversation = context.getters.conversation(token)
 		const participants = [
 			{ id: conversation.actorId, source: conversation.actorType, label: context.rootGetters.getDisplayName() },
-			{ id: conversation.name, source: ATTENDEE.ACTOR_TYPE.USERS, label: conversation.displayName },
 			...newParticipants,
 		]
 		const roomName = getDisplayNamesList(participants.map(participant => participant.label), CONVERSATION.MAX_NAME_LENGTH)


### PR DESCRIPTION
### ☑️ Resolves

* Fix regression from #14730
* In store:
  * second participant was duplicated from event dialog -> removed
* In conversation:
  * second participant of 1-1 was passed to vuex store with other newParticipants -> kept
* In call:
  * only one new participant always passed -> add original

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="469" alt="image" src="https://github.com/user-attachments/assets/e8f82bfe-659a-4634-b9f5-490c6398d54a" /> | <img width="386" alt="image" src="https://github.com/user-attachments/assets/fb43b4fc-3748-4486-9ad7-ca39ea55b1ca" />
a | <img width="236" alt="2025-04-24_14h47_09" src="https://github.com/user-attachments/assets/3ac9c234-2465-4894-8bca-f886c1f307b9" /><img width="272" alt="2025-04-24_14h47_22" src="https://github.com/user-attachments/assets/c4958a38-4f0d-428b-b82c-6833b0fe0282" />

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required