### PR TITLE
fix: migrate to outline icons in admin settings

### DIFF
--- a/src/components/AdminSettings/BotsSettings.vue
+++ b/src/components/AdminSettings/BotsSettings.vue
@@ -82,9 +82,9 @@ import { t } from '@nextcloud/l10n'
 import moment from '@nextcloud/moment'
 import NcButton from '@nextcloud/vue/components/NcButton'
 import NcPopover from '@nextcloud/vue/components/NcPopover'
-import Cancel from 'vue-material-design-icons/Cancel.vue'
-import Check from 'vue-material-design-icons/Check.vue'
-import Lock from 'vue-material-design-icons/Lock.vue'
+import IconCancel from 'vue-material-design-icons/Cancel.vue'
+import IconCheck from 'vue-material-design-icons/Check.vue'
+import IconLockOutline from 'vue-material-design-icons/LockOutline.vue'
 import { BOT } from '../../constants.ts'
 import { getAllBots } from '../../services/botsService.ts'
 
@@ -142,12 +142,12 @@ export default {
 		getStateIcon(state) {
 			switch (state) {
 				case BOT.STATE.NO_SETUP:
-					return { state_icon_component: Lock, state_icon_label: t('spreed', 'Locked for moderators'), state_icon_color: 'var(--color-warning)' }
+					return { state_icon_component: IconLockOutline, state_icon_label: t('spreed', 'Locked for moderators'), state_icon_color: 'var(--color-warning)' }
 				case BOT.STATE.ENABLED:
-					return { state_icon_component: Check, state_icon_label: t('spreed', 'Enabled'), state_icon_color: 'var(--color-success)' }
+					return { state_icon_component: IconCheck, state_icon_label: t('spreed', 'Enabled'), state_icon_color: 'var(--color-success)' }
 				case BOT.STATE.DISABLED:
 				default:
-					return { state_icon_component: Cancel, state_icon_label: t('spreed', 'Disabled'), state_icon_color: 'var(--color-error)' }
+					return { state_icon_component: IconCancel, state_icon_label: t('spreed', 'Disabled'), state_icon_color: 'var(--color-error)' }
 			}
 		},
 	},

--- a/src/components/AdminSettings/MatterbridgeIntegration.vue
+++ b/src/components/AdminSettings/MatterbridgeIntegration.vue
@@ -35,7 +35,7 @@
 			<NcButton :disabled="isInstalling"
 				@click="enableMatterbridgeApp">
 				<template v-if="isInstalling" #icon>
-					<span class="icon icon-loading-small" />
+					<NcLoadingIcon :size="20" />
 				</template>
 				{{ installButtonText }}
 			</NcButton>
@@ -49,6 +49,7 @@ import { loadState } from '@nextcloud/initial-state'
 import { t } from '@nextcloud/l10n'
 import NcButton from '@nextcloud/vue/components/NcButton'
 import NcCheckboxRadioSwitch from '@nextcloud/vue/components/NcCheckboxRadioSwitch'
+import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
 import {
 	enableMatterbridgeApp,
 	getMatterbridgeVersion,
@@ -61,6 +62,7 @@ export default {
 	components: {
 		NcButton,
 		NcCheckboxRadioSwitch,
+		NcLoadingIcon,
 	},
 
 	data() {

--- a/src/components/AdminSettings/RecordingServer.vue
+++ b/src/components/AdminSettings/RecordingServer.vue
@@ -26,13 +26,13 @@
 			:aria-label="t('spreed', 'Delete this server')"
 			@click="removeServer">
 			<template #icon>
-				<IconDelete :size="20" />
+				<IconDeleteOutline :size="20" />
 			</template>
 		</NcButton>
 
 		<span v-if="server" class="test-connection">
 			<NcLoadingIcon v-if="!checked" :size="20" />
-			<IconAlertCircle v-else-if="errorMessage" :size="20" fill-color="var(--color-error)" />
+			<IconAlertCircleOutline v-else-if="errorMessage" :size="20" fill-color="var(--color-error)" />
 			<IconCheck v-else :size="20" fill-color="var(--color-success)" />
 			{{ connectionState }}
 		</span>
@@ -55,9 +55,9 @@ import NcButton from '@nextcloud/vue/components/NcButton'
 import NcCheckboxRadioSwitch from '@nextcloud/vue/components/NcCheckboxRadioSwitch'
 import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
 import NcTextField from '@nextcloud/vue/components/NcTextField'
-import IconAlertCircle from 'vue-material-design-icons/AlertCircle.vue'
+import IconAlertCircleOutline from 'vue-material-design-icons/AlertCircleOutline.vue'
 import IconCheck from 'vue-material-design-icons/Check.vue'
-import IconDelete from 'vue-material-design-icons/Delete.vue'
+import IconDeleteOutline from 'vue-material-design-icons/DeleteOutline.vue'
 import IconReload from 'vue-material-design-icons/Reload.vue'
 import { getWelcomeMessage } from '../../services/recordingService.js'
 
@@ -65,9 +65,9 @@ export default {
 	name: 'RecordingServer',
 
 	components: {
-		IconAlertCircle,
+		IconAlertCircleOutline,
 		IconCheck,
-		IconDelete,
+		IconDeleteOutline,
 		IconReload,
 		NcButton,
 		NcCheckboxRadioSwitch,

--- a/src/components/AdminSettings/RecordingServers.vue
+++ b/src/components/AdminSettings/RecordingServers.vue
@@ -37,7 +37,7 @@
 				:disabled="loading"
 				@click="newServer">
 				<template #icon>
-					<span v-if="loading" class="icon icon-loading-small" />
+					<NcLoadingIcon v-if="loading" :size="20" />
 					<IconPlus v-else :size="20" />
 				</template>
 				{{ t('spreed', 'Add a new recording backend server') }}
@@ -104,6 +104,7 @@ import { t } from '@nextcloud/l10n'
 import debounce from 'debounce'
 import NcButton from '@nextcloud/vue/components/NcButton'
 import NcCheckboxRadioSwitch from '@nextcloud/vue/components/NcCheckboxRadioSwitch'
+import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
 import NcNoteCard from '@nextcloud/vue/components/NcNoteCard'
 import NcPasswordField from '@nextcloud/vue/components/NcPasswordField'
 import IconPlus from 'vue-material-design-icons/Plus.vue'
@@ -125,6 +126,7 @@ export default {
 	components: {
 		NcButton,
 		NcCheckboxRadioSwitch,
+		NcLoadingIcon,
 		NcNoteCard,
 		NcPasswordField,
 		IconPlus,

--- a/src/components/AdminSettings/RecordingServers.vue
+++ b/src/components/AdminSettings/RecordingServers.vue
@@ -38,7 +38,7 @@
 				@click="newServer">
 				<template #icon>
 					<span v-if="loading" class="icon icon-loading-small" />
-					<Plus v-else :size="20" />
+					<IconPlus v-else :size="20" />
 				</template>
 				{{ t('spreed', 'Add a new recording backend server') }}
 			</NcButton>
@@ -106,12 +106,11 @@ import NcButton from '@nextcloud/vue/components/NcButton'
 import NcCheckboxRadioSwitch from '@nextcloud/vue/components/NcCheckboxRadioSwitch'
 import NcNoteCard from '@nextcloud/vue/components/NcNoteCard'
 import NcPasswordField from '@nextcloud/vue/components/NcPasswordField'
-import Plus from 'vue-material-design-icons/Plus.vue'
+import IconPlus from 'vue-material-design-icons/Plus.vue'
 import RecordingServer from '../../components/AdminSettings/RecordingServer.vue'
 import TransitionWrapper from '../UIShared/TransitionWrapper.vue'
 import { CONFIG } from '../../constants.ts'
 import { hasTalkFeature } from '../../services/CapabilitiesManager.ts'
-import { EventBus } from '../../services/EventBus.ts'
 
 const recordingConsentCapability = hasTalkFeature('local', 'recording-consent')
 const recordingConsentOptions = [
@@ -128,7 +127,7 @@ export default {
 		NcCheckboxRadioSwitch,
 		NcNoteCard,
 		NcPasswordField,
-		Plus,
+		IconPlus,
 		RecordingServer,
 		TransitionWrapper,
 	},

--- a/src/components/AdminSettings/SignalingServer.vue
+++ b/src/components/AdminSettings/SignalingServer.vue
@@ -25,13 +25,13 @@
 			:aria-label="t('spreed', 'Delete this server')"
 			@click="removeServer">
 			<template #icon>
-				<IconDelete :size="20" />
+				<IconDeleteOutline :size="20" />
 			</template>
 		</NcButton>
 
 		<span v-if="server" class="test-connection">
 			<NcLoadingIcon v-if="!checked" :size="20" />
-			<IconAlertCircle v-else-if="errorMessage" :size="20" fill-color="var(--color-error)" />
+			<IconAlertCircleOutline v-else-if="errorMessage" :size="20" fill-color="var(--color-error)" />
 			<IconAlertCircleOutline v-else-if="warningMessage" :size="20" fill-color="var(--color-warning)" />
 			<IconCheck v-else :size="20" fill-color="var(--color-success)" />
 			{{ connectionState }}
@@ -69,10 +69,9 @@ import NcButton from '@nextcloud/vue/components/NcButton'
 import NcCheckboxRadioSwitch from '@nextcloud/vue/components/NcCheckboxRadioSwitch'
 import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
 import NcTextField from '@nextcloud/vue/components/NcTextField'
-import IconAlertCircle from 'vue-material-design-icons/AlertCircle.vue'
 import IconAlertCircleOutline from 'vue-material-design-icons/AlertCircleOutline.vue'
 import IconCheck from 'vue-material-design-icons/Check.vue'
-import IconDelete from 'vue-material-design-icons/Delete.vue'
+import IconDeleteOutline from 'vue-material-design-icons/DeleteOutline.vue'
 import IconReload from 'vue-material-design-icons/Reload.vue'
 import { EventBus } from '../../services/EventBus.ts'
 import { fetchSignalingSettings, getWelcomeMessage } from '../../services/signalingService.js'
@@ -82,10 +81,9 @@ export default {
 	name: 'SignalingServer',
 
 	components: {
-		IconAlertCircle,
 		IconAlertCircleOutline,
 		IconCheck,
-		IconDelete,
+		IconDeleteOutline,
 		IconReload,
 		NcButton,
 		NcCheckboxRadioSwitch,

--- a/src/components/AdminSettings/SignalingServers.vue
+++ b/src/components/AdminSettings/SignalingServers.vue
@@ -54,7 +54,7 @@
 			:disabled="loading"
 			@click="newServer">
 			<template #icon>
-				<span v-if="loading" class="icon icon-loading-small" />
+				<NcLoadingIcon v-if="loading" :size="20" />
 				<IconPlus v-else :size="20" />
 			</template>
 			{{ t('spreed', 'Add High-performance backend server') }}
@@ -93,6 +93,7 @@ import debounce from 'debounce'
 import { computed, onBeforeUnmount, ref } from 'vue'
 import NcButton from '@nextcloud/vue/components/NcButton'
 import NcCheckboxRadioSwitch from '@nextcloud/vue/components/NcCheckboxRadioSwitch'
+import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
 import NcNoteCard from '@nextcloud/vue/components/NcNoteCard'
 import NcPasswordField from '@nextcloud/vue/components/NcPasswordField'
 import IconPlus from 'vue-material-design-icons/Plus.vue'

--- a/src/components/AdminSettings/SignalingServers.vue
+++ b/src/components/AdminSettings/SignalingServers.vue
@@ -55,7 +55,7 @@
 			@click="newServer">
 			<template #icon>
 				<span v-if="loading" class="icon icon-loading-small" />
-				<Plus v-else :size="20" />
+				<IconPlus v-else :size="20" />
 			</template>
 			{{ t('spreed', 'Add High-performance backend server') }}
 		</NcButton>
@@ -95,7 +95,7 @@ import NcButton from '@nextcloud/vue/components/NcButton'
 import NcCheckboxRadioSwitch from '@nextcloud/vue/components/NcCheckboxRadioSwitch'
 import NcNoteCard from '@nextcloud/vue/components/NcNoteCard'
 import NcPasswordField from '@nextcloud/vue/components/NcPasswordField'
-import Plus from 'vue-material-design-icons/Plus.vue'
+import IconPlus from 'vue-material-design-icons/Plus.vue'
 import SignalingServer from '../../components/AdminSettings/SignalingServer.vue'
 import { SIGNALING } from '../../constants.ts'
 

--- a/src/components/AdminSettings/StunServer.vue
+++ b/src/components/AdminSettings/StunServer.vue
@@ -20,7 +20,7 @@
 				label-outside />
 		</div>
 
-		<AlertCircle v-show="!isValidServer"
+		<IconAlertCircleOutline v-show="!isValidServer"
 			class="stun-server__alert"
 			:title="t('spreed', 'The server address is invalid')"
 			fill-color="#E9322D" />
@@ -30,7 +30,7 @@
 			:aria-label="t('spreed', 'Delete this server')"
 			@click="removeServer">
 			<template #icon>
-				<Delete :size="20" />
+				<IconDeleteOutline :size="20" />
 			</template>
 		</NcButton>
 	</li>
@@ -40,15 +40,15 @@
 import { t } from '@nextcloud/l10n'
 import NcButton from '@nextcloud/vue/components/NcButton'
 import NcTextField from '@nextcloud/vue/components/NcTextField'
-import AlertCircle from 'vue-material-design-icons/AlertCircle.vue'
-import Delete from 'vue-material-design-icons/Delete.vue'
+import IconAlertCircleOutline from 'vue-material-design-icons/AlertCircleOutline.vue'
+import IconDeleteOutline from 'vue-material-design-icons/DeleteOutline.vue'
 
 export default {
 	name: 'StunServer',
 
 	components: {
-		AlertCircle,
-		Delete,
+		IconAlertCircleOutline,
+		IconDeleteOutline,
 		NcButton,
 		NcTextField,
 	},

--- a/src/components/AdminSettings/StunServers.vue
+++ b/src/components/AdminSettings/StunServers.vue
@@ -31,7 +31,7 @@
 			@click="newServer">
 			<template #icon>
 				<span v-if="loading" class="icon icon-loading-small" />
-				<Plus v-else :size="20" />
+				<IconPlus v-else :size="20" />
 			</template>
 			{{ t('spreed', 'Add a new STUN server') }}
 		</NcButton>
@@ -44,7 +44,7 @@ import { loadState } from '@nextcloud/initial-state'
 import { t } from '@nextcloud/l10n'
 import debounce from 'debounce'
 import NcButton from '@nextcloud/vue/components/NcButton'
-import Plus from 'vue-material-design-icons/Plus.vue'
+import IconPlus from 'vue-material-design-icons/Plus.vue'
 import StunServer from '../../components/AdminSettings/StunServer.vue'
 import TransitionWrapper from '../UIShared/TransitionWrapper.vue'
 
@@ -54,7 +54,7 @@ export default {
 	components: {
 		NcButton,
 		StunServer,
-		Plus,
+		IconPlus,
 		TransitionWrapper,
 	},
 

--- a/src/components/AdminSettings/StunServers.vue
+++ b/src/components/AdminSettings/StunServers.vue
@@ -30,7 +30,7 @@
 			:disabled="loading"
 			@click="newServer">
 			<template #icon>
-				<span v-if="loading" class="icon icon-loading-small" />
+				<NcLoadingIcon v-if="loading" :size="20" />
 				<IconPlus v-else :size="20" />
 			</template>
 			{{ t('spreed', 'Add a new STUN server') }}
@@ -44,6 +44,7 @@ import { loadState } from '@nextcloud/initial-state'
 import { t } from '@nextcloud/l10n'
 import debounce from 'debounce'
 import NcButton from '@nextcloud/vue/components/NcButton'
+import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
 import IconPlus from 'vue-material-design-icons/Plus.vue'
 import StunServer from '../../components/AdminSettings/StunServer.vue'
 import TransitionWrapper from '../UIShared/TransitionWrapper.vue'
@@ -52,6 +53,7 @@ export default {
 	name: 'StunServers',
 
 	components: {
+		NcLoadingIcon,
 		NcButton,
 		StunServer,
 		IconPlus,

--- a/src/components/AdminSettings/TurnServer.vue
+++ b/src/components/AdminSettings/TurnServer.vue
@@ -55,9 +55,9 @@
 			@click="testServer">
 			<template #icon>
 				<span v-if="testing" class="icon icon-loading-small" />
-				<AlertCircle v-else-if="testingError" fill-color="#E9322D" />
-				<Check v-else-if="testingSuccess" fill-color="#46BA61" />
-				<Pulse v-else />
+				<IconAlertCircleOutline v-else-if="testingError" fill-color="#E9322D" />
+				<IconCheck v-else-if="testingSuccess" fill-color="#46BA61" />
+				<IconPulse v-else />
 			</template>
 		</NcButton>
 		<NcButton v-show="!loading"
@@ -65,7 +65,7 @@
 			:aria-label="t('spreed', 'Delete this server')"
 			@click="removeServer">
 			<template #icon>
-				<Delete :size="20" />
+				<IconDeleteOutline :size="20" />
 			</template>
 		</NcButton>
 	</li>
@@ -81,10 +81,10 @@ import NcButton from '@nextcloud/vue/components/NcButton'
 import NcPasswordField from '@nextcloud/vue/components/NcPasswordField'
 import NcSelect from '@nextcloud/vue/components/NcSelect'
 import NcTextField from '@nextcloud/vue/components/NcTextField'
-import AlertCircle from 'vue-material-design-icons/AlertCircle.vue'
-import Check from 'vue-material-design-icons/Check.vue'
-import Delete from 'vue-material-design-icons/Delete.vue'
-import Pulse from 'vue-material-design-icons/Pulse.vue'
+import IconAlertCircleOutline from 'vue-material-design-icons/AlertCircleOutline.vue'
+import IconCheck from 'vue-material-design-icons/Check.vue'
+import IconDeleteOutline from 'vue-material-design-icons/DeleteOutline.vue'
+import IconPulse from 'vue-material-design-icons/Pulse.vue'
 import { isCertificateValid } from '../../services/certificateService.ts'
 import { convertToUnix } from '../../utils/formattedTime.ts'
 
@@ -92,14 +92,14 @@ export default {
 	name: 'TurnServer',
 
 	components: {
-		AlertCircle,
-		Check,
-		Delete,
+		IconAlertCircleOutline,
+		IconCheck,
+		IconDeleteOutline,
 		NcButton,
 		NcSelect,
 		NcTextField,
 		NcPasswordField,
-		Pulse,
+		IconPulse,
 	},
 
 	props: {

--- a/src/components/AdminSettings/TurnServer.vue
+++ b/src/components/AdminSettings/TurnServer.vue
@@ -54,7 +54,7 @@
 			:disabled="!testAvailable"
 			@click="testServer">
 			<template #icon>
-				<span v-if="testing" class="icon icon-loading-small" />
+				<NcLoadingIcon v-if="testing" :size="20" />
 				<IconAlertCircleOutline v-else-if="testingError" fill-color="#E9322D" />
 				<IconCheck v-else-if="testingSuccess" fill-color="#46BA61" />
 				<IconPulse v-else />
@@ -78,6 +78,7 @@ import hmacSHA1 from 'crypto-js/hmac-sha1.js'
 import debounce from 'debounce'
 import webrtcSupport from 'webrtcsupport'
 import NcButton from '@nextcloud/vue/components/NcButton'
+import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
 import NcPasswordField from '@nextcloud/vue/components/NcPasswordField'
 import NcSelect from '@nextcloud/vue/components/NcSelect'
 import NcTextField from '@nextcloud/vue/components/NcTextField'
@@ -92,6 +93,7 @@ export default {
 	name: 'TurnServer',
 
 	components: {
+		NcLoadingIcon,
 		IconAlertCircleOutline,
 		IconCheck,
 		IconDeleteOutline,
@@ -213,15 +215,6 @@ export default {
 				{ value: 'turn', label: t('spreed', '{option} only', { option: 'turn:' }) },
 				{ value: 'turns', label: t('spreed', '{option} only', { option: 'turns:' }) },
 			]
-		},
-
-		testIconClasses() {
-			return {
-				'icon-category-monitoring': !this.testing && !this.testingError && !this.testingSuccess,
-				'icon-loading-small': this.testing,
-				'icon-error': this.testingError,
-				'icon-checkmark': this.testingSuccess,
-			}
 		},
 
 		testResult() {

--- a/src/components/AdminSettings/TurnServers.vue
+++ b/src/components/AdminSettings/TurnServers.vue
@@ -36,7 +36,7 @@
 			@click="newServer">
 			<template #icon>
 				<span v-if="loading" class="icon icon-loading-small" />
-				<Plus v-else :size="20" />
+				<IconPlus v-else :size="20" />
 			</template>
 			{{ t('spreed', 'Add a new TURN server') }}
 		</NcButton>
@@ -49,7 +49,7 @@ import { loadState } from '@nextcloud/initial-state'
 import { t } from '@nextcloud/l10n'
 import debounce from 'debounce'
 import NcButton from '@nextcloud/vue/components/NcButton'
-import Plus from 'vue-material-design-icons/Plus.vue'
+import IconPlus from 'vue-material-design-icons/Plus.vue'
 import TurnServer from '../../components/AdminSettings/TurnServer.vue'
 import TransitionWrapper from '../UIShared/TransitionWrapper.vue'
 
@@ -59,7 +59,7 @@ export default {
 	components: {
 		NcButton,
 		TurnServer,
-		Plus,
+		IconPlus,
 		TransitionWrapper,
 	},
 

--- a/src/components/AdminSettings/TurnServers.vue
+++ b/src/components/AdminSettings/TurnServers.vue
@@ -35,7 +35,7 @@
 			:disabled="loading"
 			@click="newServer">
 			<template #icon>
-				<span v-if="loading" class="icon icon-loading-small" />
+				<NcLoadingIcon v-if="loading" :size="20" />
 				<IconPlus v-else :size="20" />
 			</template>
 			{{ t('spreed', 'Add a new TURN server') }}
@@ -49,6 +49,7 @@ import { loadState } from '@nextcloud/initial-state'
 import { t } from '@nextcloud/l10n'
 import debounce from 'debounce'
 import NcButton from '@nextcloud/vue/components/NcButton'
+import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
 import IconPlus from 'vue-material-design-icons/Plus.vue'
 import TurnServer from '../../components/AdminSettings/TurnServer.vue'
 import TransitionWrapper from '../UIShared/TransitionWrapper.vue'
@@ -57,6 +58,7 @@ export default {
 	name: 'TurnServers',
 
 	components: {
+		NcLoadingIcon,
 		NcButton,
 		TurnServer,
 		IconPlus,

--- a/src/components/AdminSettings/WebServerSetupChecks.vue
+++ b/src/components/AdminSettings/WebServerSetupChecks.vue
@@ -21,8 +21,8 @@
 					:aria-label="virtualBackgroundAvailableAriaLabel"
 					@click="checkVirtualBackground">
 					<template #icon>
-						<AlertCircle v-if="virtualBackgroundAvailable === false" :size="20" />
-						<Check v-else-if="virtualBackgroundAvailable === true" :size="20" />
+						<IconAlertCircleOutline v-if="virtualBackgroundAvailable === false" :size="20" />
+						<IconCheck v-else-if="virtualBackgroundAvailable === true" :size="20" />
 						<span v-else class="icon icon-loading-small" />
 					</template>
 				</NcButton>
@@ -37,8 +37,8 @@ import { t } from '@nextcloud/l10n'
 import { generateFilePath } from '@nextcloud/router'
 import NcButton from '@nextcloud/vue/components/NcButton'
 import NcNoteCard from '@nextcloud/vue/components/NcNoteCard'
-import AlertCircle from 'vue-material-design-icons/AlertCircle.vue'
-import Check from 'vue-material-design-icons/Check.vue'
+import IconAlertCircleOutline from 'vue-material-design-icons/AlertCircleOutline.vue'
+import IconCheck from 'vue-material-design-icons/Check.vue'
 import { VIRTUAL_BACKGROUND } from '../../constants.ts'
 import JitsiStreamBackgroundEffect from '../../utils/media/effects/virtual-background/JitsiStreamBackgroundEffect.js'
 import VirtualBackground from '../../utils/media/pipeline/VirtualBackground.js'
@@ -47,10 +47,10 @@ export default {
 	name: 'WebServerSetupChecks',
 
 	components: {
-		AlertCircle,
+		IconAlertCircleOutline,
 		NcButton,
 		NcNoteCard,
-		Check,
+		IconCheck,
 	},
 
 	data() {

--- a/src/components/AdminSettings/WebServerSetupChecks.vue
+++ b/src/components/AdminSettings/WebServerSetupChecks.vue
@@ -23,7 +23,7 @@
 					<template #icon>
 						<IconAlertCircleOutline v-if="virtualBackgroundAvailable === false" :size="20" />
 						<IconCheck v-else-if="virtualBackgroundAvailable === true" :size="20" />
-						<span v-else class="icon icon-loading-small" />
+						<NcLoadingIcon v-else :size="20" />
 					</template>
 				</NcButton>
 			</li>
@@ -36,6 +36,7 @@ import { loadState } from '@nextcloud/initial-state'
 import { t } from '@nextcloud/l10n'
 import { generateFilePath } from '@nextcloud/router'
 import NcButton from '@nextcloud/vue/components/NcButton'
+import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
 import NcNoteCard from '@nextcloud/vue/components/NcNoteCard'
 import IconAlertCircleOutline from 'vue-material-design-icons/AlertCircleOutline.vue'
 import IconCheck from 'vue-material-design-icons/Check.vue'
@@ -47,6 +48,7 @@ export default {
 	name: 'WebServerSetupChecks',
 
 	components: {
+		NcLoadingIcon,
 		IconAlertCircleOutline,
 		NcButton,
 		NcNoteCard,


### PR DESCRIPTION
### ☑️ Resolves

* Ref #15473

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

<img width="192" alt="image" src="https://github.com/user-attachments/assets/6b8a99e6-a019-48d0-910d-99fb45923734" />
<img width="180" alt="image" src="https://github.com/user-attachments/assets/e8ba6b93-a02d-49bc-9676-dd12adf094a6" />

---
<img width="209" alt="image" src="https://github.com/user-attachments/assets/d4d490d0-4f5a-493d-b2fc-c3a2dd904b1b" />
<img width="164" alt="image" src="https://github.com/user-attachments/assets/84925b51-63c3-463b-80fa-f59ac8b72282" />
<img width="240" alt="image" src="https://github.com/user-attachments/assets/2739247d-e8d5-4197-8431-31e1c938c5e7" />


### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Not risky to browser differences / client
- [x] 🖌️ Design was reviewed, approved or inspired by the design team