### PR TITLE
fix: check if property exists before using getValue

### DIFF
--- a/lib/Listener/CalDavEventListener.php
+++ b/lib/Listener/CalDavEventListener.php
@@ -66,7 +66,7 @@ class CalDavEventListener implements IEventListener {
 
 		$vevent = $vobject->VEVENT;
 		// Check if the location is set and if the location string contains a call url
-		$location = $vevent->LOCATION->getValue();
+		$location = $vevent->LOCATION?->getValue();
 		if ($location === null || !str_contains($location, '/call/')) {
 			$this->logger->debug('No location for the event or event is not a call link, skipping for calendar event integration');
 			return;


### PR DESCRIPTION
### ☑️ Resolves

* Fix
- if the location property does not exist using getValue will error.

![image](https://github.com/user-attachments/assets/cf4a4380-820c-4f61-8aae-33011f41a9b3)


