### PR TITLE
fix(vue3): migrate to getFilePickerBuilder()

### DIFF
--- a/src/components/ConversationSettings/ConversationAvatarEditor.vue
+++ b/src/components/ConversationSettings/ConversationAvatarEditor.vue
@@ -58,7 +58,7 @@
 					</NcButton>
 					<NcButton :title="t('spreed', 'Choose conversation picture from files')"
 						:aria-label="t('spreed', 'Choose conversation picture from files')"
-						@click="showFilePicker = true">
+						@click="showFilePicker">
 						<template #icon>
 							<Folder :size="20" />
 						</template>
@@ -94,20 +94,12 @@
 				</div>
 			</div>
 		</div>
-
-		<FilePicker v-if="showFilePicker"
-			:name="t('spreed', 'Choose your conversation picture')"
-			container="#vue-avatar-section"
-			:buttons="filePickerButtons"
-			:multiselect="false"
-			:mimetype-filter="validMimeTypes"
-			@close="showFilePicker = false" />
 	</section>
 </template>
 
 <script>
 import { showError } from '@nextcloud/dialogs'
-import { FilePicker } from '@nextcloud/dialogs'
+import { getFilePickerBuilder } from '@nextcloud/dialogs'
 import { t } from '@nextcloud/l10n'
 import { generateUrl } from '@nextcloud/router'
 import { useIsDarkTheme } from '@nextcloud/vue/composables/useIsDarkTheme'
@@ -132,7 +124,6 @@ export default {
 
 	components: {
 		ConversationIcon,
-		FilePicker,
 		NcButton,
 		NcColorPicker,
 		NcEmojiPicker,
@@ -184,7 +175,6 @@ export default {
 	data() {
 		return {
 			showCropper: false,
-			showFilePicker: false,
 			loading: false,
 			cropperOptions: {
 				aspectRatio: 1,
@@ -217,14 +207,6 @@ export default {
 
 		showControls() {
 			return this.editable && (this.showCropper || this.emojiAvatar)
-		},
-
-		filePickerButtons() {
-			return [{
-				label: t('spreed', 'Choose'),
-				callback: (nodes) => this.handleFileChoose(nodes),
-				variant: 'primary',
-			}]
 		},
 	},
 
@@ -265,6 +247,21 @@ export default {
 				this.showCropper = true
 			}
 			reader.readAsDataURL(file)
+		},
+
+		async showFilePicker() {
+			const filePicker = getFilePickerBuilder(t('spreed', 'Choose your conversation picture'))
+				.setContainer('#vue-avatar-section')
+				.setMultiSelect(false)
+				.addMimeTypeFilter('image/png')
+				.addMimeTypeFilter('image/jpeg') // FIXME upstream: pass as array
+				.addButton({
+					label: t('spreed', 'Choose'),
+					callback: (nodes) => this.handleFileChoose(nodes),
+					variant: 'primary',
+				})
+				.build()
+			await filePicker.pickNodes()
 		},
 
 		async handleFileChoose(nodes) {

--- a/src/components/MediaSettings/VideoBackgroundEditor.vue
+++ b/src/components/MediaSettings/VideoBackgroundEditor.vue
@@ -31,7 +31,7 @@
 				</button>
 				<button class="background-editor__element"
 					:class="{ 'background-editor__element--selected': isCustomBackground }"
-					@click="showFilePicker = true">
+					@click="showFilePicker">
 					<IconFolder :size="20" />
 					{{ t('spreed', 'Files') }}
 				</button>
@@ -60,20 +60,12 @@
 			tabindex="-1"
 			aria-hidden="true"
 			@change="handleFileInput">
-
-		<FilePicker v-if="showFilePicker"
-			:name="t('spreed', 'Select a file')"
-			:path="relativeBackgroundsFolderPath"
-			container=".media-settings"
-			:buttons="filePickerButtons"
-			:multiselect="false"
-			@close="showFilePicker = false" />
 	</div>
 </template>
 
 <script>
 import { showError } from '@nextcloud/dialogs'
-import { FilePicker } from '@nextcloud/dialogs'
+import { getFilePickerBuilder } from '@nextcloud/dialogs'
 import { t } from '@nextcloud/l10n'
 import { generateUrl, imagePath } from '@nextcloud/router'
 import IconBlur from 'vue-material-design-icons/Blur.vue'
@@ -104,7 +96,6 @@ export default {
 	name: 'VideoBackgroundEditor',
 
 	components: {
-		FilePicker,
 		IconBlur,
 		IconCancel,
 		IconCheckBold,
@@ -139,7 +130,6 @@ export default {
 	data() {
 		return {
 			selectedBackground: undefined,
-			showFilePicker: false,
 		}
 	},
 
@@ -162,14 +152,6 @@ export default {
 
 		relativeBackgroundsFolderPath() {
 			return this.$store.getters.getAttachmentFolder() + '/Backgrounds'
-		},
-
-		filePickerButtons() {
-			return [{
-				label: t('spreed', 'Confirm'),
-				callback: (nodes) => this.handleFileChoose(nodes),
-				variant: 'primary',
-			}]
 		},
 	},
 
@@ -243,6 +225,20 @@ export default {
 				console.debug(error)
 				showError(t('spreed', 'Error while uploading the file'))
 			}
+		},
+
+		async showFilePicker() {
+			const filePicker = getFilePickerBuilder(t('spreed', 'Select a file'))
+				.setContainer('.media-settings')
+				.startAt(this.relativeBackgroundsFolderPath)
+				.setMultiSelect(false)
+				.addButton({
+					label: t('spreed', 'Confirm'),
+					callback: (nodes) => this.handleFileChoose(nodes),
+					variant: 'primary',
+				})
+				.build()
+			await filePicker.pickNodes()
 		},
 
 		handleFileChoose(nodes) {


### PR DESCRIPTION
### ☑️ Resolves

* `@nextcloud/dialogs` no longer export FilePicker as a component, we should migrate to get... API provided


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
Doesn't work | ![image](https://github.com/user-attachments/assets/e3df118e-c7f2-4d72-9390-e7204026d8b9)

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required