### PR TITLE
fix(openapi): Remove unused return documentation

### DIFF
--- a/lib/Controller/BotController.php
+++ b/lib/Controller/BotController.php
@@ -125,7 +125,6 @@ class BotController extends AEnvironmentAwareOCSController {
 	 * 201: Message sent successfully
 	 * 400: When the replyTo is invalid or message is empty
 	 * 401: Sending message is not allowed
-	 * 404: Room or session not found
 	 * 413: Message too long
 	 */
 	#[BruteForceProtection(action: 'bot')]


### PR DESCRIPTION
## 🛠️ API Checklist
Ref https://github.com/nextcloud/openapi-extractor/actions/runs/15105903623/job/42454551559?pr=242

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
