### PR TITLE
fix(groupware): omit duplicate upcoming events

### DIFF
--- a/src/stores/groupware.ts
+++ b/src/stores/groupware.ts
@@ -100,7 +100,12 @@ export const useGroupwareStore = defineStore('groupware', {
 			const location = generateUrl('call/{token}', { token }, { baseURL: getBaseUrl() })
 			try {
 				const response = await getUpcomingEvents(location)
-				Vue.set(this.upcomingEvents, token, response.data.ocs.data.events)
+				const uniqueEvents = response.data.ocs.data.events.filter((event, index, array) => {
+					// Keep only first meeting with the same location and start time
+					return index === array.findIndex((item) => item.start === event.start)
+				})
+
+				Vue.set(this.upcomingEvents, token, uniqueEvents)
 			} catch (error) {
 				console.error(error)
 			}


### PR DESCRIPTION
### ☑️ Resolves

* Fix #14496 



## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![2025-05-29_15h24_20](https://github.com/user-attachments/assets/f39156d6-2ad8-43a2-9c8c-e4f106ce232c) | ![2025-05-29_15h19_40](https://github.com/user-attachments/assets/8e75fa7b-bd77-4d5f-b33d-bbf418b4358b)


### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required