### PR TITLE
fix(sip): Allow guests to start calls in direct-dialin

### DIFF
--- a/lib/Listener/RestrictStartingCalls.php
+++ b/lib/Listener/RestrictStartingCalls.php
@@ -54,6 +54,15 @@ class RestrictStartingCalls implements IEventListener {
 			return;
 		}
 
+		if (in_array($room->getObjectType(), [
+			Room::OBJECT_TYPE_PHONE_LEGACY,
+			Room::OBJECT_TYPE_PHONE_TEMPORARY,
+			Room::OBJECT_TYPE_PHONE_PERSIST,
+		], true) && $room->getObjectId() === Room::OBJECT_ID_PHONE_INCOMING) {
+			// Always allow guests to use the direct-dialin
+			return;
+		}
+
 		if (!$event->getParticipant()->canStartCall($this->serverConfig)
 			&& !$this->participantService->hasActiveSessionsInCall($room)) {
 			throw new ForbiddenException('Can not start a call');


### PR DESCRIPTION
## 🛠️ API Checklist

- Restrict starting calls to "Logged in users and Moderators"
- Try a SIP direct dialin

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
