### PR TITLE
feat(threads): Recent threads, no more read marker and add conversation token

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -18,7 +18,7 @@
 * 🌉 **Sync with other chat solutions** With [Matterbridge](https://github.com/42wim/matterbridge/) being integrated in Talk, you can easily sync a lot of other chat solutions to Nextcloud Talk and vice-versa.
 ]]></description>
 
-	<version>22.0.0-dev.9</version>
+	<version>22.0.0-dev.10</version>
 	<licence>agpl</licence>
 
 	<author>Anna Larch</author>

--- a/lib/Chat/ChatManager.php
+++ b/lib/Chat/ChatManager.php
@@ -450,15 +450,9 @@ class ChatManager {
 			if (!empty($alreadyNotifiedUsers)) {
 				$userIds = array_column($alreadyNotifiedUsers, 'id');
 				$this->participantService->markUsersAsMentioned($chat, Attendee::ACTOR_USERS, $userIds, (int)$comment->getId(), $usersDirectlyMentioned);
-				if ($thread !== null) {
-					$this->threadService->markAttendeesAsMentioned($chat, Attendee::ACTOR_USERS, $userIds, (int)$comment->getId(), $usersDirectlyMentioned);
-				}
 			}
 			if (!empty($federatedUsersDirectlyMentioned)) {
 				$this->participantService->markUsersAsMentioned($chat, Attendee::ACTOR_FEDERATED_USERS, $federatedUsersDirectlyMentioned, (int)$comment->getId(), $federatedUsersDirectlyMentioned);
-				if ($thread !== null) {
-					$this->threadService->markAttendeesAsMentioned($chat, Attendee::ACTOR_FEDERATED_USERS, $federatedUsersDirectlyMentioned, (int)$comment->getId(), $federatedUsersDirectlyMentioned);
-				}
 			}
 
 			// User was not mentioned, send a normal notification

--- a/lib/Controller/ThreadController.php
+++ b/lib/Controller/ThreadController.php
@@ -130,6 +130,9 @@ class ThreadController extends AEnvironmentAwareOCSController {
 		foreach ($threads as $thread) {
 			$firstMessage = $lastMessage = null;
 			$attendee = $attendees[$thread->getId()] ?? null;
+			if ($attendee === null) {
+				$attendee = ThreadAttendee::createFromParticipant($thread->getId(), $this->participant);
+			}
 
 			$first = $comments[$thread->getId()] ?? null;
 			if ($first !== null) {
@@ -145,7 +148,7 @@ class ThreadController extends AEnvironmentAwareOCSController {
 
 			$list[] = [
 				'thread' => $thread->jsonSerialize(),
-				'attendee' => $attendee?->jsonSerialize(),
+				'attendee' => $attendee->jsonSerialize(),
 				'first' => $firstMessage?->toArray($this->getResponseFormat()),
 				'last' => $lastMessage?->toArray($this->getResponseFormat()),
 			];

--- a/lib/Controller/ThreadController.php
+++ b/lib/Controller/ThreadController.php
@@ -147,7 +147,7 @@ class ThreadController extends AEnvironmentAwareOCSController {
 			}
 
 			$list[] = [
-				'thread' => $thread->jsonSerialize(),
+				'thread' => $thread->toArray($this->room),
 				'attendee' => $attendee->jsonSerialize(),
 				'first' => $firstMessage?->toArray($this->getResponseFormat()),
 				'last' => $lastMessage?->toArray($this->getResponseFormat()),

--- a/lib/Controller/ThreadController.php
+++ b/lib/Controller/ThreadController.php
@@ -51,11 +51,9 @@ class ThreadController extends AEnvironmentAwareOCSController {
 	}
 
 	/**
-	 * Get list of threads in a conversation
+	 * Get recent active threads in a conversation
 	 *
 	 * @param int<1, 50> $limit Number of threads to return
-	 * @param int $offsetId The last thread ID that was known, default 0 starts from the newest
-	 * @psalm-param non-negative-int $offsetId
 	 * @return DataResponse<Http::STATUS_OK, list<TalkThreadInfo>, array{}>
 	 *
 	 * 200: List of threads returned
@@ -63,12 +61,12 @@ class ThreadController extends AEnvironmentAwareOCSController {
 	#[PublicPage]
 	#[RequireModeratorOrNoLobby]
 	#[RequireParticipant]
-	#[ApiRoute(verb: 'GET', url: '/api/{apiVersion}/chat/{token}/threads', requirements: [
+	#[ApiRoute(verb: 'GET', url: '/api/{apiVersion}/chat/{token}/threads/recent', requirements: [
 		'apiVersion' => '(v1)',
 		'token' => '[a-z0-9]{4,30}',
 	])]
-	public function listThreads(int $limit = 25, int $offsetId = 0): DataResponse {
-		$threads = $this->threadService->findByRoom($this->room, $limit, $offsetId);
+	public function getRecentActiveThreads(int $limit = 50): DataResponse {
+		$threads = $this->threadService->getRecentByRoomId($this->room, $limit);
 		$list = $this->prepareListOfThreads($threads);
 		return new DataResponse($list);
 	}

--- a/lib/Migration/Version22000Date20250710124258.php
+++ b/lib/Migration/Version22000Date20250710124258.php
@@ -45,6 +45,20 @@ class Version22000Date20250710124258 extends SimpleMigrationStep {
 			$table->addIndex(['last_activity'], 'talkthread_lastactive');
 		}
 
+		$table = $schema->getTable('talk_thread_attendees');
+		if ($table->hasColumn('last_read_message')) {
+			$table->dropColumn('last_read_message');
+		}
+		if ($table->hasColumn('last_mention_message')) {
+			$table->dropColumn('last_mention_message');
+		}
+		if ($table->hasColumn('last_mention_direct')) {
+			$table->dropColumn('last_mention_direct');
+		}
+		if ($table->hasColumn('read_privacy')) {
+			$table->dropColumn('read_privacy');
+		}
+
 		return $schema;
 	}
 }

--- a/lib/Migration/Version22000Date20250710124258.php
+++ b/lib/Migration/Version22000Date20250710124258.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Talk\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+use Override;
+
+/**
+ * Add the last activity (for sorting) and thread name for future feature to name a thread
+ */
+class Version22000Date20250710124258 extends SimpleMigrationStep {
+	/**
+	 * @param IOutput $output
+	 * @param Closure(): ISchemaWrapper $schemaClosure
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	#[Override]
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$table = $schema->getTable('talk_threads');
+		if (!$table->hasColumn('last_activity')) {
+			$table->addColumn('last_activity', Types::DATETIME, [
+				'notnull' => false,
+			]);
+			$table->addColumn('name', Types::STRING, [
+				'notnull' => false,
+				'length' => 255,
+				'default' => '',
+			]);
+
+			$table->addIndex(['last_activity'], 'talkthread_lastactive');
+		}
+
+		return $schema;
+	}
+}

--- a/lib/Model/Thread.php
+++ b/lib/Model/Thread.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace OCA\Talk\Model;
 
 use OCA\Talk\ResponseDefinitions;
+use OCA\Talk\Room;
 use OCP\AppFramework\Db\Entity;
 use OCP\DB\Types;
 
@@ -27,7 +28,7 @@ use OCP\DB\Types;
  *
  * @psalm-import-type TalkThread from ResponseDefinitions
  */
-class Thread extends Entity implements \JsonSerializable {
+class Thread extends Entity {
 	protected int $roomId = 0;
 	protected int $lastMessageId = 0;
 	protected int $numReplies = 0;
@@ -45,11 +46,11 @@ class Thread extends Entity implements \JsonSerializable {
 	/**
 	 * @return TalkThread
 	 */
-	#[\Override]
-	public function jsonSerialize(): array {
+	public function toArray(Room $room): array {
 		return [
 			'id' => max(1, $this->getId()),
 			// 'roomId' => max(1, $this->getRoomId()),
+			'roomToken' => $room->getToken(),
 			'lastMessageId' => max(0, $this->getLastMessageId()),
 			'numReplies' => max(0, $this->getNumReplies()),
 			'lastActivity' => max(0, $this->getLastActivity()?->getTimestamp() ?? 0),

--- a/lib/Model/Thread.php
+++ b/lib/Model/Thread.php
@@ -20,6 +20,10 @@ use OCP\DB\Types;
  * @method int getLastMessageId()
  * @method void setNumReplies(int $numReplies)
  * @method int getNumReplies()
+ * @method void setLastActivity(\DateTime $lastActivity)
+ * @method \DateTime|null getLastActivity()
+ * @method void setName(string $name)
+ * @method string getName()
  *
  * @psalm-import-type TalkThread from ResponseDefinitions
  */
@@ -27,11 +31,15 @@ class Thread extends Entity implements \JsonSerializable {
 	protected int $roomId = 0;
 	protected int $lastMessageId = 0;
 	protected int $numReplies = 0;
+	protected ?\DateTime $lastActivity = null;
+	protected string $name = '';
 
 	public function __construct() {
 		$this->addType('roomId', Types::BIGINT);
 		$this->addType('lastMessageId', Types::BIGINT);
 		$this->addType('numReplies', Types::BIGINT);
+		$this->addType('lastActivity', Types::DATETIME);
+		$this->addType('name', Types::STRING);
 	}
 
 	/**
@@ -41,9 +49,11 @@ class Thread extends Entity implements \JsonSerializable {
 	public function jsonSerialize(): array {
 		return [
 			'id' => max(1, $this->getId()),
-			'roomId' => max(1, $this->getRoomId()),
+			// 'roomId' => max(1, $this->getRoomId()),
 			'lastMessageId' => max(0, $this->getLastMessageId()),
 			'numReplies' => max(0, $this->getNumReplies()),
+			'lastActivity' => max(0, $this->getLastActivity()?->getTimestamp() ?? 0),
+			// 'name' => $this->getName(),
 		];
 	}
 }

--- a/lib/Model/ThreadMapper.php
+++ b/lib/Model/ThreadMapper.php
@@ -43,10 +43,9 @@ class ThreadMapper extends QBMapper {
 
 	/**
 	 * @param int<1, 50> $limit
-	 * @param non-negative-int $offsetId
 	 * @return list<Thread>
 	 */
-	public function findByRoomId(int $roomId, int $limit, int $offsetId = 0): array {
+	public function getRecentByRoomId(int $roomId, int $limit): array {
 		$query = $this->db->getQueryBuilder();
 		$query->select('*')
 			->from($this->getTableName())
@@ -55,16 +54,8 @@ class ThreadMapper extends QBMapper {
 				$query->createNamedParameter($roomId, IQueryBuilder::PARAM_INT),
 				IQueryBuilder::PARAM_INT,
 			))
-			->orderBy('id', 'DESC')
+			->orderBy('last_activity', 'DESC')
 			->setMaxResults($limit);
-
-		if ($offsetId !== 0) {
-			$query->andWhere($query->expr()->lt(
-				'id',
-				$query->createNamedParameter($offsetId, IQueryBuilder::PARAM_INT),
-				IQueryBuilder::PARAM_INT,
-			));
-		}
 
 		return $this->findEntities($query);
 	}

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -449,8 +449,8 @@ namespace OCA\Talk;
  *
  * @psalm-type TalkThread = array{
  *     id: positive-int,
- *     roomId: positive-int,
  *     lastMessageId: non-negative-int,
+ *     lastActivity: non-negative-int,
  *     numReplies: non-negative-int,
  * }
  *

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -456,15 +456,11 @@ namespace OCA\Talk;
  *
  * @psalm-type TalkThreadAttendee = array{
  *      notificationLevel: 0|1|2|3,
- *      lastReadMessage: non-negative-int,
- *      lastMentionMessage: non-negative-int,
- *      lastMentionDirect: non-negative-int,
- *      readPrivacy: 0|1,
  * }
  *
  * @psalm-type TalkThreadInfo = array{
  *      thread: TalkThread,
- *      attendee: ?TalkThreadAttendee,
+ *      attendee: TalkThreadAttendee,
  *      first: ?TalkChatMessage,
  *      last: ?TalkChatMessage,
  * }

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -449,6 +449,7 @@ namespace OCA\Talk;
  *
  * @psalm-type TalkThread = array{
  *     id: positive-int,
+ *     roomToken: string,
  *     lastMessageId: non-negative-int,
  *     lastActivity: non-negative-int,
  *     numReplies: non-negative-int,

--- a/lib/Service/ThreadService.php
+++ b/lib/Service/ThreadService.php
@@ -63,12 +63,11 @@ class ThreadService {
 
 	/**
 	 * @param int<1, 50> $limit
-	 * @param non-negative-int $offsetId
 	 * @return list<Thread>
 	 */
-	public function findByRoom(Room $room, int $limit, int $offsetId = 0): array {
+	public function getRecentByRoomId(Room $room, int $limit): array {
 		$limit = min(50, max(1, $limit));
-		return $this->threadMapper->findByRoomId($room->getId(), $limit, $offsetId);
+		return $this->threadMapper->getRecentByRoomId($room->getId(), $limit);
 	}
 
 	/**

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -2015,8 +2015,9 @@
                 "type": "object",
                 "required": [
                     "id",
-                    "roomId",
+                    "roomToken",
                     "lastMessageId",
+                    "lastActivity",
                     "numReplies"
                 ],
                 "properties": {
@@ -2025,12 +2026,15 @@
                         "format": "int64",
                         "minimum": 1
                     },
-                    "roomId": {
-                        "type": "integer",
-                        "format": "int64",
-                        "minimum": 1
+                    "roomToken": {
+                        "type": "string"
                     },
                     "lastMessageId": {
+                        "type": "integer",
+                        "format": "int64",
+                        "minimum": 0
+                    },
+                    "lastActivity": {
                         "type": "integer",
                         "format": "int64",
                         "minimum": 0
@@ -2045,11 +2049,7 @@
             "ThreadAttendee": {
                 "type": "object",
                 "required": [
-                    "notificationLevel",
-                    "lastReadMessage",
-                    "lastMentionMessage",
-                    "lastMentionDirect",
-                    "readPrivacy"
+                    "notificationLevel"
                 ],
                 "properties": {
                     "notificationLevel": {
@@ -2060,29 +2060,6 @@
                             1,
                             2,
                             3
-                        ]
-                    },
-                    "lastReadMessage": {
-                        "type": "integer",
-                        "format": "int64",
-                        "minimum": 0
-                    },
-                    "lastMentionMessage": {
-                        "type": "integer",
-                        "format": "int64",
-                        "minimum": 0
-                    },
-                    "lastMentionDirect": {
-                        "type": "integer",
-                        "format": "int64",
-                        "minimum": 0
-                    },
-                    "readPrivacy": {
-                        "type": "integer",
-                        "format": "int64",
-                        "enum": [
-                            0,
-                            1
                         ]
                     }
                 }
@@ -2100,8 +2077,7 @@
                         "$ref": "#/components/schemas/Thread"
                     },
                     "attendee": {
-                        "$ref": "#/components/schemas/ThreadAttendee",
-                        "nullable": true
+                        "$ref": "#/components/schemas/ThreadAttendee"
                     },
                     "first": {
                         "$ref": "#/components/schemas/ChatMessage",
@@ -20855,10 +20831,10 @@
                 }
             }
         },
-        "/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/threads": {
+        "/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/threads/recent": {
             "get": {
-                "operationId": "thread-list-threads",
-                "summary": "Get list of threads in a conversation",
+                "operationId": "thread-get-recent-active-threads",
+                "summary": "Get recent active threads in a conversation",
                 "tags": [
                     "thread"
                 ],
@@ -20900,20 +20876,9 @@
                         "schema": {
                             "type": "integer",
                             "format": "int64",
-                            "default": 25,
+                            "default": 50,
                             "minimum": 1,
                             "maximum": 50
-                        }
-                    },
-                    {
-                        "name": "offsetId",
-                        "in": "query",
-                        "description": "The last thread ID that was known, default 0 starts from the newest",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "default": 0,
-                            "minimum": 0
                         }
                     },
                     {

--- a/openapi.json
+++ b/openapi.json
@@ -1920,8 +1920,9 @@
                 "type": "object",
                 "required": [
                     "id",
-                    "roomId",
+                    "roomToken",
                     "lastMessageId",
+                    "lastActivity",
                     "numReplies"
                 ],
                 "properties": {
@@ -1930,12 +1931,15 @@
                         "format": "int64",
                         "minimum": 1
                     },
-                    "roomId": {
-                        "type": "integer",
-                        "format": "int64",
-                        "minimum": 1
+                    "roomToken": {
+                        "type": "string"
                     },
                     "lastMessageId": {
+                        "type": "integer",
+                        "format": "int64",
+                        "minimum": 0
+                    },
+                    "lastActivity": {
                         "type": "integer",
                         "format": "int64",
                         "minimum": 0
@@ -1950,11 +1954,7 @@
             "ThreadAttendee": {
                 "type": "object",
                 "required": [
-                    "notificationLevel",
-                    "lastReadMessage",
-                    "lastMentionMessage",
-                    "lastMentionDirect",
-                    "readPrivacy"
+                    "notificationLevel"
                 ],
                 "properties": {
                     "notificationLevel": {
@@ -1965,29 +1965,6 @@
                             1,
                             2,
                             3
-                        ]
-                    },
-                    "lastReadMessage": {
-                        "type": "integer",
-                        "format": "int64",
-                        "minimum": 0
-                    },
-                    "lastMentionMessage": {
-                        "type": "integer",
-                        "format": "int64",
-                        "minimum": 0
-                    },
-                    "lastMentionDirect": {
-                        "type": "integer",
-                        "format": "int64",
-                        "minimum": 0
-                    },
-                    "readPrivacy": {
-                        "type": "integer",
-                        "format": "int64",
-                        "enum": [
-                            0,
-                            1
                         ]
                     }
                 }
@@ -2005,8 +1982,7 @@
                         "$ref": "#/components/schemas/Thread"
                     },
                     "attendee": {
-                        "$ref": "#/components/schemas/ThreadAttendee",
-                        "nullable": true
+                        "$ref": "#/components/schemas/ThreadAttendee"
                     },
                     "first": {
                         "$ref": "#/components/schemas/ChatMessage",
@@ -20760,10 +20736,10 @@
                 }
             }
         },
-        "/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/threads": {
+        "/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/threads/recent": {
             "get": {
-                "operationId": "thread-list-threads",
-                "summary": "Get list of threads in a conversation",
+                "operationId": "thread-get-recent-active-threads",
+                "summary": "Get recent active threads in a conversation",
                 "tags": [
                     "thread"
                 ],
@@ -20805,20 +20781,9 @@
                         "schema": {
                             "type": "integer",
                             "format": "int64",
-                            "default": 25,
+                            "default": 50,
                             "minimum": 1,
                             "maximum": 50
-                        }
-                    },
-                    {
-                        "name": "offsetId",
-                        "in": "query",
-                        "description": "The last thread ID that was known, default 0 starts from the newest",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "default": 0,
-                            "minimum": 0
                         }
                     },
                     {

--- a/src/types/openapi/openapi-full.ts
+++ b/src/types/openapi/openapi-full.ts
@@ -1593,15 +1593,15 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
-    "/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/threads": {
+    "/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/threads/recent": {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        /** Get list of threads in a conversation */
-        get: operations["thread-list-threads"];
+        /** Get recent active threads in a conversation */
+        get: operations["thread-get-recent-active-threads"];
         put?: never;
         post?: never;
         delete?: never;
@@ -2829,10 +2829,11 @@ export type components = {
         Thread: {
             /** Format: int64 */
             id: number;
-            /** Format: int64 */
-            roomId: number;
+            roomToken: string;
             /** Format: int64 */
             lastMessageId: number;
+            /** Format: int64 */
+            lastActivity: number;
             /** Format: int64 */
             numReplies: number;
         };
@@ -2842,17 +2843,6 @@ export type components = {
              * @enum {integer}
              */
             notificationLevel: 0 | 1 | 2 | 3;
-            /** Format: int64 */
-            lastReadMessage: number;
-            /** Format: int64 */
-            lastMentionMessage: number;
-            /** Format: int64 */
-            lastMentionDirect: number;
-            /**
-             * Format: int64
-             * @enum {integer}
-             */
-            readPrivacy: 0 | 1;
         };
         ThreadInfo: {
             thread: components["schemas"]["Thread"];
@@ -10231,13 +10221,11 @@ export interface operations {
             };
         };
     };
-    "thread-list-threads": {
+    "thread-get-recent-active-threads": {
         parameters: {
             query?: {
                 /** @description Number of threads to return */
                 limit?: number;
-                /** @description The last thread ID that was known, default 0 starts from the newest */
-                offsetId?: number;
             };
             header: {
                 /** @description Required to be true for the API request to pass */

--- a/src/types/openapi/openapi.ts
+++ b/src/types/openapi/openapi.ts
@@ -1593,15 +1593,15 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
-    "/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/threads": {
+    "/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/threads/recent": {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        /** Get list of threads in a conversation */
-        get: operations["thread-list-threads"];
+        /** Get recent active threads in a conversation */
+        get: operations["thread-get-recent-active-threads"];
         put?: never;
         post?: never;
         delete?: never;
@@ -2291,10 +2291,11 @@ export type components = {
         Thread: {
             /** Format: int64 */
             id: number;
-            /** Format: int64 */
-            roomId: number;
+            roomToken: string;
             /** Format: int64 */
             lastMessageId: number;
+            /** Format: int64 */
+            lastActivity: number;
             /** Format: int64 */
             numReplies: number;
         };
@@ -2304,17 +2305,6 @@ export type components = {
              * @enum {integer}
              */
             notificationLevel: 0 | 1 | 2 | 3;
-            /** Format: int64 */
-            lastReadMessage: number;
-            /** Format: int64 */
-            lastMentionMessage: number;
-            /** Format: int64 */
-            lastMentionDirect: number;
-            /**
-             * Format: int64
-             * @enum {integer}
-             */
-            readPrivacy: 0 | 1;
         };
         ThreadInfo: {
             thread: components["schemas"]["Thread"];
@@ -9693,13 +9683,11 @@ export interface operations {
             };
         };
     };
-    "thread-list-threads": {
+    "thread-get-recent-active-threads": {
         parameters: {
             query?: {
                 /** @description Number of threads to return */
                 limit?: number;
-                /** @description The last thread ID that was known, default 0 starts from the newest */
-                offsetId?: number;
             };
             header: {
                 /** @description Required to be true for the API request to pass */

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -2734,10 +2734,10 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 		}, $results));
 	}
 
-	#[Then('/^user "([^"]*)" sees the following threads in room "([^"]*)" with (\d+)(?: \((v1)\))?$/')]
-	public function userSeesTheFollowingThreadsInRoom(string $user, string $identifier, int $statusCode, string $apiVersion = 'v1', ?TableNode $formData = null): void {
+	#[Then('/^user "([^"]*)" sees the following recent threads in room "([^"]*)" with (\d+)(?: \((v1)\))?$/')]
+	public function userSeesTheFollowingRecentThreadsInRoom(string $user, string $identifier, int $statusCode, string $apiVersion = 'v1', ?TableNode $formData = null): void {
 		$this->setCurrentUser($user);
-		$this->sendRequest('GET', '/apps/spreed/api/' . $apiVersion . '/chat/' . self::$identifierToToken[$identifier] . '/threads');
+		$this->sendRequest('GET', '/apps/spreed/api/' . $apiVersion . '/chat/' . self::$identifierToToken[$identifier] . '/threads/recent');
 		$this->assertStatusCode($this->response, $statusCode);
 
 		$results = $this->getDataFromResponse($this->response);
@@ -2754,6 +2754,8 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 			$result = $this->getDataFromResponse($this->response);
 			$this->compareThreadsResponse($formData, [$result]);
 		}
+
+		sleep(1);
 	}
 
 	protected function compareThreadsResponse(?TableNode $formData, array $results): void {
@@ -2767,7 +2769,7 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 		Assert::assertCount($count, $results, 'Result count does not match');
 
 		$expected = array_map(static function (array $result) {
-			foreach (['t.id', 't.lastMessage', 'a.lastReadMessage', 'a.lastMentionMessage', 'a.lastMentionDirect', 'firstMessage', 'lastMessage'] as $field) {
+			foreach (['t.id', 't.lastMessage', 'firstMessage', 'lastMessage'] as $field) {
 				if (isset($result[$field])) {
 					if ($result[$field] === '0') {
 						$result[$field] = 0;
@@ -2790,9 +2792,6 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 				't.id' => $actual['thread']['id'],
 				't.numReplies' => $actual['thread']['numReplies'],
 				't.lastMessage' => $actual['thread']['lastMessageId'],
-				'a.lastReadMessage' => $actual['attendee']['lastReadMessage'] ?? null,
-				'a.lastMentionMessage' => $actual['attendee']['lastMentionMessage'] ?? null,
-				'a.lastMentionDirect' => $actual['attendee']['lastMentionDirect'] ?? null,
 				'firstMessage' => $actual['first']['id'] ?? null,
 				'lastMessage' => $actual['last']['id'] ?? null,
 			];

--- a/tests/integration/features/chat-4/threads.feature
+++ b/tests/integration/features/chat-4/threads.feature
@@ -9,9 +9,9 @@ Feature: chat-4/threads
       | roomName | room |
     And user "participant1" adds user "participant2" to room "room" with 200 (v4)
     And user "participant1" sends message "Message 1" to room "room" with 201
-    Then user "participant1" sees the following threads in room "room" with 200
+    Then user "participant1" sees the following recent threads in room "room" with 200
     And user "participant2" sends reply "Message 1-1" on message "Message 1" to room "room" with 201
-    Then user "participant1" sees the following threads in room "room" with 200
+    Then user "participant1" sees the following recent threads in room "room" with 200
 
   Scenario: Create thread on root message
     Given user "participant1" creates room "room" (v4)
@@ -20,8 +20,8 @@ Feature: chat-4/threads
     And user "participant1" adds user "participant2" to room "room" with 200 (v4)
     And user "participant1" sends message "Message 1" to room "room" with 201
     And user "participant1" creates thread "Message 1" in room "room" with 200
-      | t.id      | t.numReplies | t.lastMessage | a.lastReadMessage | a.lastMentionMessage | a.lastMentionDirect | firstMessage | lastMessage |
-      | Message 1 | 0            | 0             | Message 1         | 0                    | 0                   | Message 1    | NULL        |
+      | t.id      | t.numReplies | t.lastMessage | firstMessage | lastMessage |
+      | Message 1 | 0            | 0             | Message 1    | NULL        |
 
   Scenario: Create thread on root with reply
     Given user "participant1" creates room "room" (v4)
@@ -31,8 +31,8 @@ Feature: chat-4/threads
     And user "participant1" sends message "Message 1" to room "room" with 201
     And user "participant2" sends reply "Message 1-1" on message "Message 1" to room "room" with 201
     And user "participant1" creates thread "Message 1" in room "room" with 200
-      | t.id      | t.numReplies | t.lastMessage | a.lastReadMessage | a.lastMentionMessage | a.lastMentionDirect | firstMessage | lastMessage |
-      | Message 1 | 1            | Message 1-1   | Message 1         | 0                    | 0                   | Message 1    | Message 1-1 |
+      | t.id      | t.numReplies | t.lastMessage | firstMessage | lastMessage |
+      | Message 1 | 1            | Message 1-1   | Message 1    | Message 1-1 |
 
   Scenario: Create thread on reply
     Given user "participant1" creates room "room" (v4)
@@ -42,29 +42,42 @@ Feature: chat-4/threads
     And user "participant1" sends message "Message 1" to room "room" with 201
     And user "participant2" sends reply "Message 1-1" on message "Message 1" to room "room" with 201
     And user "participant1" creates thread "Message 1-1" in room "room" with 200
-      | t.id      | t.numReplies | t.lastMessage | a.lastReadMessage | a.lastMentionMessage | a.lastMentionDirect | firstMessage | lastMessage |
-      | Message 1 | 1            | Message 1-1   | Message 1         | 0                    | 0                   | Message 1    | Message 1-1 |
+      | t.id      | t.numReplies | t.lastMessage | firstMessage | lastMessage |
+      | Message 1 | 1            | Message 1-1   | Message 1    | Message 1-1 |
 
-  Scenario: Mention marker works ~~before and~~ only after threading for now
+  Scenario: Creating a thread again does not conflict nor duplicate
     Given user "participant1" creates room "room" (v4)
       | roomType | 2 |
       | roomName | room |
     And user "participant1" adds user "participant2" to room "room" with 200 (v4)
-    And user "participant1" sends message "Message 1 @participant2" to room "room" with 201
-    And user "participant2" reads message "Message 1 @participant2" in room "room" with 200
-    When user "participant1" creates thread "Message 1 @participant2" in room "room" with 200
-    When user "participant2" creates thread "Message 1 @participant2" in room "room" with 200
-    Then user "participant1" sees the following threads in room "room" with 200
-      | t.id         | t.numReplies | t.lastMessage | a.lastReadMessage | a.lastMentionMessage | a.lastMentionDirect | firstMessage     | lastMessage |
-      | Message 1 @participant2 | 0 | 0       | Message 1 @participant2 | 0                    | 0                   | Message 1 @participant2 | NULL |
-    Then user "participant2" sees the following threads in room "room" with 200
-      | t.id         | t.numReplies | t.lastMessage | a.lastReadMessage | a.lastMentionMessage | a.lastMentionDirect | firstMessage     | lastMessage |
-#      | Message 1 @participant2 | 0 | 0       | Message 1 @participant2 | Message 1 @participant2 | Message 1 @participant2 | Message 1 @participant2 | NULL |
-      | Message 1 @participant2 | 0 | 0       | Message 1 @participant2 | 0                    | 0                   | Message 1 @participant2 | NULL |
-    When user "participant1" sends reply "Message 1-1 @participant2" on message "Message 1 @participant2" to room "room" with 201
-    Then user "participant1" sees the following threads in room "room" with 200
-      | t.id         | t.numReplies | t.lastMessage              | a.lastReadMessage      | a.lastMentionMessage | a.lastMentionDirect       | firstMessage | lastMessage |
-      | Message 1 @participant2 | 1 | Message 1-1 @participant2 | Message 1 @participant2 | 0                    | Message 1-1 @participant2 | Message 1 @participant2 | Message 1-1 @participant2 |
-    Then user "participant2" sees the following threads in room "room" with 200
-      | t.id         | t.numReplies | t.lastMessage | a.lastReadMessage | a.lastMentionMessage | a.lastMentionDirect | firstMessage | lastMessage |
-      | Message 1 @participant2 | 1 | Message 1-1 @participant2 | Message 1 @participant2 | Message 1-1 @participant2 | Message 1-1 @participant2 | Message 1 @participant2 | Message 1-1 @participant2 |
+    And user "participant1" sends message "Message 1" to room "room" with 201
+    When user "participant1" creates thread "Message 1" in room "room" with 200
+    When user "participant2" creates thread "Message 1" in room "room" with 200
+    Then user "participant1" sees the following recent threads in room "room" with 200
+      | t.id      | t.numReplies | t.lastMessage | firstMessage | lastMessage |
+      | Message 1 | 0            | 0             | Message 1    | NULL        |
+    Then user "participant2" sees the following recent threads in room "room" with 200
+      | t.id      | t.numReplies | t.lastMessage | firstMessage | lastMessage |
+      | Message 1 | 0            | 0             | Message 1    | NULL        |
+
+  Scenario: Recent threads are sorted by last activity
+    Given user "participant1" creates room "room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    And user "participant1" adds user "participant2" to room "room" with 200 (v4)
+    And user "participant1" sends message "Message 1" to room "room" with 201
+    And user "participant2" sends message "Message 2" to room "room" with 201
+    When user "participant2" creates thread "Message 2" in room "room" with 200
+    Then user "participant1" sees the following recent threads in room "room" with 200
+      | t.id      | t.numReplies | t.lastMessage | firstMessage | lastMessage |
+      | Message 2 | 0            | 0             | Message 2    | NULL        |
+    When user "participant1" creates thread "Message 1" in room "room" with 200
+    Then user "participant1" sees the following recent threads in room "room" with 200
+      | t.id      | t.numReplies | t.lastMessage | firstMessage | lastMessage |
+      | Message 1 | 0            | 0             | Message 1    | NULL        |
+      | Message 2 | 0            | 0             | Message 2    | NULL        |
+    When user "participant1" sends reply "Message 2-1" on message "Message 2" to room "room" with 201
+    Then user "participant2" sees the following recent threads in room "room" with 200
+      | t.id      | t.numReplies | t.lastMessage | firstMessage | lastMessage |
+      | Message 2 | 1            | Message 2-1   | Message 2    | Message 2-1 |
+      | Message 1 | 0            | 0             | Message 1    | NULL        |


### PR DESCRIPTION
- [x] Ref #9679 
- [x] We can not find a suitable way for a read marker logic so for now we hide it just like teams, slack, telegram and all others
- [x] Track last activity of threads and change the list to recent threads
- [x] Always return a thread attendee and the room token

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
