### PR TITLE
ci(openapi): Bump nextcloud/openapi-extractor to 1.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
 		"cs:check": "php-cs-fixer fix --dry-run --diff",
 		"cs:fix": "php-cs-fixer fix",
 		"lint": "find . -name \\*.php -not -path './vendor/*' -not -path './vendor-bin/*' -not -path './lib/Vendor/*' -not -path './build/*' -not -path './tests/integration/vendor/*' -print0 | xargs -0 -n1 php -l",
-		"openapi": "generate-spec --verbose && (npm run typescript:generate || echo 'Please manually regenerate the typescript OpenAPI models')",
+		"openapi": "generate-spec && (npm run typescript:generate || echo 'Please manually regenerate the typescript OpenAPI models')",
 		"rector:check": "rector --dry-run",
 		"rector:fix": "rector",
 		"psalm": "psalm --no-cache --threads=$(nproc)",

--- a/openapi-backend-recording.json
+++ b/openapi-backend-recording.json
@@ -379,6 +379,22 @@
                         }
                     },
                     {
+                        "name": "talk-recording-random",
+                        "in": "header",
+                        "description": "Random seed used to generate the request checksum",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "talk-recording-checksum",
+                        "in": "header",
+                        "description": "Checksum over the request body to verify authenticity from the recording backend",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
                         "name": "OCS-APIRequest",
                         "in": "header",
                         "description": "Required to be true for the API request to pass",
@@ -638,6 +654,22 @@
                         "schema": {
                             "type": "string",
                             "pattern": "^[a-z0-9]{4,30}$"
+                        }
+                    },
+                    {
+                        "name": "talk-recording-random",
+                        "in": "header",
+                        "description": "Random seed used to generate the request checksum",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "talk-recording-checksum",
+                        "in": "header",
+                        "description": "Checksum over the request body to verify authenticity from the recording backend",
+                        "schema": {
+                            "type": "string"
                         }
                     },
                     {

--- a/openapi-backend-signaling.json
+++ b/openapi-backend-signaling.json
@@ -380,6 +380,22 @@
                         }
                     },
                     {
+                        "name": "spreed-signaling-random",
+                        "in": "header",
+                        "description": "Random seed used to generate the request checksum",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "spreed-signaling-checksum",
+                        "in": "header",
+                        "description": "Checksum over the request body to verify authenticity from the signaling backend",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
                         "name": "OCS-APIRequest",
                         "in": "header",
                         "description": "Required to be true for the API request to pass",

--- a/openapi-backend-sipbridge.json
+++ b/openapi-backend-sipbridge.json
@@ -981,6 +981,23 @@
                     {
                         "name": "x-nextcloud-federation",
                         "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "talk-sipbridge-random",
+                        "in": "header",
+                        "description": "Random seed used to generate the request checksum",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "talk-sipbridge-checksum",
+                        "in": "header",
+                        "description": "Checksum over the request body to verify authenticity from the Sipbridge",
                         "schema": {
                             "type": "string"
                         }
@@ -1143,6 +1160,22 @@
                         "schema": {
                             "type": "string",
                             "pattern": "^\\d{7,32}$"
+                        }
+                    },
+                    {
+                        "name": "talk-sipbridge-random",
+                        "in": "header",
+                        "description": "Random seed used to generate the request checksum",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "talk-sipbridge-checksum",
+                        "in": "header",
+                        "description": "Checksum over the request body to verify authenticity from the Sipbridge",
+                        "schema": {
+                            "type": "string"
                         }
                     },
                     {
@@ -1335,6 +1368,22 @@
                         "schema": {
                             "type": "string",
                             "pattern": "^[a-z0-9]{4,30}$"
+                        }
+                    },
+                    {
+                        "name": "talk-sipbridge-random",
+                        "in": "header",
+                        "description": "Random seed used to generate the request checksum",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "talk-sipbridge-checksum",
+                        "in": "header",
+                        "description": "Checksum over the request body to verify authenticity from the Sipbridge",
+                        "schema": {
+                            "type": "string"
                         }
                     },
                     {
@@ -1544,6 +1593,22 @@
                         "schema": {
                             "type": "string",
                             "pattern": "^[a-z0-9]{4,30}$"
+                        }
+                    },
+                    {
+                        "name": "talk-sipbridge-random",
+                        "in": "header",
+                        "description": "Random seed used to generate the request checksum",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "talk-sipbridge-checksum",
+                        "in": "header",
+                        "description": "Checksum over the request body to verify authenticity from the Sipbridge",
+                        "schema": {
+                            "type": "string"
                         }
                     },
                     {
@@ -1766,6 +1831,22 @@
                         }
                     },
                     {
+                        "name": "talk-sipbridge-random",
+                        "in": "header",
+                        "description": "Random seed used to generate the request checksum",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "talk-sipbridge-checksum",
+                        "in": "header",
+                        "description": "Checksum over the request body to verify authenticity from the Sipbridge",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
                         "name": "OCS-APIRequest",
                         "in": "header",
                         "description": "Required to be true for the API request to pass",
@@ -1969,6 +2050,22 @@
                         }
                     },
                     {
+                        "name": "talk-sipbridge-random",
+                        "in": "header",
+                        "description": "Random seed used to generate the request checksum",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "talk-sipbridge-checksum",
+                        "in": "header",
+                        "description": "Checksum over the request body to verify authenticity from the Sipbridge",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
                         "name": "OCS-APIRequest",
                         "in": "header",
                         "description": "Required to be true for the API request to pass",
@@ -2124,6 +2221,22 @@
                         "name": "options",
                         "in": "query",
                         "description": "Additional details to verify the validity of the request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "talk-sipbridge-random",
+                        "in": "header",
+                        "description": "Random seed used to generate the request checksum",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "talk-sipbridge-checksum",
+                        "in": "header",
+                        "description": "Checksum over the request body to verify authenticity from the Sipbridge",
                         "schema": {
                             "type": "string"
                         }

--- a/openapi-federation.json
+++ b/openapi-federation.json
@@ -1058,6 +1058,14 @@
                         }
                     },
                     {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
                         "name": "OCS-APIRequest",
                         "in": "header",
                         "description": "Required to be true for the API request to pass",
@@ -1130,6 +1138,14 @@
                         "in": "query",
                         "description": "Federation CloudID to get the avatar for",
                         "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
                         "schema": {
                             "type": "string"
                         }
@@ -1235,6 +1251,14 @@
                         }
                     },
                     {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
                         "name": "OCS-APIRequest",
                         "in": "header",
                         "description": "Required to be true for the API request to pass",
@@ -1317,6 +1341,14 @@
                         "in": "query",
                         "description": "Federation CloudID to get the avatar for",
                         "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
                         "schema": {
                             "type": "string"
                         }
@@ -1840,6 +1872,14 @@
                         }
                     },
                     {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
                         "name": "OCS-APIRequest",
                         "in": "header",
                         "description": "Required to be true for the API request to pass",
@@ -1963,6 +2003,14 @@
                         "in": "query",
                         "description": "Federated session id to leave with",
                         "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
                         "schema": {
                             "type": "string"
                         }

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -2171,6 +2171,14 @@
                         }
                     },
                     {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
                         "name": "OCS-APIRequest",
                         "in": "header",
                         "description": "Required to be true for the API request to pass",
@@ -2458,6 +2466,14 @@
                         "schema": {
                             "type": "string",
                             "pattern": "^[a-z0-9]{4,30}$"
+                        }
+                    },
+                    {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
                         }
                     },
                     {
@@ -4622,6 +4638,14 @@
                         }
                     },
                     {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
                         "name": "OCS-APIRequest",
                         "in": "header",
                         "description": "Required to be true for the API request to pass",
@@ -4742,6 +4766,14 @@
                         "schema": {
                             "type": "string",
                             "pattern": "^[a-z0-9]{4,30}$"
+                        }
+                    },
+                    {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
                         }
                     },
                     {
@@ -4916,6 +4948,14 @@
                         }
                     },
                     {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
                         "name": "OCS-APIRequest",
                         "in": "header",
                         "description": "Required to be true for the API request to pass",
@@ -5067,6 +5107,14 @@
                                 0,
                                 1
                             ]
+                        }
+                    },
+                    {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
                         }
                     },
                     {
@@ -5924,6 +5972,14 @@
                         }
                     },
                     {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
                         "name": "OCS-APIRequest",
                         "in": "header",
                         "description": "Required to be true for the API request to pass",
@@ -6384,6 +6440,14 @@
                         }
                     },
                     {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
                         "name": "OCS-APIRequest",
                         "in": "header",
                         "description": "Required to be true for the API request to pass",
@@ -6522,6 +6586,14 @@
                         "schema": {
                             "type": "string",
                             "pattern": "^[a-z0-9]{4,30}$"
+                        }
+                    },
+                    {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
                         }
                     },
                     {
@@ -7106,6 +7178,14 @@
                         }
                     },
                     {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
                         "name": "OCS-APIRequest",
                         "in": "header",
                         "description": "Required to be true for the API request to pass",
@@ -7410,6 +7490,14 @@
                             "type": "integer",
                             "format": "int64",
                             "minimum": 0
+                        }
+                    },
+                    {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
                         }
                     },
                     {
@@ -7753,6 +7841,14 @@
                         }
                     },
                     {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
                         "name": "OCS-APIRequest",
                         "in": "header",
                         "description": "Required to be true for the API request to pass",
@@ -7885,6 +7981,14 @@
                         }
                     },
                     {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
                         "name": "OCS-APIRequest",
                         "in": "header",
                         "description": "Required to be true for the API request to pass",
@@ -8011,6 +8115,14 @@
                         }
                     },
                     {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
                         "name": "OCS-APIRequest",
                         "in": "header",
                         "description": "Required to be true for the API request to pass",
@@ -8134,6 +8246,14 @@
                             "type": "integer",
                             "format": "int64",
                             "minimum": 0
+                        }
+                    },
+                    {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
                         }
                     },
                     {
@@ -8357,6 +8477,14 @@
                         }
                     },
                     {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
                         "name": "OCS-APIRequest",
                         "in": "header",
                         "description": "Required to be true for the API request to pass",
@@ -8442,6 +8570,14 @@
                         "schema": {
                             "type": "string",
                             "pattern": "^[a-z0-9]{4,30}$"
+                        }
+                    },
+                    {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
                         }
                     },
                     {
@@ -8564,6 +8700,14 @@
                                 0,
                                 1
                             ]
+                        }
+                    },
+                    {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
                         }
                     },
                     {
@@ -10067,6 +10211,14 @@
                         }
                     },
                     {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
                         "name": "OCS-APIRequest",
                         "in": "header",
                         "description": "Required to be true for the API request to pass",
@@ -10276,6 +10428,14 @@
                         "schema": {
                             "type": "integer",
                             "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
                         }
                     },
                     {
@@ -10498,6 +10658,14 @@
                         }
                     },
                     {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
                         "name": "OCS-APIRequest",
                         "in": "header",
                         "description": "Required to be true for the API request to pass",
@@ -10651,6 +10819,14 @@
                         }
                     },
                     {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
                         "name": "OCS-APIRequest",
                         "in": "header",
                         "description": "Required to be true for the API request to pass",
@@ -10799,6 +10975,14 @@
                             "type": "integer",
                             "format": "int64",
                             "minimum": 0
+                        }
+                    },
+                    {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
                         }
                     },
                     {
@@ -10967,6 +11151,14 @@
                             "type": "integer",
                             "format": "int64",
                             "minimum": 0
+                        }
+                    },
+                    {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
                         }
                     },
                     {
@@ -11388,6 +11580,14 @@
                         }
                     },
                     {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
                         "name": "OCS-APIRequest",
                         "in": "header",
                         "description": "Required to be true for the API request to pass",
@@ -11591,6 +11791,14 @@
                         }
                     },
                     {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
                         "name": "OCS-APIRequest",
                         "in": "header",
                         "description": "Required to be true for the API request to pass",
@@ -11755,6 +11963,14 @@
                         "schema": {
                             "type": "string",
                             "nullable": true
+                        }
+                    },
+                    {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
                         }
                     },
                     {
@@ -13203,6 +13419,23 @@
                     {
                         "name": "x-nextcloud-federation",
                         "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "talk-sipbridge-random",
+                        "in": "header",
+                        "description": "Random seed used to generate the request checksum",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "talk-sipbridge-checksum",
+                        "in": "header",
+                        "description": "Checksum over the request body to verify authenticity from the Sipbridge",
                         "schema": {
                             "type": "string"
                         }
@@ -14898,6 +15131,14 @@
                         }
                     },
                     {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
                         "name": "OCS-APIRequest",
                         "in": "header",
                         "description": "Required to be true for the API request to pass",
@@ -15463,6 +15704,14 @@
                         "schema": {
                             "type": "string",
                             "pattern": "^[a-z0-9]{4,30}$"
+                        }
+                    },
+                    {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
                         }
                     },
                     {
@@ -18809,6 +19058,14 @@
                         }
                     },
                     {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
                         "name": "OCS-APIRequest",
                         "in": "header",
                         "description": "Required to be true for the API request to pass",
@@ -19763,6 +20020,7 @@
                     {
                         "name": "talk-recording-random",
                         "in": "header",
+                        "description": "Random seed used to generate the request checksum",
                         "schema": {
                             "type": "string"
                         }
@@ -19770,6 +20028,7 @@
                     {
                         "name": "talk-recording-checksum",
                         "in": "header",
+                        "description": "Checksum over the request body to verify authenticity from the recording backend",
                         "schema": {
                             "type": "string"
                         }
@@ -20523,6 +20782,14 @@
                         }
                     },
                     {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
                         "name": "OCS-APIRequest",
                         "in": "header",
                         "description": "Required to be true for the API request to pass",
@@ -20595,6 +20862,14 @@
                         "in": "query",
                         "description": "Federation CloudID to get the avatar for",
                         "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
                         "schema": {
                             "type": "string"
                         }
@@ -20700,6 +20975,14 @@
                         }
                     },
                     {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
                         "name": "OCS-APIRequest",
                         "in": "header",
                         "description": "Required to be true for the API request to pass",
@@ -20782,6 +21065,14 @@
                         "in": "query",
                         "description": "Federation CloudID to get the avatar for",
                         "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
                         "schema": {
                             "type": "string"
                         }
@@ -21305,6 +21596,14 @@
                         }
                     },
                     {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
                         "name": "OCS-APIRequest",
                         "in": "header",
                         "description": "Required to be true for the API request to pass",
@@ -21428,6 +21727,14 @@
                         "in": "query",
                         "description": "Federated session id to leave with",
                         "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
                         "schema": {
                             "type": "string"
                         }
@@ -23366,6 +23673,22 @@
                         }
                     },
                     {
+                        "name": "talk-recording-random",
+                        "in": "header",
+                        "description": "Random seed used to generate the request checksum",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "talk-recording-checksum",
+                        "in": "header",
+                        "description": "Checksum over the request body to verify authenticity from the recording backend",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
                         "name": "OCS-APIRequest",
                         "in": "header",
                         "description": "Required to be true for the API request to pass",
@@ -23628,6 +23951,22 @@
                         }
                     },
                     {
+                        "name": "talk-recording-random",
+                        "in": "header",
+                        "description": "Random seed used to generate the request checksum",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "talk-recording-checksum",
+                        "in": "header",
+                        "description": "Checksum over the request body to verify authenticity from the recording backend",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
                         "name": "OCS-APIRequest",
                         "in": "header",
                         "description": "Required to be true for the API request to pass",
@@ -23810,6 +24149,22 @@
                         "schema": {
                             "type": "string",
                             "pattern": "^\\d{7,32}$"
+                        }
+                    },
+                    {
+                        "name": "talk-sipbridge-random",
+                        "in": "header",
+                        "description": "Random seed used to generate the request checksum",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "talk-sipbridge-checksum",
+                        "in": "header",
+                        "description": "Checksum over the request body to verify authenticity from the Sipbridge",
+                        "schema": {
+                            "type": "string"
                         }
                     },
                     {
@@ -24002,6 +24357,22 @@
                         "schema": {
                             "type": "string",
                             "pattern": "^[a-z0-9]{4,30}$"
+                        }
+                    },
+                    {
+                        "name": "talk-sipbridge-random",
+                        "in": "header",
+                        "description": "Random seed used to generate the request checksum",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "talk-sipbridge-checksum",
+                        "in": "header",
+                        "description": "Checksum over the request body to verify authenticity from the Sipbridge",
+                        "schema": {
+                            "type": "string"
                         }
                     },
                     {
@@ -24211,6 +24582,22 @@
                         "schema": {
                             "type": "string",
                             "pattern": "^[a-z0-9]{4,30}$"
+                        }
+                    },
+                    {
+                        "name": "talk-sipbridge-random",
+                        "in": "header",
+                        "description": "Random seed used to generate the request checksum",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "talk-sipbridge-checksum",
+                        "in": "header",
+                        "description": "Checksum over the request body to verify authenticity from the Sipbridge",
+                        "schema": {
+                            "type": "string"
                         }
                     },
                     {
@@ -24433,6 +24820,22 @@
                         }
                     },
                     {
+                        "name": "talk-sipbridge-random",
+                        "in": "header",
+                        "description": "Random seed used to generate the request checksum",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "talk-sipbridge-checksum",
+                        "in": "header",
+                        "description": "Checksum over the request body to verify authenticity from the Sipbridge",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
                         "name": "OCS-APIRequest",
                         "in": "header",
                         "description": "Required to be true for the API request to pass",
@@ -24636,6 +25039,22 @@
                         }
                     },
                     {
+                        "name": "talk-sipbridge-random",
+                        "in": "header",
+                        "description": "Random seed used to generate the request checksum",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "talk-sipbridge-checksum",
+                        "in": "header",
+                        "description": "Checksum over the request body to verify authenticity from the Sipbridge",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
                         "name": "OCS-APIRequest",
                         "in": "header",
                         "description": "Required to be true for the API request to pass",
@@ -24791,6 +25210,22 @@
                         "name": "options",
                         "in": "query",
                         "description": "Additional details to verify the validity of the request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "talk-sipbridge-random",
+                        "in": "header",
+                        "description": "Random seed used to generate the request checksum",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "talk-sipbridge-checksum",
+                        "in": "header",
+                        "description": "Checksum over the request body to verify authenticity from the Sipbridge",
                         "schema": {
                             "type": "string"
                         }
@@ -24988,6 +25423,22 @@
                                 "v3"
                             ],
                             "default": "v3"
+                        }
+                    },
+                    {
+                        "name": "spreed-signaling-random",
+                        "in": "header",
+                        "description": "Random seed used to generate the request checksum",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "spreed-signaling-checksum",
+                        "in": "header",
+                        "description": "Checksum over the request body to verify authenticity from the signaling backend",
+                        "schema": {
+                            "type": "string"
                         }
                     },
                     {

--- a/openapi.json
+++ b/openapi.json
@@ -2076,6 +2076,14 @@
                         }
                     },
                     {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
                         "name": "OCS-APIRequest",
                         "in": "header",
                         "description": "Required to be true for the API request to pass",
@@ -2363,6 +2371,14 @@
                         "schema": {
                             "type": "string",
                             "pattern": "^[a-z0-9]{4,30}$"
+                        }
+                    },
+                    {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
                         }
                     },
                     {
@@ -4527,6 +4543,14 @@
                         }
                     },
                     {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
                         "name": "OCS-APIRequest",
                         "in": "header",
                         "description": "Required to be true for the API request to pass",
@@ -4647,6 +4671,14 @@
                         "schema": {
                             "type": "string",
                             "pattern": "^[a-z0-9]{4,30}$"
+                        }
+                    },
+                    {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
                         }
                     },
                     {
@@ -4821,6 +4853,14 @@
                         }
                     },
                     {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
                         "name": "OCS-APIRequest",
                         "in": "header",
                         "description": "Required to be true for the API request to pass",
@@ -4972,6 +5012,14 @@
                                 0,
                                 1
                             ]
+                        }
+                    },
+                    {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
                         }
                     },
                     {
@@ -5829,6 +5877,14 @@
                         }
                     },
                     {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
                         "name": "OCS-APIRequest",
                         "in": "header",
                         "description": "Required to be true for the API request to pass",
@@ -6289,6 +6345,14 @@
                         }
                     },
                     {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
                         "name": "OCS-APIRequest",
                         "in": "header",
                         "description": "Required to be true for the API request to pass",
@@ -6427,6 +6491,14 @@
                         "schema": {
                             "type": "string",
                             "pattern": "^[a-z0-9]{4,30}$"
+                        }
+                    },
+                    {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
                         }
                     },
                     {
@@ -7011,6 +7083,14 @@
                         }
                     },
                     {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
                         "name": "OCS-APIRequest",
                         "in": "header",
                         "description": "Required to be true for the API request to pass",
@@ -7315,6 +7395,14 @@
                             "type": "integer",
                             "format": "int64",
                             "minimum": 0
+                        }
+                    },
+                    {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
                         }
                     },
                     {
@@ -7658,6 +7746,14 @@
                         }
                     },
                     {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
                         "name": "OCS-APIRequest",
                         "in": "header",
                         "description": "Required to be true for the API request to pass",
@@ -7790,6 +7886,14 @@
                         }
                     },
                     {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
                         "name": "OCS-APIRequest",
                         "in": "header",
                         "description": "Required to be true for the API request to pass",
@@ -7916,6 +8020,14 @@
                         }
                     },
                     {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
                         "name": "OCS-APIRequest",
                         "in": "header",
                         "description": "Required to be true for the API request to pass",
@@ -8039,6 +8151,14 @@
                             "type": "integer",
                             "format": "int64",
                             "minimum": 0
+                        }
+                    },
+                    {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
                         }
                     },
                     {
@@ -8262,6 +8382,14 @@
                         }
                     },
                     {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
                         "name": "OCS-APIRequest",
                         "in": "header",
                         "description": "Required to be true for the API request to pass",
@@ -8347,6 +8475,14 @@
                         "schema": {
                             "type": "string",
                             "pattern": "^[a-z0-9]{4,30}$"
+                        }
+                    },
+                    {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
                         }
                     },
                     {
@@ -8469,6 +8605,14 @@
                                 0,
                                 1
                             ]
+                        }
+                    },
+                    {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
                         }
                     },
                     {
@@ -9972,6 +10116,14 @@
                         }
                     },
                     {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
                         "name": "OCS-APIRequest",
                         "in": "header",
                         "description": "Required to be true for the API request to pass",
@@ -10181,6 +10333,14 @@
                         "schema": {
                             "type": "integer",
                             "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
                         }
                     },
                     {
@@ -10403,6 +10563,14 @@
                         }
                     },
                     {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
                         "name": "OCS-APIRequest",
                         "in": "header",
                         "description": "Required to be true for the API request to pass",
@@ -10556,6 +10724,14 @@
                         }
                     },
                     {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
                         "name": "OCS-APIRequest",
                         "in": "header",
                         "description": "Required to be true for the API request to pass",
@@ -10704,6 +10880,14 @@
                             "type": "integer",
                             "format": "int64",
                             "minimum": 0
+                        }
+                    },
+                    {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
                         }
                     },
                     {
@@ -10872,6 +11056,14 @@
                             "type": "integer",
                             "format": "int64",
                             "minimum": 0
+                        }
+                    },
+                    {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
                         }
                     },
                     {
@@ -11293,6 +11485,14 @@
                         }
                     },
                     {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
                         "name": "OCS-APIRequest",
                         "in": "header",
                         "description": "Required to be true for the API request to pass",
@@ -11496,6 +11696,14 @@
                         }
                     },
                     {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
                         "name": "OCS-APIRequest",
                         "in": "header",
                         "description": "Required to be true for the API request to pass",
@@ -11660,6 +11868,14 @@
                         "schema": {
                             "type": "string",
                             "nullable": true
+                        }
+                    },
+                    {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
                         }
                     },
                     {
@@ -13108,6 +13324,23 @@
                     {
                         "name": "x-nextcloud-federation",
                         "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "talk-sipbridge-random",
+                        "in": "header",
+                        "description": "Random seed used to generate the request checksum",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "talk-sipbridge-checksum",
+                        "in": "header",
+                        "description": "Checksum over the request body to verify authenticity from the Sipbridge",
                         "schema": {
                             "type": "string"
                         }
@@ -14803,6 +15036,14 @@
                         }
                     },
                     {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
                         "name": "OCS-APIRequest",
                         "in": "header",
                         "description": "Required to be true for the API request to pass",
@@ -15368,6 +15609,14 @@
                         "schema": {
                             "type": "string",
                             "pattern": "^[a-z0-9]{4,30}$"
+                        }
+                    },
+                    {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
                         }
                     },
                     {
@@ -18714,6 +18963,14 @@
                         }
                     },
                     {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
                         "name": "OCS-APIRequest",
                         "in": "header",
                         "description": "Required to be true for the API request to pass",
@@ -19668,6 +19925,7 @@
                     {
                         "name": "talk-recording-random",
                         "in": "header",
+                        "description": "Random seed used to generate the request checksum",
                         "schema": {
                             "type": "string"
                         }
@@ -19675,6 +19933,7 @@
                     {
                         "name": "talk-recording-checksum",
                         "in": "header",
+                        "description": "Checksum over the request body to verify authenticity from the recording backend",
                         "schema": {
                             "type": "string"
                         }

--- a/src/types/openapi/openapi-backend-recording.ts
+++ b/src/types/openapi/openapi-backend-recording.ts
@@ -145,6 +145,10 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Random seed used to generate the request checksum */
+                "talk-recording-random"?: string;
+                /** @description Checksum over the request body to verify authenticity from the recording backend */
+                "talk-recording-checksum"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -235,6 +239,10 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Random seed used to generate the request checksum */
+                "talk-recording-random"?: string;
+                /** @description Checksum over the request body to verify authenticity from the recording backend */
+                "talk-recording-checksum"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };

--- a/src/types/openapi/openapi-backend-signaling.ts
+++ b/src/types/openapi/openapi-backend-signaling.ts
@@ -131,6 +131,10 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Random seed used to generate the request checksum */
+                "spreed-signaling-random"?: string;
+                /** @description Checksum over the request body to verify authenticity from the signaling backend */
+                "spreed-signaling-checksum"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };

--- a/src/types/openapi/openapi-backend-sipbridge.ts
+++ b/src/types/openapi/openapi-backend-sipbridge.ts
@@ -515,7 +515,12 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
                 "x-nextcloud-federation"?: string;
+                /** @description Random seed used to generate the request checksum */
+                "talk-sipbridge-random"?: string;
+                /** @description Checksum over the request body to verify authenticity from the Sipbridge */
+                "talk-sipbridge-checksum"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -577,6 +582,10 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Random seed used to generate the request checksum */
+                "talk-sipbridge-random"?: string;
+                /** @description Checksum over the request body to verify authenticity from the Sipbridge */
+                "talk-sipbridge-checksum"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -652,6 +661,10 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Random seed used to generate the request checksum */
+                "talk-sipbridge-random"?: string;
+                /** @description Checksum over the request body to verify authenticity from the Sipbridge */
+                "talk-sipbridge-checksum"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -732,6 +745,10 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Random seed used to generate the request checksum */
+                "talk-sipbridge-random"?: string;
+                /** @description Checksum over the request body to verify authenticity from the Sipbridge */
+                "talk-sipbridge-checksum"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -836,6 +853,10 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Random seed used to generate the request checksum */
+                "talk-sipbridge-random"?: string;
+                /** @description Checksum over the request body to verify authenticity from the Sipbridge */
+                "talk-sipbridge-checksum"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -931,6 +952,10 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Random seed used to generate the request checksum */
+                "talk-sipbridge-random"?: string;
+                /** @description Checksum over the request body to verify authenticity from the Sipbridge */
+                "talk-sipbridge-checksum"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -995,6 +1020,10 @@ export interface operations {
                 options?: string;
             };
             header: {
+                /** @description Random seed used to generate the request checksum */
+                "talk-sipbridge-random"?: string;
+                /** @description Checksum over the request body to verify authenticity from the Sipbridge */
+                "talk-sipbridge-checksum"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };

--- a/src/types/openapi/openapi-federation.ts
+++ b/src/types/openapi/openapi-federation.ts
@@ -547,6 +547,8 @@ export interface operations {
                 darkTheme?: 0 | 1;
             };
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -577,6 +579,8 @@ export interface operations {
                 cloudId: string;
             };
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -609,6 +613,8 @@ export interface operations {
                 darkTheme?: 0 | 1;
             };
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -640,6 +646,8 @@ export interface operations {
                 cloudId: string;
             };
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -842,6 +850,8 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -899,6 +909,8 @@ export interface operations {
                 sessionId: string;
             };
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };

--- a/src/types/openapi/openapi-full.ts
+++ b/src/types/openapi/openapi-full.ts
@@ -2786,6 +2786,8 @@ export interface operations {
                 darkTheme?: 0 | 1;
             };
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -2946,6 +2948,8 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -3784,6 +3788,8 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -3815,6 +3821,8 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -3884,6 +3892,8 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -3974,6 +3984,8 @@ export interface operations {
                 all?: 0 | 1;
             };
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -4332,6 +4344,8 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -4492,6 +4506,8 @@ export interface operations {
                 markNotificationsAsRead?: 0 | 1;
             };
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -4532,6 +4548,8 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -4795,6 +4813,8 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -4931,6 +4951,8 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -5047,6 +5069,8 @@ export interface operations {
                 limit?: number;
             };
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -5089,6 +5113,8 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -5138,6 +5164,8 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -5197,6 +5225,8 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -5278,6 +5308,8 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -5321,6 +5353,8 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -5360,6 +5394,8 @@ export interface operations {
                 includeStatus?: 0 | 1;
             };
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -5932,6 +5968,8 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -6019,6 +6057,8 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -6123,6 +6163,8 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -6182,6 +6224,8 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -6231,6 +6275,8 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -6306,6 +6352,8 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -6462,6 +6510,8 @@ export interface operations {
                 reaction?: string | null;
             };
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -6511,6 +6561,8 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -6600,6 +6652,8 @@ export interface operations {
                 reaction: string;
             };
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -7212,7 +7266,12 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
                 "x-nextcloud-federation"?: string;
+                /** @description Random seed used to generate the request checksum */
+                "talk-sipbridge-random"?: string;
+                /** @description Checksum over the request body to verify authenticity from the Sipbridge */
+                "talk-sipbridge-checksum"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -7868,6 +7927,8 @@ export interface operations {
                 includeStatus?: 0 | 1;
             };
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -8077,6 +8138,8 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -9415,6 +9478,8 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -9789,7 +9854,9 @@ export interface operations {
                 token?: string;
             };
             header: {
+                /** @description Random seed used to generate the request checksum */
                 "talk-recording-random"?: string;
+                /** @description Checksum over the request body to verify authenticity from the recording backend */
                 "talk-recording-checksum"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
@@ -10079,6 +10146,8 @@ export interface operations {
                 darkTheme?: 0 | 1;
             };
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -10109,6 +10178,8 @@ export interface operations {
                 cloudId: string;
             };
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -10141,6 +10212,8 @@ export interface operations {
                 darkTheme?: 0 | 1;
             };
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -10172,6 +10245,8 @@ export interface operations {
                 cloudId: string;
             };
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -10374,6 +10449,8 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -10431,6 +10508,8 @@ export interface operations {
                 sessionId: string;
             };
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -11238,6 +11317,10 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Random seed used to generate the request checksum */
+                "talk-recording-random"?: string;
+                /** @description Checksum over the request body to verify authenticity from the recording backend */
+                "talk-recording-checksum"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -11328,6 +11411,10 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Random seed used to generate the request checksum */
+                "talk-recording-random"?: string;
+                /** @description Checksum over the request body to verify authenticity from the recording backend */
+                "talk-recording-checksum"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -11402,6 +11489,10 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Random seed used to generate the request checksum */
+                "talk-sipbridge-random"?: string;
+                /** @description Checksum over the request body to verify authenticity from the Sipbridge */
+                "talk-sipbridge-checksum"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -11477,6 +11568,10 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Random seed used to generate the request checksum */
+                "talk-sipbridge-random"?: string;
+                /** @description Checksum over the request body to verify authenticity from the Sipbridge */
+                "talk-sipbridge-checksum"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -11557,6 +11652,10 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Random seed used to generate the request checksum */
+                "talk-sipbridge-random"?: string;
+                /** @description Checksum over the request body to verify authenticity from the Sipbridge */
+                "talk-sipbridge-checksum"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -11661,6 +11760,10 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Random seed used to generate the request checksum */
+                "talk-sipbridge-random"?: string;
+                /** @description Checksum over the request body to verify authenticity from the Sipbridge */
+                "talk-sipbridge-checksum"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -11756,6 +11859,10 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Random seed used to generate the request checksum */
+                "talk-sipbridge-random"?: string;
+                /** @description Checksum over the request body to verify authenticity from the Sipbridge */
+                "talk-sipbridge-checksum"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -11820,6 +11927,10 @@ export interface operations {
                 options?: string;
             };
             header: {
+                /** @description Random seed used to generate the request checksum */
+                "talk-sipbridge-random"?: string;
+                /** @description Checksum over the request body to verify authenticity from the Sipbridge */
+                "talk-sipbridge-checksum"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -11907,6 +12018,10 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Random seed used to generate the request checksum */
+                "spreed-signaling-random"?: string;
+                /** @description Checksum over the request body to verify authenticity from the signaling backend */
+                "spreed-signaling-checksum"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };

--- a/src/types/openapi/openapi.ts
+++ b/src/types/openapi/openapi.ts
@@ -2248,6 +2248,8 @@ export interface operations {
                 darkTheme?: 0 | 1;
             };
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -2408,6 +2410,8 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -3246,6 +3250,8 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -3277,6 +3283,8 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -3346,6 +3354,8 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -3436,6 +3446,8 @@ export interface operations {
                 all?: 0 | 1;
             };
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -3794,6 +3806,8 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -3954,6 +3968,8 @@ export interface operations {
                 markNotificationsAsRead?: 0 | 1;
             };
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -3994,6 +4010,8 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -4257,6 +4275,8 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -4393,6 +4413,8 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -4509,6 +4531,8 @@ export interface operations {
                 limit?: number;
             };
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -4551,6 +4575,8 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -4600,6 +4626,8 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -4659,6 +4687,8 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -4740,6 +4770,8 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -4783,6 +4815,8 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -4822,6 +4856,8 @@ export interface operations {
                 includeStatus?: 0 | 1;
             };
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -5394,6 +5430,8 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -5481,6 +5519,8 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -5585,6 +5625,8 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -5644,6 +5686,8 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -5693,6 +5737,8 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -5768,6 +5814,8 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -5924,6 +5972,8 @@ export interface operations {
                 reaction?: string | null;
             };
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -5973,6 +6023,8 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -6062,6 +6114,8 @@ export interface operations {
                 reaction: string;
             };
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -6674,7 +6728,12 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
                 "x-nextcloud-federation"?: string;
+                /** @description Random seed used to generate the request checksum */
+                "talk-sipbridge-random"?: string;
+                /** @description Checksum over the request body to verify authenticity from the Sipbridge */
+                "talk-sipbridge-checksum"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -7330,6 +7389,8 @@ export interface operations {
                 includeStatus?: 0 | 1;
             };
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -7539,6 +7600,8 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -8877,6 +8940,8 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -9251,7 +9316,9 @@ export interface operations {
                 token?: string;
             };
             header: {
+                /** @description Random seed used to generate the request checksum */
                 "talk-recording-random"?: string;
+                /** @description Checksum over the request body to verify authenticity from the recording backend */
                 "talk-recording-checksum"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;

--- a/vendor-bin/openapi-extractor/composer.json
+++ b/vendor-bin/openapi-extractor/composer.json
@@ -5,6 +5,6 @@
 		}
 	},
 	"require-dev": {
-		"nextcloud/openapi-extractor": "^1.7.0"
+		"nextcloud/openapi-extractor": "^1.8"
 	}
 }

--- a/vendor-bin/openapi-extractor/composer.lock
+++ b/vendor-bin/openapi-extractor/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3b94d80b90be8e9bc53a683dc4be4720",
+    "content-hash": "f854d667ebf53a194ba66c04cd3b409c",
     "packages": [],
     "packages-dev": [
         {
@@ -82,16 +82,16 @@
         },
         {
             "name": "nextcloud/openapi-extractor",
-            "version": "v1.7.0",
+            "version": "v1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-releases/openapi-extractor.git",
-                "reference": "50391ff00656b88a9ca0d934c386c3e20642f24a"
+                "reference": "4c7a66afce9938279473fc08cadf011de41150f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-releases/openapi-extractor/zipball/50391ff00656b88a9ca0d934c386c3e20642f24a",
-                "reference": "50391ff00656b88a9ca0d934c386c3e20642f24a",
+                "url": "https://api.github.com/repos/nextcloud-releases/openapi-extractor/zipball/4c7a66afce9938279473fc08cadf011de41150f8",
+                "reference": "4c7a66afce9938279473fc08cadf011de41150f8",
                 "shasum": ""
             },
             "require": {
@@ -123,9 +123,9 @@
             "description": "A tool for extracting OpenAPI specifications from Nextcloud source code",
             "support": {
                 "issues": "https://github.com/nextcloud-releases/openapi-extractor/issues",
-                "source": "https://github.com/nextcloud-releases/openapi-extractor/tree/v1.7.0"
+                "source": "https://github.com/nextcloud-releases/openapi-extractor/tree/v1.8.0"
             },
-            "time": "2025-05-15T08:30:31+00:00"
+            "time": "2025-06-03T13:01:15+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -235,13 +235,13 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
+    "platform": {},
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.1"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
