### PR TITLE
fix(config): Don't break with incomplete server URLs

### DIFF
--- a/lib/Config.php
+++ b/lib/Config.php
@@ -305,25 +305,29 @@ class Config {
 			$urls[] = $this->getWebSocketDomainForSignalingServer($server['server']);
 		}
 
-		return $urls;
+		return array_filter($urls);
 	}
 
 	protected function getWebSocketDomainForSignalingServer(string $url): string {
+		if (str_ends_with($url, ':') || str_ends_with($url, ':/') || str_ends_with($url, '://')) {
+			return '';
+		}
+
 		$url .= '/';
 		if (str_starts_with($url, 'https://')) {
-			return 'wss://' . substr($url, 8, strpos($url, '/', 9) - 8);
+			return 'wss://' . substr($url, 8, strpos($url, '/', 8) - 8);
 		}
 
 		if (str_starts_with($url, 'http://')) {
-			return 'ws://' . substr($url, 7, strpos($url, '/', 8) - 7);
+			return 'ws://' . substr($url, 7, strpos($url, '/', 7) - 7);
 		}
 
 		if (str_starts_with($url, 'wss://')) {
-			return substr($url, 0, strpos($url, '/', 7));
+			return substr($url, 0, strpos($url, '/', 6));
 		}
 
 		if (str_starts_with($url, 'ws://')) {
-			return substr($url, 0, strpos($url, '/', 6));
+			return substr($url, 0, strpos($url, '/', 5));
 		}
 
 		$protocol = strpos($url, '://');

--- a/tests/php/ConfigTest.php
+++ b/tests/php/ConfigTest.php
@@ -309,6 +309,24 @@ class ConfigTest extends TestCase {
 			['wss://blabla.nextcloud.com:8443/', 'wss://blabla.nextcloud.com:8443'],
 			['wss://blabla.nextcloud.com:8443/signaling', 'wss://blabla.nextcloud.com:8443'],
 			['wss://blabla.nextcloud.com:8443/signaling/', 'wss://blabla.nextcloud.com:8443'],
+
+			// Admin got interrupted before finishing typing
+			['wss://', ''],
+			['ws://', ''],
+			['https://', ''],
+			['http://', ''],
+			['wss:/', ''],
+			['https:/', ''],
+			['wss:', ''],
+			['https:', ''],
+			['wss', 'wss'],
+			['https', 'https'],
+			['ws', 'ws'],
+			['http', 'http'],
+			['w', 'w'],
+			['htt', 'htt'],
+			['ht', 'ht'],
+			['h', 'h'],
 		];
 	}
 


### PR DESCRIPTION
Could happen when admin got interrupted before finishing typing, but then it auto saves and a user opens talk or the admin settings.


### ☑️ Resolves

* Fix #15449 

## 🛠️ API Checklist
### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
