### PR TITLE
fix(instant-meetings): Fix missing retention duration from instant meetings

### DIFF
--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -178,6 +178,7 @@ class Capabilities implements IPublicCapability {
 			'description-length',
 			'retention-event',
 			'retention-phone',
+			'retention-instant-meetings',
 		],
 		'federation' => [
 			'enabled',

--- a/src/components/UIShared/ConversationActionsShortcut.vue
+++ b/src/components/UIShared/ConversationActionsShortcut.vue
@@ -26,6 +26,7 @@ import { hasTalkFeature, getTalkConfig } from '../../services/CapabilitiesManage
 const supportsArchive = hasTalkFeature('local', 'archived-conversations-v2')
 const retentionEventPeriod = getTalkConfig('local', 'conversations', 'retention-event')
 const retentionPhonePeriod = getTalkConfig('local', 'conversations', 'retention-phone')
+const retentionInstantMeetingPeriod = getTalkConfig('local', 'conversations', 'retention-instant-meetings')
 
 const props = defineProps<{
 	token: string,
@@ -45,7 +46,7 @@ const expirationDuration = computed(() => {
 	} else if (props.objectType === CONVERSATION.OBJECT_TYPE.PHONE_TEMPORARY) {
 		return retentionPhonePeriod
 	} else if (props.objectType === CONVERSATION.OBJECT_TYPE.INSTANT_MEETING) {
-		return 0 // FIXME: get actual value from the server
+		return retentionInstantMeetingPeriod
 	}
 	return 0
 })

--- a/tests/php/CapabilitiesTest.php
+++ b/tests/php/CapabilitiesTest.php
@@ -396,10 +396,10 @@ class CapabilitiesTest extends TestCase {
 		foreach ($configFeatures as $feature) {
 			foreach (array_keys($configDefinition[$feature]['properties']) as $config) {
 				$suffix = '';
-				if (isset($data['spreed']['config-local'][$feature]) && in_array($config, Capabilities::LOCAL_CONFIGS[$feature])) {
+				if (in_array($config, Capabilities::LOCAL_CONFIGS[$feature])) {
 					$suffix = ' (local)';
 				}
-				$this->assertCapabilityIsDocumented("`config => $feature => $config`" . $suffix);
+				$this->assertCapabilityIsDocumented("`config => $feature => $config`" . $suffix . ' - ');
 			}
 		}
 	}


### PR DESCRIPTION
## 🛠️ API Checklist
- [x] Make sure non-local configs are documented as such
- [x] Mark instant-meetings as local config
- [x] Make sure the frontend uses it

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
