### PR TITLE
fix(events): Don't apply retention before the event happened

### DIFF
--- a/lib/BackgroundJob/ExpireObjectRooms.php
+++ b/lib/BackgroundJob/ExpireObjectRooms.php
@@ -52,6 +52,13 @@ class ExpireObjectRooms extends TimedJob {
 
 		$numDeletedRooms = 0;
 		foreach ($rooms as $room) {
+			if ($objectType === Room::OBJECT_TYPE_EVENT) {
+				[, $endTime] = explode('#', $room->getObjectId());
+				if ($endTime < $now) {
+					continue;
+				}
+			}
+
 			$this->roomService->deleteRoom($room);
 			$numDeletedRooms++;
 		}


### PR DESCRIPTION
### ☑️ Resolves

* Otherwise event conversations for events in 5 weeks will be deleted by the time the event happened :see_no_evil: 

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
