### PR TITLE
fix: make audio output feature work in calls for Safari

### DIFF
--- a/src/utils/webrtc/CallParticipantsAudioPlayer.js
+++ b/src/utils/webrtc/CallParticipantsAudioPlayer.js
@@ -159,11 +159,15 @@ CallParticipantsAudioPlayer.prototype = {
 			return
 		}
 
-		const promises = []
-		for (const audioElement of this._audioElements.values()) {
-			promises.push(this._setAudioElementOutput(deviceId, audioElement))
+		if (this._mixAudio) {
+			await this._setAudioElementOutput(deviceId, this._audioElement)
+		} else {
+			const promises = []
+			for (const audioElement of this._audioElements.values()) {
+				promises.push(this._setAudioElementOutput(deviceId, audioElement))
+			}
+			await Promise.all(promises)
 		}
-		await Promise.all(promises)
 	},
 
 	async _setAudioElementOutput(deviceId, audioElement = null) {


### PR DESCRIPTION
### ☑️ Resolves

* ~~Safari does not support AudioContext#setSinkId (required for call audio mixer)~~
* ~~UI was considering only Audio#setSinkId~~
* AudioContext destination was actually given to `<audio>` element, which we can modify

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
Screenshot before | to be added

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [x] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
