### PR TITLE
fix(TS): use real types for `getTalkConfig`

### DIFF
--- a/src/components/UIShared/ConversationActionsShortcut.vue
+++ b/src/components/UIShared/ConversationActionsShortcut.vue
@@ -52,7 +52,7 @@ const descriptionLabel = computed(() => {
 	if (expirationDuration.value === 0) {
 		return t('spreed', 'Would you like to delete this conversation?')
 	}
-	const expirationDurationFormatted = new Intl.RelativeTimeFormat(getLanguage(), { numeric: 'always' }).format(expirationDuration.value, 'days')
+	const expirationDurationFormatted = new Intl.RelativeTimeFormat(getLanguage(), { numeric: 'always' }).format(expirationDuration.value!, 'days')
 	return t('spreed', 'This conversation will be automatically deleted for everyone {expirationDurationFormatted} of no activity.', { expirationDurationFormatted })
 })
 

--- a/src/services/CapabilitiesManager.ts
+++ b/src/services/CapabilitiesManager.ts
@@ -70,18 +70,17 @@ export function hasTalkFeature(token: string = 'local', feature: string): boolea
  * @param key1 top-level key (e.g. 'attachments')
  * @param key2 second-level key (e.g. 'allowed')
  */
-export function getTalkConfig(token: string = 'local', key1: keyof Config, key2: string) {
+export function getTalkConfig<
+	T extends keyof Config,
+	K extends keyof Config[T],
+>(token: string = 'local', key1: T, key2: K): Config[T][K] | undefined {
 	const remoteCapabilities = getRemoteCapability(token)
-	const locals = localCapabilities?.spreed?.config?.[key1]
-	if (localCapabilities?.spreed?.['config-local']?.[key1]?.includes(key2)) {
-		// @ts-expect-error Vue: Element implicitly has an any type because expression of type string can't be used to index type
+	if (localCapabilities?.spreed?.['config-local']?.[key1]?.includes(String(key2))) {
 		return localCapabilities?.spreed?.config?.[key1]?.[key2]
 	} else if (token === 'local' || !remoteCapabilities) {
-		// @ts-expect-error Vue: Element implicitly has an any type because expression of type string can't be used to index type
 		return localCapabilities?.spreed?.config?.[key1]?.[key2]
 	} else {
 		// TODO discuss handling remote config (respect remote only / both / minimal)
-		// @ts-expect-error Vue: Element implicitly has an any type because expression of type string can't be used to index type
 		return remoteCapabilities?.spreed?.config?.[key1]?.[key2]
 	}
 }


### PR DESCRIPTION
### ☑️ Resolves

* Type inferring works now, don't know, why it was an issue back then

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

![image](https://github.com/user-attachments/assets/4ede9c3b-867d-48f1-809a-d1fa8c63ed2f)