### PR TITLE
chore(deps): bump @nextcloud/vue from 8.26.1 to 8.27.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@nextcloud/router": "^3.0.1",
         "@nextcloud/sharing": "^0.2.4",
         "@nextcloud/upload": "^1.10.0",
-        "@nextcloud/vue": "^8.26.1",
+        "@nextcloud/vue": "^8.27.0",
         "@vue/web-component-wrapper": "^1.3.0",
         "@vueuse/components": "^11.3.0",
         "@vueuse/core": "^11.2.0",
@@ -4048,9 +4048,9 @@
       }
     },
     "node_modules/@nextcloud/vue": {
-      "version": "8.26.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.26.1.tgz",
-      "integrity": "sha512-kaTtiNeaiE2nT4mLe1X3oIbuNZbIYOQknPTa9gF6yCCn8gMwMTfg/JL/7Kr1a+UsLYNLLCizGZoCjEzR2DDpYA==",
+      "version": "8.27.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.27.0.tgz",
+      "integrity": "sha512-v9aTv5G5zVKN8PJVAP/WTcTspDXr6yxZtgGyQ4El5pZzMWk2+3wANT+VU4mdNCIpiJ2xyYorLs/Gg0Z9y73Anw==",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@floating-ui/dom": "^1.1.0",
@@ -4086,6 +4086,7 @@
         "remark-breaks": "^4.0.0",
         "remark-parse": "^11.0.0",
         "remark-rehype": "^11.0.0",
+        "remark-unlink-protocols": "^1.0.0",
         "splitpanes": "^2.4.1",
         "string-length": "^5.0.1",
         "striptags": "^3.2.0",
@@ -13715,6 +13716,20 @@
         "safe-buffer": "^5.1.2"
       }
     },
+    "node_modules/mdast-squeeze-paragraphs": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-squeeze-paragraphs/-/mdast-squeeze-paragraphs-6.0.0.tgz",
+      "integrity": "sha512-6NDbJPTg0M0Ye+TlYwX1KJ1LFbp515P2immRJyJQhc9Na9cetHzSoHNYIQcXpANEAP1sm9yd/CTZU2uHqR5A+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-find-and-replace": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.1.tgz",
@@ -16612,6 +16627,17 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-unlink-protocols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/remark-unlink-protocols/-/remark-unlink-protocols-1.0.0.tgz",
+      "integrity": "sha512-5j/F28jhFmxeyz8nuJYYIWdR4nNpKWZ8A+tVwnK/0pq7Rjue33CINEYSckSq2PZvedhKUwbn08qyiuGoPLBung==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-squeeze-paragraphs": "^6.0.0",
+        "unist-util-visit": "^5.0.0"
       }
     },
     "node_modules/require-directory": {
@@ -23291,9 +23317,9 @@
       }
     },
     "@nextcloud/vue": {
-      "version": "8.26.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.26.1.tgz",
-      "integrity": "sha512-kaTtiNeaiE2nT4mLe1X3oIbuNZbIYOQknPTa9gF6yCCn8gMwMTfg/JL/7Kr1a+UsLYNLLCizGZoCjEzR2DDpYA==",
+      "version": "8.27.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.27.0.tgz",
+      "integrity": "sha512-v9aTv5G5zVKN8PJVAP/WTcTspDXr6yxZtgGyQ4El5pZzMWk2+3wANT+VU4mdNCIpiJ2xyYorLs/Gg0Z9y73Anw==",
       "requires": {
         "@floating-ui/dom": "^1.1.0",
         "@linusborg/vue-simple-portal": "^0.1.5",
@@ -23328,6 +23354,7 @@
         "remark-breaks": "^4.0.0",
         "remark-parse": "^11.0.0",
         "remark-rehype": "^11.0.0",
+        "remark-unlink-protocols": "^1.0.0",
         "splitpanes": "^2.4.1",
         "string-length": "^5.0.1",
         "striptags": "^3.2.0",
@@ -30520,6 +30547,15 @@
         "safe-buffer": "^5.1.2"
       }
     },
+    "mdast-squeeze-paragraphs": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-squeeze-paragraphs/-/mdast-squeeze-paragraphs-6.0.0.tgz",
+      "integrity": "sha512-6NDbJPTg0M0Ye+TlYwX1KJ1LFbp515P2immRJyJQhc9Na9cetHzSoHNYIQcXpANEAP1sm9yd/CTZU2uHqR5A+w==",
+      "requires": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-visit": "^5.0.0"
+      }
+    },
     "mdast-util-find-and-replace": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.1.tgz",
@@ -32504,6 +32540,16 @@
             "unist-util-stringify-position": "^4.0.0"
           }
         }
+      }
+    },
+    "remark-unlink-protocols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/remark-unlink-protocols/-/remark-unlink-protocols-1.0.0.tgz",
+      "integrity": "sha512-5j/F28jhFmxeyz8nuJYYIWdR4nNpKWZ8A+tVwnK/0pq7Rjue33CINEYSckSq2PZvedhKUwbn08qyiuGoPLBung==",
+      "requires": {
+        "@types/mdast": "^4.0.0",
+        "mdast-squeeze-paragraphs": "^6.0.0",
+        "unist-util-visit": "^5.0.0"
       }
     },
     "require-directory": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@nextcloud/router": "^3.0.1",
     "@nextcloud/sharing": "^0.2.4",
     "@nextcloud/upload": "^1.10.0",
-    "@nextcloud/vue": "^8.26.1",
+    "@nextcloud/vue": "^8.27.0",
     "@vue/web-component-wrapper": "^1.3.0",
     "@vueuse/components": "^11.3.0",
     "@vueuse/core": "^11.2.0",

--- a/src/components/LeftSidebar/ConversationsList/Conversation.vue
+++ b/src/components/LeftSidebar/ConversationsList/Conversation.vue
@@ -169,25 +169,23 @@
 
 					<NcActionButton v-if="supportImportantConversations"
 						type="checkbox"
-						class="conversation__action--with-subline"
-						:name="t('spreed', 'Important conversation')"
+						:description="labelImportantHint"
 						:model-value="item.isImportant"
 						@click="toggleImportant(!item.isImportant)">
 						<template #icon>
 							<IconMessageAlert :size="16" />
 						</template>
-						{{ labelImportantHint }}
+						{{ t('spreed', 'Important conversation') }}
 					</NcActionButton>
 					<NcActionButton v-if="supportSensitiveConversations"
 						type="checkbox"
-						class="conversation__action--with-subline"
-						:name="t('spreed', 'Sensitive conversation')"
+						:description="t('spreed', 'Hide message text')"
 						:model-value="item.isSensitive"
 						@click="toggleSensitive(!item.isSensitive)">
 						<template #icon>
 							<IconShieldLock :size="16" />
 						</template>
-						{{ t('spreed', 'Hide message text') }}
+						{{ t('spreed', 'Sensitive conversation') }}
 					</NcActionButton>
 				</template>
 			</template>
@@ -659,24 +657,6 @@ export default {
 			overflow: hidden;
 			text-overflow: ellipsis;
 			white-space: nowrap;
-		}
-	}
-
-	// FIXME: migrate to subline once it's ready
-	&__action--with-subline {
-		:deep(.action-button__longtext-wrapper) {
-			align-self: center;
-			padding-block: var(--default-grid-baseline);
-			line-height: 1;
-		}
-		:deep(.action-button__name) {
-			font-weight: 400;
-		}
-		:deep(.action-button__longtext) {
-			padding: 0;
-			color: var(--color-text-maxcontrast);
-			font-size: var(--font-size-small);
-			line-height: var(--default-font-size);
 		}
 	}
 }

--- a/src/components/RightSidebar/RightSidebarContent.vue
+++ b/src/components/RightSidebar/RightSidebarContent.vue
@@ -474,19 +474,6 @@ function handleHeaderClick() {
 		inset-inline-end: calc(var(--default-grid-baseline) + var(--app-sidebar-close-button-offset));
 		display: flex;
 		gap: var(--default-grid-baseline);
-
-		// Copy opaque styles of close button
-		:deep(.button-vue--icon-only),
-		:deep(.action-item) {
-			opacity: 0.7;
-
-			&:hover,
-			&:focus,
-			&:active,
-			&.action-item--open {
-				opacity: 1;
-			}
-		}
 	}
 
 	&__events {


### PR DESCRIPTION
### ☑️ Resolves

* Bump `@nextcloud/vue` library to 8.27.0
* Drop overriden styles, replace with new features/bugfixes

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="227" alt="image" src="https://github.com/user-attachments/assets/d0ee7fb6-5561-44a1-8a52-517ca4bf8794" /> | <img width="209" alt="image" src="https://github.com/user-attachments/assets/8c3ba8a5-b83e-4f54-8760-e62a58b1c12d" />


### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required