### PR TITLE
fix(meeting): allow to toggle lobby state for instant meetings

### DIFF
--- a/lib/Service/RoomService.php
+++ b/lib/Service/RoomService.php
@@ -534,6 +534,7 @@ class RoomService {
 			Room::OBJECT_TYPE_EMAIL,
 			Room::OBJECT_TYPE_EVENT,
 			Room::OBJECT_TYPE_EXTENDED_CONVERSATION,
+			Room::OBJECT_TYPE_INSTANT_MEETING,
 		], true)) {
 			throw new LobbyException(LobbyException::REASON_OBJECT);
 		}

--- a/src/components/ConversationSettings/LobbySettings.vue
+++ b/src/components/ConversationSettings/LobbySettings.vue
@@ -205,27 +205,11 @@ export default {
 	methods: {
 		t,
 		async toggleLobby() {
-			const newLobbyState = this.conversation.lobbyState !== WEBINAR.LOBBY.NON_MODERATORS
 			this.isLobbyStateLoading = true
-			try {
-				await this.$store.dispatch('toggleLobby', {
-					token: this.token,
-					enableLobby: newLobbyState,
-				})
-				if (newLobbyState) {
-					showSuccess(t('spreed', 'You restricted the conversation to moderators'))
-				} else {
-					showSuccess(t('spreed', 'You opened the conversation to everyone'))
-				}
-			} catch (e) {
-				if (newLobbyState) {
-					console.error('Error occurred when restricting the conversation to moderator', e)
-					showError(t('spreed', 'Error occurred when restricting the conversation to moderator'))
-				} else {
-					console.error('Error occurred when opening the conversation to everyone', e)
-					showError(t('spreed', 'Error occurred when opening the conversation to everyone'))
-				}
-			}
+			await this.$store.dispatch('toggleLobby', {
+				token: this.token,
+				enableLobby: this.conversation.lobbyState !== WEBINAR.LOBBY.NON_MODERATORS,
+			})
 			this.isLobbyStateLoading = false
 		},
 

--- a/src/components/RightSidebar/LobbyStatus.vue
+++ b/src/components/RightSidebar/LobbyStatus.vue
@@ -29,18 +29,11 @@ const supportImportEmails = computed(() => hasTalkFeature(props.token, 'email-cs
  */
 async function disableLobby() {
 	isLobbyStateLoading.value = true
-	try {
-		await store.dispatch('toggleLobby', {
-			token: props.token,
-			enableLobby: false,
-		})
-		showSuccess(t('spreed', 'You opened the conversation to everyone'))
-	} catch (e) {
-		console.error('Error occurred when opening the conversation to everyone', e)
-		showError(t('spreed', 'An error occurred when opening the conversation to everyone'))
-	} finally {
-		isLobbyStateLoading.value = false
-	}
+	await store.dispatch('toggleLobby', {
+		token: props.token,
+		enableLobby: false,
+	})
+	isLobbyStateLoading.value = false
 }
 </script>
 

--- a/src/store/conversationsStore.js
+++ b/src/store/conversationsStore.js
@@ -627,13 +627,20 @@ const actions = {
 			if (enableLobby) {
 				await changeLobbyState(token, WEBINAR.LOBBY.NON_MODERATORS)
 				conversation.lobbyState = WEBINAR.LOBBY.NON_MODERATORS
+				showSuccess(t('spreed', 'You restricted the conversation to moderators'))
 			} else {
 				await changeLobbyState(token, WEBINAR.LOBBY.NONE)
 				conversation.lobbyState = WEBINAR.LOBBY.NONE
+				showSuccess(t('spreed', 'You opened the conversation to everyone'))
 			}
 			commit('addConversation', conversation)
 		} catch (error) {
-			console.error('Error while updating webinar lobby: ', error)
+			console.error('Error occurred while updating webinar lobby: ', error)
+			if (enableLobby) {
+				showError(t('spreed', 'Error occurred when restricting the conversation to moderator'))
+			} else {
+				showError(t('spreed', 'Error occurred when opening the conversation to everyone'))
+			}
 		}
 	},
 


### PR DESCRIPTION
### ☑️ Resolves

* Allow to enable lobby in 'Instant meeting' conversations
* Refactor frontend code to get rid of error handling duplication logic

## 🖌️ UI Checklist

no visual changes

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Not risky to browser differences / client

---

## 🛠️ API Checklist

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not possible
- [ ] 📘 API documentation in `docs/` has been updated or is not required
- [ ] 🔖 Capability is added or not needed 
