### PR TITLE
fix(sidebar): mutual events showing incorrect events

### DIFF
--- a/lib/Dashboard/Event.php
+++ b/lib/Dashboard/Event.php
@@ -138,6 +138,27 @@ class Event implements \JsonSerializable {
 		}
 	}
 
+	public function isAttendee(array $attendees, string $email): bool {
+		foreach ($attendees as $attendee) {
+			if (!isset($attendee[1]['PARTSTAT'])) {
+				continue;
+			}
+
+			// Calendar emails start with 'mailto:'
+			if (substr($attendee[0], 7) === $email) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+
+	public function isOrganizer(array $organizer, string $email): bool {
+		// Calendar emails start with 'mailto:'
+		return substr($organizer[0], 7) === $email;
+	}
+
 	/**
 	 * Takes the room token, start and end time and attendees to build an identifier
 	 * If the identifier already exists, another event is happening at the same time


### PR DESCRIPTION
Due to a bug in CalDAV search, recurrences that are not a match will still be returned if the ATTENDEE is found in a recurrence exception.

See https://github.com/nextcloud/server/issues/52979 for more details on this bug.

Build an additional filter for the event so we only show mutual events if the other participant is the organizer or an attendee of the current recurrence / event.


### ☑️ Resolves

* Fix #…

<!--
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
░░░███████░░░█████████░░█████░
░░███░░░███░░░███░░░███░░███░░
░░█████████░░░████████░░░███░░
░░███░░░███░░░███░░░░░░░░███░░
░█████░█████░█████░░░░░░█████░
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching frontend/UI code
-->

## 🛠️ API Checklist

### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
