### PR TITLE
fix: migrate to getCSPNonce

### DIFF
--- a/src/collections.js
+++ b/src/collections.js
@@ -3,10 +3,11 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import { getCSPNonce } from '@nextcloud/auth'
 import { t } from '@nextcloud/l10n'
 import { requestRoomSelection } from './utils/requestRoomSelection.js'
 
-__webpack_nonce__ = btoa(OC.requestToken)
+__webpack_nonce__ = getCSPNonce()
 // eslint-disable-next-line
 __webpack_public_path__ = OC.linkTo('spreed', 'js/')
 

--- a/src/deck.js
+++ b/src/deck.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { getRequestToken } from '@nextcloud/auth'
+import { getCSPNonce } from '@nextcloud/auth'
 import { showError, showSuccess } from '@nextcloud/dialogs'
 import { t } from '@nextcloud/l10n'
 import { generateFilePath, generateUrl } from '@nextcloud/router'
@@ -71,7 +71,7 @@ function init() {
 }
 
 // CSP config for webpack dynamic chunk loading
-__webpack_nonce__ = btoa(getRequestToken())
+__webpack_nonce__ = getCSPNonce()
 
 // Correct the root of the app for chunk loading
 // OC.linkTo matches the apps folders

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -2,6 +2,7 @@
  * SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+import type { getCSPNonce } from '@nextcloud/auth'
 
 type ExitFullscreen = typeof document.exitFullscreen
 type RequestFullscreen = typeof document.documentElement.requestFullscreen
@@ -41,7 +42,7 @@ declare global {
 	 */
 	const IS_DESKTOP: false
 
-	let __webpack_nonce__: ReturnType<typeof btoa>
+	let __webpack_nonce__: ReturnType<typeof getCSPNonce>
 	let __webpack_public_path__: string
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { getRequestToken } from '@nextcloud/auth'
+import { getCSPNonce } from '@nextcloud/auth'
 import { emit } from '@nextcloud/event-bus'
 import { generateFilePath } from '@nextcloud/router'
 import Vue, { watch } from 'vue'
@@ -24,7 +24,7 @@ import 'leaflet-defaulticon-compatibility'
 
 if (!IS_DESKTOP) {
 	// CSP config for webpack dynamic chunk loading
-	__webpack_nonce__ = btoa(getRequestToken())
+	__webpack_nonce__ = getCSPNonce()
 
 	// Correct the root of the app for chunk loading
 	// OC.linkTo matches the apps folders

--- a/src/mainFilesSidebar.js
+++ b/src/mainFilesSidebar.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { getRequestToken } from '@nextcloud/auth'
+import { getCSPNonce } from '@nextcloud/auth'
 import { generateFilePath } from '@nextcloud/router'
 import Vue from 'vue'
 import Vuex from 'vuex'
@@ -19,7 +19,7 @@ import 'leaflet-defaulticon-compatibility/dist/leaflet-defaulticon-compatibility
 import 'leaflet-defaulticon-compatibility'
 
 // CSP config for webpack dynamic chunk loading
-__webpack_nonce__ = btoa(getRequestToken())
+__webpack_nonce__ = getCSPNonce()
 
 // Correct the root of the app for chunk loading
 // OC.linkTo matches the apps folders

--- a/src/mainPublicShareAuthSidebar.js
+++ b/src/mainPublicShareAuthSidebar.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { getRequestToken } from '@nextcloud/auth'
+import { getCSPNonce } from '@nextcloud/auth'
 import { generateFilePath } from '@nextcloud/router'
 import Vue from 'vue'
 import Vuex from 'vuex'
@@ -19,7 +19,7 @@ import 'leaflet-defaulticon-compatibility/dist/leaflet-defaulticon-compatibility
 import 'leaflet-defaulticon-compatibility'
 
 // CSP config for webpack dynamic chunk loading
-__webpack_nonce__ = btoa(getRequestToken())
+__webpack_nonce__ = getCSPNonce()
 
 // Correct the root of the app for chunk loading
 // OC.linkTo matches the apps folders

--- a/src/mainPublicShareSidebar.js
+++ b/src/mainPublicShareSidebar.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { getRequestToken } from '@nextcloud/auth'
+import { getCSPNonce } from '@nextcloud/auth'
 import { generateFilePath } from '@nextcloud/router'
 import { getSharingToken } from '@nextcloud/sharing/public'
 import Vue, { reactive } from 'vue'
@@ -20,7 +20,7 @@ import 'leaflet-defaulticon-compatibility/dist/leaflet-defaulticon-compatibility
 import 'leaflet-defaulticon-compatibility'
 
 // CSP config for webpack dynamic chunk loading
-__webpack_nonce__ = btoa(getRequestToken())
+__webpack_nonce__ = getCSPNonce()
 
 // Correct the root of the app for chunk loading
 // OC.linkTo matches the apps folders

--- a/src/mainRecording.js
+++ b/src/mainRecording.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { getRequestToken } from '@nextcloud/auth'
+import { getCSPNonce } from '@nextcloud/auth'
 import { generateFilePath } from '@nextcloud/router'
 import Vue from 'vue'
 import VueRouter from 'vue-router'
@@ -26,7 +26,7 @@ import 'leaflet-defaulticon-compatibility/dist/leaflet-defaulticon-compatibility
 import 'leaflet-defaulticon-compatibility'
 
 // CSP config for webpack dynamic chunk loading
-__webpack_nonce__ = btoa(getRequestToken())
+__webpack_nonce__ = getCSPNonce()
 
 // Correct the root of the app for chunk loading
 // OC.linkTo matches the apps folders

--- a/src/maps.js
+++ b/src/maps.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { getRequestToken } from '@nextcloud/auth'
+import { getCSPNonce } from '@nextcloud/auth'
 import { showError, showSuccess } from '@nextcloud/dialogs'
 import { t } from '@nextcloud/l10n'
 import { generateFilePath, generateUrl } from '@nextcloud/router'
@@ -69,7 +69,7 @@ function init() {
 }
 
 // CSP config for webpack dynamic chunk loading
-__webpack_nonce__ = btoa(getRequestToken())
+__webpack_nonce__ = getCSPNonce()
 
 // Correct the root of the app for chunk loading
 // OC.linkTo matches the apps folders

--- a/src/search.js
+++ b/src/search.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { getRequestToken } from '@nextcloud/auth'
+import { getCSPNonce } from '@nextcloud/auth'
 import { emit } from '@nextcloud/event-bus'
 import { t } from '@nextcloud/l10n'
 import { generateFilePath, imagePath } from '@nextcloud/router'
@@ -42,7 +42,7 @@ function init() {
 }
 
 // CSP config for webpack dynamic chunk loading
-__webpack_nonce__ = btoa(getRequestToken())
+__webpack_nonce__ = getCSPNonce()
 
 // Correct the root of the app for chunk loading
 // OC.linkTo matches the apps folders


### PR DESCRIPTION
### ☑️ Resolves

* Migrate to using `getCSPNonce` according to https://docs.nextcloud.com/server/latest/developer_manual/app_publishing_maintenance/app_upgrade_guide/upgrade_to_30.html#csp-nonce

## 🖌️ UI Checklist

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client