### PR TITLE
fix: throttle participants request instead of debouncing

### DIFF
--- a/src/composables/useGetParticipants.js
+++ b/src/composables/useGetParticipants.js
@@ -2,7 +2,6 @@
  * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-import debounce from 'debounce'
 import { ref, nextTick, computed, watch, onBeforeUnmount, onMounted } from 'vue'
 
 import { subscribe, unsubscribe } from '@nextcloud/event-bus'
@@ -29,6 +28,8 @@ export function useGetParticipants(isActive = ref(true), isTopBar = true) {
 		|| conversation.value?.type === CONVERSATION.TYPE.ONE_TO_ONE_FORMER)
 	let fetchingParticipants = false
 	let pendingChanges = true
+	let throttleFastUpdateTimeout = null
+	let throttleSlowUpdateTimeout = null
 
 	/**
 	 * Initialise the get participants listeners
@@ -40,7 +41,7 @@ export function useGetParticipants(isActive = ref(true), isTopBar = true) {
 		// FIXME this works only temporary until signaling is fixed to be only on the calls
 		// Then we have to search for another solution. Maybe the room list which we update
 		// periodically gets a hash of all online sessions?
-		EventBus.on('signaling-participant-list-changed', debounceUpdateParticipants)
+		EventBus.on('signaling-participant-list-changed', throttleUpdateParticipants)
 		subscribe('guest-promoted', onJoinedConversation)
 	}
 
@@ -50,7 +51,7 @@ export function useGetParticipants(isActive = ref(true), isTopBar = true) {
 	 */
 	function stopGetParticipants() {
 		EventBus.off('joined-conversation', onJoinedConversation)
-		EventBus.off('signaling-participant-list-changed', debounceUpdateParticipants)
+		EventBus.off('signaling-participant-list-changed', throttleUpdateParticipants)
 		unsubscribe('guest-promoted', onJoinedConversation)
 	}
 
@@ -58,11 +59,11 @@ export function useGetParticipants(isActive = ref(true), isTopBar = true) {
 		if (isOneToOneConversation.value) {
 			cancelableGetParticipants()
 		} else {
-			nextTick(() => debounceUpdateParticipants())
+			nextTick(() => throttleUpdateParticipants())
 		}
 	}
 
-	const debounceUpdateParticipants = () => {
+	const throttleUpdateParticipants = () => {
 		if (!isActive.value && !isInCall.value) {
 			// Update is ignored but there is a flag to force the participants update
 			pendingChanges = true
@@ -70,9 +71,9 @@ export function useGetParticipants(isActive = ref(true), isTopBar = true) {
 		}
 
 		if (isDocumentVisible.value && (isInCall.value || !conversation.value?.hasCall)) {
-			debounceFastUpdateParticipants()
+			throttleFastUpdate()
 		} else {
-			debounceSlowUpdateParticipants()
+			throttleSlowUpdate()
 		}
 	    pendingChanges = false
 	}
@@ -85,17 +86,29 @@ export function useGetParticipants(isActive = ref(true), isTopBar = true) {
 		}
 
 		fetchingParticipants = true
-		debounceFastUpdateParticipants.clear()
-		debounceSlowUpdateParticipants.clear()
+
+		// Cancel the parallel request queue to not fetch twice
+		clearTimeout(throttleFastUpdateTimeout)
+		throttleFastUpdateTimeout = null
+		clearTimeout(throttleSlowUpdateTimeout)
+		throttleSlowUpdateTimeout = null
 
 		await store.dispatch('fetchParticipants', { token: token.value })
 		fetchingParticipants = false
 	}
 
-	const debounceFastUpdateParticipants = debounce(
-		cancelableGetParticipants, 3000)
-	const debounceSlowUpdateParticipants = debounce(
-		cancelableGetParticipants, 15000)
+	const throttleFastUpdate = () => {
+		if (throttleFastUpdateTimeout) {
+			return
+		}
+		throttleFastUpdateTimeout = setTimeout(cancelableGetParticipants, 3_000)
+	}
+	const throttleSlowUpdate = () => {
+		if (throttleSlowUpdateTimeout) {
+			return
+		}
+		throttleSlowUpdateTimeout = setTimeout(cancelableGetParticipants, 15_000)
+	}
 
 	onMounted(() => {
 		if (isTopBar) {
@@ -105,7 +118,7 @@ export function useGetParticipants(isActive = ref(true), isTopBar = true) {
 
 	watch(isActive, (newValue) => {
 		if (newValue && pendingChanges) {
-			debounceUpdateParticipants()
+			throttleUpdateParticipants()
 		}
 	})
 


### PR DESCRIPTION
### ☑️ Resolves

* I was wrong in  #11064 =P
	* Original solution was introduced in 29936c357a3953e995dea091a384e55dccb5785c
	* Previous request still cancels the parallel one, but each debounce trigger pushed the request invocation.
	* E.g. if there is a signaling message every 2 seconds (with update interval of 3 seconds), we will never request the list
	* At the start of the large calls, that explains , if you're not in the call yet, why participants loading is taking long (but maybe that also spreads the server load from when everyone joins at the same time)
	* After joining (or without a call), interval is 3 seconds, so it's harder to notice.
* New approach:
  * Do not debounce requests by 3/15 seconds, but delay the first invocation by 3/15 seconds, and ignore consequent ones happening within that interval

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="331" alt="2025-05-14_19h29_12" src="https://github.com/user-attachments/assets/b523b395-b38f-483d-91ba-b7fbab60aae3" /> | <img width="340" alt="2025-05-14_19h26_13" src="https://github.com/user-attachments/assets/a6a11d55-5f20-4bff-a761-67628afb0cf1" />

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required