### PR TITLE
fix(ResponseDefinitions): define 'hide-download' field to message parameters

### DIFF
--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -76,6 +76,7 @@ namespace OCA\Talk;
  *     path?: string,
  *     mimetype?: string,
  *     'preview-available'?: 'yes'|'no',
+ *     'hide-download'?: 'yes'|'no',
  *     mtime?: string,
  *     latitude?: string,
  *     longitude?: string,

--- a/openapi-backend-sipbridge.json
+++ b/openapi-backend-sipbridge.json
@@ -534,6 +534,13 @@
                             "no"
                         ]
                     },
+                    "hide-download": {
+                        "type": "string",
+                        "enum": [
+                            "yes",
+                            "no"
+                        ]
+                    },
                     "mtime": {
                         "type": "string"
                     },

--- a/openapi-federation.json
+++ b/openapi-federation.json
@@ -588,6 +588,13 @@
                             "no"
                         ]
                     },
+                    "hide-download": {
+                        "type": "string",
+                        "enum": [
+                            "yes",
+                            "no"
+                        ]
+                    },
                     "mtime": {
                         "type": "string"
                     },

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -1385,6 +1385,13 @@
                             "no"
                         ]
                     },
+                    "hide-download": {
+                        "type": "string",
+                        "enum": [
+                            "yes",
+                            "no"
+                        ]
+                    },
                     "mtime": {
                         "type": "string"
                     },

--- a/openapi.json
+++ b/openapi.json
@@ -1290,6 +1290,13 @@
                             "no"
                         ]
                     },
+                    "hide-download": {
+                        "type": "string",
+                        "enum": [
+                            "yes",
+                            "no"
+                        ]
+                    },
                     "mtime": {
                         "type": "string"
                     },

--- a/src/types/openapi/openapi-backend-sipbridge.ts
+++ b/src/types/openapi/openapi-backend-sipbridge.ts
@@ -276,6 +276,8 @@ export type components = {
             mimetype?: string;
             /** @enum {string} */
             "preview-available"?: "yes" | "no";
+            /** @enum {string} */
+            "hide-download"?: "yes" | "no";
             mtime?: string;
             latitude?: string;
             longitude?: string;

--- a/src/types/openapi/openapi-federation.ts
+++ b/src/types/openapi/openapi-federation.ts
@@ -303,6 +303,8 @@ export type components = {
             mimetype?: string;
             /** @enum {string} */
             "preview-available"?: "yes" | "no";
+            /** @enum {string} */
+            "hide-download"?: "yes" | "no";
             mtime?: string;
             latitude?: string;
             longitude?: string;

--- a/src/types/openapi/openapi-full.ts
+++ b/src/types/openapi/openapi-full.ts
@@ -2544,6 +2544,8 @@ export type components = {
             mimetype?: string;
             /** @enum {string} */
             "preview-available"?: "yes" | "no";
+            /** @enum {string} */
+            "hide-download"?: "yes" | "no";
             mtime?: string;
             latitude?: string;
             longitude?: string;

--- a/src/types/openapi/openapi.ts
+++ b/src/types/openapi/openapi.ts
@@ -2006,6 +2006,8 @@ export type components = {
             mimetype?: string;
             /** @enum {string} */
             "preview-available"?: "yes" | "no";
+            /** @enum {string} */
+            "hide-download"?: "yes" | "no";
             mtime?: string;
             latitude?: string;
             longitude?: string;


### PR DESCRIPTION
### ☑️ Resolves

* Fixup to #15095
* Define field via openapi / TS


## 🛠️ API Checklist

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not possible
- [ ] 📘 API documentation in `docs/` has been updated or is not required
- [ ] 🔖 Capability is added or not needed 
