### PR TITLE
fix(vue3): fullscreen mode in Vue 3 container 

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -692,15 +692,15 @@ body .modal-wrapper * {
 }
 
 // Styles for the app content at fullscreen mode
+:root:has(body.talk-in-fullscreen) {
+	--body-container-margin: 0px !important;
+	--body-container-radius: 0px !important;
+	--header-height: 0px !important;
+}
+
 body.talk-in-fullscreen {
 	#header {
 		display: none !important;
-	}
-	#content-vue {
-		margin: 0;
-		height: 100%;
-		width: 100%;
-		border-radius: 0;
 	}
 }
 


### PR DESCRIPTION
### ☑️ Resolves

* Fullscreen layout due to mounting inside `#content` instead of replacing it

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/user-attachments/assets/0142660c-a8b1-4ec9-86c5-8b119d217120) | ![image](https://github.com/user-attachments/assets/53f5bc73-1814-44de-aa24-d33c074c7c68)

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
