### PR TITLE
feat(userstatus): use busy status for calls

### DIFF
--- a/lib/Status/Listener.php
+++ b/lib/Status/Listener.php
@@ -62,7 +62,7 @@ class Listener implements IEventListener {
 
 	protected function setUserStatus(BeforeParticipantModifiedEvent $event): void {
 
-		$status = IUserStatus::AWAY;
+		$status = IUserStatus::BUSY;
 
 		$userId = $event->getParticipant()->getAttendee()->getActorId();
 
@@ -90,13 +90,13 @@ class Listener implements IEventListener {
 	}
 
 	protected function revertUserStatusOnLeaveCall(BeforeParticipantModifiedEvent $event): void {
-		$this->statusManager->revertUserStatus($event->getParticipant()->getAttendee()->getActorId(), 'call', IUserStatus::AWAY);
+		$this->statusManager->revertUserStatus($event->getParticipant()->getAttendee()->getActorId(), 'call', IUserStatus::BUSY);
 	}
 
 	protected function revertUserStatusOnEndCallForEveryone(CallEndedForEveryoneEvent $event): void {
 		$userIds = $event->getUserIds();
 		if (!empty($userIds)) {
-			$this->statusManager->revertMultipleUserStatus($userIds, 'call', IUserStatus::AWAY);
+			$this->statusManager->revertMultipleUserStatus($userIds, 'call', IUserStatus::BUSY);
 		}
 	}
 }

--- a/tests/integration/features/chat-1/one-to-one.feature
+++ b/tests/integration/features/chat-1/one-to-one.feature
@@ -87,3 +87,6 @@ Feature: chat/one-to-one
     Then user "participant2" set status to "away" with 200 (v1)
     Then user "participant1" gets room "one-to-one room" with 200 (v4)
       | status | away |
+    Then user "participant2" set status to "busy" with 200 (v1)
+    Then user "participant1" gets room "one-to-one room" with 200 (v4)
+      | status | busy |


### PR DESCRIPTION
### ☑️ Resolves

Part of https://github.com/nextcloud/spreed/issues/15465

The "busy" status has existed in the user_status app since NC 28, so I don't think we need to worry about checking if it exists.


---

<!--
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
░░░███████░░░█████████░░█████░
░░███░░░███░░░███░░░███░░███░░
░░█████████░░░████████░░░███░░
░░███░░░███░░░███░░░░░░░░███░░
░█████░█████░█████░░░░░░█████░
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching frontend/UI code
-->

## 🛠️ API Checklist

### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
