### PR TITLE
perf(participants): reduce amount of participants list updates

### DIFF
--- a/src/services/EventBus.ts
+++ b/src/services/EventBus.ts
@@ -44,6 +44,7 @@ export type Events = {
 	'signaling-join-call-failed': [string, { meta: components['schemas']['OCSMeta'], data: { error: string } }],
 	'signaling-join-room': [string],
 	'signaling-participant-list-changed': void,
+	'signaling-participant-list-updated': void,
 	'signaling-recording-status-changed': [string, number],
 	'signaling-settings-updated': [SignalingSettings],
 	'signaling-users-changed': [StandaloneSignalingUpdateSession[]],

--- a/src/utils/signaling.js
+++ b/src/utils/signaling.js
@@ -1436,6 +1436,7 @@ Signaling.Standalone.prototype.processRoomListEvent = function(data) {
 		if (data.event.update.properties['participant-list']) {
 			console.debug('Room list event for participant list', data)
 			if (data.event.update.roomid === this.currentRoomToken) {
+				this._trigger('participantListUpdated')
 				this._trigger('participantListChanged')
 			} else {
 				// Participant list in another room changed, we don't really care
@@ -1502,6 +1503,7 @@ Signaling.Standalone.prototype.processRoomParticipantsEvent = function(data) {
 				console.error('Unknown room participant event', data)
 			}
 		} else {
+			console.debug('Users changed', data.event.update.users || [])
 			// With updated user list
 			this._trigger('usersChanged', [data.event.update.users || []])
 		}


### PR DESCRIPTION
### ☑️ Resolves

* On top of #12556
  * ATM testing in real calls to gather data (how it affects amount of data fetched)
  * long poll updates currently set to 60 seconds
  * long poll updates are needed for user_status update (but if all participants have 1-1 with you, you would get the data every 30 seconds via other source)
  * ~~room-list updates are disabled for the sake of experiment, so results would be slightly different if add/remove participants, or at webinars with guests~~ fake requests should replicate the old behaviour (how many would have been)

> [!IMPORTANT]
> 🚧 Experimental feature: set config to enable:
> `occ config:app:set spreed experiments_users --value=1`

## 🖌️ UI Checklist

### 🚧 Tests

<details>
<summary>First attempt</summary>

1. Small call (8 participants), some people are joining/leaving conversation, but not the call
	- Joined in the middle (36-56 minutes of the call)
	- End of call triggered ~10-15 attempts to update, all debounced to 1-minute
	- Total stats:
		- long poll triggers: 27
		- usual triggers: 27
		- actual fetch requests: 9 (1 upon join, 7 during call, 1 after end)

2. Large call (80+ participants), some people are joining/leaving conversation and call
	- Joined in the start
	- First 10 minutes stats:
		- long poll triggers: 200
		- usual triggers: 260
		- actual fetch requests: 3
	- Full call (50 minutes) stats:
		- long poll triggers: 520
		- usual triggers: 580
		- actual fetch requests: 7

⚠️  Something went wrong with debounce functions (small call didn't update that often, so 1 minute could be triggered, didn't happen for the big call):
- if debounce triggerring interval is lower than set delay (e.g. we receive a signaling message to update every 45s, with interval set to 60s), it will never be called
- need a max timer like in https://vueuse.org/shared/useDebounceFn/#usedebouncefn
- implement own or migrate to useDebounceFn
</details>

1. Small call (4-5 participants), some people are joining/leaving conversation, but not the call
	- Was checking from outside of the call (13 minutes of the call)
	- Total stats:
		- usual triggers: 19 (two were ignored, as within 3-s interval)
		- long poll triggers: 21
		- fake fetch requests: 18
		- actual fetch requests: 8 🔽 
		
1. Large call (90+ participants), some people are reconnecting 
	- Joined 5 minutes before the start

Status | before | +05:00 | +30:00 | end
-- | -- | -- | -- | --
current | 17 | 72 | 152 | 166
new | 18 | 239 | 357 | 497
current fetch | 17 | 71 | 152 | 166
new fetch | 4 | 12 | 36 | 37

Complete analysis:
<img width="636" alt="2025-05-20_17h18_35" src="https://github.com/user-attachments/assets/1aac0c36-a73a-49a8-b05a-192af63d6d19" />

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [x] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required