### PR TITLE
fix(settings): Change the talk hash when updating attachment location

### DIFF
--- a/lib/Config.php
+++ b/lib/Config.php
@@ -70,7 +70,7 @@ class Config {
 	public function getUserReadPrivacy(string $userId): int {
 		return match ((int)$this->config->getUserValue(
 			$userId,
-			'spreed', 'read_status_privacy',
+			'spreed', UserPreference::ATTACHMENT_FOLDER,
 			(string)Participant::PRIVACY_PUBLIC)) {
 			Participant::PRIVACY_PUBLIC => Participant::PRIVACY_PUBLIC,
 			default => Participant::PRIVACY_PRIVATE,
@@ -83,7 +83,7 @@ class Config {
 	public function getUserTypingPrivacy(string $userId): int {
 		return match ((int)$this->config->getUserValue(
 			$userId,
-			'spreed', 'typing_privacy',
+			'spreed', UserPreference::TYPING_PRIVACY,
 			(string)Participant::PRIVACY_PUBLIC)) {
 			Participant::PRIVACY_PUBLIC => Participant::PRIVACY_PUBLIC,
 			default => Participant::PRIVACY_PRIVATE,
@@ -233,7 +233,7 @@ class Config {
 		return $this->config->getUserValue(
 			$userId,
 			'spreed',
-			'recording_folder',
+			UserPreference::RECORDING_FOLDER,
 			$this->getAttachmentFolder($userId) . '/Recording'
 		);
 	}
@@ -284,7 +284,7 @@ class Config {
 
 	public function getAttachmentFolder(string $userId): string {
 		$defaultAttachmentFolder = $this->config->getAppValue('spreed', 'default_attachment_folder', '/Talk');
-		return $this->config->getUserValue($userId, 'spreed', 'attachment_folder', $defaultAttachmentFolder);
+		return $this->config->getUserValue($userId, 'spreed', UserPreference::ATTACHMENT_FOLDER, $defaultAttachmentFolder);
 	}
 
 	/**

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -66,6 +66,7 @@ use OCA\Talk\Service\RecordingService;
 use OCA\Talk\Service\RoomFormatter;
 use OCA\Talk\Service\RoomService;
 use OCA\Talk\Service\SessionService;
+use OCA\Talk\Settings\UserPreference;
 use OCA\Talk\Share\Helper\Preloader;
 use OCA\Talk\TalkSession;
 use OCA\Talk\Webinary;
@@ -192,6 +193,7 @@ class RoomController extends AEnvironmentAwareOCSController {
 
 		if ($this->userId !== null) {
 			$values[] = $this->appConfig->getAppValueInt('experiments_users');
+			$values[] = $this->config->getUserValue($this->userId, 'spreed', UserPreference::ATTACHMENT_FOLDER);
 		} else {
 			$values[] = $this->appConfig->getAppValueInt('experiments_guests');
 		}

--- a/lib/Federation/Proxy/TalkV1/ProxyRequest.php
+++ b/lib/Federation/Proxy/TalkV1/ProxyRequest.php
@@ -16,6 +16,7 @@ use OCA\Talk\AppInfo\Application;
 use OCA\Talk\Exceptions\CannotReachRemoteException;
 use OCA\Talk\Exceptions\RemoteClientException;
 use OCA\Talk\Participant;
+use OCA\Talk\Settings\UserPreference;
 use OCP\AppFramework\Http;
 use OCP\Http\Client\IClientService;
 use OCP\Http\Client\IResponse;
@@ -36,7 +37,12 @@ class ProxyRequest {
 	}
 
 	public function overwrittenRemoteTalkHash(string $hash): string {
-		$typingIndicator = $this->config->getUserValue($this->userSession->getUser()?->getUID(), Application::APP_ID, 'typing_privacy', Participant::PRIVACY_PRIVATE);
+		$typingIndicator = $this->config->getUserValue(
+			$this->userSession->getUser()?->getUID(),
+			Application::APP_ID,
+			UserPreference::TYPING_PRIVACY,
+			Participant::PRIVACY_PRIVATE,
+		);
 		return sha1(json_encode([
 			'remoteHash' => $hash,
 			'manipulated' => [

--- a/lib/Service/RecordingService.php
+++ b/lib/Service/RecordingService.php
@@ -19,6 +19,7 @@ use OCA\Talk\Manager;
 use OCA\Talk\Participant;
 use OCA\Talk\Recording\BackendNotifier;
 use OCA\Talk\Room;
+use OCA\Talk\Settings\UserPreference;
 use OCP\AppFramework\Services\IAppConfig;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Files\File;
@@ -428,7 +429,7 @@ class RecordingService {
 					'userId' => $owner,
 				]);
 
-				$this->serverConfig->setUserValue($owner, 'spreed', 'attachment_folder', '/');
+				$this->serverConfig->setUserValue($owner, 'spreed', UserPreference::ATTACHMENT_FOLDER, '/');
 			}
 		} catch (NotFoundException $e) {
 			/** @var Folder */

--- a/lib/Settings/BeforePreferenceSetEventListener.php
+++ b/lib/Settings/BeforePreferenceSetEventListener.php
@@ -55,7 +55,7 @@ class BeforePreferenceSetEventListener implements IEventListener {
 	 * @internal Make private/protected once SettingsController route was removed
 	 */
 	public function validatePreference(string $userId, string $key, string|int|null $value): bool {
-		if ($key === 'attachment_folder') {
+		if ($key === UserPreference::ATTACHMENT_FOLDER) {
 			return $this->validateAttachmentFolder($userId, $value);
 		}
 
@@ -71,7 +71,7 @@ class BeforePreferenceSetEventListener implements IEventListener {
 			|| $key === UserPreference::READ_STATUS_PRIVACY) {
 			$valid = is_numeric($value) && ((int)$value === Participant::PRIVACY_PRIVATE || (int)$value === Participant::PRIVACY_PUBLIC);
 
-			if ($valid && $key === 'read_status_privacy') {
+			if ($valid && $key === UserPreference::READ_STATUS_PRIVACY) {
 				$this->participantService->updateReadPrivacyForActor(Attendee::ACTOR_USERS, $userId, (int)$value);
 			}
 			return $valid;

--- a/lib/Settings/UserPreference.php
+++ b/lib/Settings/UserPreference.php
@@ -9,12 +9,14 @@ declare(strict_types=1);
 namespace OCA\Talk\Settings;
 
 class UserPreference {
+	public const ATTACHMENT_FOLDER = 'attachment_folder';
 	public const BLUR_VIRTUAL_BACKGROUND = 'blur_virtual_background';
 	public const CALLS_START_WITHOUT_MEDIA = 'calls_start_without_media';
 	public const CONVERSATIONS_LIST_STYLE = 'conversations_list_style';
 	public const PLAY_SOUNDS = 'play_sounds';
 	public const TYPING_PRIVACY = 'typing_privacy';
 	public const READ_STATUS_PRIVACY = 'read_status_privacy';
+	public const RECORDING_FOLDER = 'recording_folder';
 
 	public const CONVERSATION_LIST_STYLE_TWO_LINES = 'two-lines';
 	public const CONVERSATION_LIST_STYLE_COMPACT = 'compact';

--- a/lib/TInitialState.php
+++ b/lib/TInitialState.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace OCA\Talk;
 
 use OC\User\NoUserException;
+use OCA\Talk\Settings\UserPreference;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Services\IInitialState;
 use OCP\Files\IRootFolder;
@@ -115,7 +116,7 @@ trait TInitialState {
 
 		$this->initialState->provideInitialState(
 			'play_sounds',
-			$this->serverConfig->getUserValue($user->getUID(), 'spreed', 'play_sounds', 'yes') === 'yes'
+			$this->serverConfig->getUserValue($user->getUID(), 'spreed', UserPreference::PLAY_SOUNDS, 'yes') === 'yes'
 		);
 
 		$this->initialState->provideInitialState(
@@ -150,7 +151,7 @@ trait TInitialState {
 					$freeSpace = $folder->getFreeSpace();
 				} catch (NotPermittedException $e) {
 					$attachmentFolder = '/';
-					$this->serverConfig->setUserValue($user->getUID(), 'spreed', 'attachment_folder', '/');
+					$this->serverConfig->setUserValue($user->getUID(), 'spreed', UserPreference::ATTACHMENT_FOLDER, '/');
 					$freeSpace = $userFolder->getFreeSpace();
 				}
 			} catch (NoUserException $e) {


### PR DESCRIPTION
### ☑️ Resolves

* Ref #15258 

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
