### PR TITLE
fix(ConversationActionsShortcut): hide component if nothing to show

### DIFF
--- a/src/components/UIShared/ConversationActionsShortcut.vue
+++ b/src/components/UIShared/ConversationActionsShortcut.vue
@@ -51,6 +51,8 @@ const expirationDuration = computed(() => {
 	return 0
 })
 
+const isShown = computed(() => isModerator.value || expirationDuration.value !== 0)
+
 const descriptionLabel = computed(() => {
 	if (expirationDuration.value === 0) {
 		return t('spreed', 'Would you like to delete this conversation?')
@@ -109,7 +111,8 @@ async function showConfirmationDialog() {
 </script>
 
 <template>
-	<div class="conversation-actions"
+	<div v-if="isShown"
+		class="conversation-actions"
 		:class="{ 'conversation-actions--highlighted': props.isHighlighted }">
 		<p>{{ descriptionLabel }}</p>
 		<div v-if="isModerator"


### PR DESCRIPTION
### ☑️ Resolves

* Fix redundant label shown to users non-moderators in rooms with 0 retention


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="378" alt="2025-05-20_12h32_03" src="https://github.com/user-attachments/assets/f5f9b642-3cdb-4aa7-a1b4-7d186037fef8" /> | <img width="361" alt="2025-05-20_12h32_35" src="https://github.com/user-attachments/assets/c555d198-5c24-4485-8505-d90a8012d9ae" />
<!-- ☀️ Light theme | 🌑 Dark Theme -->


### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required