### PR TITLE
fix(message): support mention-all metadata in system messages

### DIFF
--- a/lib/Activity/Listener.php
+++ b/lib/Activity/Listener.php
@@ -87,7 +87,7 @@ class Listener implements IEventListener {
 			$actorType = Attendee::ACTOR_GUESTS;
 			$actorId = Attendee::ACTOR_ID_SYSTEM;
 		}
-		$this->chatManager->addSystemMessage($room, $actorType, $actorId, json_encode([
+		$this->chatManager->addSystemMessage($room, $actor, $actorType, $actorId, json_encode([
 			'message' => $message,
 			'parameters' => [
 				'users' => $userIds,

--- a/lib/Chat/ChatManager.php
+++ b/lib/Chat/ChatManager.php
@@ -140,6 +140,7 @@ class ChatManager {
 	 */
 	public function addSystemMessage(
 		Room $chat,
+		?Participant $participant,
 		string $actorType,
 		string $actorId,
 		string $message,
@@ -181,11 +182,14 @@ class ChatManager {
 			$comment->setVerb(self::VERB_SYSTEM);
 		}
 
+		$metadata = [];
 		if ($silent) {
-			$comment->setMetaData([
-				Message::METADATA_SILENT => true,
-			]);
+			$metadata[Message::METADATA_SILENT] = true;
 		}
+		if ($chat->getMentionPermissions() === Room::MENTION_PERMISSIONS_EVERYONE || $participant?->hasModeratorPermissions()) {
+			$metadata[Message::METADATA_CAN_MENTION_ALL] = true;
+		}
+		$comment->setMetaData($metadata);
 
 		$this->setMessageExpiration($chat, $comment);
 
@@ -614,6 +618,7 @@ class ChatManager {
 
 		return $this->addSystemMessage(
 			$chat,
+			$participant,
 			$participant->getAttendee()->getActorType(),
 			$participant->getAttendee()->getActorId(),
 			json_encode(['message' => 'message_deleted', 'parameters' => ['message' => $comment->getId()]]),
@@ -703,6 +708,7 @@ class ChatManager {
 
 		return $this->addSystemMessage(
 			$chat,
+			$participant,
 			$participant->getAttendee()->getActorType(),
 			$participant->getAttendee()->getActorId(),
 			json_encode(['message' => 'message_edited', 'parameters' => ['message' => $comment->getId()]]),
@@ -735,6 +741,7 @@ class ChatManager {
 
 		return $this->addSystemMessage(
 			$chat,
+			null,
 			$actorType,
 			$actorId,
 			json_encode(['message' => 'history_cleared', 'parameters' => []]),

--- a/lib/Chat/ReactionManager.php
+++ b/lib/Chat/ReactionManager.php
@@ -123,6 +123,7 @@ class ReactionManager {
 
 		$this->chatManager->addSystemMessage(
 			$chat,
+			null,
 			$actorType,
 			$actorId,
 			json_encode(['message' => 'reaction_revoked', 'parameters' => ['message' => (int)$comment->getId()]]),

--- a/lib/Chat/SystemMessage/Listener.php
+++ b/lib/Chat/SystemMessage/Listener.php
@@ -522,7 +522,7 @@ class Listener implements IEventListener {
 		}
 
 		return $this->chatManager->addSystemMessage(
-			$room, $actorType, $actorId,
+			$room, $participant, $actorType, $actorId,
 			json_encode(['message' => $message, 'parameters' => $parameters]),
 			$this->timeFactory->getDateTime(),
 			$message === 'file_shared',

--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -268,6 +268,7 @@ class ChatController extends AEnvironmentAwareOCSController {
 
 				$this->chatManager->addSystemMessage(
 					$this->room,
+					$this->participant,
 					$this->participant->getAttendee()->getActorType(),
 					$this->participant->getAttendee()->getActorId(),
 					json_encode(['message' => 'thread_created', 'parameters' => ['thread' => (int)$comment->getId(), 'title' => $thread->getName()]]),
@@ -362,7 +363,7 @@ class ChatController extends AEnvironmentAwareOCSController {
 		]);
 
 		try {
-			$comment = $this->chatManager->addSystemMessage($this->room, $actorType, $actorId, $message, $creationDateTime, true, $referenceId);
+			$comment = $this->chatManager->addSystemMessage($this->room, $this->participant, $actorType, $actorId, $message, $creationDateTime, true, $referenceId);
 		} catch (MessageTooLongException $e) {
 			return new DataResponse(['error' => 'message'], Http::STATUS_REQUEST_ENTITY_TOO_LARGE);
 		} catch (\Exception $e) {

--- a/lib/Controller/PollController.php
+++ b/lib/Controller/PollController.php
@@ -127,7 +127,7 @@ class PollController extends AEnvironmentAwareOCSController {
 		], JSON_THROW_ON_ERROR);
 
 		try {
-			$this->chatManager->addSystemMessage($this->room, $attendee->getActorType(), $attendee->getActorId(), $message, $this->timeFactory->getDateTime(), true);
+			$this->chatManager->addSystemMessage($this->room, $this->participant, $attendee->getActorType(), $attendee->getActorId(), $message, $this->timeFactory->getDateTime(), true);
 		} catch (\Exception $e) {
 			$this->logger->error($e->getMessage(), ['exception' => $e]);
 		}
@@ -338,7 +338,7 @@ class PollController extends AEnvironmentAwareOCSController {
 						],
 					],
 				], JSON_THROW_ON_ERROR);
-				$this->chatManager->addSystemMessage($this->room, $attendee->getActorType(), $attendee->getActorId(), $message, $this->timeFactory->getDateTime(), false);
+				$this->chatManager->addSystemMessage($this->room, $this->participant, $attendee->getActorType(), $attendee->getActorId(), $message, $this->timeFactory->getDateTime(), false);
 			} catch (\Exception $e) {
 				$this->logger->error($e->getMessage(), ['exception' => $e]);
 			}
@@ -410,7 +410,7 @@ class PollController extends AEnvironmentAwareOCSController {
 					],
 				],
 			], JSON_THROW_ON_ERROR);
-			$this->chatManager->addSystemMessage($this->room, $attendee->getActorType(), $attendee->getActorId(), $message, $this->timeFactory->getDateTime(), true);
+			$this->chatManager->addSystemMessage($this->room, $this->participant, $attendee->getActorType(), $attendee->getActorId(), $message, $this->timeFactory->getDateTime(), true);
 		} catch (\Exception $e) {
 			$this->logger->error($e->getMessage(), ['exception' => $e]);
 		}

--- a/lib/Controller/ThreadController.php
+++ b/lib/Controller/ThreadController.php
@@ -188,6 +188,7 @@ class ThreadController extends AEnvironmentAwareOCSController {
 
 		$this->chatManager->addSystemMessage(
 			$this->room,
+			$this->participant,
 			$this->participant->getAttendee()->getActorType(),
 			$this->participant->getAttendee()->getActorId(),
 			json_encode(['message' => 'thread_renamed', 'parameters' => ['thread' => $threadId, 'title' => $thread->getName()]]),

--- a/lib/MatterbridgeManager.php
+++ b/lib/MatterbridgeManager.php
@@ -646,6 +646,7 @@ class MatterbridgeManager {
 	private function sendSystemMessage(Room $room, string $userId, string $message): void {
 		$this->chatManager->addSystemMessage(
 			$room,
+			null,
 			Attendee::ACTOR_USERS,
 			$userId,
 			json_encode(['message' => $message, 'parameters' => []]),

--- a/lib/Service/RecordingService.php
+++ b/lib/Service/RecordingService.php
@@ -553,6 +553,7 @@ class RecordingService {
 		try {
 			$this->chatManager->addSystemMessage(
 				$room,
+				$participant,
 				$participant->getAttendee()->getActorType(),
 				$participant->getAttendee()->getActorId(),
 				$message,

--- a/tests/php/Chat/ChatManagerTest.php
+++ b/tests/php/Chat/ChatManagerTest.php
@@ -467,7 +467,7 @@ class ChatManagerTest extends TestCase {
 		$chatManager = $this->getManager(['addSystemMessage']);
 		$chatManager->expects($this->once())
 			->method('addSystemMessage')
-			->with($chat, Attendee::ACTOR_USERS, 'user', $this->anything(), $this->anything(), false, null, $comment)
+			->with($chat, $participant, Attendee::ACTOR_USERS, 'user', $this->anything(), $this->anything(), false, null, $comment)
 			->willReturn($systemMessage);
 
 		$this->assertSame($systemMessage, $chatManager->deleteMessage($chat, $comment, $participant, $date));
@@ -557,7 +557,7 @@ class ChatManagerTest extends TestCase {
 		$chatManager = $this->getManager(['addSystemMessage']);
 		$chatManager->expects($this->once())
 			->method('addSystemMessage')
-			->with($chat, Attendee::ACTOR_USERS, 'user', $this->anything(), $this->anything(), false, null, $comment)
+			->with($chat, $participant, Attendee::ACTOR_USERS, 'user', $this->anything(), $this->anything(), false, null, $comment)
 			->willReturn($systemMessage);
 
 		$this->assertSame($systemMessage, $chatManager->deleteMessage($chat, $comment, $participant, $date));
@@ -665,6 +665,7 @@ class ChatManagerTest extends TestCase {
 			->method('addSystemMessage')
 			->with(
 				$chat,
+				null,
 				'users',
 				'admin',
 				json_encode(['message' => 'history_cleared', 'parameters' => []]),

--- a/tests/php/Chat/SystemMessage/ListenerTest.php
+++ b/tests/php/Chat/SystemMessage/ListenerTest.php
@@ -233,6 +233,7 @@ class ListenerTest extends TestCase {
 		foreach ($expectedMessages as $expectedMessage) {
 			$consecutive[] = [
 				$room,
+				null,
 				$expectedMessage['actorType'],
 				$expectedMessage['actorId'],
 				json_encode($expectedMessage['message']),
@@ -335,6 +336,7 @@ class ListenerTest extends TestCase {
 		foreach ($expectedMessages as $expectedMessage) {
 			$consecutive[] = [
 				$room,
+				null,
 				Attendee::ACTOR_USERS,
 				'alice_actor',
 				json_encode($expectedMessage),
@@ -627,6 +629,7 @@ class ListenerTest extends TestCase {
 				->method('addSystemMessage')
 				->with(
 					$room,
+					$participant,
 					$expectedActorType,
 					$expectedActorId,
 					json_encode($expectedMessage),

--- a/tests/php/Controller/ChatControllerTest.php
+++ b/tests/php/Controller/ChatControllerTest.php
@@ -679,6 +679,7 @@ class ChatControllerTest extends TestCase {
 		$this->chatManager->expects($this->once())
 			->method('addSystemMessage')
 			->with($this->room,
+				$participant,
 				'users',
 				$this->userId,
 				json_encode([


### PR DESCRIPTION
### ☑️ Resolves

* Fix #15489 

<!--
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
░░░███████░░░█████████░░█████░
░░███░░░███░░░███░░░███░░███░░
░░█████████░░░████████░░░███░░
░░███░░░███░░░███░░░░░░░░███░░
░█████░█████░█████░░░░░░█████░
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching frontend/UI code
-->

### 📝 Description

This PR modifies the `addSystemMessage` method to optionally accept a `?Participant` argument. This allows us to determine if system messages should include the `METADATA_CAN_MENTION_ALL` based on either room settings or the participant's moderator permissions.

Also includes test updates to validate the new behavior.

### 🚧 Tasks

- [x] Updated addSystemMessage to accept an optional ?Participant argument.
- [x] Updated related logic to conditionally set can_mention_all metadata if allowed by room or participant permissions.
- [x] Updated tests to reflect changes in addSystemMessage signature and behavior.

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
