### PR TITLE
fix(RightSidebar): adjust profile info expanding logic

### DIFF
--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -22,7 +22,8 @@
 			<span v-if="unreadMessagesCounter > 0" class="chat-button-unread-marker" />
 		</template>
 		<template #info>
-			<RightSidebarContent :is-user="!!getUserId"
+			<RightSidebarContent ref="sidebarContent"
+				:is-user="!!getUserId"
 				:mode="CONTENT_MODES[contentModeIndex]"
 				:state="showSearchMessagesTab ? 'search' : 'default'"
 				@update:mode="handleUpdateMode"
@@ -187,6 +188,7 @@ export default {
 
 	setup() {
 		const sidebar = ref(null)
+		const sidebarContent = ref(null)
 		const contentModeIndex = ref(0)
 
 		let throttleTimeout = null
@@ -199,7 +201,7 @@ export default {
 			throttleTimeout = setTimeout(() => {
 				clearTimeout(throttleTimeout)
 				throttleTimeout = null
-			}, 300 /* var(--animation-slow) */)
+			}, 100 /* delay after last fired event */)
 		}
 
 		useEventListener(sidebar, 'wheel', throttleHandleWheelEvent, { capture: true })
@@ -221,13 +223,9 @@ export default {
 				// Shrink before scrolling other content (block following scroll events)
 				event.preventDefault()
 			} else {
-				let target = event.target
-				while (target !== sidebar.value?.$el) {
-					if (target.scrollTop !== 0) {
-						// Expand only if other content is scrolled to the top
-						return
-					}
-					target = target.parentNode
+				if (!sidebarContent.value?.$el?.contains(event.target)) {
+					// Expand only if event happens within the RightSidebarContent component
+					return
 				}
 			}
 
@@ -238,6 +236,7 @@ export default {
 			CONTENT_MODES,
 			contentModeIndex,
 			sidebar,
+			sidebarContent,
 			sidebarStore: useSidebarStore()
 		}
 	},

--- a/src/components/RightSidebar/RightSidebarContent.vue
+++ b/src/components/RightSidebar/RightSidebarContent.vue
@@ -169,6 +169,20 @@ function joinFields(firstSubstring?: string | null, secondSubstring?: string | n
 function onError() {
 	profileImageFailed.value = true
 }
+
+/**
+ * Handles image click (alternative to scroll)
+ */
+function handleImageClick() {
+	emit('update:mode', props.mode === 'preview' ? 'full' : 'preview')
+}
+
+/**
+ * Handles header click (alternative to scroll)
+ */
+function handleHeaderClick() {
+	emit('update:mode', props.mode === 'preview' ? 'compact' : 'preview')
+}
 </script>
 
 <template>
@@ -207,14 +221,15 @@ function onError() {
 						:src="avatarUrl"
 						:alt="conversation.displayName"
 						@error="onError"
-						@click="mode === 'preview' && emit('update:mode', 'full')">
+						@click="handleImageClick">
 				</div>
 				<!-- User / conversation profile information -->
-				<div class="content__header">
+				<div class="content__header animated">
 					<NcAppSidebarHeader class="content__name content__name--has-actions"
 						:class="{ 'content__name--has-profile-actions': profileActions.length }"
 						:name="sidebarTitle"
-						:title="sidebarTitle" />
+						:title="sidebarTitle"
+						@click.native="handleHeaderClick" />
 					<div v-if="mode !== 'compact' && profileInfo"
 						class="content__info">
 						<span v-for="row in profileInformation"
@@ -399,6 +414,7 @@ function onError() {
 		border-radius: 50%;
 		object-fit: cover;
 		object-position: top;
+		cursor: pointer;
 
 		&.icon {
 			background-size: 50%;
@@ -431,6 +447,7 @@ function onError() {
 			overflow: hidden;
 			white-space: nowrap;
 			text-overflow: ellipsis;
+			cursor: pointer;
 
 			&--has-actions {
 				padding-inline-end: calc(var(--actions-offset) + var(--app-sidebar-close-button-offset));


### PR DESCRIPTION
### ☑️ Resolves

* Throttle wheel events to the last+100ms instead of last+300ms
* Allow wheel events to expand only  in the content area (where header//image is)
* Wheel events to shrink are intact (scroll in the chat/attendees list still work to hide it)
* Clicking on image:
  * has correct cursor
  * expand to full size or back to preview (only 2 options)
* Clicking on header:
  * has correct cursor;
  * has correct width animation;
  * expand/shrink to preview size; or shrink to compact, if was in preview


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before

https://github.com/user-attachments/assets/a813a7b0-1e7c-45dc-9aee-169bf4d9c033

🏡 After

https://github.com/user-attachments/assets/e70eecda-2b67-41d8-8204-66895dd2e68e

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required