### PR TITLE
fix: lint '@nextcloud/vue/no-deprecated-props' rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -36,7 +36,6 @@ export default [
 	{
 		rules: {
 			'@nextcloud-l10n/non-breaking-space': 'off', // changes translation strings
-			'@nextcloud/vue/no-deprecated-props': 'off', // TODO
 			'@stylistic/array-bracket-newline': 'off', // changes array formatting
 			'@stylistic/max-statements-per-line': 'off', // non-fixable
 			'@typescript-eslint/no-unused-expressions': 'off', // non-fixable

--- a/src/App.vue
+++ b/src/App.vue
@@ -431,7 +431,7 @@ export default {
 						},
 						{
 							label: t('spreed', 'Leave call'),
-							type: 'primary',
+							variant: 'primary',
 							callback: () => {
 								beforeRouteChangeListener(to, from, next)
 							},

--- a/src/FilesSidebarTabApp.vue
+++ b/src/FilesSidebarTabApp.vue
@@ -11,14 +11,14 @@
 			<div class="icon icon-talk" />
 			<h2>{{ t('spreed', 'Discuss this file') }}</h2>
 			<p>{{ t('spreed', 'Share this file with others to discuss it') }}</p>
-			<NcButton type="primary" @click="openSharingTab">
+			<NcButton variant="primary" @click="openSharingTab">
 				{{ t('spreed', 'Share this file') }}
 			</NcButton>
 		</div>
 		<div v-else-if="isTalkSidebarSupportedForFile && !token" class="emptycontent room-not-joined">
 			<div class="icon icon-talk" />
 			<h2>{{ t('spreed', 'Discuss this file') }}</h2>
-			<NcButton type="primary" @click="joinConversation">
+			<NcButton variant="primary" @click="joinConversation">
 				{{ t('spreed', 'Join conversation') }}
 			</NcButton>
 		</div>

--- a/src/PublicShareAuthRequestPasswordButton.vue
+++ b/src/PublicShareAuthRequestPasswordButton.vue
@@ -9,7 +9,7 @@
 			automatic colouring of the confirm icon by the Theming app. -->
 		<div id="submit-wrapper" class="request-password-wrapper">
 			<NcButton id="request-password-button"
-				type="primary"
+				variant="primary"
 				:wide="true"
 				:disabled="isRequestInProgress"
 				@click="requestPassword">

--- a/src/PublicShareSidebar.vue
+++ b/src/PublicShareSidebar.vue
@@ -9,7 +9,7 @@
 			<div v-if="!conversation" class="emptycontent room-not-joined">
 				<div class="icon icon-talk" />
 				<h2>{{ t('spreed', 'Discuss this file') }}</h2>
-				<NcButton type="primary"
+				<NcButton variant="primary"
 					class="button-centered"
 					:disabled="joiningConversation"
 					@click="joinConversation">

--- a/src/components/AdminSettings/AllowedGroups.vue
+++ b/src/components/AdminSettings/AllowedGroups.vue
@@ -35,7 +35,7 @@
 				label="displayname"
 				no-wrap
 				@search-change="debounceSearchGroup" />
-			<NcButton type="primary"
+			<NcButton variant="primary"
 				:disabled="loading"
 				@click="saveAllowedGroups">
 				{{ saveLabelAllowedGroups }}
@@ -59,7 +59,7 @@
 				label="displayname"
 				no-wrap
 				@search-change="debounceSearchGroup" />
-			<NcButton type="primary"
+			<NcButton variant="primary"
 				:disabled="loading"
 				@click="saveStartConversationsGroups">
 				{{ saveLabelStartConversations }}

--- a/src/components/AdminSettings/AllowedGroups.vue
+++ b/src/components/AdminSettings/AllowedGroups.vue
@@ -30,7 +30,7 @@
 				:tag-width="60"
 				:loading="loadingGroups"
 				:show-no-options="false"
-				:close-on-select="false"
+				keep-open
 				track-by="id"
 				label="displayname"
 				no-wrap
@@ -54,7 +54,7 @@
 				:tag-width="60"
 				:loading="loadingGroups"
 				:show-no-options="false"
-				:close-on-select="false"
+				keep-open
 				track-by="id"
 				label="displayname"
 				no-wrap

--- a/src/components/AdminSettings/BotsSettings.vue
+++ b/src/components/AdminSettings/BotsSettings.vue
@@ -49,7 +49,7 @@
 				<div :id="`last_error_bot_${bot.id}`" class="last-error">
 					<NcPopover v-if="bot.last_error_message"
 						container="#bots_settings"
-						:focus-trap="false">
+						no-focus-trap>
 						<template #trigger>
 							<NcButton variant="error" :aria-label="bot.last_error_message">
 								{{ bot.last_error_date }}

--- a/src/components/AdminSettings/BotsSettings.vue
+++ b/src/components/AdminSettings/BotsSettings.vue
@@ -51,7 +51,7 @@
 						container="#bots_settings"
 						:focus-trap="false">
 						<template #trigger>
-							<NcButton type="error" :aria-label="bot.last_error_message">
+							<NcButton variant="error" :aria-label="bot.last_error_message">
 								{{ bot.last_error_date }}
 							</NcButton>
 						</template>
@@ -68,7 +68,7 @@
 			</li>
 		</ul>
 
-		<NcButton type="primary"
+		<NcButton variant="primary"
 			href="https://nextcloud-talk.readthedocs.io/en/latest/bot-list/"
 			target="_blank"
 			rel="noreferrer nofollow">

--- a/src/components/AdminSettings/Federation.vue
+++ b/src/components/AdminSettings/Federation.vue
@@ -67,7 +67,7 @@
 					:tag-width="60"
 					:loading="loadingGroups"
 					:show-no-options="false"
-					:close-on-select="false"
+					keep-open
 					track-by="id"
 					label="displayname"
 					no-wrap

--- a/src/components/AdminSettings/Federation.vue
+++ b/src/components/AdminSettings/Federation.vue
@@ -73,7 +73,7 @@
 					no-wrap
 					@search-change="debounceSearchGroup" />
 
-				<NcButton type="primary"
+				<NcButton variant="primary"
 					:disabled="loading"
 					@click="saveAllowedGroups">
 					{{ saveLabelAllowedGroups }}

--- a/src/components/AdminSettings/HostedSignalingServer.vue
+++ b/src/components/AdminSettings/HostedSignalingServer.vue
@@ -108,7 +108,7 @@
 				{{ requestError }}
 			</p>
 
-			<NcButton type="error"
+			<NcButton variant="error"
 				class="additional-top-margin"
 				:disabled="loading"
 				@click="deleteAccount">

--- a/src/components/AdminSettings/RecordingServer.vue
+++ b/src/components/AdminSettings/RecordingServer.vue
@@ -21,7 +21,7 @@
 		</NcCheckboxRadioSwitch>
 
 		<NcButton v-show="!loading"
-			type="tertiary"
+			variant="tertiary"
 			:title="t('spreed', 'Delete this server')"
 			:aria-label="t('spreed', 'Delete this server')"
 			@click="removeServer">
@@ -38,7 +38,7 @@
 		</span>
 
 		<NcButton v-if="server && checked"
-			type="tertiary"
+			variant="tertiary"
 			:title="t('spreed', 'Test this server')"
 			:aria-label="t('spreed', 'Test this server')"
 			@click="checkServerVersion">

--- a/src/components/AdminSettings/SIPBridge.vue
+++ b/src/components/AdminSettings/SIPBridge.vue
@@ -33,7 +33,7 @@
 				:tag-width="60"
 				:loading="loadingGroups"
 				:show-no-options="false"
-				:close-on-select="false"
+				keep-open
 				track-by="id"
 				label="displayname"
 				no-wrap

--- a/src/components/AdminSettings/SIPBridge.vue
+++ b/src/components/AdminSettings/SIPBridge.vue
@@ -68,7 +68,7 @@
 				{{ t('spreed', 'This information is sent in invitation emails as well as displayed in the sidebar to all participants.') }}
 			</p>
 
-			<NcButton type="primary"
+			<NcButton variant="primary"
 				class="additional-top-margin"
 				:disabled="loading || !isEdited"
 				@click="saveSIPSettings">

--- a/src/components/AdminSettings/SignalingServer.vue
+++ b/src/components/AdminSettings/SignalingServer.vue
@@ -20,7 +20,7 @@
 		</NcCheckboxRadioSwitch>
 
 		<NcButton v-show="!loading"
-			type="tertiary"
+			variant="tertiary"
 			:title="t('spreed', 'Delete this server')"
 			:aria-label="t('spreed', 'Delete this server')"
 			@click="removeServer">
@@ -37,7 +37,7 @@
 			{{ connectionState }}
 
 			<NcButton v-if="server && checked"
-				type="tertiary"
+				variant="tertiary"
 				:title="t('spreed', 'Test this server')"
 				:aria-label="t('spreed', 'Test this server')"
 				@click="checkServerVersion">

--- a/src/components/AdminSettings/SignalingServers.vue
+++ b/src/components/AdminSettings/SignalingServers.vue
@@ -12,13 +12,13 @@
 			{{ t('spreed', 'Install the High-performance backend to ensure calls with multiple participants work seamlessly.') }}
 
 			<NcButton v-if="props.hasValidSubscription"
-				type="primary"
+				variant="primary"
 				class="additional-top-margin"
 				href="https://portal.nextcloud.com/article/Nextcloud-Talk/High-Performance-Backend/Installation-of-Nextcloud-Talk-High-Performance-Backend">
 				{{ t('spreed', 'Nextcloud portal') }} ↗
 			</NcButton>
 			<NcButton v-else
-				type="primary"
+				variant="primary"
 				class="additional-top-margin"
 				href="https://nextcloud-talk.readthedocs.io/en/latest/quick-install/">
 				{{ t('spreed', 'Quick installation guide') }} ↗

--- a/src/components/AdminSettings/StunServer.vue
+++ b/src/components/AdminSettings/StunServer.vue
@@ -26,7 +26,7 @@
 			fill-color="#E9322D" />
 
 		<NcButton v-show="!loading"
-			type="tertiary"
+			variant="tertiary"
 			:aria-label="t('spreed', 'Delete this server')"
 			@click="removeServer">
 			<template #icon>

--- a/src/components/AdminSettings/TurnServer.vue
+++ b/src/components/AdminSettings/TurnServer.vue
@@ -49,7 +49,7 @@
 			no-wrap />
 
 		<NcButton v-show="!loading"
-			type="tertiary"
+			variant="tertiary"
 			:aria-label="testResult"
 			:disabled="!testAvailable"
 			@click="testServer">
@@ -61,7 +61,7 @@
 			</template>
 		</NcButton>
 		<NcButton v-show="!loading"
-			type="tertiary"
+			variant="tertiary"
 			:aria-label="t('spreed', 'Delete this server')"
 			@click="removeServer">
 			<template #icon>

--- a/src/components/AdminSettings/WebServerSetupChecks.vue
+++ b/src/components/AdminSettings/WebServerSetupChecks.vue
@@ -14,7 +14,7 @@
 		<ul class="web-server-setup-checks">
 			<li class="virtual-background">
 				{{ t('spreed', 'Files required for virtual background can be loaded') }}
-				<NcButton type="tertiary"
+				<NcButton variant="tertiary"
 					class="vue-button-inline"
 					:class="{ 'success-button': virtualBackgroundAvailable === true, 'error-button': virtualBackgroundAvailable === false }"
 					:title="virtualBackgroundAvailableTitle"

--- a/src/components/BreakoutRoomsEditor/BreakoutRoomsEditor.vue
+++ b/src/components/BreakoutRoomsEditor/BreakoutRoomsEditor.vue
@@ -50,13 +50,13 @@
 				</div>
 				<div class="breakout-rooms-editor__buttons">
 					<NcButton v-if="mode === '2'"
-						type="primary"
+						variant="primary"
 						:disabled="isInvalidAmount"
 						@click="isEditingParticipants = true">
 						{{ t('spreed', 'Assign participants to rooms') }}
 					</NcButton>
 					<NcButton v-else
-						type="primary"
+						variant="primary"
 						:disabled="isInvalidAmount"
 						@click="handleCreateRooms">
 						{{ t('spreed', 'Create rooms') }}

--- a/src/components/BreakoutRoomsEditor/BreakoutRoomsParticipantsEditor.vue
+++ b/src/components/BreakoutRoomsEditor/BreakoutRoomsParticipantsEditor.vue
@@ -31,7 +31,7 @@
 				class="delete"
 				:title="deleteButtonLabel"
 				:aria-label="deleteButtonLabel"
-				type="error"
+				variant="error"
 				@click="toggleShowDialog">
 				<template #icon>
 					<Delete :size="20" />
@@ -39,14 +39,14 @@
 				{{ deleteButtonLabel }}
 			</NcButton>
 			<NcButton v-if="!isReorganizingAttendees"
-				type="tertiary"
+				variant="tertiary"
 				@click="goBack">
 				<template #icon>
 					<IconArrowLeft class="bidirectional-icon" :size="20" />
 				</template>
 				{{ t('spreed', 'Back') }}
 			</NcButton>
-			<NcButton v-if="hasAssigned" type="tertiary" @click="resetAssignments">
+			<NcButton v-if="hasAssigned" variant="tertiary" @click="resetAssignments">
 				<template #icon>
 					<Reload :size="20" />
 				</template>
@@ -78,10 +78,10 @@
 			:message="dialogMessage"
 			container=".participants-editor">
 			<template #actions>
-				<NcButton type="tertiary" @click="toggleShowDialog">
+				<NcButton variant="tertiary" @click="toggleShowDialog">
 					{{ t('spreed', 'Cancel') }}
 				</NcButton>
-				<NcButton type="error" @click="deleteBreakoutRooms">
+				<NcButton variant="error" @click="deleteBreakoutRooms">
 					{{ t('spreed', 'Delete breakout rooms') }}
 				</NcButton>
 			</template>

--- a/src/components/BreakoutRoomsEditor/BreakoutRoomsParticipantsEditor.vue
+++ b/src/components/BreakoutRoomsEditor/BreakoutRoomsParticipantsEditor.vue
@@ -53,7 +53,7 @@
 				{{ resetButtonLabel }}
 			</NcButton>
 			<NcActions v-if="hasSelected"
-				type="primary"
+				variant="primary"
 				container=".participants-editor__buttons"
 				:menu-name="t('spreed', 'Assign')">
 				<NcActionButton v-for="(item, index) in assignments"

--- a/src/components/BreakoutRoomsEditor/BreakoutRoomsParticipantsEditor.vue
+++ b/src/components/BreakoutRoomsEditor/BreakoutRoomsParticipantsEditor.vue
@@ -67,7 +67,7 @@
 				</NcActionButton>
 			</NcActions>
 			<NcButton :disabled="!hasAssigned"
-				:type="confirmButtonType"
+				:variant="hasUnassigned ? 'secondary' : 'primary'"
 				@click="handleSubmit">
 				{{ confirmButtonLabel }}
 			</NcButton>
@@ -202,10 +202,6 @@ export default {
 
 		confirmButtonLabel() {
 			return this.isReorganizingAttendees ? t('spreed', 'Confirm') : t('spreed', 'Create breakout rooms')
-		},
-
-		confirmButtonType() {
-			return this.hasUnassigned ? 'secondary' : 'primary'
 		},
 
 		resetButtonLabel() {

--- a/src/components/CalendarEventsDialog.vue
+++ b/src/components/CalendarEventsDialog.vue
@@ -420,7 +420,7 @@ async function submitNewMeeting() {
 					<NcCheckboxRadioSwitch v-model="selectAll" @update:modelValue="toggleAll">
 						{{ inviteLabel }}
 					</NcCheckboxRadioSwitch>
-					<NcButton v-if="!isOneToOneConversation && !selectAll" type="tertiary" @click="isSelectorOpen = true">
+					<NcButton v-if="!isOneToOneConversation && !selectAll" variant="tertiary" @click="isSelectorOpen = true">
 						<template #icon>
 							<IconAccountPlus :size="20" />
 						</template>
@@ -433,7 +433,7 @@ async function submitNewMeeting() {
 					<p v-if="invalidHint" class="calendar-meeting__invalid-hint">
 						{{ invalidHint }}
 					</p>
-					<NcButton type="primary"
+					<NcButton variant="primary"
 						:disabled="!selectedCalendar || submitting || !!invalid"
 						@click="submitNewMeeting">
 						<template #icon>
@@ -483,7 +483,7 @@ async function submitNewMeeting() {
 					</template>
 				</NcEmptyContent>
 				<template #actions>
-					<NcButton type="primary" @click="isSelectorOpen = false">
+					<NcButton variant="primary" @click="isSelectorOpen = false">
 						<template #icon>
 							<IconCheck :size="20" />
 						</template>

--- a/src/components/CalendarEventsDialog.vue
+++ b/src/components/CalendarEventsDialog.vue
@@ -311,7 +311,7 @@ async function submitNewMeeting() {
 	<div>
 		<NcPopover :container="container"
 			:popper-hide-triggers="hideTriggers"
-			:focus-trap="canScheduleMeeting || upcomingEvents.length !== 0"
+			:no-focus-trap="!canScheduleMeeting && upcomingEvents.length === 0"
 			popup-role="dialog">
 			<template #trigger>
 				<NcButton class="upcoming-meeting"

--- a/src/components/CallView/Grid/Grid.vue
+++ b/src/components/CallView/Grid/Grid.vue
@@ -7,7 +7,7 @@
 	<div ref="gridWrapper" class="grid-main-wrapper" :class="{ 'is-grid': !isStripe, transparent: isLessThanTwoVideos }">
 		<NcButton v-if="isStripe && !isRecording"
 			class="stripe--collapse"
-			type="tertiary-no-background"
+			variant="tertiary-no-background"
 			:title="stripeButtonTitle"
 			:aria-label="stripeButtonTitle"
 			@click="handleClickStripeCollapse">
@@ -24,7 +24,7 @@
 			<div v-if="!isStripe || stripeOpen" class="wrapper" :style="wrapperStyle">
 				<div :class="[isStripe ? 'stripe-wrapper' : 'grid-wrapper']">
 					<NcButton v-if="hasPreviousPage && gridWidth > 0"
-						type="tertiary-no-background"
+						variant="tertiary-no-background"
 						class="grid-navigation grid-navigation__previous"
 						:aria-label="t('spreed', 'Previous page of videos')"
 						@click="handleClickPrevious">
@@ -86,7 +86,7 @@
 							@click-video="handleClickLocalVideo" />
 					</div>
 					<NcButton v-if="hasNextPage && gridWidth > 0"
-						type="tertiary-no-background"
+						variant="tertiary-no-background"
 						class="grid-navigation grid-navigation__next"
 						:aria-label="t('spreed', 'Next page of videos')"
 						@click="handleClickNext">
@@ -108,7 +108,7 @@
 					@click-video="handleClickLocalVideo" />
 
 				<template v-if="devMode">
-					<NcButton type="tertiary"
+					<NcButton variant="tertiary"
 						class="dev-mode__toggle"
 						aria-label="Toggle screenshot mode"
 						@click="screenshotMode = !screenshotMode">

--- a/src/components/CallView/shared/EmptyCallView.vue
+++ b/src/components/CallView/shared/EmptyCallView.vue
@@ -17,7 +17,7 @@
 				{{ message }}
 			</p>
 			<NcButton v-if="showLink"
-				type="primary"
+				variant="primary"
 				@click.stop="handleCopyLink">
 				{{ t('spreed', 'Copy link') }}
 			</NcButton>

--- a/src/components/CallView/shared/LocalAudioControlButton.vue
+++ b/src/components/CallView/shared/LocalAudioControlButton.vue
@@ -9,7 +9,7 @@
 		:show-triggers="[]"
 		:hide-triggers="['click']"
 		:auto-hide="false"
-		:focus-trap="false"
+		no-focus-trap
 		:shown="popupShown">
 		<template #trigger>
 			<NcButton :title="audioButtonTitle"

--- a/src/components/CallView/shared/LocalAudioControlButton.vue
+++ b/src/components/CallView/shared/LocalAudioControlButton.vue
@@ -13,7 +13,7 @@
 		:shown="popupShown">
 		<template #trigger>
 			<NcButton :title="audioButtonTitle"
-				:type="type"
+				:variant="variant"
 				:aria-label="audioButtonAriaLabel"
 				:class="{ 'no-audio-available': !model.attributes.audioAvailable }"
 				:disabled="!isAudioAllowed"
@@ -75,7 +75,7 @@ export default {
 			default: false,
 		},
 
-		type: {
+		variant: {
 			type: String,
 			default: 'tertiary-no-background',
 		},

--- a/src/components/CallView/shared/LocalVideo.vue
+++ b/src/components/CallView/shared/LocalVideo.vue
@@ -50,7 +50,7 @@
 
 		<div class="bottom-bar">
 			<NcButton v-if="isBig"
-				type="tertiary"
+				variant="tertiary"
 				class="bottom-bar__button"
 				@click="handleStopFollowing">
 				{{ stopFollowingLabel }}

--- a/src/components/CallView/shared/LocalVideoControlButton.vue
+++ b/src/components/CallView/shared/LocalVideoControlButton.vue
@@ -5,7 +5,7 @@
 
 <template>
 	<NcButton :title="videoButtonTitle"
-		:type="type"
+		:variant="variant"
 		:aria-label="videoButtonAriaLabel"
 		:class="{ 'no-video-available': !model.attributes.videoAvailable }"
 		:disabled="!isVideoAllowed"
@@ -52,7 +52,7 @@ export default {
 			default: OCP.Accessibility.disableKeyboardShortcuts(),
 		},
 
-		type: {
+		variant: {
 			type: String,
 			default: 'tertiary-no-background',
 		},

--- a/src/components/CallView/shared/PresenterOverlay.vue
+++ b/src/components/CallView/shared/PresenterOverlay.vue
@@ -40,7 +40,7 @@
 		:aria-label="t('spreed', 'Show presenter')"
 		:title="t('spreed', 'Show presenter')"
 		class="presenter-overlay--collapsed"
-		type="tertiary-no-background"
+		variant="tertiary-no-background"
 		@click="$emit('click')">
 		<template #icon>
 			<AccountBox fill-color="#ffffff" :size="20" />

--- a/src/components/CallView/shared/VideoBottomBar.vue
+++ b/src/components/CallView/shared/VideoBottomBar.vue
@@ -36,7 +36,7 @@
 					:title="audioButtonTitle"
 					:aria-label="audioButtonTitle"
 					class="audioIndicator"
-					type="tertiary-no-background"
+					variant="tertiary-no-background"
 					:disabled="isAudioButtonDisabled"
 					@click.stop="forceMute">
 					<template #icon>
@@ -50,7 +50,7 @@
 					:title="videoButtonTitle"
 					:aria-label="videoButtonTitle"
 					class="videoIndicator"
-					type="tertiary-no-background"
+					variant="tertiary-no-background"
 					@click.stop="toggleVideo">
 					<template #icon>
 						<VideoIcon v-if="isRemoteVideoEnabled" :size="20" fill-color="#ffffff" />
@@ -64,7 +64,7 @@
 					:aria-label="t('spreed', 'Show screen')"
 					class="screenSharingIndicator"
 					:class="{ 'screen-visible': sharedData.screenVisible }"
-					type="tertiary-no-background"
+					variant="tertiary-no-background"
 					@click.stop="switchToScreen">
 					<template #icon>
 						<Monitor :size="20" fill-color="#ffffff" />
@@ -80,7 +80,7 @@
 
 			<NcButton v-if="showStopFollowingButton"
 				class="following-button"
-				type="tertiary"
+				variant="tertiary"
 				@click="handleStopFollowing">
 				{{ t('spreed', 'Stop following') }}
 			</NcButton>

--- a/src/components/CallView/shared/ViewerOverlayCallView.vue
+++ b/src/components/CallView/shared/ViewerOverlayCallView.vue
@@ -79,13 +79,13 @@
 								:token="token"
 								:conversation="conversation"
 								:model="localModel"
-								type="secondary"
+								variant="secondary"
 								disable-keyboard-shortcuts />
 							<LocalVideoControlButton class="viewer-overlay__button"
 								:token="token"
 								:conversation="conversation"
 								:model="localModel"
-								type="secondary"
+								variant="secondary"
 								disable-keyboard-shortcuts />
 						</div>
 					</div>

--- a/src/components/CallView/shared/ViewerOverlayCallView.vue
+++ b/src/components/CallView/shared/ViewerOverlayCallView.vue
@@ -11,7 +11,7 @@
 				:style="computedStyle">
 				<div class="viewer-overlay__collapse"
 					:class="{ collapsed: isCollapsed }">
-					<NcButton type="secondary"
+					<NcButton variant="secondary"
 						class="viewer-overlay__button"
 						:aria-label="
 							isCollapsed ? t('spreed', 'Collapse') : t('spreed', 'Expand')
@@ -30,7 +30,7 @@
 						tabindex="0"
 						@click="maximize">
 						<div class="video-overlay__top-bar">
-							<NcButton type="secondary"
+							<NcButton variant="secondary"
 								class="viewer-overlay__button"
 								:aria-label="t('spreed', 'Expand')"
 								@click.stop="maximize">

--- a/src/components/ChatView.vue
+++ b/src/components/ChatView.vue
@@ -31,7 +31,7 @@
 		<div class="scroll-to-bottom">
 			<TransitionWrapper name="fade">
 				<NcButton v-show="!isChatScrolledToBottom && !isLoadingChat"
-					type="secondary"
+					variant="secondary"
 					:aria-label="t('spreed', 'Scroll to bottom')"
 					:title="t('spreed', 'Scroll to bottom')"
 					class="scroll-to-bottom__button"

--- a/src/components/ConversationSettings/BanSettings/BannedItem.vue
+++ b/src/components/ConversationSettings/BanSettings/BannedItem.vue
@@ -8,7 +8,7 @@
 		<div class="ban-item__header">
 			<span class="ban-item__caption">{{ ban.bannedDisplayName }}</span>
 			<div class="ban-item__buttons">
-				<NcButton type="tertiary" @click="showDetails = !showDetails">
+				<NcButton variant="tertiary" @click="showDetails = !showDetails">
 					{{ showDetails ? t('spreed', 'Hide details') : t('spreed', 'Show details') }}
 				</NcButton>
 				<NcButton @click="$emit('unban-participant')">

--- a/src/components/ConversationSettings/BotsSettings.vue
+++ b/src/components/ConversationSettings/BotsSettings.vue
@@ -23,7 +23,7 @@
 				</div>
 				<div v-if="isLoading[bot.id]" class="bots-settings__item-loader icon icon-loading-small" />
 				<NcButton class="bots-settings__item-button"
-					:type="bot.state ? 'primary' : 'secondary'"
+					:variant="bot.state ? 'primary' : 'secondary'"
 					:disabled="isBotLocked(bot) || isLoading[bot.id]"
 					@click="toggleBotState(bot)">
 					{{ toggleButtonTitle(bot) }}

--- a/src/components/ConversationSettings/BreakoutRoomsSettings.vue
+++ b/src/components/ConversationSettings/BreakoutRoomsSettings.vue
@@ -9,7 +9,7 @@
 			<p class="breakout-rooms-settings__hint">
 				{{ hintText }}
 			</p>
-			<NcButton type="secondary"
+			<NcButton variant="secondary"
 				@click="openBreakoutRoomsEditor">
 				<template #icon>
 					<DotsCircle :size="20" />

--- a/src/components/ConversationSettings/ConversationAvatarEditor.vue
+++ b/src/components/ConversationSettings/ConversationAvatarEditor.vue
@@ -223,7 +223,7 @@ export default {
 			return [{
 				label: t('spreed', 'Choose'),
 				callback: (nodes) => this.handleFileChoose(nodes),
-				type: 'primary',
+				variant: 'primary',
 			}]
 		},
 	},

--- a/src/components/ConversationSettings/ConversationAvatarEditor.vue
+++ b/src/components/ConversationSettings/ConversationAvatarEditor.vue
@@ -87,7 +87,7 @@
 						{{ t('spreed', 'Cancel') }}
 					</NcButton>
 					<NcButton v-if="!controlled"
-						type="primary"
+						variant="primary"
 						@click="saveAvatar">
 						{{ t('spreed', 'Set picture') }}
 					</NcButton>

--- a/src/components/ConversationSettings/ConversationPermissionsSettings.vue
+++ b/src/components/ConversationSettings/ConversationPermissionsSettings.vue
@@ -58,7 +58,7 @@
 			<!-- Edit advanced permissions -->
 			<NcButton v-show="showEditButton"
 				class="edit-button"
-				type="tertiary"
+				variant="tertiary"
 				:aria-label="t('spreed', 'Edit permissions')"
 				@click="showPermissionsEditor = true">
 				<template #icon>

--- a/src/components/ConversationSettings/DangerZone.vue
+++ b/src/components/ConversationSettings/DangerZone.vue
@@ -14,7 +14,7 @@
 				<p class="app-settings-section__hint">
 					{{ t('spreed', 'Once a conversation is left, to rejoin a closed conversation, an invite is needed. An open conversation can be rejoined at any time.') }}
 				</p>
-				<NcButton type="warning" @click="toggleShowLeaveConversationDialog">
+				<NcButton variant="warning" @click="toggleShowLeaveConversationDialog">
 					{{ t('spreed', 'Leave conversation') }}
 				</NcButton>
 				<NcDialog class="danger-zone__dialog"
@@ -28,13 +28,13 @@
 						</p>
 					</template>
 					<template #actions>
-						<NcButton type="tertiary" @click="toggleShowLeaveConversationDialog">
+						<NcButton variant="tertiary" @click="toggleShowLeaveConversationDialog">
 							{{ t('spreed', 'No') }}
 						</NcButton>
-						<NcButton v-if="supportsArchive && !conversation.isArchived" type="secondary" @click="toggleArchiveConversation">
+						<NcButton v-if="supportsArchive && !conversation.isArchived" variant="secondary" @click="toggleArchiveConversation">
 							{{ t('spreed', 'Archive conversation') }}
 						</NcButton>
-						<NcButton type="warning" @click="leaveConversation">
+						<NcButton variant="warning" @click="leaveConversation">
 							{{ t('spreed', 'Yes') }}
 						</NcButton>
 					</template>
@@ -47,7 +47,7 @@
 				<p class="app-settings-section__hint">
 					{{ t('spreed', 'Permanently delete this conversation.') }}
 				</p>
-				<NcButton type="error"
+				<NcButton variant="error"
 					@click="toggleShowDeleteConversationDialog">
 					{{ t('spreed', 'Delete conversation') }}
 				</NcButton>
@@ -57,10 +57,10 @@
 					:message="deleteConversationDialogMessage"
 					container=".danger-zone">
 					<template #actions>
-						<NcButton type="tertiary" @click="toggleShowDeleteConversationDialog">
+						<NcButton variant="tertiary" @click="toggleShowDeleteConversationDialog">
 							{{ t('spreed', 'No') }}
 						</NcButton>
-						<NcButton type="error" @click="deleteConversation">
+						<NcButton variant="error" @click="deleteConversation">
 							{{ t('spreed', 'Yes') }}
 						</NcButton>
 					</template>
@@ -73,7 +73,7 @@
 				<p class="app-settings-section__hint">
 					{{ t('spreed', 'Permanently delete all the messages in this conversation.') }}
 				</p>
-				<NcButton type="error"
+				<NcButton variant="error"
 					@click="toggleShowDeleteChatDialog">
 					{{ t('spreed', 'Delete chat messages') }}
 				</NcButton>
@@ -83,10 +83,10 @@
 					:message="deleteChatDialogMessage"
 					container=".danger-zone">
 					<template #actions>
-						<NcButton type="tertiary" @click="toggleShowDeleteChatDialog">
+						<NcButton variant="tertiary" @click="toggleShowDeleteChatDialog">
 							{{ t('spreed', 'No') }}
 						</NcButton>
-						<NcButton type="error" @click="clearChatHistory">
+						<NcButton variant="error" @click="clearChatHistory">
 							{{ t('spreed', 'Yes') }}
 						</NcButton>
 					</template>

--- a/src/components/ConversationSettings/ExpirationSettings.vue
+++ b/src/components/ConversationSettings/ExpirationSettings.vue
@@ -18,7 +18,6 @@
 				:input-label="t('spreed', 'Set message expiration')"
 				:options="expirationOptions"
 				label="label"
-				close-on-select
 				:clearable="false" />
 		</template>
 

--- a/src/components/ConversationSettings/LinkShareSettings.vue
+++ b/src/components/ConversationSettings/LinkShareSettings.vue
@@ -37,7 +37,7 @@
 					<NcNoteCard v-else-if="!isSaving"
 						type="warning">
 						{{ t('spreed', 'Password protection is needed for public conversations') }}
-						<NcButton class="warning__button" type="primary" @click="enforcePassword">
+						<NcButton class="warning__button" variant="primary" @click="enforcePassword">
 							{{ t('spreed', 'Set a password') }}
 						</NcButton>
 					</NcNoteCard>
@@ -55,8 +55,8 @@
 						@valid="isValid = true"
 						@invalid="isValid = false" />
 					<NcButton :disabled="isSaving || !isValid"
-						type="primary"
-						native-type="submit"
+						variant="primary"
+						type="submit"
 						class="password-form__button">
 						<template #icon>
 							<IconContentSaveOutline />
@@ -64,7 +64,7 @@
 						{{ t('spreed', 'Save password') }}
 					</NcButton>
 					<NcButton v-if="password"
-						type="tertiary"
+						variant="tertiary"
 						:aria-label="t('spreed', 'Copy password')"
 						:title="t('spreed', 'Copy password')"
 						class="password-form__button"

--- a/src/components/ConversationSettings/Matterbridge/MatterbridgeSettings.vue
+++ b/src/components/ConversationSettings/Matterbridge/MatterbridgeSettings.vue
@@ -42,7 +42,7 @@
 						({{ processStateText }})
 					</NcCheckboxRadioSwitch>
 					<NcButton v-if="enabled"
-						type="tertiary"
+						variant="tertiary"
 						:title="t('spreed', 'Show Matterbridge log')"
 						:aria-label="t('spreed', 'Show Matterbridge log')"
 						@click="showLogContent">

--- a/src/components/Dashboard/EventCard.vue
+++ b/src/components/Dashboard/EventCard.vue
@@ -177,7 +177,7 @@ function handleJoin({ call = false } = {}) {
 			</template>
 		</p>
 		<span class="event-card__room secondary_text">
-			<NcChip type="tertiary"
+			<NcChip variant="tertiary"
 				:text="roomLabel"
 				no-close>
 				<template #icon>

--- a/src/components/Dashboard/EventCard.vue
+++ b/src/components/Dashboard/EventCard.vue
@@ -208,7 +208,7 @@ function handleJoin({ call = false } = {}) {
 				{{ invitesLabel }}
 			</span>
 			<NcButton v-if="(hasCall && !isInCall)"
-				type="primary"
+				variant="primary"
 				@click="handleJoin({ call: true })">
 				<template #icon>
 					<IconVideo :size="20" />
@@ -217,14 +217,14 @@ function handleJoin({ call = false } = {}) {
 			</NcButton>
 		</span>
 		<span class="event-card__invitation-info hovered">
-			<NcButton type="tertiary"
+			<NcButton variant="tertiary"
 				@click="handleJoin">
 				<template #icon>
 					<NcIconSvgWrapper :svg="IconTalk" :size="20" />
 				</template>
 				{{ t('spreed', 'View conversation') }}
 			</NcButton>
-			<NcButton type="tertiary"
+			<NcButton variant="tertiary"
 				:href="props.eventRoom.eventLink"
 				target="_blank"
 				:title="t('spreed', 'View event on Calendar')"

--- a/src/components/Dashboard/TalkDashboard.vue
+++ b/src/components/Dashboard/TalkDashboard.vue
@@ -172,7 +172,7 @@ function scrollEventCards({ direction }: { direction: 'backward' | 'forward' }) 
 			<NcPopover v-if="canStartConversations"
 				popup-role="dialog">
 				<template #trigger>
-					<NcButton type="primary">
+					<NcButton variant="primary">
 						<template #icon>
 							<IconVideo />
 						</template>
@@ -187,7 +187,7 @@ function scrollEventCards({ direction }: { direction: 'backward' | 'forward' }) 
 					<NcInputField id="room-name"
 						v-model="conversationName"
 						:placeholder="t('spreed', 'Meeting')" />
-					<NcButton type="primary"
+					<NcButton variant="primary"
 						@click="startMeeting">
 						{{ t('spreed', 'Create and copy link') }}
 					</NcButton>
@@ -215,7 +215,7 @@ function scrollEventCards({ direction }: { direction: 'backward' | 'forward' }) 
 				</template>
 				{{ t('spreed', 'Call a phone number') }}
 			</NcButton>
-			<NcButton type="tertiary"
+			<NcButton variant="tertiary"
 				@click="emit('talk:media-settings:show', 'device-check')">
 				<template #icon>
 					<IconMicrophone :size="20" />
@@ -240,7 +240,7 @@ function scrollEventCards({ direction }: { direction: 'backward' | 'forward' }) 
 			<div class="talk-dashboard__event-cards__scroll-indicator">
 				<NcButton v-show="backwardScrollable"
 					class="button-slide backward"
-					type="tertiary"
+					variant="tertiary"
 					:title="t('spreed', 'Scroll backward')"
 					:aria-label="t('spreed', 'Scroll backward')"
 					@click="scrollEventCards({ direction: 'backward' })">
@@ -250,7 +250,7 @@ function scrollEventCards({ direction }: { direction: 'backward' | 'forward' }) 
 				</NcButton>
 				<NcButton v-show="forwardScrollable"
 					class="button-slide forward"
-					type="tertiary"
+					variant="tertiary"
 					:title="t('spreed', 'Scroll forward')"
 					:aria-label="t('spreed', 'Scroll forward')"
 					@click="scrollEventCards({ direction: 'forward' })">
@@ -268,7 +268,7 @@ function scrollEventCards({ direction }: { direction: 'backward' | 'forward' }) 
 				{{ t('spreed', 'Schedule a meeting with a colleague from your calendar') }}
 			</span>
 			<NcButton class="talk-dashboard__calendar-button"
-				type="secondary"
+				variant="secondary"
 				:href="generateUrl('apps/calendar')"
 				target="_blank">
 				<template #icon>

--- a/src/components/ExtendOneToOneDialog.vue
+++ b/src/components/ExtendOneToOneDialog.vue
@@ -72,7 +72,7 @@ async function extendOneToOneConversation() {
 	<NcPopover :container="container"
 		popup-role="dialog">
 		<template #trigger>
-			<NcButton type="tertiary"
+			<NcButton variant="tertiary"
 				:title="t('spreed', 'Start a group conversation')"
 				:aria-label="t('spreed', 'Start a group conversation')">
 				<template #icon>
@@ -90,7 +90,7 @@ async function extendOneToOneConversation() {
 					:selected-participants.sync="selectedParticipants"
 					only-users />
 				<NcButton class="start-group__action"
-					type="primary"
+					variant="primary"
 					:disabled="!selectedParticipants.length"
 					@click="extendOneToOneConversation">
 					{{ t('spreed', 'Create conversation') }}

--- a/src/components/GuestWelcomeWindow.vue
+++ b/src/components/GuestWelcomeWindow.vue
@@ -29,7 +29,7 @@
 				@keydown.enter="handleChooseUserName" />
 
 			<NcButton class="submit-button"
-				type="primary"
+				variant="primary"
 				:disabled="invalidGuestUsername"
 				@click="handleChooseUserName">
 				{{ t('spreed', 'Submit name and join') }}
@@ -42,7 +42,7 @@
 
 			<div class="login-info">
 				<span> {{ t('spreed', 'Do you already have an account?') }}</span>
-				<NcButton type="secondary"
+				<NcButton variant="secondary"
 					:href="getLoginUrl()">
 					{{ t('spreed', 'Log in') }}
 				</NcButton>

--- a/src/components/ImportEmailsDialog.vue
+++ b/src/components/ImportEmailsDialog.vue
@@ -162,7 +162,7 @@ async function submitList(file: File | null) {
 		</div>
 
 		<template #actions>
-			<NcButton type="primary"
+			<NcButton variant="primary"
 				:disabled="!uploadResult"
 				@click="submitList(importedFile)">
 				{{ t('spreed', 'Send invitations') }}

--- a/src/components/LeftSidebar/ConversationsList/Conversation.vue
+++ b/src/components/LeftSidebar/ConversationsList/Conversation.vue
@@ -219,13 +219,13 @@
 					</p>
 				</template>
 				<template #actions>
-					<NcButton type="tertiary" @click="isLeaveDialogOpen = false">
+					<NcButton variant="tertiary" @click="isLeaveDialogOpen = false">
 						{{ t('spreed', 'No') }}
 					</NcButton>
-					<NcButton v-if="supportsArchive && !item.isArchived" type="secondary" @click="toggleArchiveConversation">
+					<NcButton v-if="supportsArchive && !item.isArchived" variant="secondary" @click="toggleArchiveConversation">
 						{{ t('spreed', 'Archive conversation') }}
 					</NcButton>
-					<NcButton type="warning" @click="leaveConversation">
+					<NcButton variant="warning" @click="leaveConversation">
 						{{ t('spreed', 'Yes') }}
 					</NcButton>
 				</template>
@@ -235,10 +235,10 @@
 				:name="t('spreed', 'Delete conversation')"
 				:message="dialogDeleteMessage">
 				<template #actions>
-					<NcButton type="tertiary" @click="isDeleteDialogOpen = false">
+					<NcButton variant="tertiary" @click="isDeleteDialogOpen = false">
 						{{ t('spreed', 'No') }}
 					</NcButton>
-					<NcButton type="error" @click="deleteConversation">
+					<NcButton variant="error" @click="deleteConversation">
 						{{ t('spreed', 'Yes') }}
 					</NcButton>
 				</template>

--- a/src/components/LeftSidebar/InvitationHandler.vue
+++ b/src/components/LeftSidebar/InvitationHandler.vue
@@ -26,7 +26,7 @@
 							:arguments="getRichParameters(item)"
 							:reference-limit="0" />
 					</div>
-					<NcButton type="tertiary"
+					<NcButton variant="tertiary"
 						class="inbox__item-button"
 						:aria-label="t('spreed', 'Decline invitation')"
 						:title="t('spreed', 'Decline invitation')"
@@ -37,7 +37,7 @@
 							<CancelIcon v-else :size="20" />
 						</template>
 					</NcButton>
-					<NcButton type="primary"
+					<NcButton variant="primary"
 						class="inbox__item-button"
 						:aria-label="t('spreed', 'Accept invitation')"
 						:title="t('spreed', 'Accept invitation')"

--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -33,7 +33,7 @@
 				<TransitionWrapper name="radial-reveal">
 					<!-- Filters -->
 					<NcActions v-show="searchText === ''"
-						:type="isFiltered ? 'secondary' : 'tertiary'"
+						:variant="isFiltered ? 'secondary' : 'tertiary'"
 						class="filters"
 						:class="{ 'hidden-visually': isSearching }">
 						<template #icon>

--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -9,7 +9,7 @@
 			<div class="new-conversation">
 				<TransitionWrapper name="radial-reveal">
 					<NcButton v-show="searchText === ''"
-						type="tertiary"
+						variant="tertiary"
 						:class="{ 'hidden-visually': isSearching }"
 						class="talk-home-button"
 						:title="t('spreed', 'Talk home')"
@@ -192,7 +192,7 @@
 					@scroll.native="debounceHandleScroll" />
 				<NcButton v-if="!preventFindingUnread && lastUnreadMentionBelowViewportIndex !== null"
 					class="unread-mention-button"
-					type="primary"
+					variant="primary"
 					@click="scrollBottomUnread">
 					{{ t('spreed', 'Unread mentions') }}
 				</NcButton>
@@ -216,7 +216,7 @@
 			<div class="left-sidebar__settings-button-container">
 				<template v-if="!isSearching && supportsArchive">
 					<NcButton v-if="showArchived"
-						type="tertiary"
+						variant="tertiary"
 						wide
 						@click="showArchived = false">
 						<template #icon>
@@ -225,7 +225,7 @@
 						{{ t('spreed', 'Back to conversations') }}
 					</NcButton>
 					<NcButton v-else-if="archivedConversationsList.length"
-						type="tertiary"
+						variant="tertiary"
 						wide
 						@click="showArchived = true">
 						<template #icon>
@@ -238,7 +238,7 @@
 					</NcButton>
 				</template>
 
-				<NcButton type="tertiary" wide @click="showSettings">
+				<NcButton variant="tertiary" wide @click="showSettings">
 					<template #icon>
 						<Cog :size="20" />
 					</template>

--- a/src/components/MediaSettings/MediaDevicesSelector.vue
+++ b/src/components/MediaSettings/MediaDevicesSelector.vue
@@ -116,7 +116,7 @@ function updateDeviceId(deviceId: NcSelectOption['id']) {
 			:placeholder="deviceSelectorPlaceholder"
 			:disabled="!enabled || !deviceOptionsAvailable" />
 
-		<NcButton type="tertiary"
+		<NcButton variant="tertiary"
 			:title="t('spreed', 'Refresh devices list')"
 			:aria-lebel="t('spreed', 'Refresh devices list')"
 			@click="$emit('refresh')">

--- a/src/components/MediaSettings/MediaDevicesSpeakerTest.vue
+++ b/src/components/MediaSettings/MediaDevicesSpeakerTest.vue
@@ -6,7 +6,7 @@
 <template>
 	<div class="media-devices-checker">
 		<IconVolumeHigh class="media-devices-checker__icon" :size="16" />
-		<NcButton type="secondary" @click="playTestSound">
+		<NcButton variant="secondary" @click="playTestSound">
 			{{ buttonLabel }}
 		</NcButton>
 		<div v-if="isPlayingTestSound" class="equalizer">

--- a/src/components/MediaSettings/MediaSettings.vue
+++ b/src/components/MediaSettings/MediaSettings.vue
@@ -20,7 +20,7 @@
 					disablePictureInPicture
 					tabindex="-1" />
 				<NcButton v-if="showVideo"
-					type="secondary"
+					variant="secondary"
 					class="media-settings__preview-mirror"
 					:title="mirrorToggleLabel"
 					:aria-label="mirrorToggleLabel"
@@ -45,7 +45,7 @@
 				<!-- Audio and video toggles -->
 				<div class="media-settings__toggles">
 					<!-- Audio toggle -->
-					<NcButton type="tertiary"
+					<NcButton variant="tertiary"
 						:title="audioButtonTitle"
 						:aria-label="audioButtonTitle"
 						:disabled="!audioPreviewAvailable"
@@ -60,7 +60,7 @@
 					</NcButton>
 
 					<!-- Video toggle -->
-					<NcButton type="tertiary"
+					<NcButton variant="tertiary"
 						:title="videoButtonTitle"
 						:aria-label="videoButtonTitle"
 						:disabled="!videoPreviewAvailable"

--- a/src/components/MediaSettings/MediaSettingsTabs.vue
+++ b/src/components/MediaSettings/MediaSettingsTabs.vue
@@ -93,7 +93,7 @@ function handleTabsAfterClosed() {
 				:key="tab.id"
 				wide
 				role="tab"
-				:type="isSelected(tab.id) ? 'secondary' : 'tertiary'"
+				:variant="isSelected(tab.id) ? 'secondary' : 'tertiary'"
 				:aria-selected="isSelected(tab.id) ? 'true' : 'false'"
 				:aria-controls="getRefId('panel', tab.id)"
 				@click.stop="handleTabClick(tab.id)">

--- a/src/components/MediaSettings/VideoBackgroundEditor.vue
+++ b/src/components/MediaSettings/VideoBackgroundEditor.vue
@@ -166,7 +166,7 @@ export default {
 			return [{
 				label: t('spreed', 'Confirm'),
 				callback: (nodes) => this.handleFileChoose(nodes),
-				type: 'primary',
+				variant: 'primary',
 			}]
 		},
 	},

--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -57,7 +57,7 @@
 				@delete="handleDelete" />
 			<div v-else-if="showCombinedSystemMessageToggle"
 				class="message-buttons-bar">
-				<NcButton type="tertiary"
+				<NcButton variant="tertiary"
 					:aria-label="t('spreed', 'Show or collapse system messages')"
 					:title="t('spreed', 'Show or collapse system messages')"
 					@click="toggleCombinedSystemMessage">

--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
@@ -8,7 +8,7 @@
 	<div v-click-outside="handleClickOutside">
 		<template v-if="!isReactionsMenuOpen">
 			<NcButton v-if="canReact"
-				type="tertiary"
+				variant="tertiary"
 				:aria-label="t('spreed', 'Add a reaction to this message')"
 				:title="t('spreed', 'Add a reaction to this message')"
 				@click="openReactionsMenu">
@@ -17,7 +17,7 @@
 				</template>
 			</NcButton>
 			<NcButton v-if="canReply"
-				type="tertiary"
+				variant="tertiary"
 				:aria-label="t('spreed', 'Reply')"
 				:title="t('spreed', 'Reply')"
 				@click="handleReply">
@@ -226,7 +226,7 @@
 		</template>
 
 		<template v-else>
-			<NcButton type="tertiary"
+			<NcButton variant="tertiary"
 				:aria-label="t('spreed', 'Close reactions menu')"
 				@click="closeReactionsMenu">
 				<template #icon>
@@ -235,7 +235,7 @@
 			</NcButton>
 			<NcButton v-for="emoji in frequentlyUsedEmojis"
 				:key="emoji"
-				type="tertiary"
+				variant="tertiary"
 				:aria-label="t('spreed', 'React with {emoji}', { emoji })"
 				@click="handleReactionClick(emoji)">
 				<template #icon>
@@ -248,7 +248,7 @@
 				@select="handleReactionClick"
 				@after-show="onEmojiPickerOpen"
 				@after-hide="onEmojiPickerClose">
-				<NcButton type="tertiary"
+				<NcButton variant="tertiary"
 					:aria-label="t('spreed', 'React with another emoji')">
 					<template #icon>
 						<Plus :size="20" />

--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageForwarder.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageForwarder.vue
@@ -28,10 +28,10 @@
 				</template>
 			</NcEmptyContent>
 			<template #actions>
-				<NcButton type="tertiary" @click="handleClose">
+				<NcButton variant="tertiary" @click="handleClose">
 					{{ t('spreed', 'Dismiss') }}
 				</NcButton>
-				<NcButton type="primary" @click="openConversation">
+				<NcButton variant="primary" @click="openConversation">
 					{{ t('spreed', 'Go to conversation') }}
 				</NcButton>
 			</template>

--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageTranslateDialog.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageTranslateDialog.vue
@@ -30,7 +30,7 @@
 					:options="optionsTo"
 					no-wrap />
 
-				<NcButton type="primary"
+				<NcButton variant="primary"
 					:disabled="isLoading"
 					class="translate-dialog__button"
 					@click="handleTranslate">

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
@@ -50,7 +50,7 @@
 		<NcButton v-if="isUploadEditor"
 			class="remove-file"
 			tabindex="1"
-			type="primary"
+			variant="primary"
 			:aria-label="removeAriaLabel"
 			@click="$emit('remove-file', file.id)">
 			<template #icon>

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/MessageBody.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/MessageBody.vue
@@ -61,7 +61,7 @@
 			<NcButton v-if="containsCodeBlocks"
 				v-show="currentCodeBlock !== null"
 				class="message-copy-code"
-				type="tertiary"
+				variant="tertiary"
 				:aria-label="t('spreed', 'Copy code block')"
 				:title="t('spreed', 'Copy code block')"
 				:style="{ top: copyButtonOffset }"

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/Poll.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/Poll.vue
@@ -10,7 +10,7 @@
 			<IconPoll class="poll-card__header-icon" :size="20" />
 			<span class="poll-card__header-name">{{ name }}</span>
 			<NcButton v-if="canEditPollDraft"
-				type="tertiary"
+				variant="tertiary"
 				:title="t('spreed', 'Edit poll draft')"
 				:aria-label="t('spreed', 'Edit poll draft')"
 				@click.stop="editDraft">
@@ -18,7 +18,7 @@
 					<IconPencil :size="20" />
 				</template>
 			</NcButton>
-			<NcButton type="tertiary"
+			<NcButton variant="tertiary"
 				:title="t('spreed', 'Delete poll draft')"
 				:aria-label="t('spreed', 'Delete poll draft')"
 				@click.stop="deleteDraft">
@@ -49,7 +49,7 @@
 	<!-- Poll results button in system message -->
 	<NcButton v-else
 		class="poll-closed"
-		type="secondary"
+		variant="secondary"
 		@click="openPoll">
 		{{ t('spreed', 'See results') }}
 	</NcButton>

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/Reactions.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/Reactions.vue
@@ -14,7 +14,7 @@
 			:popper-triggers="['hover']"
 			@after-show="fetchReactions">
 			<template #trigger>
-				<NcButton :type="userHasReacted(reaction) ? 'primary' : 'secondary'"
+				<NcButton :variant="userHasReacted(reaction) ? 'primary' : 'secondary'"
 					size="small"
 					@click="handleReactionClick(reaction)">
 					<span class="reaction-emoji">{{ reaction }}</span> {{ reactionsCount(reaction) }}

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/Reactions.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/Reactions.vue
@@ -9,7 +9,7 @@
 		<NcPopover v-for="reaction in reactionsSorted"
 			:key="reaction"
 			:delay="200"
-			:focus-trap="false"
+			no-focus-trap
 			:triggers="['hover']"
 			:popper-triggers="['hover']"
 			@after-show="fetchReactions">

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/ReactionsList.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/ReactionsList.vue
@@ -13,7 +13,7 @@
 					<NcButton v-for="reaction in reactionsMenu"
 						:key="reaction"
 						:class="{ active: reactionFilter === reaction, 'all-reactions__button': reaction === '♡' }"
-						type="tertiary"
+						variant="tertiary"
 						@click="handleTabClick(reaction)">
 						<HeartOutlineIcon v-if="reaction === '♡'" :size="15" />
 						<span v-else>

--- a/src/components/NewConversationDialog/NewConversationDialog.vue
+++ b/src/components/NewConversationDialog/NewConversationDialog.vue
@@ -40,12 +40,12 @@
 				<!-- First page -->
 				<NcButton v-if="page === 0 && conversationName"
 					:disabled="disabled"
-					type="tertiary"
+					variant="tertiary"
 					@click="handleCreateConversation">
 					{{ t('spreed', 'Create conversation') }}
 				</NcButton>
 				<NcButton v-if="page === 0"
-					type="primary"
+					variant="primary"
 					:disabled="disabled"
 					class="new-group-conversation__button"
 					@click="switchToPage(1)">
@@ -53,12 +53,12 @@
 				</NcButton>
 				<!-- Second page -->
 				<NcButton v-if="page === 1"
-					type="tertiary"
+					variant="tertiary"
 					@click="switchToPage(0)">
 					{{ t('spreed', 'Back') }}
 				</NcButton>
 				<NcButton v-if="page === 1"
-					type="primary"
+					variant="primary"
 					class="new-group-conversation__button"
 					@click="handleCreateConversation">
 					{{ t('spreed', 'Create conversation') }}
@@ -87,13 +87,13 @@
 					<NcButton v-if="!error && success && isPublic"
 						id="copy-link"
 						ref="copyLink"
-						type="secondary"
+						variant="secondary"
 						@click="onClickCopyLink">
 						{{ t('spreed', 'Copy link') }}
 					</NcButton>
 					<NcButton v-if="!error && success && isPublic && newConversation.hasPassword"
 						id="copy-password"
-						type="secondary"
+						variant="secondary"
 						@click="onClickCopyPassword">
 						{{ t('spreed', 'Copy password') }}
 					</NcButton>

--- a/src/components/NewMessage/NewMessage.vue
+++ b/src/components/NewMessage/NewMessage.vue
@@ -41,7 +41,7 @@
 
 				<div class="new-message-form__emoji-picker">
 					<NcEmojiPicker v-if="!disabled"
-						:close-on-select="false"
+						keep-open
 						:set-return-focus="getContenteditable"
 						@select="addEmoji">
 						<NcButton :disabled="disabled"

--- a/src/components/NewMessage/NewMessage.vue
+++ b/src/components/NewMessage/NewMessage.vue
@@ -45,7 +45,7 @@
 						:set-return-focus="getContenteditable"
 						@select="addEmoji">
 						<NcButton :disabled="disabled"
-							type="tertiary"
+							variant="tertiary"
 							:aria-label="t('spreed', 'Add emoji')"
 							:aria-haspopup="true">
 							<template #icon>
@@ -55,7 +55,7 @@
 					</NcEmojiPicker>
 					<!-- Disabled emoji picker placeholder button -->
 					<NcButton v-else
-						type="tertiary"
+						variant="tertiary"
 						:aria-label="t('spreed', 'Add emoji')"
 						:disabled="true">
 						<template #icon>
@@ -118,8 +118,8 @@
 
 			<!-- Edit -->
 			<template v-else-if="messageToEdit">
-				<NcButton type="tertiary"
-					native-type="submit"
+				<NcButton variant="tertiary"
+					type="submit"
 					:title="t('spreed', 'Cancel editing')"
 					:aria-label="t('spreed', 'Cancel editing')"
 					@click="handleAbortEdit">
@@ -128,8 +128,8 @@
 					</template>
 				</NcButton>
 				<NcButton :disabled="disabledEdit"
-					type="tertiary"
-					native-type="submit"
+					variant="tertiary"
+					type="submit"
 					:title="t('spreed', 'Edit message')"
 					:aria-label="t('spreed', 'Edit message')"
 					@click="handleEdit">
@@ -142,8 +142,8 @@
 			<!-- Send buttons -->
 			<template v-else>
 				<NcButton :disabled="disabled"
-					type="tertiary"
-					native-type="submit"
+					variant="tertiary"
+					type="submit"
 					:title="sendMessageLabel"
 					:aria-label="sendMessageLabel"
 					@click="handleSubmit">

--- a/src/components/NewMessage/NewMessage.vue
+++ b/src/components/NewMessage/NewMessage.vue
@@ -449,7 +449,7 @@ export default {
 			return [{
 				label: t('spreed', 'Choose'),
 				callback: (nodes) => this.handleFileShare(nodes),
-				type: 'primary',
+				variant: 'primary',
 			}]
 		},
 

--- a/src/components/NewMessage/NewMessageAbsenceInfo.vue
+++ b/src/components/NewMessage/NewMessageAbsenceInfo.vue
@@ -29,7 +29,7 @@
 		</div>
 		<NcButton v-if="userAbsenceMessage && isTextMoreThanOneLine"
 			class="absence-reminder__button"
-			type="tertiary"
+			variant="tertiary"
 			:title="!collapsed ? t('spreed', 'Collapse') : t('spreed', 'Expand')"
 			:aria-label="!collapsed ? t('spreed', 'Collapse') : t('spreed', 'Expand')"
 			@click="toggleCollapsed">

--- a/src/components/NewMessage/NewMessageAudioRecorder.vue
+++ b/src/components/NewMessage/NewMessageAudioRecorder.vue
@@ -8,7 +8,7 @@
 		<NcButton v-if="!isRecording"
 			:title="startRecordingTitle"
 			:aria-label="startRecordingTitle"
-			type="tertiary"
+			variant="tertiary"
 			:disabled="!canStartRecording"
 			@click="start">
 			<template #icon>
@@ -16,7 +16,7 @@
 			</template>
 		</NcButton>
 		<div v-else class="wrapper">
-			<NcButton type="error"
+			<NcButton variant="error"
 				:title="abortRecordingTitle"
 				:aria-label="abortRecordingTitle"
 				@click="abortRecording">
@@ -29,7 +29,7 @@
 				<span class="time">
 					{{ parsedRecordTime }}</span>
 			</div>
-			<NcButton type="success"
+			<NcButton variant="success"
 				:title="stopRecordingTitle"
 				:aria-label="stopRecordingTitle"
 				:class="{ 'audio-recorder__trigger--recording': isRecording }"

--- a/src/components/NewMessage/NewMessageChatSummary.vue
+++ b/src/components/NewMessage/NewMessageChatSummary.vue
@@ -12,7 +12,7 @@
 		</template>
 		<NcButton v-if="isTextMoreThanOneLine"
 			class="chat-summary__button"
-			type="tertiary"
+			variant="tertiary"
 			:title="!collapsed ? t('spreed', 'Collapse') : t('spreed', 'Expand')"
 			:aria-label="!collapsed ? t('spreed', 'Collapse') : t('spreed', 'Expand')"
 			@click="toggleCollapsed">
@@ -37,7 +37,7 @@
 		<div class="chat-summary__actions">
 			<NcButton v-if="loading"
 				class="chat-summary__action"
-				type="primary"
+				variant="primary"
 				:disabled="cancelling"
 				@click="cancelSummary">
 				<template v-if="cancelling" #icon>
@@ -47,7 +47,7 @@
 			</NcButton>
 			<NcButton v-else-if="chatSummaryMessage"
 				class="chat-summary__action"
-				type="primary"
+				variant="primary"
 				@click="dismissSummary">
 				{{ t('spreed', 'Dismiss') }}
 			</NcButton>

--- a/src/components/NewMessage/NewMessageNewFileDialog.vue
+++ b/src/components/NewMessage/NewMessageNewFileDialog.vue
@@ -36,7 +36,7 @@
 		</form>
 
 		<template #actions>
-			<NcButton type="primary"
+			<NcButton variant="primary"
 				:disabled="loading"
 				@click="handleCreateNewFile">
 				<template v-if="loading" #icon>

--- a/src/components/NewMessage/NewMessageUploadEditor.vue
+++ b/src/components/NewMessage/NewMessageUploadEditor.vue
@@ -39,7 +39,7 @@
 					</template>
 					<NcButton key="add-more"
 						:aria-label="addMoreAriaLabel"
-						type="tertiary"
+						variant="tertiary"
 						class="add-more-button"
 						size="large"
 						@click="clickImportInput">
@@ -54,10 +54,10 @@
 					:local-url="voiceMessageLocalURL" />
 			</template>
 			<div v-if="!supportMediaCaption" class="upload-editor__actions">
-				<NcButton type="tertiary" @click="handleDismiss">
+				<NcButton variant="tertiary" @click="handleDismiss">
 					{{ t('spreed', 'Dismiss') }}
 				</NcButton>
-				<NcButton ref="submitButton" type="primary" @click="handleLegacyUpload">
+				<NcButton ref="submitButton" variant="primary" @click="handleLegacyUpload">
 					{{ t('spreed', 'Send') }}
 				</NcButton>
 			</div>

--- a/src/components/PermissionsEditor/PermissionsEditor.vue
+++ b/src/components/PermissionsEditor/PermissionsEditor.vue
@@ -44,9 +44,9 @@
 						{{ t('spreed', 'Share the screen') }}
 					</NcCheckboxRadioSwitch>
 					<NcButton ref="submit"
-						native-type="submit"
+						type="submit"
 						class="button-update-permission"
-						type="primary"
+						variant="primary"
 						:disabled="submitButtonDisabled">
 						{{ t('spreed', 'Update permissions') }}
 					</NcButton>

--- a/src/components/PollViewer/PollEditor.vue
+++ b/src/components/PollViewer/PollEditor.vue
@@ -11,7 +11,7 @@
 		@update:open="emit('close')">
 		<NcButton v-if="supportPollDrafts && isOpenedFromDraft"
 			class="poll-editor__back-button"
-			type="tertiary"
+			variant="tertiary"
 			:title="t('spreed', 'Back')"
 			:aria-label="t('spreed', 'Back')"
 			@click="goBack">
@@ -58,7 +58,7 @@
 				v-model="pollForm.options[index]"
 				:label="t('spreed', 'Answer {option}', { option: index + 1 })" />
 			<NcButton v-if="pollForm.options.length > 2"
-				type="tertiary"
+				variant="tertiary"
 				:aria-label="t('spreed', 'Delete poll option')"
 				@click="deleteOption(index)">
 				<template #icon>
@@ -68,7 +68,7 @@
 		</div>
 
 		<!-- Add options -->
-		<NcButton class="poll-editor__add-more" type="tertiary" @click="addOption">
+		<NcButton class="poll-editor__add-more" variant="tertiary" @click="addOption">
 			<template #icon>
 				<Plus />
 			</template>
@@ -102,7 +102,7 @@
 					{{ t('spreed', 'Export draft to file') }}
 				</NcActionLink>
 			</NcActions>
-			<NcButton type="primary" :disabled="!isFilled" @click="handleSubmit">
+			<NcButton variant="primary" :disabled="!isFilled" @click="handleSubmit">
 				{{ createPollLabel }}
 			</NcButton>
 		</template>

--- a/src/components/PollViewer/PollViewer.vue
+++ b/src/components/PollViewer/PollViewer.vue
@@ -62,14 +62,14 @@
 			<div v-if="isPollOpen" class="poll-modal__actions">
 				<!-- Submit vote button-->
 				<NcButton v-if="modalPage === 'voting'"
-					type="primary"
+					variant="primary"
 					:disabled="disabled"
 					@click="submitVote">
 					{{ t('spreed', 'Submit vote') }}
 				</NcButton>
 				<!-- Vote again-->
 				<NcButton v-else
-					type="secondary"
+					variant="secondary"
 					@click="modalPage = 'voting'">
 					{{ t('spreed', 'Change your vote') }}
 				</NcButton>

--- a/src/components/PollViewer/PollVotersDetails.vue
+++ b/src/components/PollViewer/PollVotersDetails.vue
@@ -6,7 +6,7 @@
 <template>
 	<NcPopover class="poll-voters-details" trigger="hover">
 		<template #trigger>
-			<NcButton type="tertiary-no-background"
+			<NcButton variant="tertiary-no-background"
 				:aria-label="t('spreed', 'Voted participants')"
 				class="poll-voters-details__button">
 				<template #icon>

--- a/src/components/Quote.vue
+++ b/src/components/Quote.vue
@@ -43,7 +43,7 @@ components.
 
 		<NcButton v-if="canCancel"
 			class="quote__close"
-			type="tertiary"
+			variant="tertiary"
 			:title="cancelQuoteLabel"
 			:aria-label="cancelQuoteLabel"
 			@click="handleAbort">

--- a/src/components/RightSidebar/BreakoutRooms/BreakoutRoomItem.vue
+++ b/src/components/RightSidebar/BreakoutRooms/BreakoutRoomItem.vue
@@ -9,7 +9,7 @@
 		@mouseenter="elementHoveredOrFocused = true"
 		@mouseleave="elementHoveredOrFocused = false">
 		<div class="breakout-room-item__wrapper">
-			<NcButton type="tertiary"
+			<NcButton variant="tertiary"
 				:aria-label="toggleParticipantsListLabel"
 				@focus="elementHoveredOrFocused = true"
 				@blur="elementHoveredOrFocused = false"

--- a/src/components/RightSidebar/BreakoutRooms/BreakoutRoomsActions.vue
+++ b/src/components/RightSidebar/BreakoutRooms/BreakoutRoomsActions.vue
@@ -11,7 +11,7 @@
 			<NcButton v-if="breakoutRoomsNotStarted && canModerate"
 				:title="startLabelTitle"
 				:aria-label="startLabel"
-				type="primary"
+				variant="primary"
 				:wide="true"
 				:disabled="!isInCall"
 				@click="startBreakoutRooms">
@@ -23,7 +23,7 @@
 			<NcButton v-else-if="canModerate"
 				:title="stopLabel"
 				:aria-label="stopLabel"
-				type="error"
+				variant="error"
 				:wide="true"
 				@click="stopBreakoutRooms">
 				<template #icon>
@@ -36,7 +36,7 @@
 			<NcButton v-if="canModerate && !isInBreakoutRoom"
 				:title="sendMessageLabel"
 				:aria-label="sendMessageLabel"
-				type="secondary"
+				variant="secondary"
 				:wide="true"
 				@click="isSendMessageDialogOpened = true">
 				<template #icon>
@@ -48,7 +48,7 @@
 				:title="backToMainRoomLabel"
 				:aria-label="backToMainRoomLabel"
 				:wide="true"
-				type="secondary"
+				variant="secondary"
 				@click="switchToParentRoom">
 				<template #icon>
 					<IconArrowLeft class="bidirectional-icon" :size="20" />
@@ -59,7 +59,7 @@
 				:title="backToBreakoutRoomLabel"
 				:aria-label="backToBreakoutRoomLabel"
 				:wide="true"
-				type="secondary"
+				variant="secondary"
 				@click="switchToBreakoutRoom">
 				<template #icon>
 					<ArrowRight class="bidirectional-icon" :size="20" />

--- a/src/components/RightSidebar/LobbyStatus.vue
+++ b/src/components/RightSidebar/LobbyStatus.vue
@@ -39,7 +39,7 @@ async function disableLobby() {
 
 <template>
 	<div class="lobby-status">
-		<NcButton type="success" @click="disableLobby">
+		<NcButton variant="success" @click="disableLobby">
 			<template #icon>
 				<IconLockOpen :size="20" />
 			</template>

--- a/src/components/RightSidebar/Participants/Participant.vue
+++ b/src/components/RightSidebar/Participants/Participant.vue
@@ -49,7 +49,7 @@
 			<!-- Phone participant dial action -->
 			<template v-if="isInCall && canBeModerated && isPhoneActor">
 				<NcButton v-if="!participant.inCall"
-					type="success"
+					variant="success"
 					:aria-label="t('spreed', 'Dial out phone')"
 					:title="t('spreed', 'Dial out phone')"
 					:disabled="disabled"
@@ -59,7 +59,7 @@
 					</template>
 				</NcButton>
 				<template v-else>
-					<NcButton type="error"
+					<NcButton variant="error"
 						:aria-label="t('spreed', 'Hang up phone')"
 						:title="t('spreed', 'Hang up phone')"
 						:disabled="disabled"
@@ -85,7 +85,7 @@
 			<!-- Grant or revoke lobby permissions (inline button) -->
 			<template v-if="showToggleLobbyAction">
 				<NcButton v-if="canSkipLobby"
-					type="tertiary"
+					variant="tertiary"
 					:title="t('spreed', 'Move back to lobby')"
 					:aria-label="t('spreed', 'Move back to lobby')"
 					@click="setLobbyPermission(false)">
@@ -94,7 +94,7 @@
 					</template>
 				</NcButton>
 				<NcButton v-else
-					type="tertiary"
+					variant="tertiary"
 					:title="t('spreed', 'Move to conversation')"
 					:aria-label="t('spreed', 'Move to conversation')"
 					@click="setLobbyPermission(true)">
@@ -295,10 +295,10 @@
 					</template>
 				</template>
 				<template #actions>
-					<NcButton type="tertiary" :disabled="isLoading" @click="isRemoveDialogOpen = false">
+					<NcButton variant="tertiary" :disabled="isLoading" @click="isRemoveDialogOpen = false">
 						{{ t('spreed', 'Dismiss') }}
 					</NcButton>
-					<NcButton type="error" :disabled="isLoading || !!maxLengthWarning" @click="removeParticipant">
+					<NcButton variant="error" :disabled="isLoading || !!maxLengthWarning" @click="removeParticipant">
 						{{ t('spreed', 'Remove') }}
 					</NcButton>
 				</template>

--- a/src/components/RightSidebar/Participants/ParticipantsSearchResults.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsSearchResults.vue
@@ -40,7 +40,7 @@
 				<ul>
 					<NcButton v-for="(integration, index) in integrations"
 						:key="'integration' + index"
-						type="tertiary-no-background"
+						variant="tertiary-no-background"
 						@click="runIntegration(integration)">
 						<!-- FIXME: dynamically change the material design icon -->
 						<template #icon>
@@ -71,7 +71,7 @@
 			</NcEmptyContent>
 			<NcButton v-else-if="displaySearchHint"
 				class="participants-search-results__hint"
-				type="tertiary"
+				variant="tertiary"
 				@click="handleClickHint">
 				<template #icon>
 					<AccountSearch :size="20" />

--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -90,7 +90,7 @@
 				<SipSettings v-if="showSIPSettings" :conversation="conversation" />
 				<div v-if="!getUserId" id="app-settings">
 					<div id="app-settings-header">
-						<NcButton type="tertiary" @click="showSettings">
+						<NcButton variant="tertiary" @click="showSettings">
 							<template #icon>
 								<IconCog :size="20" />
 							</template>

--- a/src/components/RightSidebar/RightSidebarContent.vue
+++ b/src/components/RightSidebar/RightSidebarContent.vue
@@ -198,7 +198,7 @@ function handleHeaderClick() {
 						{{ action.title }}
 					</NcActionLink>
 				</NcActions>
-				<NcButton type="tertiary"
+				<NcButton variant="tertiary"
 					:title="t('spreed', 'Search messages')"
 					:aria-label="t('spreed', 'Search messages')"
 					@click="emit('update:search', true)">
@@ -263,7 +263,7 @@ function handleHeaderClick() {
 		<!-- Search messages in this conversation -->
 		<template v-else-if="isUser && state === 'search'">
 			<div class="content__header content__header--row">
-				<NcButton type="tertiary"
+				<NcButton variant="tertiary"
 					:title="t('spreed', 'Back')"
 					:aria-label="t('spreed', 'Back')"
 					@click="emit('update:search', false)">

--- a/src/components/RightSidebar/SearchMessages/SearchMessagesTab.vue
+++ b/src/components/RightSidebar/SearchMessages/SearchMessagesTab.vue
@@ -297,7 +297,7 @@ watch([searchText, fromUser, sinceDate, untilDate], debounceFetchSearchResults)
 					<div v-show="hasFilter && !searchDetailsOpened"
 						class="search-form__search-bubbles">
 						<NcChip v-if="fromUser"
-							type="tertiary"
+							variant="tertiary"
 							:text="fromUser.displayName"
 							@close="fromUser = null">
 							<template #icon>
@@ -308,7 +308,7 @@ watch([searchText, fromUser, sinceDate, untilDate], debounceFetchSearchResults)
 							</template>
 						</NcChip>
 						<NcChip v-if="sinceDate"
-							type="tertiary"
+							variant="tertiary"
 							:text="t('spreed', 'Since') + ' ' + sinceDate?.toLocaleDateString()"
 							@close="sinceDate = null">
 							<template #icon>
@@ -316,7 +316,7 @@ watch([searchText, fromUser, sinceDate, untilDate], debounceFetchSearchResults)
 							</template>
 						</NcChip>
 						<NcChip v-if="untilDate"
-							type="tertiary"
+							variant="tertiary"
 							:text="t('spreed', 'Until') + ' ' + untilDate?.toLocaleDateString()"
 							@close="untilDate = null">
 							<template #icon>

--- a/src/components/RightSidebar/SearchMessages/SearchMessagesTab.vue
+++ b/src/components/RightSidebar/SearchMessages/SearchMessagesTab.vue
@@ -256,7 +256,7 @@ watch([searchText, fromUser, sinceDate, untilDate], debounceFetchSearchResults)
 					<NcButton :pressed.sync="searchDetailsOpened"
 						:aria-label="t('spreed', 'Search options')"
 						:title="t('spreed', 'Search options')"
-						type="tertiary-no-background">
+						variant="tertiary-no-background">
 						<template #icon>
 							<IconFilter :size="15" />
 						</template>
@@ -348,7 +348,7 @@ watch([searchText, fromUser, sinceDate, untilDate], debounceFetchSearchResults)
 				</template>
 			</NcEmptyContent>
 			<template v-if="canLoadMore">
-				<NcButton wide type="tertiary" @click="fetchSearchResults(false)">
+				<NcButton wide variant="tertiary" @click="fetchSearchResults(false)">
 					{{ t('spreed', 'Load more results') }}
 				</NcButton>
 			</template>

--- a/src/components/RightSidebar/SharedItems/SharedItemsBrowser.vue
+++ b/src/components/RightSidebar/SharedItems/SharedItemsBrowser.vue
@@ -16,7 +16,7 @@
 					<NcButton v-if="sharedItems[type]"
 						:key="type"
 						:class="{ active: activeTab === type }"
-						type="tertiary"
+						variant="tertiary"
 						@click="handleTabClick(type)">
 						{{ sharedItemTitle[type] || sharedItemTitle.default }}
 					</NcButton>

--- a/src/components/RightSidebar/SharedItems/SharedItemsTab.vue
+++ b/src/components/RightSidebar/SharedItems/SharedItemsTab.vue
@@ -26,7 +26,7 @@
 						:limit="limit(type)"
 						:items="sharedItems[type]" />
 					<NcButton v-if="hasMore(type, sharedItems[type])"
-						type="tertiary-no-background"
+						variant="tertiary-no-background"
 						class="more"
 						wide
 						@click="showMore(type)">

--- a/src/components/RoomSelector.vue
+++ b/src/components/RoomSelector.vue
@@ -38,7 +38,7 @@
 		<template #actions>
 			<NcButton v-if="!loading && availableRooms.length > 0"
 				class="selector__action"
-				type="primary"
+				variant="primary"
 				:disabled="!selectedRoom"
 				@click="onSubmit">
 				{{ t('spreed', 'Select conversation') }}

--- a/src/components/SetGuestUsername.vue
+++ b/src/components/SetGuestUsername.vue
@@ -30,7 +30,7 @@
 
 		<div class="login-info">
 			<span> {{ t('spreed', 'Do you already have an account?') }}</span>
-			<NcButton type="secondary"
+			<NcButton variant="secondary"
 				:href="getLoginUrl()">
 				{{ t('spreed', 'Log in') }}
 			</NcButton>

--- a/src/components/SettingsDialog/SettingsDialog.vue
+++ b/src/components/SettingsDialog/SettingsDialog.vue
@@ -340,7 +340,7 @@ export default {
 			return [{
 				label: t('spreed', 'Choose'),
 				callback: (nodes) => this.selectAttachmentFolder(nodes),
-				type: 'primary',
+				variant: 'primary',
 			}]
 		},
 	},

--- a/src/components/SettingsDialog/SettingsDialog.vue
+++ b/src/components/SettingsDialog/SettingsDialog.vue
@@ -41,7 +41,7 @@
 				<p class="app-settings-section__input" @click="showFilePicker = true">
 					{{ attachmentFolder }}
 				</p>
-				<NcButton type="primary"
+				<NcButton variant="primary"
 					@click="showFilePicker = true">
 					{{ t('spreed', 'Browse …') }}
 				</NcButton>

--- a/src/components/TopBar/CallButton.vue
+++ b/src/components/TopBar/CallButton.vue
@@ -10,7 +10,7 @@
 			:title="startCallTitle"
 			:aria-label="startCallLabel"
 			:disabled="startCallButtonDisabled || loading || isJoiningCall"
-			:type="startCallButtonType"
+			:variant="hasCall ? 'success' : 'primary'"
 			@click="handleClick">
 			<template #icon>
 				<NcLoadingIcon v-if="isJoiningCall || loading" :size="20" />
@@ -307,17 +307,6 @@ export default {
 				return t('spreed', 'You will be able to join the call only after a moderator starts it.')
 			}
 
-			return ''
-		},
-
-		startCallButtonType() {
-			if (!this.isInLobby) {
-				if (!this.hasCall) {
-					return 'primary'
-				} else {
-					return 'success'
-				}
-			}
 			return ''
 		},
 

--- a/src/components/TopBar/CallButton.vue
+++ b/src/components/TopBar/CallButton.vue
@@ -56,7 +56,7 @@
 			:aria-label="leaveCallCombinedLabel"
 			:menu-name="showButtonText ? leaveCallCombinedLabel : undefined"
 			force-name
-			:type="isScreensharing ? 'tertiary' : 'error'">
+			:variant="isScreensharing ? 'tertiary' : 'error'">
 			<template #icon>
 				<NcLoadingIcon v-if="loading" :size="20" />
 				<IconPhoneHangup v-else-if="!isBreakoutRoom" :size="20" />

--- a/src/components/TopBar/CallButton.vue
+++ b/src/components/TopBar/CallButton.vue
@@ -26,7 +26,7 @@
 		<NcButton v-else-if="showLeaveCallButton && canEndForAll && isPhoneRoom"
 			id="call_button"
 			:aria-label="endCallLabel"
-			type="error"
+			variant="error"
 			:disabled="loading"
 			@click="leaveCall(true)">
 			<template #icon>
@@ -40,7 +40,7 @@
 		<NcButton v-else-if="showLeaveCallButton && !canEndForAll && !isBreakoutRoom"
 			id="call_button"
 			:aria-label="leaveCallLabel"
-			:type="isScreensharing ? 'tertiary' : 'error'"
+			:variant="isScreensharing ? 'tertiary' : 'error'"
 			:disabled="loading"
 			@click="leaveCall(false)">
 			<template #icon>

--- a/src/components/TopBar/CallTime.vue
+++ b/src/components/TopBar/CallTime.vue
@@ -6,7 +6,7 @@
 <template>
 	<NcPopover class="call-time"
 		:shown.sync="showPopover"
-		:focus-trap="isShowRecordingControls"
+		:no-focus-trap="!isShowRecordingControls"
 		:triggers="[]">
 		<template #trigger>
 			<NcButton :disabled="isButtonDisabled"

--- a/src/components/TopBar/CallTime.vue
+++ b/src/components/TopBar/CallTime.vue
@@ -12,7 +12,7 @@
 			<NcButton :disabled="isButtonDisabled"
 				:wide="true"
 				:title="recordingButtonTitle"
-				type="tertiary"
+				variant="tertiary"
 				@click="showPopover = !showPopover">
 				<template v-if="isRecording || isStartingRecording" #icon>
 					<IconRecordCircle v-if="isRecording"
@@ -38,7 +38,7 @@
 		<template v-if="isShowRecordingControls">
 			<hr v-if="isCallDurationHintShown" class="solid">
 			<NcButton v-if="isStartingRecording"
-				type="tertiary-no-background"
+				variant="tertiary-no-background"
 				:wide="true"
 				@click="stopRecording">
 				<template #icon>
@@ -47,7 +47,7 @@
 				{{ t('spreed', 'Cancel recording start') }}
 			</NcButton>
 			<NcButton v-else
-				type="tertiary-no-background"
+				variant="tertiary-no-background"
 				:wide="true"
 				@click="stopRecording">
 				<template #icon>

--- a/src/components/TopBar/ReactionMenu.vue
+++ b/src/components/TopBar/ReactionMenu.vue
@@ -4,7 +4,7 @@
 -->
 
 <template>
-	<NcActions type="tertiary"
+	<NcActions variant="tertiary"
 		:title="t('spreed', 'Send a reaction')"
 		:aria-label="t('spreed', 'Send a reaction')"
 		class="reaction">

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -68,7 +68,7 @@
 			<NcButton v-if="isInCall && isModeratorOrUser"
 				:title="participantsInCallAriaLabel"
 				:aria-label="participantsInCallAriaLabel"
-				type="tertiary"
+				variant="tertiary"
 				@click="openSidebar('participants')">
 				<template #icon>
 					<IconAccountMultiplePlus v-if="canExtendOneToOneConversation" :size="20" />

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -36,7 +36,7 @@
 						{{ statusMessage }}
 					</p>
 					<NcPopover v-if="conversation.description"
-						:focus-trap="false"
+						no-focus-trap
 						:delay="500"
 						:boundary="boundaryElement"
 						:popper-triggers="['hover']"

--- a/src/components/TopBar/TopBarMediaControls.vue
+++ b/src/components/TopBar/TopBarMediaControls.vue
@@ -14,7 +14,7 @@
 				:shown="showQualityWarningTooltip">
 				<template #trigger>
 					<NcButton id="quality_warning_button"
-						type="tertiary-no-background"
+						variant="tertiary-no-background"
 						class="trigger"
 						:aria-label="qualityWarningAriaLabel"
 						@click="mouseover = !mouseover">
@@ -27,13 +27,13 @@
 					<span>{{ qualityWarningTooltip.content }}</span>
 					<div class="hint__actions">
 						<NcButton v-if="qualityWarningTooltip.action"
-							type="primary"
+							variant="primary"
 							class="hint__button"
 							@click="executeQualityWarningTooltipAction">
 							{{ qualityWarningTooltip.actionLabel }}
 						</NcButton>
 						<NcButton v-if="!isQualityWarningTooltipDismissed"
-							type="tertiary"
+							variant="tertiary"
 							class="hint__button"
 							@click="dismissQualityWarningTooltip">
 							{{ t('spreed', 'Dismiss') }}
@@ -55,7 +55,7 @@
 
 		<NcButton v-if="isVirtualBackgroundAvailable && isSidebar"
 			:title="toggleVirtualBackgroundButtonLabel"
-			type="tertiary"
+			variant="tertiary"
 			:aria-label="toggleVirtualBackgroundButtonLabel"
 			:class="blurButtonClass"
 			@click.stop="toggleVirtualBackground">
@@ -94,7 +94,7 @@
 		</NcActions>
 		<NcButton v-else-if="!isSidebar"
 			:title="screenSharingButtonTitle"
-			type="tertiary"
+			variant="tertiary"
 			:aria-label="screenSharingButtonAriaLabel"
 			:disabled="!isScreensharingAllowed"
 			@click.stop="toggleScreenSharingMenu">

--- a/src/components/TopBar/TopBarMediaControls.vue
+++ b/src/components/TopBar/TopBarMediaControls.vue
@@ -46,12 +46,12 @@
 		<LocalAudioControlButton :token="token"
 			:conversation="conversation"
 			:model="model"
-			type="tertiary" />
+			variant="tertiary" />
 
 		<LocalVideoControlButton :token="token"
 			:conversation="conversation"
 			:model="model"
-			type="tertiary" />
+			variant="tertiary" />
 
 		<NcButton v-if="isVirtualBackgroundAvailable && isSidebar"
 			:title="toggleVirtualBackgroundButtonLabel"

--- a/src/components/TopBar/TopBarMediaControls.vue
+++ b/src/components/TopBar/TopBarMediaControls.vue
@@ -10,7 +10,7 @@
 				:aria-label="qualityWarningAriaLabel"
 				trigger="hover"
 				:auto-hide="false"
-				:focus-trap="false"
+				no-focus-trap
 				:shown="showQualityWarningTooltip">
 				<template #trigger>
 					<NcButton id="quality_warning_button"

--- a/src/components/TopBar/TopBarMediaControls.vue
+++ b/src/components/TopBar/TopBarMediaControls.vue
@@ -68,7 +68,7 @@
 		<NcActions v-if="!isSidebar && isScreensharing"
 			id="screensharing-button"
 			:title="screenSharingButtonTitle"
-			type="error"
+			variant="error"
 			:aria-label="screenSharingButtonAriaLabel"
 			:class="screenSharingButtonClass"
 			class="app-navigation-entry-utils-menu-button"

--- a/src/components/TopBar/TopBarMenu.vue
+++ b/src/components/TopBar/TopBarMenu.vue
@@ -8,7 +8,7 @@
 		<TransitionExpand v-if="isInCall" :show="isHandRaised" direction="horizontal">
 			<NcButton :title="raiseHandButtonLabel"
 				:aria-label="raiseHandButtonLabel"
-				type="tertiary"
+				variant="tertiary"
 				@click.stop="toggleHandRaised">
 				<template #icon>
 					<!-- The following icon is much bigger than all the others

--- a/src/components/TopBar/TopBarMenu.vue
+++ b/src/components/TopBar/TopBarMenu.vue
@@ -21,7 +21,7 @@
 		<NcActions v-if="!isSidebar"
 			:title="t('spreed', 'Conversation actions')"
 			:aria-label="t('spreed', 'Conversation actions')"
-			type="tertiary">
+			variant="tertiary">
 			<!-- Menu icon: white if in call -->
 			<template v-if="isInCall" #icon>
 				<IconDotsHorizontal :size="20" />

--- a/src/components/UIShared/ConfirmDialog.vue
+++ b/src/components/UIShared/ConfirmDialog.vue
@@ -11,9 +11,6 @@ type NcDialogButtonProps = {
 	callback?: () => unknown | false | Promise<unknown | false>
 	disabled?: boolean
 	icon?: string
-	// FIXME deprecated, use type since 8.24.0
-	nativeType?: string
-	// FIXME deprecated, use variant since 8.24.0
 	type?: string
 	variant?: string
 }

--- a/src/components/UIShared/ConversationActionsShortcut.vue
+++ b/src/components/UIShared/ConversationActionsShortcut.vue
@@ -110,7 +110,7 @@ async function showConfirmationDialog() {
 		<p>{{ descriptionLabel }}</p>
 		<div v-if="isModerator"
 			class="conversation-actions__buttons">
-			<NcButton type="error"
+			<NcButton variant="error"
 				@click="showConfirmationDialog">
 				<template #icon>
 					<IconDelete />
@@ -118,7 +118,7 @@ async function showConfirmationDialog() {
 				{{ t('spreed', 'Delete now') }}
 			</NcButton>
 			<NcButton v-if="supportsArchive"
-				type="secondary"
+				variant="secondary"
 				@click="resetObjectConversation">
 				<template #icon>
 					<IconCheckUnderline />

--- a/src/components/UIShared/ConversationActionsShortcut.vue
+++ b/src/components/UIShared/ConversationActionsShortcut.vue
@@ -89,11 +89,11 @@ async function showConfirmationDialog() {
 		buttons: [
 			{
 				label: t('spreed', 'No'),
-				type: 'tertiary',
+				variant: 'tertiary',
 			},
 			{
 				label: t('spreed', 'Yes'),
-				type: 'error',
+				variant: 'error',
 				callback: () => {
 					deleteEventConversation()
 				},

--- a/src/components/UIShared/DialpadPanel.vue
+++ b/src/components/UIShared/DialpadPanel.vue
@@ -55,7 +55,7 @@
 
 			<NcButton v-if="!dialing"
 				class="dial-panel__button"
-				type="tertiary"
+				variant="tertiary"
 				:aria-label="t('spreed', 'Delete')"
 				@click="handleBackspace">
 				<template #icon>

--- a/src/components/UIShared/EditableTextField.vue
+++ b/src/components/UIShared/EditableTextField.vue
@@ -24,14 +24,14 @@
 			@keydown.esc="handleCancelEditing" />
 		<template v-if="!loading">
 			<template v-if="editing">
-				<NcButton type="tertiary"
+				<NcButton variant="tertiary"
 					:aria-label="t('spreed', 'Cancel editing')"
 					@click="handleCancelEditing">
 					<template #icon>
 						<IconClose :size="20" />
 					</template>
 				</NcButton>
-				<NcButton type="primary"
+				<NcButton variant="primary"
 					:aria-label="t('spreed', 'Submit')"
 					:disabled="!canSubmit"
 					@click="handleSubmitText">
@@ -48,7 +48,7 @@
 				</div>
 			</template>
 			<NcButton v-if="!editing && editable"
-				type="tertiary"
+				variant="tertiary"
 				class="editable-text-field__edit"
 				:aria-label="editButtonAriaLabel"
 				@click="handleEditText">

--- a/src/composables/useSessionIssueHandler.ts
+++ b/src/composables/useSessionIssueHandler.ts
@@ -75,7 +75,7 @@ export function useSessionIssueHandler(): DeepReadonly<Ref<boolean>> {
 				},
 				{
 					label: t('spreed', 'Join here'),
-					type: 'primary',
+					variant: 'primary',
 					callback: () => true,
 				},
 			],


### PR DESCRIPTION
### ☑️ Resolves

* Fix usage of props deprecated in Vue 3 libraries
 * See separate commits:
   * auto fixed `type|variant` by eslint (including some props from unreleased https://github.com/nextcloud-libraries/eslint-config/pull/1069)
   * manually fixed `type|variant` (can not be covered by lib)
   * manually fixed `focus-trap`
   * manually fixed `close-on-select`

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

No visual changes

### 🚧 Tasks

```
error  Using `user-select` is deprecated - use `NcSelectUsers` component instead  @nextcloud/vue/no-deprecated-props
```
 - does not emit selected value for v-model


### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
