### PR TITLE
fix: show schedule meeting invite option for fresh 1-1 conversations

### DIFF
--- a/src/components/CalendarEventsDialog.vue
+++ b/src/components/CalendarEventsDialog.vue
@@ -88,6 +88,7 @@ const calendarOptions = computed<CalendarOption[]>(() => groupwareStore.writeabl
 })))
 const canScheduleMeeting = computed(() => {
 	return hasTalkFeature(props.token, 'schedule-meeting') && store.getters.isModerator && calendarOptions.value.length !== 0
+		&& conversation.value.type !== CONVERSATION.TYPE.ONE_TO_ONE_FORMER
 })
 
 const selectedCalendar = ref<CalendarOption | null>(null)

--- a/src/components/CalendarEventsDialog.vue
+++ b/src/components/CalendarEventsDialog.vue
@@ -160,6 +160,11 @@ const isMatch = (string: string = '') => string.toLowerCase().includes(searchTex
 
 const conversation = computed<Conversation>(() => store.getters.conversation(props.token))
 const participants = computed(() => {
+	if (isOneToOneConversation.value && store.getters.participantsList(props.token).length === 1) {
+		// Second participant is not yet added to conversation, need to fake data from conversation object
+		// We do not have an attendeeId, so 'attendeeIds' in payload should be 'null' (selectAll === true)
+		return [{ id: conversation.value.name, source: ATTENDEE.ACTOR_TYPE.USERS, displayName: conversation.value.displayName }]
+	}
 	return store.getters.participantsList(props.token).filter((participant: Participant) => {
 		return [ATTENDEE.ACTOR_TYPE.USERS, ATTENDEE.ACTOR_TYPE.EMAILS].includes(participant.actorType)
 			&& participant.attendeeId !== conversation.value.attendeeId

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -209,6 +209,7 @@ export default {
 
 		canExtendOneToOneConversation() {
 			return supportConversationCreationAll && this.isOneToOneConversation
+				&& this.conversation.type !== CONVERSATION.TYPE.ONE_TO_ONE_FORMER
 		},
 
 		isModeratorOrUser() {


### PR DESCRIPTION
### ☑️ Resolves

* Fix #14964
* Follow-up to #14965
  * Just created conversation with no messages has no second participants added, therefore should be faked

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="354" alt="2025-04-28_11h55_06" src="https://github.com/user-attachments/assets/0ec80ec1-163d-473b-9d25-d7451466272a" /> | <img width="353" alt="2025-04-28_11h57_30" src="https://github.com/user-attachments/assets/d78d6a04-a478-429c-aee0-cc2faa05440c" />
<img width="494" alt="image" src="https://github.com/user-attachments/assets/d868cfd5-74c5-4a31-97c1-7e20918b33a2" /> | <img width="502" alt="image" src="https://github.com/user-attachments/assets/8bff1344-bad3-4302-b6ca-7cecf97a9697" />

### 🚧 Tasks

- [ ] Follow-up: separate getters for `1to1` and `1to1+former1to1`

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required