### PR TITLE
chore(tests): Cleanup bootstrap.php to be forward-compatible

### DIFF
--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -1,16 +1,20 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2016 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+use OCP\App\IAppManager;
+use OCP\Server;
+
 if (!defined('PHPUNIT_RUN')) {
 	define('PHPUNIT_RUN', 1);
 }
+
 require_once __DIR__ . '/../../../../lib/base.php';
-\OC::$loader->addValidRoot(\OC::$SERVERROOT . '/tests');
-\OC_App::loadApp('spreed');
-if (!class_exists(\PHPUnit\Framework\TestCase::class)) {
-	require_once('PHPUnit/Autoload.php');
-}
-\OC_Hook::clear();
+require_once __DIR__ . '/../../../../tests/autoload.php';
+
+Server::get(IAppManager::class)->loadApp('spreed');


### PR DESCRIPTION
This uses the new tests/autoload.php from nextcloud/server instead of messing directly with OC private autoloader.

See https://github.com/nextcloud/server/pull/52951 and https://github.com/nextcloud/server/pull/52945 for context.