### PR TITLE
Fix joining and leaving conversations in route changes

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -358,7 +358,6 @@ export default {
 				} else {
 					console.info('Conversation received, but the current conversation is not in the list. Redirecting to not found page')
 					this.$router.push({ name: 'notfound', params: { skipLeaveWarning: true } })
-					this.tokenStore.updateToken('')
 				}
 			}
 		})
@@ -372,6 +371,14 @@ export default {
 				// Nextcloud Talk configuration changed, reload the page when changing configuration
 				window.location = generateUrl('call/' + to.params.token)
 				return
+			}
+
+			if (from.name === 'conversation') {
+				this.$store.dispatch('leaveConversation', { token: from.params.token })
+
+				if (to.name !== 'conversation') {
+					this.tokenStore.updateToken('')
+				}
 			}
 
 			/**
@@ -389,6 +396,8 @@ export default {
 				}
 				// Update current token in the token store
 				this.tokenStore.updateToken(to.params.token)
+
+				this.$store.dispatch('joinConversation', { token: to.params.token })
 			}
 
 			/**
@@ -588,7 +597,6 @@ export default {
 			} catch (exception) {
 				console.info('Conversation received, but the current conversation is not in the list. Redirecting to /apps/spreed')
 				this.$router.push({ name: 'notfound', params: { skipLeaveWarning: true } })
-				this.tokenStore.updateToken('')
 			} finally {
 				this.isRefreshingCurrentConversation = false
 			}

--- a/src/App.vue
+++ b/src/App.vue
@@ -20,6 +20,7 @@
 
 <script>
 import { getCurrentUser } from '@nextcloud/auth'
+import { showError } from '@nextcloud/dialogs'
 import { emit, subscribe, unsubscribe } from '@nextcloud/event-bus'
 import { t } from '@nextcloud/l10n'
 import { generateUrl } from '@nextcloud/router'
@@ -595,8 +596,13 @@ export default {
 				 */
 				EventBus.emit('conversations-received', { singleConversation: response.data.ocs.data })
 			} catch (exception) {
-				console.info('Conversation received, but the current conversation is not in the list. Redirecting to /apps/spreed')
-				this.$router.push({ name: 'notfound', params: { skipLeaveWarning: true } })
+				if (exception.response?.status === 404) {
+					console.info('Conversation received, but the current conversation is not in the list. Redirecting to /apps/spreed')
+					this.$router.push({ name: 'notfound', params: { skipLeaveWarning: true } })
+				} else {
+					console.error('Error getting room data', exception)
+					showError(t('spreed', 'Error occurred when getting the conversation information'))
+				}
 			} finally {
 				this.isRefreshingCurrentConversation = false
 			}

--- a/src/components/LeftSidebar/CallPhoneDialog/CallPhoneDialog.vue
+++ b/src/components/LeftSidebar/CallPhoneDialog/CallPhoneDialog.vue
@@ -57,6 +57,7 @@ import { CONVERSATION, PARTICIPANT } from '../../../constants.ts'
 import { callSIPDialOut } from '../../../services/callsService.ts'
 import { hasTalkFeature } from '../../../services/CapabilitiesManager.ts'
 import { createLegacyConversation } from '../../../services/conversationsService.ts'
+import { EventBus } from '../../../services/EventBus.ts'
 import { addParticipant } from '../../../services/participantsService.js'
 import { useActorStore } from '../../../stores/actor.ts'
 
@@ -138,7 +139,6 @@ export default {
 				await addParticipant(conversation.token, this.participantPhoneItem.id, this.participantPhoneItem.source)
 
 				this.$router.push({ name: 'conversation', params: { token: conversation.token } })
-				await this.$store.dispatch('joinConversation', { token: conversation.token })
 			} catch (exception) {
 				console.debug(exception)
 				showError(t('spreed', 'An error occurred while calling a phone number'))
@@ -150,9 +150,15 @@ export default {
 				return
 			}
 
-			this.startPhoneCall(conversation.token, this.participantPhoneItem.phoneNumber)
+			EventBus.once('joined-conversation', ({ token }) => {
+				if (conversation.token !== token) {
+					return
+				}
 
-			this.closeModal()
+				this.startPhoneCall(conversation.token, this.participantPhoneItem.phoneNumber)
+
+				this.closeModal()
+			})
 		},
 
 		async startPhoneCall(token, phoneNumber) {

--- a/src/components/LeftSidebar/CallPhoneDialog/CallPhoneDialog.vue
+++ b/src/components/LeftSidebar/CallPhoneDialog/CallPhoneDialog.vue
@@ -139,10 +139,6 @@ export default {
 
 				this.$router.push({ name: 'conversation', params: { token: conversation.token } })
 				await this.$store.dispatch('joinConversation', { token: conversation.token })
-
-				this.startPhoneCall(conversation.token, this.participantPhoneItem.phoneNumber)
-
-				this.closeModal()
 			} catch (exception) {
 				console.debug(exception)
 				showError(t('spreed', 'An error occurred while calling a phone number'))
@@ -150,7 +146,13 @@ export default {
 					this.$store.dispatch('deleteConversationFromServer', { token: conversation.token })
 				}
 				this.closeModal()
+
+				return
 			}
+
+			this.startPhoneCall(conversation.token, this.participantPhoneItem.phoneNumber)
+
+			this.closeModal()
 		},
 
 		async startPhoneCall(token, phoneNumber) {

--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -937,15 +937,8 @@ export default {
 				// this is triggered when the hash in the URL changes
 				return
 			}
-			if (from.name === 'conversation') {
-				this.$store.dispatch('leaveConversation', { token: from.params.token })
-				if (to.name !== 'conversation') {
-					this.tokenStore.updateToken('')
-				}
-			}
 			if (to.name === 'conversation') {
 				this.abortSearch()
-				this.$store.dispatch('joinConversation', { token: to.params.token })
 				this.showArchived = this.$store.getters.conversation(to.params.token)?.isArchived ?? false
 				this.scrollToConversation(to.params.token)
 			}


### PR DESCRIPTION
Fixes #15459

## TODO
- [ ] Verify that everything still works as intended after rebasing to latest _main_

## How to test (scenario 1)

- Create a public conversation
- Copy the conversation link
- Start a call
- In a private window, use the conversation link to join the conversation as a guest
- Join the call
- Add `throw new \Exception();` to the beginning of [RoomController::getSingleRoom()](https://github.com/nextcloud/spreed/blob/28b85f33a9789a73ba49b4716fcc5ab69d9aa603/lib/Controller/RoomController.php#L399)
- Wait until the conversation is fetch again

### Result with this pull request (second commit)

In the private window, _The conversation does not exist_ is shown and the audio of the call is no longer active; in the original window the guest is no longer in the call

### Result with this pull request (third commit)

In the private window, the call view is still visible, but an error toast about issues updating the conversation is shown; in the original window the guest is still in the call

### Result without this pull request

In the private window, _The conversation does not exist_ is shown, but the audio of the call is still active; in the original window the guest is still in the call



## How to test (scenario 2)

- Create a public conversation
- Copy the conversation link
- Start a call
- In a private window, use the conversation link to join the conversation as a guest
- Join the call
- Add `return new DataResponse([], Http::STATUS_NOT_FOUND);` to the beginning of [RoomController::getSingleRoom()](https://github.com/nextcloud/spreed/blob/28b85f33a9789a73ba49b4716fcc5ab69d9aa603/lib/Controller/RoomController.php#L399)
- Wait until the conversation is fetch again

### Result with this pull request

In the private window, _The conversation does not exist_ is shown and the audio of the call is no longer active; in the original window the guest is no longer in the call

### Result without this pull request

In the private window, _The conversation does not exist_ is shown, but the audio of the call is still active; in the original window the guest is still in the call



## How to test (scenario 3)

- Create a group conversation
- Copy the group conversation link
- Create a public conversation
- Paste the link to the group conversation in a new message
- Copy the public conversation link
- Start a call
- In a private window, use the public conversation link to join the conversation as a guest
- Join the call
- Click on the link to the group conversation in the chat message
- Confirm leaving the call in the dialog

### Result with this pull request

In the private window, _The conversation does not exist_ is shown and the audio of the call is no longer active; in the original window the guest is no longer in the call

### Result without this pull request

In the private window, _The conversation does not exist_ is shown, but the audio of the call is still active; in the original window the guest is still in the call



## How to test (scenario 4)

- Create a public conversation
- Copy the public conversation link
- Create another public conversation
- Paste the link to the first public conversation in a new message
- Copy the second public conversation link
- Start a call
- In a private window, use the second public conversation link to join the conversation as a guest
- Join the call
- Click on the link to the first public conversation in the chat message
- Confirm leaving the call in the dialog

### Result with this pull request

In the private window, the first public conversation is loaded and the audio of the call is no longer active; in the original window the guest is no longer in the call

### Result without this pull request

In the private window, the first public conversation never finishes to load, but the audio of the call is still active; in the original window the guest is still in the call
