### PR TITLE
fix: do not show event-room actions for non-moderators

### DIFF
--- a/src/components/ConversationSettings/BasicInfo.vue
+++ b/src/components/ConversationSettings/BasicInfo.vue
@@ -6,7 +6,7 @@
 <template>
 	<Fragment>
 		<!-- eslint-disable-next-line vue/no-v-html -->
-		<p v-if="isEventConversation" class="app-settings-section__hint" v-html="calendarHint" />
+		<p v-if="canFullModerate && isEventConversation" class="app-settings-section__hint" v-html="calendarHint" />
 		<h4 class="app-settings-section__subtitle">
 			{{ t('spreed', 'Name') }}
 		</h4>

--- a/src/components/UIShared/ConversationActionsShortcut.vue
+++ b/src/components/UIShared/ConversationActionsShortcut.vue
@@ -109,9 +109,9 @@ async function showConfirmationDialog() {
 	<div class="conversation-actions"
 		:class="{ 'conversation-actions--highlighted': props.isHighlighted }">
 		<p>{{ descriptionLabel }}</p>
-		<div class="conversation-actions__buttons">
-			<NcButton v-if="isModerator"
-				type="error"
+		<div v-if="isModerator"
+			class="conversation-actions__buttons">
+			<NcButton type="error"
 				@click="showConfirmationDialog">
 				<template #icon>
 					<IconDelete />


### PR DESCRIPTION
### ☑️ Resolves

* Fix regression from #14714
* Non-moderators can not unbind / delete conversations


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="378" alt="2025-05-08_17h38_41" src="https://github.com/user-attachments/assets/b7f6bf13-8b62-4f97-8443-f41a420e3035" /> | <img width="378" alt="image" src="https://github.com/user-attachments/assets/4a776757-060c-4733-9ece-9d9900d3e79b" />
<img width="323" alt="image" src="https://github.com/user-attachments/assets/8b8fed3b-c3b5-4d29-ae82-fba80a907cc7" /> | <img width="288" alt="image" src="https://github.com/user-attachments/assets/1a78367b-b2cd-4feb-8755-e5e450f62be8" />

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
