### PR TITLE
feat(pinia): initialize pinia globally

### DIFF
--- a/src/init.js
+++ b/src/init.js
@@ -13,12 +13,15 @@ import BrowserStorage from './services/BrowserStorage.js'
 import { EventBus } from './services/EventBus.ts'
 import store from './store/index.js'
 import { useIntegrationsStore } from './stores/integrations.js'
+import pinia from './stores/pinia.ts'
 
 import '@nextcloud/dialogs/style.css'
 
 if (!window.OCA.Talk) {
 	window.OCA.Talk = {}
 }
+
+const integrationsStore = useIntegrationsStore(pinia)
 
 /**
  * Frontend message API for adding actions to talk messages.
@@ -36,7 +39,6 @@ window.OCA.Talk.registerMessageAction = ({ label, callback, icon }) => {
 		callback,
 		icon,
 	}
-	const integrationsStore = useIntegrationsStore()
 	integrationsStore.addMessageAction(messageAction)
 }
 
@@ -47,7 +49,6 @@ window.OCA.Talk.registerParticipantSearchAction = ({ label, callback, show, icon
 		show,
 		icon,
 	}
-	const integrationsStore = useIntegrationsStore()
 	integrationsStore.addParticipantSearchAction(participantSearchAction)
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -6,7 +6,6 @@
 import { getRequestToken } from '@nextcloud/auth'
 import { emit } from '@nextcloud/event-bus'
 import { generateFilePath } from '@nextcloud/router'
-import { createPinia, PiniaVuePlugin } from 'pinia'
 import Vue, { watch } from 'vue'
 import VueRouter from 'vue-router'
 import Vuex from 'vuex'
@@ -14,6 +13,7 @@ import App from './App.vue'
 import router from './router/router.ts'
 import { SettingsAPI } from './services/SettingsAPI.ts'
 import store from './store/index.js'
+import pinia from './stores/pinia.ts'
 import { useSidebarStore } from './stores/sidebar.ts'
 
 import './init.js'
@@ -36,11 +36,8 @@ if (!IS_DESKTOP) {
 Vue.prototype.OC = OC
 Vue.prototype.OCA = OCA
 
-Vue.use(PiniaVuePlugin)
 Vue.use(Vuex)
 Vue.use(VueRouter)
-
-const pinia = createPinia()
 
 const instance = new Vue({
 	el: '#content',

--- a/src/main.js
+++ b/src/main.js
@@ -59,7 +59,7 @@ const Sidebar = function() {
 	this.state = {
 		file: '',
 	}
-	const sidebarStore = useSidebarStore()
+	const sidebarStore = useSidebarStore(pinia)
 	watch(() => sidebarStore.show, (sidebarShown) => {
 		if (!sidebarShown) {
 			this.state.file = ''

--- a/src/mainFilesSidebar.js
+++ b/src/mainFilesSidebar.js
@@ -5,12 +5,12 @@
 
 import { getRequestToken } from '@nextcloud/auth'
 import { generateFilePath } from '@nextcloud/router'
-import { createPinia, PiniaVuePlugin } from 'pinia'
 import Vue from 'vue'
 import Vuex from 'vuex'
 import FilesSidebarCallViewApp from './FilesSidebarCallViewApp.vue'
 import FilesSidebarTabApp from './FilesSidebarTabApp.vue'
 import store from './store/index.js'
+import pinia from './stores/pinia.ts'
 
 import './init.js'
 // Leaflet icon patch
@@ -30,10 +30,7 @@ __webpack_public_path__ = generateFilePath('spreed', '', 'js/')
 Vue.prototype.OC = OC
 Vue.prototype.OCA = OCA
 
-Vue.use(PiniaVuePlugin)
 Vue.use(Vuex)
-
-const pinia = createPinia()
 
 const newCallView = () => new Vue({
 	store,

--- a/src/mainPublicShareAuthSidebar.js
+++ b/src/mainPublicShareAuthSidebar.js
@@ -5,12 +5,12 @@
 
 import { getRequestToken } from '@nextcloud/auth'
 import { generateFilePath } from '@nextcloud/router'
-import { createPinia, PiniaVuePlugin } from 'pinia'
 import Vue from 'vue'
 import Vuex from 'vuex'
 import PublicShareAuthRequestPasswordButton from './PublicShareAuthRequestPasswordButton.vue'
 import PublicShareAuthSidebar from './PublicShareAuthSidebar.vue'
 import store from './store/index.js'
+import pinia from './stores/pinia.ts'
 
 import './init.js'
 // Leaflet icon patch
@@ -30,10 +30,7 @@ __webpack_public_path__ = generateFilePath('spreed', '', 'js/')
 Vue.prototype.OC = OC
 Vue.prototype.OCA = OCA
 
-Vue.use(PiniaVuePlugin)
 Vue.use(Vuex)
-
-const pinia = createPinia()
 
 /**
  * Wraps all the body contents in its own container.

--- a/src/mainPublicShareSidebar.js
+++ b/src/mainPublicShareSidebar.js
@@ -6,12 +6,12 @@
 import { getRequestToken } from '@nextcloud/auth'
 import { generateFilePath } from '@nextcloud/router'
 import { getSharingToken } from '@nextcloud/sharing/public'
-import { createPinia, PiniaVuePlugin } from 'pinia'
 import Vue, { reactive } from 'vue'
 import Vuex from 'vuex'
 import PublicShareSidebar from './PublicShareSidebar.vue'
 import PublicShareSidebarTrigger from './PublicShareSidebarTrigger.vue'
 import store from './store/index.js'
+import pinia from './stores/pinia.ts'
 
 import './init.js'
 // Leaflet icon patch
@@ -31,10 +31,7 @@ __webpack_public_path__ = generateFilePath('spreed', '', 'js/')
 Vue.prototype.OC = OC
 Vue.prototype.OCA = OCA
 
-Vue.use(PiniaVuePlugin)
 Vue.use(Vuex)
-
-const pinia = createPinia()
 
 // An "isOpen" boolean should be passed to the component, but as it is a
 // primitive it would not be reactive; it needs to be wrapped in an object and

--- a/src/mainRecording.js
+++ b/src/mainRecording.js
@@ -6,13 +6,13 @@
 
 import { getRequestToken } from '@nextcloud/auth'
 import { generateFilePath } from '@nextcloud/router'
-import { createPinia, PiniaVuePlugin } from 'pinia'
 import Vue from 'vue'
 import VueRouter from 'vue-router'
 import Vuex from 'vuex'
 import Recording from './Recording.vue'
 import router from './router/router.ts'
 import store from './store/index.js'
+import pinia from './stores/pinia.ts'
 import {
 	signalingGetSettingsForRecording,
 	signalingJoinCallForRecording,
@@ -37,11 +37,8 @@ __webpack_public_path__ = generateFilePath('spreed', '', 'js/')
 Vue.prototype.OC = OC
 Vue.prototype.OCA = OCA
 
-Vue.use(PiniaVuePlugin)
 Vue.use(Vuex)
 Vue.use(VueRouter)
-
-const pinia = createPinia()
 
 window.store = store
 

--- a/src/stores/pinia.ts
+++ b/src/stores/pinia.ts
@@ -1,0 +1,11 @@
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { createPinia, PiniaVuePlugin } from 'pinia'
+import Vue from 'vue'
+
+Vue.use(PiniaVuePlugin)
+
+export default createPinia()

--- a/src/utils/sounds.js
+++ b/src/utils/sounds.js
@@ -3,7 +3,10 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import pinia from '../stores/pinia.ts'
 import { useSoundsStore } from '../stores/sounds.js'
+
+const soundsStore = useSoundsStore(pinia)
 
 export const Sounds = {
 	BLOCK_SOUND_TIMEOUT: 3000,
@@ -16,13 +19,11 @@ export const Sounds = {
 
 	_stopWaiting() {
 		console.debug('Stop waiting sound')
-		const soundsStore = useSoundsStore()
 		soundsStore.pauseAudio('wait')
 		clearInterval(this.backgroundInterval)
 	},
 
 	async playWaiting() {
-		const soundsStore = useSoundsStore()
 		if (!soundsStore.shouldPlaySounds) {
 			return
 		}
@@ -52,7 +53,6 @@ export const Sounds = {
 	async playJoin(force, playWaitingSound) {
 		this._stopWaiting()
 
-		const soundsStore = useSoundsStore()
 		if (!soundsStore.shouldPlaySounds) {
 			return
 		}
@@ -88,7 +88,6 @@ export const Sounds = {
 	async playLeave(force, playWaitingSound) {
 		this._stopWaiting()
 
-		const soundsStore = useSoundsStore()
 		if (!soundsStore.shouldPlaySounds) {
 			return
 		}


### PR DESCRIPTION
### ☑️ Resolves

* Inspired by https://pinia.vuejs.org/core-concepts/outside-component-usage.html#SSR-Apps
* that way it can be shared and used outside of components
  * sounds utils
  * webrtc
  * e.t.c.


## 🖌️ UI Checklist

### 🚧 Tasks

- [ ] Verify the concept
- [ ] test

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required