### PR TITLE
fix(RightSidebar): better error handling for user profile

### DIFF
--- a/src/components/ConversationIcon.vue
+++ b/src/components/ConversationIcon.vue
@@ -68,6 +68,7 @@ import { useIsDarkTheme } from '@nextcloud/vue/composables/useIsDarkTheme'
 import { AVATAR, CONVERSATION } from '../constants.ts'
 import { getConversationAvatarOcsUrl } from '../services/avatarService.ts'
 import { hasTalkFeature } from '../services/CapabilitiesManager.ts'
+import { getFallbackIconClass } from '../utils/conversation.ts'
 import { getPreloadedUserStatus } from '../utils/userStatus.ts'
 
 const supportsAvatar = hasTalkFeature('local', 'avatar')
@@ -173,56 +174,7 @@ export default {
 		},
 
 		iconClass() {
-			if (this.item.isDummyConversation) {
-				// Prevent a 404 when trying to load an avatar before the conversation data is actually loaded
-				return this.item.type === CONVERSATION.TYPE.PUBLIC ? 'icon-public' : 'icon-contacts'
-			}
-
-			if (!supportsAvatar || this.failed) {
-				if (this.item.objectType === CONVERSATION.OBJECT_TYPE.FILE
-					|| this.item.type === CONVERSATION.TYPE.NOTE_TO_SELF) {
-					return 'icon-file'
-				} else if (this.item.objectType === CONVERSATION.OBJECT_TYPE.VIDEO_VERIFICATION) {
-					return 'icon-password'
-				} else if (this.item.objectType === CONVERSATION.OBJECT_TYPE.EMAIL) {
-					return 'icon-mail'
-				} else if (this.item.objectType === CONVERSATION.OBJECT_TYPE.PHONE_LEGACY
-					|| this.item.objectType === CONVERSATION.OBJECT_TYPE.PHONE_PERSISTENT
-					|| this.item.objectType === CONVERSATION.OBJECT_TYPE.PHONE_TEMPORARY) {
-					return 'icon-phone'
-				} else if (this.item.objectType === CONVERSATION.OBJECT_TYPE.EVENT) {
-					return 'icon-event'
-				} else if (this.item.objectType === CONVERSATION.OBJECT_TYPE.CIRCLES) {
-					return 'icon-team'
-				} else if (this.item.type === CONVERSATION.TYPE.CHANGELOG) {
-					return 'icon-changelog'
-				} else if (this.item.type === CONVERSATION.TYPE.ONE_TO_ONE_FORMER) {
-					return 'icon-user'
-				} else if (this.item.type === CONVERSATION.TYPE.GROUP) {
-					return 'icon-contacts'
-				} else if (this.item.type === CONVERSATION.TYPE.PUBLIC) {
-					return 'icon-public'
-				}
-				return undefined
-			}
-
-			if (this.item.token) {
-				// Existing conversations use the /avatar endpoint… Always!
-				return undefined
-			}
-
-			if (this.item.objectType === CONVERSATION.OBJECT_TYPE.CIRCLES) {
-				// Team icon for group conversation suggestions
-				return 'icon-team'
-			}
-
-			if (this.item.type === CONVERSATION.TYPE.GROUP) {
-				// Group icon for group conversation suggestions
-				return 'icon-contacts'
-			}
-
-			// Fall-through for other conversation suggestions to user-avatar handling
-			return undefined
+			return getFallbackIconClass(this.item, this.failed)
 		},
 
 		themeClass() {

--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -193,12 +193,13 @@ export default {
 		const throttleHandleWheelEvent = (event) => {
 			if (!throttleTimeout) {
 				handleWheelEvent(event)
-				throttleTimeout = setTimeout(() => {
-					// do something
-					clearTimeout(throttleTimeout)
-					throttleTimeout = null
-				}, 300 /* var(--animation-slow) */)
 			}
+			clearTimeout(throttleTimeout)
+			throttleTimeout = null
+			throttleTimeout = setTimeout(() => {
+				clearTimeout(throttleTimeout)
+				throttleTimeout = null
+			}, 300 /* var(--animation-slow) */)
 		}
 
 		useEventListener(sidebar, 'wheel', throttleHandleWheelEvent, { capture: true })

--- a/src/components/RightSidebar/RightSidebarContent.vue
+++ b/src/components/RightSidebar/RightSidebarContent.vue
@@ -319,8 +319,11 @@ function onError() {
 		}
 
 		.content__header {
-			width: 100%;
 			padding-inline: calc(2 * var(--default-grid-baseline));
+		}
+
+		.content__name {
+			padding-inline-end: 0 !important;
 		}
 
 		.content__image-wrapper {
@@ -408,6 +411,7 @@ function onError() {
 		flex-direction: column;
 		align-items: start;
 		gap: var(--default-grid-baseline);
+		width: 100%;
 		padding-block: calc(2 * var(--default-grid-baseline)) var(--default-grid-baseline);
 		padding-inline-start: calc(2 * var(--default-grid-baseline));
 

--- a/src/components/RightSidebar/RightSidebarContent.vue
+++ b/src/components/RightSidebar/RightSidebarContent.vue
@@ -28,13 +28,13 @@ import CalendarEventSmall from '../UIShared/CalendarEventSmall.vue'
 import { useStore } from '../../composables/useStore.js'
 import { CONVERSATION } from '../../constants.ts'
 import { getConversationAvatarOcsUrl } from '../../services/avatarService.ts'
-import { hasTalkFeature } from '../../services/CapabilitiesManager.ts'
 import { useGroupwareStore } from '../../stores/groupware.ts'
 import type {
 	Conversation,
 	DashboardEvent,
 	UserProfileData,
 } from '../../types/index.ts'
+import { getFallbackIconClass } from '../../utils/conversation.ts'
 import { convertToUnix } from '../../utils/formattedTime.ts'
 
 type MutualEvent = {
@@ -44,7 +44,6 @@ type MutualEvent = {
 	href: DashboardEvent['eventLink'],
 	color: string,
 }
-const supportsAvatar = hasTalkFeature('local', 'avatar')
 
 const props = defineProps<{
 	isUser: boolean,
@@ -63,6 +62,7 @@ const groupwareStore = useGroupwareStore()
 const isDarkTheme = useIsDarkTheme()
 
 const profileLoading = ref(false)
+const profileImageFailed = ref(false)
 
 const token = computed(() => store.getters.getToken())
 
@@ -87,9 +87,10 @@ const sidebarTitle = computed(() => {
 	return conversation.value.displayName
 })
 
+const iconClass = computed(() => getFallbackIconClass(conversation.value, profileImageFailed.value))
+
 const avatarUrl = computed(() => {
-	if (!supportsAvatar || conversation.value.isDummyConversation) {
-		// TODO use a fallback icon (like icon-class in CnversationIcon)
+	if (iconClass.value) {
 		return undefined
 	}
 
@@ -167,6 +168,13 @@ watch(token, async () => {
 function joinFields(firstSubstring?: string | null, secondSubstring?: string | null): string {
 	return [firstSubstring, secondSubstring].filter(Boolean).join(' · ')
 }
+
+/**
+ * Handles image load error
+ */
+function onError() {
+	profileImageFailed.value = true
+}
 </script>
 
 <template>
@@ -197,9 +205,14 @@ function joinFields(firstSubstring?: string | null, secondSubstring?: string | n
 			<div class="content__scroller animated">
 				<!-- User / conversation avatar image -->
 				<div class="content__image-wrapper animated">
-					<img class="content__image animated"
+					<div v-if="iconClass"
+						class="content__image animated icon"
+						:class="iconClass" />
+					<img v-else
+						class="content__image animated"
 						:src="avatarUrl"
 						:alt="conversation.displayName"
+						@error="onError"
 						@click="mode === 'preview' && emit('update:mode', 'full')">
 				</div>
 				<!-- User / conversation profile information -->
@@ -373,13 +386,20 @@ function joinFields(firstSubstring?: string | null, secondSubstring?: string | n
 	}
 
 	.content__image {
+		display: block;
 		max-width: 100%;
 		max-height: 100%;
 		width: 100%;
 		height: 100%;
+		aspect-ratio: 1;
 		border-radius: 50%;
 		object-fit: cover;
 		object-position: top;
+
+		&.icon {
+			background-size: 50%;
+			background-color: var(--color-text-maxcontrast-default);
+		}
 	}
 
 	&__header {

--- a/src/components/RightSidebar/RightSidebarContent.vue
+++ b/src/components/RightSidebar/RightSidebarContent.vue
@@ -67,7 +67,7 @@ const profileImageFailed = ref(false)
 const token = computed(() => store.getters.getToken())
 
 const conversation = computed(() => store.getters.conversation(token.value) as Conversation)
-const isOneToOneConversation = computed(() => [CONVERSATION.TYPE.ONE_TO_ONE, CONVERSATION.TYPE.ONE_TO_ONE_FORMER].includes(conversation.value.type))
+const isOneToOneConversation = computed(() => conversation.value.type === CONVERSATION.TYPE.ONE_TO_ONE)
 
 const profileInfo = computed(() => groupwareStore.profileInfo[token.value])
 const profileActions = computed<UserProfileData['actions']>(() => {

--- a/src/stores/sounds.js
+++ b/src/stores/sounds.js
@@ -113,6 +113,10 @@ export const useSoundsStore = defineStore('sounds', {
 				return
 			}
 
+			if (!this.audioObjectsCreated) {
+				this.initAudioObjects()
+			}
+
 			try {
 				for (const key in this.audioObjects) {
 					this.pauseAudio(key)


### PR DESCRIPTION
* fix: init audio objects before setting sinkId (Not the RightSidebar, but already pushed)
  * before: join/leave sounds will be played on default system devices
* fix: update local time in RightSidebar with periodic interval
  * before: time stuck once it's computed
* fix: extract icon fallback class to utils
  * reuse function from ConversationIcon
* fix: better throttle wheel events from touchpad
  * before: this can skip preview modes, as touchpad firing a ton of events
* Fix: #15072
  * no avatar for deleted users, show conversation avatar instead


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="238" alt="image" src="https://github.com/user-attachments/assets/7d95b533-5cd6-48bd-b2df-dd3fc735f7c9" /> | <img width="238" alt="image" src="https://github.com/user-attachments/assets/6d2f29c9-2222-4f67-9ad0-9184e701d623" />
<img width="328" alt="image" src="https://github.com/user-attachments/assets/afc4b066-802e-46be-acad-616c1a871584" /> | No error

### 🚧 Tasks

- [ ] wheel event from touchpad / magic mouse

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required