### PR TITLE
chore(deps): bump @nextcloud/vue from 8.26.0 to 8.26.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@nextcloud/router": "^3.0.1",
         "@nextcloud/sharing": "^0.2.4",
         "@nextcloud/upload": "^1.9.1",
-        "@nextcloud/vue": "^8.26.0",
+        "@nextcloud/vue": "^8.26.1",
         "@vue/web-component-wrapper": "^1.3.0",
         "@vueuse/components": "^11.3.0",
         "@vueuse/core": "^11.2.0",
@@ -3822,15 +3822,15 @@
       }
     },
     "node_modules/@nextcloud/timezones": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/timezones/-/timezones-0.1.1.tgz",
-      "integrity": "sha512-ldLuLyz605sszetnp6jy6mtlThu4ICKsZThxHIZwn6t4QzjQH3xr+k8mRU7GIvKq9egUFDqBp4gBjxm3/ROZig==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/timezones/-/timezones-0.2.0.tgz",
+      "integrity": "sha512-1mwQ+asTFOgv9rxPoAMEbDF8JfnenIa2EGNS+8MATCyi6WXxYh0Lhkaq1d3l2+xNbUPHgMnk4cRYsvIo319lkA==",
+      "license": "AGPL-3.0-or-later",
       "dependencies": {
-        "ical.js": "^2.0.1"
+        "ical.js": "^2.1.0"
       },
       "engines": {
-        "node": "^20.0.0",
-        "npm": "^10.0.0"
+        "node": "^20 || ^22"
       }
     },
     "node_modules/@nextcloud/typings": {
@@ -3878,9 +3878,9 @@
       }
     },
     "node_modules/@nextcloud/vue": {
-      "version": "8.26.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.26.0.tgz",
-      "integrity": "sha512-7KyPAle4/tL2VzR0vVa5ssLAaAlDv54XJ1HPTPw9R4FIyqxDe9lICe1sRNG+uXsRY0NeYIKEmbJ3sqvbxaWdVQ==",
+      "version": "8.26.1",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.26.1.tgz",
+      "integrity": "sha512-kaTtiNeaiE2nT4mLe1X3oIbuNZbIYOQknPTa9gF6yCCn8gMwMTfg/JL/7Kr1a+UsLYNLLCizGZoCjEzR2DDpYA==",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@floating-ui/dom": "^1.1.0",
@@ -3895,7 +3895,7 @@
         "@nextcloud/logger": "^3.0.2",
         "@nextcloud/router": "^3.0.1",
         "@nextcloud/sharing": "^0.2.3",
-        "@nextcloud/timezones": "^0.1.1",
+        "@nextcloud/timezones": "^0.2.0",
         "@nextcloud/vue-select": "^3.25.1",
         "@vueuse/components": "^11.0.0",
         "@vueuse/core": "^11.0.0",
@@ -11181,9 +11181,10 @@
       }
     },
     "node_modules/ical.js": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ical.js/-/ical.js-2.0.1.tgz",
-      "integrity": "sha512-uYYb1CwTXbd9NP/xTtgQZ5ivv6bpUjQu9VM98s3X78L3XRu00uJW5ZtmnLwyxhztpf5fSiRyDpFW7ZNCePlaPw=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ical.js/-/ical.js-2.1.0.tgz",
+      "integrity": "sha512-BOVfrH55xQ6kpS3muGvIXIg2l7p+eoe12/oS7R5yrO3TL/j/bLsR0PR+tYQESFbyTbvGgPHn9zQ6tI4FWyuSaQ==",
+      "license": "MPL-2.0"
     },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
@@ -23918,11 +23919,11 @@
       "requires": {}
     },
     "@nextcloud/timezones": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/timezones/-/timezones-0.1.1.tgz",
-      "integrity": "sha512-ldLuLyz605sszetnp6jy6mtlThu4ICKsZThxHIZwn6t4QzjQH3xr+k8mRU7GIvKq9egUFDqBp4gBjxm3/ROZig==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/timezones/-/timezones-0.2.0.tgz",
+      "integrity": "sha512-1mwQ+asTFOgv9rxPoAMEbDF8JfnenIa2EGNS+8MATCyi6WXxYh0Lhkaq1d3l2+xNbUPHgMnk4cRYsvIo319lkA==",
       "requires": {
-        "ical.js": "^2.0.1"
+        "ical.js": "^2.1.0"
       }
     },
     "@nextcloud/typings": {
@@ -23957,9 +23958,9 @@
       }
     },
     "@nextcloud/vue": {
-      "version": "8.26.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.26.0.tgz",
-      "integrity": "sha512-7KyPAle4/tL2VzR0vVa5ssLAaAlDv54XJ1HPTPw9R4FIyqxDe9lICe1sRNG+uXsRY0NeYIKEmbJ3sqvbxaWdVQ==",
+      "version": "8.26.1",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.26.1.tgz",
+      "integrity": "sha512-kaTtiNeaiE2nT4mLe1X3oIbuNZbIYOQknPTa9gF6yCCn8gMwMTfg/JL/7Kr1a+UsLYNLLCizGZoCjEzR2DDpYA==",
       "requires": {
         "@floating-ui/dom": "^1.1.0",
         "@linusborg/vue-simple-portal": "^0.1.5",
@@ -23973,7 +23974,7 @@
         "@nextcloud/logger": "^3.0.2",
         "@nextcloud/router": "^3.0.1",
         "@nextcloud/sharing": "^0.2.3",
-        "@nextcloud/timezones": "^0.1.1",
+        "@nextcloud/timezones": "^0.2.0",
         "@nextcloud/vue-select": "^3.25.1",
         "@vueuse/components": "^11.0.0",
         "@vueuse/core": "^11.0.0",
@@ -29491,9 +29492,9 @@
       "peer": true
     },
     "ical.js": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ical.js/-/ical.js-2.0.1.tgz",
-      "integrity": "sha512-uYYb1CwTXbd9NP/xTtgQZ5ivv6bpUjQu9VM98s3X78L3XRu00uJW5ZtmnLwyxhztpf5fSiRyDpFW7ZNCePlaPw=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ical.js/-/ical.js-2.1.0.tgz",
+      "integrity": "sha512-BOVfrH55xQ6kpS3muGvIXIg2l7p+eoe12/oS7R5yrO3TL/j/bLsR0PR+tYQESFbyTbvGgPHn9zQ6tI4FWyuSaQ=="
     },
     "iconv-lite": {
       "version": "0.4.24",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@nextcloud/router": "^3.0.1",
     "@nextcloud/sharing": "^0.2.4",
     "@nextcloud/upload": "^1.9.1",
-    "@nextcloud/vue": "^8.26.0",
+    "@nextcloud/vue": "^8.26.1",
     "@vue/web-component-wrapper": "^1.3.0",
     "@vueuse/components": "^11.3.0",
     "@vueuse/core": "^11.2.0",


### PR DESCRIPTION
### ☑️ Resolves

* Fix NcIconSvgWrapper alignment


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/user-attachments/assets/cd692f0d-84f3-4b54-b752-413b6c6963a3) | ![image](https://github.com/user-attachments/assets/b2f17955-4ca7-4b6f-adc2-92d16fabb0f4)


### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required