### PR TITLE
fix(events): Don't use the lobby for now

### DIFF
--- a/lib/Listener/CalDavEventListener.php
+++ b/lib/Listener/CalDavEventListener.php
@@ -199,6 +199,10 @@ class CalDavEventListener implements IEventListener {
 
 		$objectId = $start . '#' . $end;
 		$this->roomService->setObject($room, Room::OBJECT_TYPE_EVENT, $objectId);
-		$this->roomService->setLobby($room, Webinary::LOBBY_NON_MODERATORS, null);
+		// TODO Reconsider the lobby later, but it needs more thoughts to:
+		// 1. Allow others to ping the owner/host
+		// 2. Automatically disable
+		//    but how to recover from adding a second event to a conversation then?
+		// $this->roomService->setLobby($room, Webinary::LOBBY_NON_MODERATORS, null);
 	}
 }

--- a/tests/php/Listener/CalDavEventListenerTest.php
+++ b/tests/php/Listener/CalDavEventListenerTest.php
@@ -529,8 +529,8 @@ EOF;
 		$this->roomService->expects(self::once())
 			->method('setReadOnly')
 			->with($room, Room::READ_ONLY);
-		$this->roomService->expects(self::never())
-			->method('setLobby');
+		// $this->roomService->expects(self::never())
+		// ->method('setLobby');
 		$this->timezoneService->expects(self::never())
 			->method('getUserTimezone');
 		$this->logger->expects(self::never())
@@ -564,9 +564,9 @@ EOF;
 		$this->roomService->expects(self::once())
 			->method('setObject')
 			->with($room, Room::OBJECT_TYPE_EVENT, '1741942800#1741946400');
-		$this->roomService->expects(self::once())
-			->method('setLobby')
-			->with($room, Webinary::LOBBY_NON_MODERATORS, null);
+		// $this->roomService->expects(self::once())
+		// ->method('setLobby')
+		// ->with($room, Webinary::LOBBY_NON_MODERATORS, null);
 		$this->timezoneService->expects(self::never())
 			->method('getUserTimezone');
 		$this->logger->expects(self::never())
@@ -617,9 +617,9 @@ EOF;
 		$this->roomService->expects(self::once())
 			->method('setObject')
 			->with($room, Room::OBJECT_TYPE_EVENT, '1741820400#1741906800');
-		$this->roomService->expects(self::once())
-			->method('setLobby')
-			->with($room, Webinary::LOBBY_NON_MODERATORS, null);
+		// $this->roomService->expects(self::once())
+		// ->method('setLobby')
+		// ->with($room, Webinary::LOBBY_NON_MODERATORS, null);
 		$this->timezoneService->expects(self::once())
 			->method('getUserTimezone')
 			->willReturn('Europe/Vienna');
@@ -671,9 +671,9 @@ EOF;
 		$this->roomService->expects(self::once())
 			->method('setObject')
 			->with($room, Room::OBJECT_TYPE_EVENT, '1741820400#1741906800');
-		$this->roomService->expects(self::once())
-			->method('setLobby')
-			->with($room, Webinary::LOBBY_NON_MODERATORS, null);
+		// $this->roomService->expects(self::once())
+		// ->method('setLobby')
+		// ->with($room, Webinary::LOBBY_NON_MODERATORS, null);
 		$this->timezoneService->expects(self::once())
 			->method('getUserTimezone')
 			->willReturn(null);


### PR DESCRIPTION
## 🛠️ API Checklist

Seems to raise too many hurdles for users at the moment

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
