### PR TITLE
fix: allow encrypted calls in Talk integrations

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -262,7 +262,7 @@ class PageController extends Controller {
 		]);
 
 		$csp = new ContentSecurityPolicy();
-		$csp->addAllowedConnectDomain('*');
+		$csp->addAllowedImageDomain('https://*.tile.openstreetmap.org');
 		$csp->addAllowedMediaDomain('blob:');
 		$csp->addAllowedWorkerSrcDomain('blob:');
 		$csp->addAllowedWorkerSrcDomain("'self'");
@@ -273,7 +273,10 @@ class PageController extends Controller {
 		$csp->addAllowedScriptDomain("'wasm-unsafe-eval'");
 		$csp->addAllowedConnectDomain('blob:');
 		$csp->addAllowedConnectDomain("'self'");
-		$csp->addAllowedImageDomain('https://*.tile.openstreetmap.org');
+		foreach ($this->talkConfig->getAllServerUrlsForCSP() as $server) {
+			$csp->addAllowedConnectDomain($server);
+		}
+
 		$response->setContentSecurityPolicy($csp);
 		if ($throttle) {
 			// Logged-in user tried to access a chat they can not access
@@ -325,7 +328,7 @@ class PageController extends Controller {
 
 		$response->setFooterVisible(false);
 		$csp = new ContentSecurityPolicy();
-		$csp->addAllowedConnectDomain('*');
+		$csp->addAllowedImageDomain('https://*.tile.openstreetmap.org');
 		$csp->addAllowedMediaDomain('blob:');
 		$csp->addAllowedWorkerSrcDomain('blob:');
 		$csp->addAllowedWorkerSrcDomain("'self'");
@@ -336,7 +339,9 @@ class PageController extends Controller {
 		$csp->addAllowedScriptDomain("'wasm-unsafe-eval'");
 		$csp->addAllowedConnectDomain('blob:');
 		$csp->addAllowedConnectDomain("'self'");
-		$csp->addAllowedImageDomain('https://*.tile.openstreetmap.org');
+		foreach ($this->talkConfig->getAllServerUrlsForCSP() as $server) {
+			$csp->addAllowedConnectDomain($server);
+		}
 		$response->setContentSecurityPolicy($csp);
 
 		return $response;
@@ -412,7 +417,7 @@ class PageController extends Controller {
 
 		$response->setFooterVisible(false);
 		$csp = new ContentSecurityPolicy();
-		$csp->addAllowedConnectDomain('*');
+		$csp->addAllowedImageDomain('https://*.tile.openstreetmap.org');
 		$csp->addAllowedMediaDomain('blob:');
 		$csp->addAllowedWorkerSrcDomain('blob:');
 		$csp->addAllowedWorkerSrcDomain("'self'");
@@ -423,7 +428,9 @@ class PageController extends Controller {
 		$csp->addAllowedScriptDomain("'wasm-unsafe-eval'");
 		$csp->addAllowedConnectDomain('blob:');
 		$csp->addAllowedConnectDomain("'self'");
-		$csp->addAllowedImageDomain('https://*.tile.openstreetmap.org');
+		foreach ($this->talkConfig->getAllServerUrlsForCSP() as $server) {
+			$csp->addAllowedConnectDomain($server);
+		}
 		$response->setContentSecurityPolicy($csp);
 		return $response;
 	}
@@ -470,7 +477,7 @@ class PageController extends Controller {
 
 		$response->setFooterVisible(false);
 		$csp = new ContentSecurityPolicy();
-		$csp->addAllowedConnectDomain('*');
+		$csp->addAllowedImageDomain('https://*.tile.openstreetmap.org');
 		$csp->addAllowedMediaDomain('blob:');
 		$csp->addAllowedWorkerSrcDomain('blob:');
 		$csp->addAllowedWorkerSrcDomain("'self'");
@@ -481,7 +488,9 @@ class PageController extends Controller {
 		$csp->addAllowedScriptDomain("'wasm-unsafe-eval'");
 		$csp->addAllowedConnectDomain('blob:');
 		$csp->addAllowedConnectDomain("'self'");
-		$csp->addAllowedImageDomain('https://*.tile.openstreetmap.org');
+		foreach ($this->talkConfig->getAllServerUrlsForCSP() as $server) {
+			$csp->addAllowedConnectDomain($server);
+		}
 		$response->setContentSecurityPolicy($csp);
 		return $response;
 	}

--- a/lib/Listener/CSPListener.php
+++ b/lib/Listener/CSPListener.php
@@ -39,6 +39,7 @@ class CSPListener implements IEventListener {
 		$csp->addAllowedChildSrcDomain("'self'");
 		$csp->addAllowedScriptDomain('blob:');
 		$csp->addAllowedScriptDomain("'self'");
+		$csp->addAllowedScriptDomain("'wasm-unsafe-eval'");
 		$csp->addAllowedConnectDomain('blob:');
 		$csp->addAllowedConnectDomain("'self'");
 		foreach ($this->config->getAllServerUrlsForCSP() as $server) {


### PR DESCRIPTION
### ☑️ Resolves

- Fix encrypted calls in Talk integrations (Files Sidebar, Password Share request)
	- this aligns CSP policy between controller and listner
	- wasm allowed for encryption
	- ConnectDomain('*') replaced with HPB, TURN, STUN servers

## 🛠️ API Checklist

### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not possible
- [ ] 📘 API documentation in `docs/` has been updated or is not required
- [ ] 🔖 Capability is added or not needed 
