### PR TITLE
fix: Enable "encodedInsertableStreams" on browsers supporting it.

### DIFF
--- a/src/utils/browserCheck.ts
+++ b/src/utils/browserCheck.ts
@@ -77,3 +77,29 @@ export function checkBrowser() {
 		showError(unsupportedWarning, { timeout: TOAST_PERMANENT_TIMEOUT })
 	}
 }
+
+/**
+ * Check if the browser supports WebRTC Encoded Transform (i.e. Firefox).
+ */
+export function supportsEncodedTransform() {
+	return (window.RTCRtpScriptTransform && window.RTCRtpSender && 'transform' in RTCRtpSender.prototype)
+}
+
+/**
+ * Check if the browser supports insertable streams (i.e. Chromium).
+ */
+export function supportsInsertableStreams() {
+	if (!(window.RTCRtpReceiver && 'createEncodedStreams' in RTCRtpReceiver.prototype && window.RTCRtpSender && 'createEncodedStreams' in RTCRtpSender.prototype)) {
+		return false
+	}
+
+	// Feature-detect transferable streams which we need to operate in a worker.
+	// See https://groups.google.com/a/chromium.org/g/blink-dev/c/1LStSgBt6AM/m/hj0odB8pCAAJ
+	const stream = new ReadableStream()
+	try {
+		window.postMessage(stream, '*', [stream])
+		return true
+	} catch {
+		return false
+	}
+}

--- a/src/utils/e2ee/encryption.js
+++ b/src/utils/e2ee/encryption.js
@@ -14,15 +14,10 @@ import Deferred from './JitsiDeferred.js'
 import E2EEcontext from './JitsiE2EEContext.js'
 import initializeOlm from './olm.js'
 import { hasTalkFeature, getTalkConfig } from '../../services/CapabilitiesManager.ts'
+import { supportsEncodedTransform, supportsInsertableStreams } from '../browserCheck.ts'
 import Signaling from '../signaling.js'
 import Peer from '../webrtc/simplewebrtc/peer.js'
 import SimpleWebRTC from '../webrtc/simplewebrtc/simplewebrtc.js'
-
-const supportsTransform
-	// Firefox
-	= (window.RTCRtpScriptTransform && window.RTCRtpSender && 'transform' in RTCRtpSender.prototype)
-	// Chrome
-	|| (window.RTCRtpReceiver && 'createEncodedStreams' in RTCRtpReceiver.prototype && window.RTCRtpSender && 'createEncodedStreams' in RTCRtpSender.prototype)
 
 // Period which we'll wait before updating / rotating our keys when a participant
 // joins or leaves.
@@ -45,7 +40,7 @@ class Encryption {
 	 * @async
 	 */
 	static async isSupported() {
-		if (!supportsTransform) {
+		if (!supportsEncodedTransform() && !supportsInsertableStreams()) {
 			throw new Error('stream transform is not supported')
 		}
 

--- a/src/utils/webrtc/simplewebrtc/webrtc.js
+++ b/src/utils/webrtc/simplewebrtc/webrtc.js
@@ -10,6 +10,7 @@ import webrtcSupport from 'webrtcsupport'
 
 import localMedia from './localmedia.js'
 import Peer from './peer.js'
+import { supportsInsertableStreams } from '../../browserCheck.ts'
 
 /**
  * @param {object} opts the options object.
@@ -36,6 +37,10 @@ export default function WebRTC(opts) {
 		},
 	}
 	let item
+
+	if (supportsInsertableStreams()) {
+		this.config.peerConnectionConfig.encodedInsertableStreams = true
+	}
 
 	// We also allow a 'logger' option. It can be any object that implements
 	// log, warn, and error methods.


### PR DESCRIPTION
Older versions of Chrome (< 124) required the flag to be passed when creating PeerConnections so "createEncodedStreams" can be used later.

See https://issues.chromium.org/issues/40943169 and https://chromiumdash.appspot.com/commit/ae3454745ca8f623435d658eba7d4bc2dc8aed17

With that also refactored the browser detection of features for E2EE.


The issue happened on one of my machines still on Chrome 122 (was developing on Chrome 132 which doesn't need the flag).