### PR TITLE
fix: adjust logic of 'conversation-received' event emitting

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -226,13 +226,17 @@ export default {
 
 	beforeMount() {
 		if (!getCurrentUser()) {
+			/**
+			 * When guest opens a public conversation, we wait for it to be fetched,
+			 * then joining and setting the 30 seconds interval to update information
+			 */
 			EventBus.once('conversations-received', (params) => {
 				if (params.singleConversation) {
 					this.$store.dispatch('joinConversation', { token: params.singleConversation.token })
 				}
-			})
-			EventBus.once('joined-conversation', () => {
-				this.fixmeDelayedSetupOfGuestUsers()
+				setInterval(() => {
+					this.refreshCurrentConversation()
+				}, 30_000)
 			})
 			EventBus.on('should-refresh-conversations', this.debounceRefreshCurrentConversation)
 		}
@@ -550,16 +554,6 @@ export default {
 				}
 				default: break
 			}
-		},
-
-		fixmeDelayedSetupOfGuestUsers() {
-			// FIXME Refresh the data now that the user joined the conversation
-			// The join request returns this data already, but it's lost in the signaling code
-			this.refreshCurrentConversation()
-
-			window.setInterval(() => {
-				this.refreshCurrentConversation()
-			}, 30000)
 		},
 
 		refreshCurrentConversation() {

--- a/src/App.vue
+++ b/src/App.vue
@@ -599,15 +599,13 @@ export default {
 				/**
 				 * Fetches a single conversation
 				 */
-				await this.$store.dispatch('fetchConversation', { token })
+				const response = await this.$store.dispatch('fetchConversation', { token })
 				isSuccessfullyFetched = true
 				/**
 				 * Emits a global event that is used in App.vue to update the page title once the
 				 * ( if the current route is a conversation and once the conversations are received)
 				 */
-				EventBus.emit('conversations-received', {
-					singleConversation: true,
-				})
+				EventBus.emit('conversations-received', { singleConversation: response.data.ocs.data })
 			} catch (exception) {
 				console.info('Conversation received, but the current conversation is not in the list. Redirecting to /apps/spreed')
 				this.$router.push({ name: 'notfound', params: { skipLeaveWarning: true } })

--- a/src/App.vue
+++ b/src/App.vue
@@ -398,6 +398,8 @@ export default {
 
 		/**
 		 * Global before guard, this is called whenever a navigation is triggered.
+		 * When app is initializing and router is not ready yet,
+		 * first navigation will be made from initial state { name : undefined }
 		 */
 		Router.beforeEach((to, from, next) => {
 			if (from.name === 'conversation' && to.name === 'conversation' && from.params.token === to.params.token) {
@@ -434,13 +436,6 @@ export default {
 
 		if (!IS_DESKTOP) {
 			checkBrowser()
-		}
-
-		if (this.$route.name === 'root' && this.isMobile) {
-			await this.$nextTick()
-			emit('toggle-navigation', {
-				open: true,
-			})
 		}
 
 		subscribe('notifications:action:execute', this.interceptNotificationActions)

--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -258,6 +258,7 @@ import { t } from '@nextcloud/l10n'
 import { useIsMobile } from '@nextcloud/vue/composables/useIsMobile'
 import debounce from 'debounce'
 import { ref } from 'vue'
+import { START_LOCATION } from 'vue-router'
 import NcActionButton from '@nextcloud/vue/components/NcActionButton'
 import NcActionCaption from '@nextcloud/vue/components/NcActionCaption'
 import NcActions from '@nextcloud/vue/components/NcActions'
@@ -949,7 +950,7 @@ export default {
 			}
 			if (this.isMobile) {
 				emit('toggle-navigation', {
-					open: false,
+					open: to.name === 'root' && from === START_LOCATION,
 				})
 			}
 		},

--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -870,7 +870,7 @@ export default {
 				 * Emits a global event that is used in App.vue to update the page title once the
 				 * ( if the current route is a conversation and once the conversations are received)
 				 */
-				EventBus.emit('conversations-received', { singleConversation: false })
+				EventBus.emit('conversations-received', {})
 				this.isFetchingConversations = false
 			} catch (error) {
 				console.debug('Error while fetching conversations: ', error)
@@ -880,8 +880,9 @@ export default {
 
 		async restoreConversations() {
 			try {
-				await this.$store.dispatch('restoreConversations')
-				EventBus.emit('conversations-received', { singleConversation: false })
+				if (await this.$store.dispatch('restoreConversations')) {
+					EventBus.emit('conversations-received', { fromBrowserStorage: true })
+				}
 			} catch (error) {
 				console.debug('Error while restoring conversations: ', error)
 			}

--- a/src/services/EventBus.ts
+++ b/src/services/EventBus.ts
@@ -21,7 +21,7 @@ import mitt from 'mitt'
 export type Events = {
 	[key: EventType]: unknown
 	'audio-player-ended': number
-	'conversations-received': { singleConversation: boolean }
+	'conversations-received': { singleConversation?: Conversation, fromBrowserStorage?: boolean }
 	'session-conflict-confirmation': string
 	'deleted-session-detected': void
 	'duplicate-session-detected': void

--- a/src/store/conversationsStore.js
+++ b/src/store/conversationsStore.js
@@ -459,13 +459,13 @@ const actions = {
 	 *
 	 * @param {object} context default store context
 	 */
-	restoreConversations(context) {
+	async restoreConversations(context) {
 		const cachedConversations = BrowserStorage.getItem('cachedConversations')
-		if (!cachedConversations?.length) {
-			return
+		if (cachedConversations === null || !cachedConversations.length) {
+			return false
 		}
 
-		context.dispatch('patchConversations', {
+		await context.dispatch('patchConversations', {
 			conversations: JSON.parse(cachedConversations),
 			withRemoving: true,
 		})
@@ -473,6 +473,7 @@ const actions = {
 		context.commit('setConversationsInitialised', true)
 
 		console.debug('Conversations have been restored from BrowserStorage')
+		return true
 	},
 
 	/**


### PR DESCRIPTION
### ☑️ Resolves

* Separated from #15412 and reworked
  * as initial route is '/', and guests are redirected to not-found, we should either wait for router to be ready, or do not use it


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="409" alt="image" src="https://github.com/user-attachments/assets/f8923ad9-ecb0-4475-a14c-77a656d679a8" /> | --
<img width="256" alt="2025-06-26_10h23_33" src="https://github.com/user-attachments/assets/5357e0f8-44a9-4422-9c8f-c8c9ed281daa" /> | --


<!-- ☀️ Light theme | 🌑 Dark Theme -->


### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required