### PR TITLE
test: make Jest fail on console.warn / console.error

### DIFF
--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -13,6 +13,7 @@
 						:class="{'hidden-visually': isSearching}"
 						class="talk-home-button"
 						:title="t('spreed', 'Talk home')"
+						:aria-label="t('spreed', 'Talk home')"
 						@click="showTalkDashboard">
 						<template #icon>
 							<IconHome :size="20" />

--- a/src/test-setup.js
+++ b/src/test-setup.js
@@ -126,3 +126,16 @@ window.URL.revokeObjectURL = jest.fn()
 
 Vue.prototype.OC = OC
 Vue.prototype.OCA = OCA
+
+// Make Jest fail on errors or warnings (like a11y warning from nextcloud/vue library)
+const originalWarn = global.console.warn
+console.warn = function(message) {
+	originalWarn.apply(console, arguments)
+	throw (message instanceof Error ? message : new Error(message))
+}
+
+const originalError = global.console.error
+console.error = function(message) {
+	originalError.apply(console, arguments)
+	throw (message instanceof Error ? message : new Error(message))
+}


### PR DESCRIPTION
### ☑️ Resolves

* Allows to capture issues at JS code before it got merged
  * Components should be mounted in any test
  * can be avoided by `console.#method = jest.fn()` in place where it's expected

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
Green CI | Red CI


### 🏁 Checklist

- [x] ⛑️ Tests are included or not possible