### PR TITLE
fix(permissions): permissions editor ignores changes

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -11,6 +11,8 @@ const ignorePatterns = [
 	'@nextcloud/dialogs',
 	'@nextcloud/vue',
 	'@mdi/svg',
+	'@vueuse/core',
+	'@vueuse/shared',
 	'bail',
 	'ccount', // ESM dependency of remark-gfm
 	'comma-separated-tokens',

--- a/src/components/PermissionsEditor/PermissionsEditor.vue
+++ b/src/components/PermissionsEditor/PermissionsEditor.vue
@@ -13,38 +13,31 @@
 				<!-- eslint-disable-next-line vue/no-v-html -->
 				<p :id="dialogHeaderId" class="title" v-html="modalTitle" />
 				<form @submit.prevent="handleSubmitPermissions">
-					<NcCheckboxRadioSwitch ref="callStart"
-						v-model="callStart"
+					<NcCheckboxRadioSwitch v-model="callStart"
 						class="checkbox">
 						{{ t('spreed', 'Start a call') }}
 					</NcCheckboxRadioSwitch>
-					<NcCheckboxRadioSwitch ref="lobbyIgnore"
-						v-model="lobbyIgnore"
+					<NcCheckboxRadioSwitch v-model="lobbyIgnore"
 						class="checkbox">
 						{{ t('spreed', 'Skip the lobby') }}
 					</NcCheckboxRadioSwitch>
-					<NcCheckboxRadioSwitch ref="chatMessagesAndReactions"
-						v-model="chatMessagesAndReactions"
+					<NcCheckboxRadioSwitch v-model="chatMessagesAndReactions"
 						class="checkbox">
 						{{ t('spreed', 'Can post messages and reactions') }}
 					</NcCheckboxRadioSwitch>
-					<NcCheckboxRadioSwitch ref="publishAudio"
-						v-model="publishAudio"
+					<NcCheckboxRadioSwitch v-model="publishAudio"
 						class="checkbox">
 						{{ t('spreed', 'Enable the microphone') }}
 					</NcCheckboxRadioSwitch>
-					<NcCheckboxRadioSwitch ref="publishVideo"
-						v-model="publishVideo"
+					<NcCheckboxRadioSwitch v-model="publishVideo"
 						class="checkbox">
 						{{ t('spreed', 'Enable the camera') }}
 					</NcCheckboxRadioSwitch>
-					<NcCheckboxRadioSwitch ref="publishScreen"
-						v-model="publishScreen"
+					<NcCheckboxRadioSwitch v-model="publishScreen"
 						class="checkbox">
 						{{ t('spreed', 'Share the screen') }}
 					</NcCheckboxRadioSwitch>
-					<NcButton ref="submit"
-						type="submit"
+					<NcButton type="submit"
 						class="button-update-permission"
 						variant="primary"
 						:disabled="submitButtonDisabled">


### PR DESCRIPTION
### ☑️ Resolves

- `<PermissionsEditor>` had template refs and component properties with the same name, for example, `lobbyIgnore` was at the same time:
  - a template ref, storing with a child component instance
  - a boolean property of the component instance
- These template refs were only added for tests - removing
- Fixing tests:
  - Submit the HTML form instead of clicking on the submit button
  - Find checkboxes by label text instead of template refs
  - Remove `wrapper.setData()` usage, it is a forbidden method for tests

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![before](https://github.com/user-attachments/assets/b667c0d7-b782-46dd-856f-8a03f502319f) | ![after](https://github.com/user-attachments/assets/d808f68f-74c8-4157-9a7e-1a784cbd67bf)

<!-- ☀️ Light theme | 🌑 Dark Theme -->

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [x] Talk Desktop
  - [x] Not risky to browser differences / client
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required