### PR TITLE
fix: Print error code and message for unhandled signaling errors

### DIFF
--- a/src/utils/signaling.js
+++ b/src/utils/signaling.js
@@ -800,7 +800,7 @@ Signaling.Standalone.prototype.connect = function() {
 				this.processErrorTokenExpired()
 				break
 			default:
-				console.error('Ignore unknown error', data)
+				console.error('Ignore unknown error: %s', JSON.stringify(data.error))
 				this._trigger('error', [data.error])
 				break
 			}


### PR DESCRIPTION
The whole error was logged, but by default its contents were not visible unless the object was expanded. Rather than explicitly printing the error code and message, which are always provided, the whole error is now stringified. This ensures that any detail will be also readable, as they would be provided as additional custom attributes.

Note that due to the length of the messages a similar result could be just get by logging the `data.error` object (instead of `data`) rather than stringifying it, but stringifying it ensures that it will be also readable when the logs are sent through WebDriver BiDi (that is, for the recording server).

## How to test
- Setup the HPB
- Create a conversation
- Open Talk administration settings and set a wrong secret for the signaling server
- Open Talk again
- Open the browser console
- Open the conversation
- Eventually an error will be logged

### Result with this pull request

`Ignore unknown error: {"code":"invalid_request","message":"The request could not be authenticated."}`

### Result without this pull request

`Ignore unknown error: Object { id: "2", type: "error", error: {…} }`
