### PR TITLE
feat(chat): Simplify the mark as unread

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -18,7 +18,7 @@
 * 🌉 **Sync with other chat solutions** With [Matterbridge](https://github.com/42wim/matterbridge/) being integrated in Talk, you can easily sync a lot of other chat solutions to Nextcloud Talk and vice-versa.
 ]]></description>
 
-	<version>22.0.0-dev.8</version>
+	<version>22.0.0-dev.9</version>
 	<licence>agpl</licence>
 
 	<author>Anna Larch</author>

--- a/lib/Migration/Version22000Date20250617162407.php
+++ b/lib/Migration/Version22000Date20250617162407.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Talk\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+use Override;
+
+class Version22000Date20250617162407 extends SimpleMigrationStep {
+	/**
+	 * @param IOutput $output
+	 * @param Closure(): ISchemaWrapper $schemaClosure
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	#[Override]
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$table = $schema->getTable('talk_attendees');
+		if (!$table->hasColumn('marked_unread')) {
+			$table->addColumn('marked_unread', Types::BOOLEAN, [
+				'default' => 0,
+				'notnull' => false,
+			]);
+		}
+
+		return $schema;
+	}
+}

--- a/lib/Model/Attendee.php
+++ b/lib/Model/Attendee.php
@@ -62,6 +62,8 @@ use OCP\DB\Types;
  * @method int getState()
  * @method void setUnreadMessages(int $unreadMessages)
  * @method int getUnreadMessages()
+ * @method void setMarkedUnread(bool $markedUnread)
+ * @method bool isMarkedUnread()
  * @method void setLastAttendeeActivity(int $lastAttendeeActivity)
  * @method int getLastAttendeeActivity()
  */
@@ -119,6 +121,7 @@ class Attendee extends Entity {
 	protected bool $archived = false;
 	protected bool $important = false;
 	protected bool $sensitive = false;
+	protected bool $markedUnread = false;
 	protected int $lastJoinedCall = 0;
 	protected int $lastReadMessage = 0;
 	protected int $lastMentionMessage = 0;
@@ -161,6 +164,7 @@ class Attendee extends Entity {
 		$this->addType('state', Types::SMALLINT);
 		$this->addType('unreadMessages', Types::BIGINT);
 		$this->addType('lastAttendeeActivity', Types::BIGINT);
+		$this->addType('markedUnread', Types::BOOLEAN);
 	}
 
 	public function getDisplayName(): string {

--- a/lib/Model/AttendeeMapper.php
+++ b/lib/Model/AttendeeMapper.php
@@ -311,6 +311,7 @@ class AttendeeMapper extends QBMapper {
 			'archived' => (bool)$row['archived'],
 			'important' => (bool)$row['important'],
 			'sensitive' => (bool)$row['sensitive'],
+			'marked_unread' => (bool)$row['marked_unread'],
 		]);
 	}
 }

--- a/lib/Model/SelectHelper.php
+++ b/lib/Model/SelectHelper.php
@@ -79,6 +79,7 @@ class SelectHelper {
 			->addSelect($alias . 'archived')
 			->addSelect($alias . 'important')
 			->addSelect($alias . 'sensitive')
+			->addSelect($alias . 'marked_unread')
 			->selectAlias($alias . 'id', 'a_id');
 	}
 

--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -244,6 +244,14 @@ class ParticipantService {
 	public function updateLastReadMessage(Participant $participant, int $lastReadMessage): void {
 		$attendee = $participant->getAttendee();
 		$attendee->setLastReadMessage($lastReadMessage);
+		$attendee->setMarkedUnread(false);
+		$attendee->setLastAttendeeActivity($this->timeFactory->getTime());
+		$this->attendeeMapper->update($attendee);
+	}
+
+	public function markUnread(Participant $participant): void {
+		$attendee = $participant->getAttendee();
+		$attendee->setMarkedUnread(true);
 		$attendee->setLastAttendeeActivity($this->timeFactory->getTime());
 		$this->attendeeMapper->update($attendee);
 	}

--- a/lib/Service/RoomFormatter.php
+++ b/lib/Service/RoomFormatter.php
@@ -425,6 +425,10 @@ class RoomFormatter {
 			$roomData['unreadMessages'] = 1;
 		}
 
+		if ($attendee->isMarkedUnread()) {
+			$roomData['unreadMentionDirect'] = true;
+		}
+
 		if ($room->isFederatedConversation()) {
 			$roomData['attendeeId'] = (int)$attendee->getRemoteId();
 			$roomData['canLeaveConversation'] = true;

--- a/src/components/LeftSidebar/ConversationsList/Conversation.vue
+++ b/src/components/LeftSidebar/ConversationsList/Conversation.vue
@@ -13,11 +13,11 @@
 		:class="{
 			'conversation--active': isActive,
 			'conversation--compact': compact,
-			'conversation--compact__read': compact && !item.unreadMessages,
+			'conversation--compact__read': compact && !item.unreadMessages && !item.unreadMentionDirect,
 		}"
 		:actions-aria-label="t('spreed', 'Conversation actions')"
 		:to="to"
-		:bold="!!item.unreadMessages"
+		:bold="!!item.unreadMessages || item.unreadMentionDirect"
 		:counter-number="item.unreadMessages"
 		:counter-type="counterType"
 		force-menu
@@ -30,6 +30,9 @@
 				:hide-user-status="item.type !== CONVERSATION.TYPE.ONE_TO_ONE && compact"
 				:show-user-online-status="compact"
 				:size="compact ? AVATAR.SIZE.COMPACT : AVATAR.SIZE.DEFAULT" />
+		</template>
+		<template v-if="item.unreadMessages === 0 && item.unreadMentionDirect" #indicator>
+			<IconCheckboxBlankCircle :size="16" fill-color="var(--color-primary-element)"/>
 		</template>
 		<template #name>
 			<template v-if="compact && iconType">
@@ -265,6 +268,7 @@ import IconArchiveOff from 'vue-material-design-icons/ArchiveOff.vue'
 import IconArrowLeft from 'vue-material-design-icons/ArrowLeft.vue'
 import IconArrowRight from 'vue-material-design-icons/ArrowRight.vue'
 import IconBell from 'vue-material-design-icons/Bell.vue'
+import IconCheckboxBlankCircle from 'vue-material-design-icons/CheckboxBlankCircle.vue'
 import IconCog from 'vue-material-design-icons/Cog.vue'
 import IconContentCopy from 'vue-material-design-icons/ContentCopy.vue'
 import IconDelete from 'vue-material-design-icons/Delete.vue'
@@ -305,6 +309,7 @@ export default {
 		IconArrowLeft,
 		IconArrowRight,
 		IconBell,
+		IconCheckboxBlankCircle,
 		IconCog,
 		IconContentCopy,
 		IconDelete,


### PR DESCRIPTION
## 🛠️ API Checklist
- Ref #15313 

### :construction: Tasks
- [ ] Marking a specific message unread can no longer be supported 🚷 (please use reminder instead?)
  - [ ] API will stay in-tact to not break clients that did not yet implement threads, but clients that support threads should not call this anymore as the behaviour for threads that are in the rage of now unread messages can not be restored easily
- [x] Marking as unread can no longer be supporting the count 🚷 (like on whatsapp, telegram, teams, slack, …)
- [ ] When reading the last message of conversation we can: 🔃 changed
  - [ ] Remove all thread-read-markers (that don't have a non-default notification setting)
  - [x] When marking conversation as unread again, we store an "out-of-band" marker that simply adds the dot
  - [x] When a further message happens marking the chat unread again, the number is simply shown again


### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not possible
- [ ] 📘 API documentation in `docs/` has been updated or is not required
- [ ] 🔖 Capability is added or not needed 
