### PR TITLE
fix(RightSidebar): make local time reactive

### DIFF
--- a/src/components/RightSidebar/RightSidebarContent.vue
+++ b/src/components/RightSidebar/RightSidebarContent.vue
@@ -24,6 +24,7 @@ import NcButton from '@nextcloud/vue/components/NcButton'
 import { useIsDarkTheme } from '@nextcloud/vue/composables/useIsDarkTheme'
 
 import CalendarEventSmall from '../UIShared/CalendarEventSmall.vue'
+import LocalTime from '../UIShared/LocalTime.vue'
 
 import { useStore } from '../../composables/useStore.js'
 import { CONVERSATION } from '../../constants.ts'
@@ -121,13 +122,6 @@ const profileInformation = computed(() => {
 		})
 	}
 
-	const currentTime = moment(new Date().setSeconds(new Date().getTimezoneOffset() * 60 + profileInfo.value.timezoneOffset))
-	fields.push({
-		key: 'timezone',
-		icon: IconClockOutline,
-		label: t('spreed', 'Local time: {time}', { time: currentTime.format('LT') })
-	})
-
 	return fields
 })
 
@@ -221,14 +215,21 @@ function onError() {
 						:class="{ 'content__name--has-profile-actions': profileActions.length }"
 						:name="sidebarTitle"
 						:title="sidebarTitle" />
-					<div v-if="mode !== 'compact' && profileInformation.length"
+					<div v-if="mode !== 'compact' && profileInfo"
 						class="content__info">
-						<p v-for="row in profileInformation"
+						<span v-for="row in profileInformation"
 							:key="row.key"
 							class="content__info-row">
 							<component :is="row.icon" :size="16" />
 							{{ row.label }}
-						</p>
+						</span>
+						<LocalTime v-if="profileInfo.timezone"
+							class="content__info-row"
+							:timezone="profileInfo.timezone">
+							<template #icon>
+								<IconClockOutline :size="16" />
+							</template>
+						</LocalTime>
 					</div>
 				</div>
 			</div>

--- a/src/components/UIShared/LocalTime.vue
+++ b/src/components/UIShared/LocalTime.vue
@@ -1,0 +1,33 @@
+<!--
+  - SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+import { t, getCanonicalLocale } from '@nextcloud/l10n'
+
+import { useCurrentTime } from '../../composables/useCurrentTime.ts'
+
+const props = defineProps<{
+	timezone: string,
+}>()
+
+const currentTime = useCurrentTime()
+
+const time = computed(() => t('spreed', 'Local time: {time}', {
+	time: Intl.DateTimeFormat(getCanonicalLocale(), {
+		timeZone: props.timezone,
+		hour: '2-digit',
+		minute: '2-digit',
+	}).format(currentTime.value),
+}))
+</script>
+
+<template>
+	<span>
+		<slot name="icon" />
+		{{ time }}
+	</span>
+</template>

--- a/src/composables/useCurrentTime.ts
+++ b/src/composables/useCurrentTime.ts
@@ -1,0 +1,54 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { createSharedComposable } from '@vueuse/core'
+import { onUnmounted, readonly, ref } from 'vue'
+import type { DeepReadonly, Ref } from 'vue'
+
+/**
+ * Composable to get current time (as Date object)
+ * @param [precision] - precision in milliseconds (defaults to one minute)
+ * @return Date reactive object with current time
+ */
+export function useCurrentTimeComposable(precision: number = 60_000): DeepReadonly<Ref<Date>> {
+	let timeout: ReturnType<typeof setTimeout>
+
+	const date = ref(new Date())
+
+	requestUpdate()
+
+	/**
+	 * Called for shared composable when all subscribers are unmounted (onScopeDispose)
+	 */
+	onUnmounted(() => {
+		clearTimeout(timeout)
+	})
+
+	/**
+	 * Recursively request an update of the current time (with compensation of microtask queue inaccuracy)
+	 */
+	function requestUpdate() {
+		date.value = new Date()
+		timeout = setTimeout(() => {
+			requestUpdate()
+		}, precision - date.value.valueOf() % precision)
+	}
+
+	return readonly(date)
+}
+
+/**
+ * Composable to get current time (as Date object)
+ * @return Date reactive object with current time (with 60 seconds precision)
+ */
+function useCurrentTimeMinuteComposable(): DeepReadonly<Ref<Date>> {
+	return useCurrentTimeComposable(60_000)
+}
+
+/**
+ * Shared composable to get current time (as Date object)
+ * @return Date reactive object with current time (with 60 seconds precision)
+ */
+export const useCurrentTime = createSharedComposable(useCurrentTimeMinuteComposable)


### PR DESCRIPTION
### ☑️ Resolves

* Ref #15096
  * make time in Right SIdebar update every minute (align with system clock)
  * introduce shared composable for Date() object
  * introduce shared component for showing the date

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

It works

### 🚧 Tasks

- [x] Cumulative error? check if has real effect (should not be noticable without seconds shown)
  - [x] Didn't notice on tab retrieved from background (after 5-7 minutes)

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [x] Talk Desktop
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required