### PR TITLE
fix(comments): Stop using deprecated method of comments manager

### DIFF
--- a/lib/Chat/ChatManager.php
+++ b/lib/Chat/ChatManager.php
@@ -848,9 +848,10 @@ class ChatManager {
 	 *                    timeout expired.
 	 */
 	public function getHistory(Room $chat, int $offset, int $limit, bool $includeLastKnown, int $threadId = 0): array {
-		return $this->commentsManager->getForObjectSince(
+		return $this->commentsManager->getCommentsWithVerbForObjectSinceComment(
 			'chat',
 			(string)$chat->getId(),
+			[],
 			$offset,
 			'desc',
 			$limit,
@@ -961,7 +962,7 @@ class ChatManager {
 		}
 
 		// Load data from the database
-		$comments = $this->commentsManager->getForObjectSince('chat', (string)$chat->getId(), $offset, 'asc', $limit, $includeLastKnown);
+		$comments = $this->commentsManager->getCommentsWithVerbForObjectSinceComment('chat', (string)$chat->getId(), [], $offset, 'asc', $limit, $includeLastKnown);
 
 		if (empty($comments)) {
 			// We only write the cache when there were no new comments,
@@ -987,13 +988,13 @@ class ChatManager {
 	protected function waitForNewMessagesWithDatabase(Room $chat, int $offset, int $limit, int $timeout, bool $includeLastKnown): array {
 		$elapsedTime = 0;
 
-		$comments = $this->commentsManager->getForObjectSince('chat', (string)$chat->getId(), $offset, 'asc', $limit, $includeLastKnown);
+		$comments = $this->commentsManager->getCommentsWithVerbForObjectSinceComment('chat', (string)$chat->getId(), [], $offset, 'asc', $limit, $includeLastKnown);
 
 		while (empty($comments) && $elapsedTime < $timeout) {
 			sleep(1);
 			$elapsedTime++;
 
-			$comments = $this->commentsManager->getForObjectSince('chat', (string)$chat->getId(), $offset, 'asc', $limit, $includeLastKnown);
+			$comments = $this->commentsManager->getCommentsWithVerbForObjectSinceComment('chat', (string)$chat->getId(), [], $offset, 'asc', $limit, $includeLastKnown);
 		}
 
 		return $comments;

--- a/tests/php/Chat/ChatManagerTest.php
+++ b/tests/php/Chat/ChatManagerTest.php
@@ -292,8 +292,8 @@ class ChatManagerTest extends TestCase {
 			->willReturn(1234);
 
 		$this->commentsManager->expects($this->once())
-			->method('getForObjectSince')
-			->with('chat', 1234, $offset, 'desc', $limit)
+			->method('getCommentsWithVerbForObjectSinceComment')
+			->with('chat', 1234, [], $offset, 'desc', $limit)
 			->willReturn($expected);
 
 		$comments = $this->chatManager->getHistory($chat, $offset, $limit, false);
@@ -317,8 +317,8 @@ class ChatManagerTest extends TestCase {
 			->willReturn(1234);
 
 		$this->commentsManager->expects($this->once())
-			->method('getForObjectSince')
-			->with('chat', 1234, $offset, 'asc', $limit)
+			->method('getCommentsWithVerbForObjectSinceComment')
+			->with('chat', 1234, [], $offset, 'asc', $limit)
 			->willReturn($expected);
 
 		$this->notifier->expects($this->once())
@@ -352,8 +352,8 @@ class ChatManagerTest extends TestCase {
 			->willReturn(1234);
 
 		$this->commentsManager->expects($this->exactly(2))
-			->method('getForObjectSince')
-			->with('chat', 1234, $offset, 'asc', $limit)
+			->method('getCommentsWithVerbForObjectSinceComment')
+			->with('chat', 1234, [], $offset, 'asc', $limit)
 			->willReturnOnConsecutiveCalls(
 				[],
 				$expected


### PR DESCRIPTION
https://github.com/nextcloud/server/blob/9836e9b16484582d309c8437ab46d82e34956941/lib/public/Comments/ICommentsManager.php#L113

Not sure how this slipped 3 years and psalm didn't complain

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
