### PR TITLE
fix(AdminSettings): show errors in UI when testing websocket connection

### DIFF
--- a/src/components/AdminSettings/SignalingServer.vue
+++ b/src/components/AdminSettings/SignalingServer.vue
@@ -247,6 +247,10 @@ export default {
 					this.errorMessage = t('spreed', 'Error: Websocket connection failed')
 					this.signalingTestInfo.push({ caption: t('spreed', 'Error code'), description: exception.socketMessage.error.code })
 					this.signalingTestInfo.push({ caption: t('spreed', 'Error message'), description: exception.socketMessage.error.message })
+				} else if (exception.CSPViolation) {
+					this.warningMessage = t('spreed', 'Error: Websocket connection failed')
+					this.signalingTestInfo.push({ caption: t('spreed', 'Error code'), description: exception.CSPViolation.type })
+					this.signalingTestInfo.push({ caption: t('spreed', 'Error message'), description: exception.CSPViolation.message })
 				} else {
 					console.error(exception)
 					this.errorMessage = t('spreed', 'Error: Websocket connection failed. Check browser console')

--- a/src/utils/SignalingStandaloneTest.js
+++ b/src/utils/SignalingStandaloneTest.js
@@ -4,6 +4,7 @@
  */
 
 import { generateOcsUrl } from '@nextcloud/router'
+import { isFirefox } from '../utils/browserCheck.ts'
 
 /**
  * This is a simplified version of Signaling prototype (see signaling.js)
@@ -43,6 +44,31 @@ class StandaloneTest {
 	connect() {
 		console.debug('Connecting to %s with params:', this.url, this.settings)
 
+		// If server url was changed, it is likely a CSP 'connect-src' mismatch
+		let CSPObserver = null
+		let CSPViolation = null
+
+		if ('ReportingObserver' in window) {
+			CSPObserver = new ReportingObserver(
+				([report]) => {
+					CSPViolation = {
+						...report.toJSON(),
+						message: 'CSP violation while connecting to WebSocket. Page reload is required',
+					}
+				},
+				{
+					types: ['csp-violation'],
+					buffered: false,
+				},
+			)
+			CSPObserver.observe()
+		} else {
+			console.warn('ReportingObserver is not available, CSP violations will not be reported')
+			if (isFirefox) {
+				console.warn('Visit about:config and set "dom.reporting.enabled" to "true" to enable CSP reporting')
+			}
+		}
+
 		return new Promise((resolve, reject) => {
 			this.socket = new WebSocket(this.url)
 
@@ -58,9 +84,14 @@ class StandaloneTest {
 			this.socket.onerror = (event) => {
 				console.error('Error on websocket', event)
 				this.disconnect()
+				if (CSPViolation) {
+					event.CSPViolation = CSPViolation
+				}
+				reject(event)
 			}
 
 			this.socket.onclose = (event) => {
+				CSPObserver?.disconnect()
 				if (event.wasClean) {
 					console.info('Connection closed cleanly:', event)
 					resolve(true)


### PR DESCRIPTION
### ☑️ Resolves

* Provides more explicit information for instance administrators about issues while testing Websocket connection

>[!IMPORTANT]
> 🔬 To test:
> - CSP violation:
>   - remove HPB
>   - reload page (CSP rules updated)
>   - add HPB
>   - wait for websocket connection
> - Hello error (easy way for invalid_backend):
>   - open HPB config
>   - disable or comment `allowall`
>   - for [backend-1] set incorrect url

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before 
CSP doesn't throw error, we're in infinite loading UI
![image](https://github.com/user-attachments/assets/0ac862b8-6cd7-4987-aef5-6fcb3920b07b)
Error from hello message doesn't throw error, we're in OK state
![image](https://github.com/user-attachments/assets/6a241f09-15bf-43eb-a559-b651a7ba0a9d)

🏡 After
CSP is captured, if browser supports it (🦊 in Firefox disabled by default)
![image](https://github.com/user-attachments/assets/e73216cb-7782-4c4e-a28f-492b11b9c319)
Hello response contains code and message (see in [signaling repo](https://github.com/strukturag/nextcloud-spreed-signaling/blob/6b04363faf8629cee3f42bebcfc1fa3355aaf8a2/docs/standalone-signaling-api-v1.md#error-codes))
![image](https://github.com/user-attachments/assets/e8f7dd6d-c83d-43bb-a478-aa7ff0054fd2)


### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [x] Firefox
  - [ ] Safari
  - [ ] Not risky to browser differences / client