### PR TITLE
fix(upcoming-events): Fix undefined array key PARTSTAT on counting at…

### DIFF
--- a/lib/Dashboard/Event.php
+++ b/lib/Dashboard/Event.php
@@ -115,6 +115,10 @@ class Event implements \JsonSerializable {
 
 	public function generateAttendance(array $attendees): void {
 		foreach ($attendees as $attendee) {
+			if (!isset($attendee[1]['PARTSTAT'])) {
+				continue;
+			}
+
 			switch ($attendee[1]['PARTSTAT']->getValue()) {
 				case 'ACCEPTED':
 					(int)$this->accepted++;


### PR DESCRIPTION
…tendance


### ☑️ Resolves
```
{
  "reqId": "DborDCXCvNtN0XtzDghW",
  "level": 3,
  …
  "url": "/ocs/v2.php/apps/spreed/api/v4/dashboard/events",
  "message": "Undefined array key \"PARTSTAT\" at /var/www/cloud.nextcloud.com/nextcloud/apps/spreed/lib/Dashboard/Event.php#118",
  …
  "version": "31.0.5.1",
  "data": {
    "app": "PHP"
  }
}
```


### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
