### PR TITLE
fix(vue3): prevent broken class/attrs due to unexpected Fragment

### DIFF
--- a/src/PublicShareAuthRequestPasswordButton.vue
+++ b/src/PublicShareAuthRequestPasswordButton.vue
@@ -4,9 +4,9 @@
 -->
 
 <template>
-	<!-- "submit-wrapper" is used to mimic the login button and thus get
-		automatic colouring of the confirm icon by the Theming app. -->
 	<div id="submit-wrapper" class="request-password-wrapper">
+		<!-- "submit-wrapper" is used to mimic the login button and thus get
+		automatic colouring of the confirm icon by the Theming app. -->
 		<NcButton id="request-password-button"
 			variant="primary"
 			:wide="true"

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/Poll.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/Poll.vue
@@ -4,7 +4,6 @@
 -->
 
 <template>
-	<!-- Poll card -->
 	<div v-if="draft" class="poll-card" @click="openDraft">
 		<span class="poll-card__header poll-card__header--draft">
 			<IconPoll class="poll-card__header-icon" :size="20" />

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/Reactions.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/Reactions.vue
@@ -4,7 +4,6 @@
 -->
 
 <template>
-	<!-- reactions buttons and popover with details -->
 	<div v-if="reactionsCount && reactionsSorted" class="reactions-wrapper">
 		<NcPopover v-for="reaction in reactionsSorted"
 			:key="reaction"

--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -4,8 +4,6 @@
 -->
 
 <template>
-	<!-- size and remain refer to the amount and initial height of the items that
-	are outside of the viewport -->
 	<div ref="scroller"
 		class="scroller messages-list__scroller"
 		:class="{

--- a/src/components/RightSidebar/BreakoutRooms/BreakoutRoomsActions.vue
+++ b/src/components/RightSidebar/BreakoutRooms/BreakoutRoomsActions.vue
@@ -4,8 +4,6 @@
 -->
 
 <template>
-	<!-- Series of buttons at the top of the tab, these affect all
-		 breakout rooms -->
 	<div v-if="canModerate || isInBreakoutRoom" class="breakout-rooms-actions">
 		<div class="breakout-rooms-actions__row">
 			<NcButton v-if="breakoutRoomsNotStarted && canModerate"


### PR DESCRIPTION

### ☑️ Resolves

* Prevent bugs like fixed in this PR: https://github.com/nextcloud/spreed/pull/15421

In vue 3 if a component has a comment on the top level, it could be wrapped into Fragment on production/tests like a component without a root node.

Most of the comments seem outdated or unneeded. One useful is moved.
The only one left is this one, but this component is a Fragment anyway.

https://github.com/nextcloud/spreed/blob/5fe99127631732696ecd2c3244b65793c87607b3/src/components/ConversationSettings/BasicInfo.vue#L6-L8