### PR TITLE
fix(upcoming-reminders): Respect sensitive conversation setting

### DIFF
--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -1188,6 +1188,11 @@ class ChatController extends AEnvironmentAwareOCSController {
 
 			$data = $message->toArray($this->getResponseFormat());
 
+			if ($participant->getAttendee()->isSensitive()) {
+				$data['message'] = '';
+				$data['messageParameters'] = [];
+			}
+
 			$resultData[] = [
 				'reminderTimestamp' => $reminder->getDateTime()->getTimestamp(),
 				'roomToken' => $reminder->getToken(),

--- a/tests/integration/features/chat-3/reminder.feature
+++ b/tests/integration/features/chat-3/reminder.feature
@@ -174,9 +174,10 @@ Feature: chat-2/reminder
       | 1234568           | room2     | Message 2 | users     | participant2 | participant2-displayname | Message 2 | []                |
       | 1234569           | room3     | Message 3 | users     | participant1 | participant1-displayname | Message 3 | []                |
     And user "participant2" removes "participant1" from room "room2" with 200 (v4)
+    And user "participant1" marks room "room1" as sensitive with 200 (v4)
     Then user "participant1" gets upcoming reminders (v1)
       | reminderTimestamp | roomToken | messageId | actorType | actorId      | actorDisplayName         | message   | messageParameters |
-      | 1234567           | room1     | Message 1 | users     | participant1 | participant1-displayname | Message 1 | []                |
+      | 1234567           | room1     | Message 1 | users     | participant1 | participant1-displayname |           | []                |
       | 1234569           | room3     | Message 3 | users     | participant1 | participant1-displayname | Message 3 | []                |
     And force run "OCA\Talk\BackgroundJob\Reminder" background jobs
     Then user "participant1" gets upcoming reminders (v1)


### PR DESCRIPTION
### ☑️ Resolves

- Mark a conversation as sensitive
- Create a reminder
- Check the dashboard
- Message should not be visible

## 🛠️ API Checklist

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
