### PR TITLE
fix(TalkDashboard): make home button a link for a11y and UX and add refresh function 

### DIFF
--- a/src/components/Dashboard/TalkDashboard.vue
+++ b/src/components/Dashboard/TalkDashboard.vue
@@ -56,33 +56,44 @@ const upcomingReminders = computed(() => dashboardStore.upcomingReminders || [])
 const eventsInitialised = computed(() => dashboardStore.eventRoomsInitialised)
 const remindersInitialised = computed(() => dashboardStore.upcomingRemindersInitialised)
 const conversationName = ref('')
-let actualiseDataInterval: ReturnType<typeof setInterval> | null = null
+let actualizeDataInterval: ReturnType<typeof setInterval> | null = null
 
 // Data fetching handlers
 
 /**
  * Fetches all necessary data for the dashboard.
  */
-async function actualiseData() {
+async function actualizeData() {
 	await Promise.all([
 		dashboardStore.fetchDashboardEventRooms(),
 		dashboardStore.fetchUpcomingReminders(),
 	])
 }
 
-onMounted(() => {
-	actualiseData()
-	actualiseDataInterval = setInterval(actualiseData, 300_000)
-})
+/**
+ * Initializes the data fetching interval and fetches initial data.
+ */
+function initActualizeData() {
+	if (actualizeDataInterval) {
+		clearInterval(actualizeDataInterval)
+	}
+	actualizeData()
+	actualizeDataInterval = setInterval(actualizeData, 300_000)
+}
+
+initActualizeData()
+EventBus.on('refresh-talk-dashboard', initActualizeData)
 
 onBeforeUnmount(() => {
-	if (actualiseDataInterval) {
-		clearInterval(actualiseDataInterval)
+	if (actualizeDataInterval) {
+		clearInterval(actualizeDataInterval)
 	}
 
 	if (eventCardsWrapper?.value) {
 		resizeObserver.disconnect()
 	}
+
+	EventBus.off('refresh-talk-dashboard', initActualizeData)
 })
 
 watch(eventCardsWrapper, (newValue) => {

--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -9,12 +9,13 @@
 			<div class="new-conversation">
 				<TransitionWrapper name="radial-reveal">
 					<NcButton v-show="searchText === ''"
-						variant="tertiary"
+						:variant="isInDashboard ? 'primary' : 'tertiary'"
 						:class="{ 'hidden-visually': isSearching }"
 						class="talk-home-button"
-						:title="t('spreed', 'Talk home')"
-						:aria-label="t('spreed', 'Talk home')"
-						@click="showTalkDashboard">
+						:title="dashboardButtonLabel"
+						:aria-label="dashboardButtonLabel"
+						:to="{ name: 'root' }"
+						@click="refreshTalkDashboard">
 						<template #icon>
 							<IconHome :size="20" />
 						</template>
@@ -508,6 +509,16 @@ export default {
 		conversationsInitialised() {
 			return this.$store.getters.conversationsInitialised
 		},
+
+		isInDashboard() {
+			return this.$route.name === 'root'
+		},
+
+		dashboardButtonLabel() {
+			return this.isInDashboard
+				? t('spreed', 'Reload Talk home')
+				: t('spreed', 'Talk home')
+		},
 	},
 
 	watch: {
@@ -942,9 +953,10 @@ export default {
 			}
 		},
 
-		showTalkDashboard() {
-			this.$router.push({ name: 'root' })
-				.catch((err) => console.debug(`Error while pushing the dashboard route: ${err}`))
+		refreshTalkDashboard() {
+			if (this.isInDashboard) {
+				EventBus.emit('refresh-talk-dashboard')
+			}
 		},
 	},
 }

--- a/src/services/EventBus.ts
+++ b/src/services/EventBus.ts
@@ -35,6 +35,7 @@ export type Events = {
 	'poll-drafts-open': { token: string, selector?: string }
 	'poll-editor-open': { token: string, id: number | null, fromDrafts: boolean, action?: string, selector?: string }
 	'refresh-peer-list': void
+	'refresh-talk-dashboard': void
 	'retry-message': number
 	'route-change': { from: Route, to: Route }
 	'scroll-chat-to-bottom': { smooth?: boolean, force?: boolean }


### PR DESCRIPTION
### ☑️ Resolves

* Fix #15321

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

When current page is dashboard.

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/user-attachments/assets/09866406-3fcc-46ac-af1d-d73ca5abd44d) | ![image](https://github.com/user-attachments/assets/00634848-3af4-4359-92ce-600bc8e53951)

<!-- ☀️ Light theme | 🌑 Dark Theme -->


### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
