### PR TITLE
perf(frontend): replace `lodash` with `es-toolkit`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -80,6 +80,7 @@
         "@vue/test-utils": "^2.4.6",
         "@vue/tsconfig": "^0.9.1",
         "css-loader": "^7.1.4",
+        "es-toolkit": "^1.47.0",
         "globals": "^17.6.0",
         "jsdom": "^29.1.1",
         "openapi-typescript": "^7.13.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,6 @@
         "leaflet": "^1.9.4",
         "leaflet-defaulticon-compatibility": "^0.1.2",
         "libphonenumber-js": "^1.13.4",
-        "lodash": "^4.18.1",
         "mitt": "^3.0.1",
         "mockconsole": "0.0.1",
         "panzoom": "^9.4.4",
@@ -9783,12 +9782,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/lodash": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "license": "MIT"
     },
     "node_modules/lodash.truncate": {
       "version": "4.4.2",
@@ -21930,11 +21923,6 @@
       "requires": {
         "p-locate": "^5.0.0"
       }
-    },
-    "lodash": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
     },
     "lodash.truncate": {
       "version": "4.4.2",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "leaflet": "^1.9.4",
     "leaflet-defaulticon-compatibility": "^0.1.2",
     "libphonenumber-js": "^1.13.4",
-    "lodash": "^4.18.1",
     "mitt": "^3.0.1",
     "mockconsole": "0.0.1",
     "panzoom": "^9.4.4",

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "@vue/test-utils": "^2.4.6",
     "@vue/tsconfig": "^0.9.1",
     "css-loader": "^7.1.4",
+    "es-toolkit": "^1.47.0",
     "globals": "^17.6.0",
     "jsdom": "^29.1.1",
     "openapi-typescript": "^7.13.0",

--- a/src/components/CallView/shared/VideoBottomBar.spec.js
+++ b/src/components/CallView/shared/VideoBottomBar.spec.js
@@ -6,7 +6,7 @@
 import { emit } from '@nextcloud/event-bus'
 import { t } from '@nextcloud/l10n'
 import { mount } from '@vue/test-utils'
-import { cloneDeep } from 'lodash'
+import { cloneDeep } from 'es-toolkit'
 import { createPinia, setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { createStore } from 'vuex'

--- a/src/components/CallView/shared/VideoVue.spec.js
+++ b/src/components/CallView/shared/VideoVue.spec.js
@@ -4,7 +4,7 @@
  */
 
 import { mount } from '@vue/test-utils'
-import { cloneDeep } from 'lodash'
+import { cloneDeep } from 'es-toolkit'
 import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { createStore } from 'vuex'

--- a/src/components/LeftSidebar/ConversationsList/Conversation.spec.js
+++ b/src/components/LeftSidebar/ConversationsList/Conversation.spec.js
@@ -5,7 +5,7 @@
 
 import { showError, showSuccess } from '@nextcloud/dialogs'
 import { flushPromises, mount } from '@vue/test-utils'
-import { cloneDeep } from 'lodash'
+import { cloneDeep } from 'es-toolkit'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { createStore } from 'vuex'
 import NcListItem from '@nextcloud/vue/components/NcListItem'

--- a/src/components/LeftSidebar/LeftSidebar.spec.js
+++ b/src/components/LeftSidebar/LeftSidebar.spec.js
@@ -5,7 +5,7 @@
 
 import { subscribe, unsubscribe } from '@nextcloud/event-bus'
 import { flushPromises, mount } from '@vue/test-utils'
-import { cloneDeep } from 'lodash'
+import { cloneDeep } from 'es-toolkit'
 import { createPinia, setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { createStore } from 'vuex'

--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.spec.js
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.spec.js
@@ -4,7 +4,7 @@
  */
 
 import { mount } from '@vue/test-utils'
-import { cloneDeep } from 'lodash'
+import { cloneDeep } from 'es-toolkit'
 import { createPinia, setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { computed } from 'vue'

--- a/src/components/MessagesList/MessagesGroup/Message/MessageItem.spec.js
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageItem.spec.js
@@ -4,7 +4,7 @@
  */
 
 import { flushPromises, mount } from '@vue/test-utils'
-import { cloneDeep } from 'lodash'
+import { cloneDeep } from 'es-toolkit'
 import { createPinia, setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { ref } from 'vue'

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/ReactionsWrapper.spec.js
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/ReactionsWrapper.spec.js
@@ -5,7 +5,7 @@
 
 import { showError } from '@nextcloud/dialogs'
 import { mount } from '@vue/test-utils'
-import { cloneDeep } from 'lodash'
+import { cloneDeep } from 'es-toolkit'
 import { createPinia, setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { createStore } from 'vuex'

--- a/src/components/MessagesList/MessagesGroup/MessagesGroup.spec.js
+++ b/src/components/MessagesList/MessagesGroup/MessagesGroup.spec.js
@@ -4,7 +4,7 @@
  */
 
 import { shallowMount } from '@vue/test-utils'
-import { cloneDeep } from 'lodash'
+import { cloneDeep } from 'es-toolkit'
 import { createPinia, setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { createStore } from 'vuex'

--- a/src/components/MessagesList/MessagesGroup/MessagesSystemGroup.spec.js
+++ b/src/components/MessagesList/MessagesGroup/MessagesSystemGroup.spec.js
@@ -4,7 +4,7 @@
  */
 
 import { shallowMount } from '@vue/test-utils'
-import { cloneDeep } from 'lodash'
+import { cloneDeep } from 'es-toolkit'
 import { createPinia, setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { createStore } from 'vuex'

--- a/src/components/MessagesList/MessagesList.spec.js
+++ b/src/components/MessagesList/MessagesList.spec.js
@@ -4,7 +4,7 @@
  */
 
 import { mount } from '@vue/test-utils'
-import { cloneDeep } from 'lodash'
+import { cloneDeep } from 'es-toolkit'
 import { createPinia, setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { ref } from 'vue'

--- a/src/components/RightSidebar/Participants/Participant.spec.js
+++ b/src/components/RightSidebar/Participants/Participant.spec.js
@@ -4,7 +4,7 @@
  */
 
 import { flushPromises, mount } from '@vue/test-utils'
-import { cloneDeep } from 'lodash'
+import { cloneDeep } from 'es-toolkit'
 import { createPinia, setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, test, vi } from 'vitest'
 import { createStore } from 'vuex'

--- a/src/components/RightSidebar/Participants/ParticipantPermissionsEditor.spec.js
+++ b/src/components/RightSidebar/Participants/ParticipantPermissionsEditor.spec.js
@@ -4,7 +4,7 @@
  */
 
 import { mount } from '@vue/test-utils'
-import { cloneDeep } from 'lodash'
+import { cloneDeep } from 'es-toolkit'
 import { createPinia, setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, test, vi } from 'vitest'
 import { nextTick } from 'vue'

--- a/src/components/RoomSelector.spec.js
+++ b/src/components/RoomSelector.spec.js
@@ -6,7 +6,7 @@
 import axios from '@nextcloud/axios'
 import { generateOcsUrl } from '@nextcloud/router'
 import { flushPromises, mount } from '@vue/test-utils'
-import { cloneDeep } from 'lodash'
+import { cloneDeep } from 'es-toolkit'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createStore, useStore } from 'vuex'
 import NcButton from '@nextcloud/vue/components/NcButton'

--- a/src/composables/useCombinedSystemMessage.js
+++ b/src/composables/useCombinedSystemMessage.js
@@ -4,7 +4,6 @@
  */
 
 import { n, t } from '@nextcloud/l10n'
-import cloneDeep from 'lodash/cloneDeep.js'
 import { useStore } from 'vuex'
 import { useActorStore } from '../stores/actor.ts'
 
@@ -46,7 +45,7 @@ export function useCombinedSystemMessage() {
 	 * @return {object}
 	 */
 	function createCombinedSystemMessage({ id, messages, type, collapsed }) {
-		const combinedMessage = cloneDeep(messages[0])
+		const combinedMessage = structuredClone(messages[0])
 		combinedMessage.id = messages[0].id + '_combined'
 
 		// Handle cases when users reconnected to the call

--- a/src/store/conversationsStore.spec.js
+++ b/src/store/conversationsStore.spec.js
@@ -5,7 +5,7 @@
 
 import { emit } from '@nextcloud/event-bus'
 import { flushPromises } from '@vue/test-utils'
-import { cloneDeep } from 'lodash'
+import { cloneDeep } from 'es-toolkit'
 import { createPinia, setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { createStore } from 'vuex'

--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -5,7 +5,6 @@
 
 import { showError } from '@nextcloud/dialogs'
 import { t } from '@nextcloud/l10n'
-import cloneDeep from 'lodash/cloneDeep.js'
 import {
 	ATTENDEE,
 	CHAT,
@@ -1396,7 +1395,7 @@ const actions = {
 	 * @param {object} data.messageToBeForwarded the message object;
 	 */
 	async forwardMessage(context, { targetToken, messageToBeForwarded }) {
-		const message = cloneDeep(messageToBeForwarded)
+		const message = structuredClone(messageToBeForwarded)
 
 		// when there is no token provided, the message will be forwarded to the Note to self conversation
 		if (!targetToken) {

--- a/src/store/messagesStore.spec.js
+++ b/src/store/messagesStore.spec.js
@@ -5,7 +5,7 @@
 
 import { showError } from '@nextcloud/dialogs'
 import { flushPromises } from '@vue/test-utils'
-import { cloneDeep } from 'lodash'
+import { cloneDeep } from 'es-toolkit'
 import { createPinia, setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, test, vi } from 'vitest'
 import { createStore, useStore } from 'vuex'

--- a/src/store/participantsStore.spec.js
+++ b/src/store/participantsStore.spec.js
@@ -6,7 +6,7 @@
 import { emit } from '@nextcloud/event-bus'
 import Hex from 'crypto-js/enc-hex.js'
 import SHA1 from 'crypto-js/sha1.js'
-import { cloneDeep } from 'lodash'
+import { cloneDeep } from 'es-toolkit'
 import { createPinia, setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { createStore } from 'vuex'

--- a/src/test-helpers.js
+++ b/src/test-helpers.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { cloneDeep } from 'lodash'
+import { cloneDeep } from 'es-toolkit'
 import NcActionButton from '@nextcloud/vue/components/NcActionButton'
 import NcActionText from '@nextcloud/vue/components/NcActionText'
 import NcButton from '@nextcloud/vue/components/NcButton'

--- a/src/utils/SignalingTypingHandler.spec.js
+++ b/src/utils/SignalingTypingHandler.spec.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { cloneDeep } from 'lodash'
+import { cloneDeep } from 'es-toolkit'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import Vuex from 'vuex'
 import storeConfig from '../store/storeConfig.js'

--- a/src/utils/e2ee/encryption.js
+++ b/src/utils/e2ee/encryption.js
@@ -6,10 +6,10 @@
 import Olm from '@matrix-org/olm'
 import base64js from 'base64-js'
 import debounce from 'debounce'
-import { isEqual } from 'lodash'
 import { v4 as uuidv4 } from 'uuid'
 import { getTalkConfig, hasTalkFeature } from '../../services/CapabilitiesManager.ts'
 import Signaling from '../signaling.js'
+import { isEqualJson } from '../utils.ts'
 import Peer from '../webrtc/simplewebrtc/peer.js'
 import SimpleWebRTC from '../webrtc/simplewebrtc/simplewebrtc.js'
 import { importKey, ratchet } from './crypto-utils.js'
@@ -501,7 +501,7 @@ class Encryption {
 			const key = base64js.toByteArray(decoded.key)
 			const index = decoded.index
 
-			if (!isEqual(sessionData.lastKey, key)) {
+			if (!isEqualJson(sessionData.lastKey, key)) {
 				sessionData.lastKey = key
 				console.debug('Key updated', sessionId, index, decoded.key)
 				this.context.setKey(sessionId, key, index)
@@ -544,7 +544,7 @@ class Encryption {
 			const key = base64js.toByteArray(decoded.key)
 			const index = decoded.index
 
-			if (!isEqual(sessionData.lastKey, key)) {
+			if (!isEqualJson(sessionData.lastKey, key)) {
 				sessionData.lastKey = key
 				console.debug('Key updated', sessionId, index, decoded.key)
 				this.context.setKey(sessionId, key, index)

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,0 +1,14 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * Compare two plain JS objects deeply via JSON serialization
+ *
+ * @param a - First object
+ * @param b - Second object
+ */
+export function isEqualJson(a: unknown, b: unknown): boolean {
+	return JSON.stringify(a) === JSON.stringify(b)
+}


### PR DESCRIPTION
### ☑️ Resolves

* Ref: https://github.com/nextcloud/spreed/issues/9406
* `Lodash` is a very old library with low performance and sometimes issues on tree-shaking
* Many functions from `lodash` are not needed in modern JS
* In runtime: replaced with our own utils
* In tests: replaced with `es-toolkit`, a good well-known replacement
  * It also has some useful utils we can use
  * Alternatives:
    * Individual libraries, like `klona` and `dequel` for deep cloning/comparison (even smaller)

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

Entity | 🏚️ Before | 🏡 After
-- | -- | --
`/js` | `164_512 kb` | `160_216 kb` (🔻2.4%)
`talk-main.js` | `6_072_269 b` | `5_983_249 b` (🔻1.5%)

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required