### PR TITLE
fix: adjust devices inputs layout to improve the use of space

### DIFF
--- a/src/components/MediaSettings/MediaDevicesSelector.vue
+++ b/src/components/MediaSettings/MediaDevicesSelector.vue
@@ -8,10 +8,8 @@ import type { ComponentPublicInstance } from 'vue'
 
 import { t } from '@nextcloud/l10n'
 import { computed } from 'vue'
-import NcButton from '@nextcloud/vue/components/NcButton'
 import NcSelect from '@nextcloud/vue/components/NcSelect'
 import IconMicrophone from 'vue-material-design-icons/Microphone.vue'
-import IconRefresh from 'vue-material-design-icons/Refresh.vue'
 import IconVideo from 'vue-material-design-icons/Video.vue'
 import IconVolumeHigh from 'vue-material-design-icons/VolumeHigh.vue'
 
@@ -105,7 +103,7 @@ function updateDeviceId(deviceId: NcSelectOption['id']) {
 		<component :is="deviceIcon"
 			class="media-devices-selector__icon"
 			title=""
-			:size="16" />
+			:size="20" />
 
 		<NcSelect v-model="deviceSelectedOption"
 			:input-id="`device-selector-${props.kind}`"
@@ -114,14 +112,10 @@ function updateDeviceId(deviceId: NcSelectOption['id']) {
 			:aria-label-combobox="t('spreed', 'Select a device')"
 			:clearable="false"
 			:placeholder="deviceSelectorPlaceholder"
-			:disabled="!enabled || !deviceOptionsAvailable" />
+			:disabled="!enabled || !deviceOptionsAvailable"
+			@open="$emit('refresh')" />
 
-		<NcButton variant="tertiary"
-			:title="t('spreed', 'Refresh devices list')"
-			:aria-lebel="t('spreed', 'Refresh devices list')"
-			@click="$emit('refresh')">
-			<IconRefresh :size="20" />
-		</NcButton>
+		<slot name="extra-action" />
 	</div>
 </template>
 
@@ -129,18 +123,19 @@ function updateDeviceId(deviceId: NcSelectOption['id']) {
 .media-devices-selector {
 	display: flex;
 	gap: var(--default-grid-baseline);
-	margin: calc(3 * var(--default-grid-baseline)) 0;
+	margin: calc(4 * var(--default-grid-baseline)) 0;
+	align-items: center;
 
 	&__icon {
 		display: flex;
 		justify-content: center;
 		align-items: center;
-		width: var(--default-clickable-area);
 		flex-shrink: 0;
 	}
 
 	:deep(.v-select.select) {
 		width: 100%;
+		margin: 0;
 	}
 }
 </style>

--- a/src/components/MediaSettings/MediaDevicesSpeakerTest.vue
+++ b/src/components/MediaSettings/MediaDevicesSpeakerTest.vue
@@ -4,26 +4,29 @@
 -->
 
 <template>
-	<div class="media-devices-checker">
-		<IconVolumeHigh class="media-devices-checker__icon" :size="16" />
-		<NcButton :disabled="disabled"
-			variant="secondary"
-			@click="playTestSound">
-			{{ buttonLabel }}
-		</NcButton>
-		<div v-if="isPlayingTestSound" class="equalizer">
-			<div v-for="bar in equalizerBars"
-				:key="bar.key"
-				class="equalizer__bar"
-				:style="bar.style" />
-		</div>
-	</div>
+	<NcButton :disabled="disabled"
+		class="media-devices-speaker-test-button"
+		:title="buttonLabel"
+		:aria-label="buttonLabel"
+		variant="secondary"
+		@click="playTestSound">
+		<template #icon>
+			<div class="equalizer">
+				<div v-for="bar in equalizerBars"
+					:key="bar.key"
+					class="equalizer__bar"
+					:class="{ 'equalizer__bar--active': isPlayingTestSound }"
+					:style="bar.style" />
+			</div>
+		</template>
+		<!-- TRANSLATORS: Button to test speakers by playing a sound -->
+		{{ t('spreed', 'Test') }}
+	</NcButton>
 </template>
 
 <script>
 import { t } from '@nextcloud/l10n'
 import NcButton from '@nextcloud/vue/components/NcButton'
-import IconVolumeHigh from 'vue-material-design-icons/VolumeHigh.vue'
 import { useSoundsStore } from '../../stores/sounds.js'
 
 export default {
@@ -31,7 +34,6 @@ export default {
 	name: 'MediaDevicesSpeakerTest',
 
 	components: {
-		IconVolumeHigh,
 		NcButton,
 	},
 
@@ -61,11 +63,11 @@ export default {
 		},
 
 		equalizerBars() {
-			return Array.from(Array(4).keys()).map((item) => ({
+			return Array.from(Array(3).keys()).map((item) => ({
 				key: item,
 				style: {
-					height: Math.random() * 100 + '%',
-					animationDelay: Math.random() * -2 + 's',
+					height: this.isPlayingTestSound ? (Math.random() * 100 + '%') : (item % 2 === 0 ? '40%' : '60%'),
+					animationDelay: this.isPlayingTestSound ? (Math.random() * -2 + 's') : undefined,
 				},
 			}))
 		},
@@ -92,40 +94,33 @@ export default {
 <style lang="scss" scoped>
 @use 'sass:math';
 
-.media-devices-checker {
-	display: flex;
-	gap: var(--default-grid-baseline);
-	margin: calc(3 * var(--default-grid-baseline)) 0;
+.media-devices-speaker-test-button {
+	flex-shrink: 0;
+	margin-inline-end: calc(var(--default-grid-baseline) / 2);
+}
 
-	&__icon {
-		display: flex;
-		justify-content: center;
-		align-items: center;
-		width: var(--default-clickable-area);
-		flex-shrink: 0;
-	}
-
-	.equalizer {
-		margin-inline-start: 8px;
-		height: var(--default-clickable-area);
+.equalizer {
+		height: calc(var(--default-clickable-area) - var(--default-grid-baseline)); // - total margin block
 		display: flex;
 		align-items: center;
 
 		&__bar {
-			width: 8px;
+			width: 5px;
 			height: 100%;
-			background: var(--color-primary-element);
+			background: var(--color-main-text);
 			border-radius: 4px;
-			margin: 0 2px;
-			will-change: height;
-			animation: equalizer 2s steps(15, end) infinite;
+			margin: 0 1px;
+
+			&--active {
+				will-change: height;
+				animation: equalizer 2s steps(15, end) infinite;
+			}
 		}
 	}
-}
 
 @keyframes equalizer {
 	@for $i from 0 through 15 {
-		#{4 * $i}% { height: math.random(70) + 20%; }
+		#{3 * $i}% { height: math.random(40) + 20%; }
 	}
 }
 </style>

--- a/src/components/MediaSettings/MediaSettings.vue
+++ b/src/components/MediaSettings/MediaSettings.vue
@@ -129,8 +129,11 @@
 						:devices="devices"
 						:device-id="audioOutputId"
 						@refresh="updateDevices"
-						@update:device-id="handleAudioOutputIdChange" />
-					<MediaDevicesSpeakerTest :disabled="audioStreamError" />
+						@update:device-id="handleAudioOutputIdChange">
+						<template #extra-action>
+							<MediaDevicesSpeakerTest :disabled="audioStreamError" />
+						</template>
+					</MediaDevicesSelector>
 				</template>
 
 				<template #tab-panel:backgrounds>


### PR DESCRIPTION
### ☑️ Resolves

Devices are now refreshed each time the list is opened. 
Moved speaker test to the side of the input for space use enhancement. 

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/user-attachments/assets/95d0614a-ef45-40bb-acd7-c6d704ffac4e) | ![image](https://github.com/user-attachments/assets/565d4c3e-88db-4094-9b98-1e6882c6a53e)

<!-- ☀️ Light theme | 🌑 Dark Theme -->

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
