### PR TITLE
feat(threads): Allow to subscribe with a different notification level

### DIFF
--- a/lib/Chat/ChatManager.php
+++ b/lib/Chat/ChatManager.php
@@ -402,22 +402,12 @@ class ChatManager {
 			$this->commentsManager->save($comment);
 			$messageId = (int)$comment->getId();
 			$threadId = (int)$comment->getTopmostParentId();
-			$thread = null;
-
 			if ($threadId) {
-				try {
-					$thread = $this->threadService->findByThreadId($threadId);
-				} catch (DoesNotExistException) {
-				}
+				$this->threadService->updateLastMessageInfoAfterReply($threadId, $messageId);
 			}
 
 			if ($participant instanceof Participant) {
 				$this->participantService->updateLastReadMessage($participant, $messageId);
-
-				if ($thread !== null) {
-					// FIXME Performance improvement, could update directly on the database without loading the thread first
-					$this->threadService->updateLastMessageInfoAfterReply($thread, $messageId);
-				}
 			}
 
 			// Update last_message

--- a/lib/Chat/ChatManager.php
+++ b/lib/Chat/ChatManager.php
@@ -402,7 +402,7 @@ class ChatManager {
 			$this->commentsManager->save($comment);
 			$messageId = (int)$comment->getId();
 			$threadId = (int)$comment->getTopmostParentId();
-			if ($threadId) {
+			if ($threadId !== 0) {
 				$this->threadService->updateLastMessageInfoAfterReply($threadId, $messageId);
 			}
 

--- a/lib/Chat/ChatManager.php
+++ b/lib/Chat/ChatManager.php
@@ -415,11 +415,7 @@ class ChatManager {
 				$this->participantService->updateLastReadMessage($participant, $messageId);
 
 				if ($thread !== null) {
-					$this->threadService->addAttendeeToThread(
-						$participant->getAttendee(),
-						$thread,
-					);
-
+					// FIXME Performance improvement, could update directly on the database without loading the thread first
 					$this->threadService->updateLastMessageInfoAfterReply($thread, $messageId);
 				}
 			}

--- a/lib/Controller/ThreadController.php
+++ b/lib/Controller/ThreadController.php
@@ -17,6 +17,7 @@ use OCA\Talk\Middleware\Attribute\RequirePermission;
 use OCA\Talk\Middleware\Attribute\RequireReadWriteConversation;
 use OCA\Talk\Model\Thread;
 use OCA\Talk\Model\ThreadAttendee;
+use OCA\Talk\Participant;
 use OCA\Talk\ResponseDefinitions;
 use OCA\Talk\Service\ThreadService;
 use OCA\Talk\Share\Helper\Preloader;
@@ -212,29 +213,97 @@ class ThreadController extends AEnvironmentAwareOCSController {
 		}
 
 		try {
-			// Todo: What if the root already expired
-			$comment = $this->chatManager->getTopMostComment($this->room, (string)$messageId);
+			$thread = $this->ensureThread($messageId);
 		} catch (NotFoundException) {
 			return new DataResponse(['error' => 'message'], Http::STATUS_NOT_FOUND);
+		} catch (\InvalidArgumentException) {
+			return new DataResponse(['error' => 'message'], Http::STATUS_BAD_REQUEST);
 		}
+
+		$list = $this->prepareListOfThreads([$thread], []);
+		/** @var TalkThreadInfo $threadInfo */
+		$threadInfo = array_shift($list);
+		return new DataResponse($threadInfo);
+	}
+
+	/**
+	 * Create a thread out of a message or reply chain
+	 *
+	 * Required capability: `threads`
+	 *
+	 * @param int $messageId The message to create a thread for (Doesn't have to be the root)
+	 * @psalm-param non-negative-int $messageId
+	 * @param int $level New level
+	 * @psalm-param Participant::NOTIFY_* $level
+	 * @return DataResponse<Http::STATUS_OK, TalkThreadInfo, array{}>|DataResponse<Http::STATUS_BAD_REQUEST|Http::STATUS_NOT_FOUND, array{error: 'level'|'message'|'status'|'top-most'}, array{}>
+	 *
+	 * 200: Thread successfully created
+	 * 400: Root message is a system message and therefor not supported or notification level was invalid
+	 * 404: Message or top most message not found
+	 */
+	#[FederationSupported]
+	#[PublicPage]
+	#[RequireModeratorOrNoLobby]
+	#[RequireParticipant]
+	#[RequirePermission(permission: RequirePermission::CHAT)]
+	#[RequireReadWriteConversation]
+	#[RequestHeader(name: 'x-nextcloud-federation', description: 'Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request', indirect: true)]
+	#[ApiRoute(verb: 'POST', url: '/api/{apiVersion}/chat/{token}/threads/{messageId}/notify', requirements: [
+		'apiVersion' => '(v1)',
+		'token' => '[a-z0-9]{4,30}',
+		'messageId' => '[0-9]+',
+	])]
+	public function setNotificationLevel(int $messageId, int $level): DataResponse {
+		if ($this->room->isFederatedConversation()) {
+			/** @var \OCA\Talk\Federation\Proxy\TalkV1\Controller\ThreadController $proxy */
+			$proxy = \OCP\Server::get(\OCA\Talk\Federation\Proxy\TalkV1\Controller\ThreadController::class);
+			return $proxy->setNotificationLevel($this->room, $this->participant, $messageId, $level);
+		}
+
+		if (!\in_array($level, [
+			Participant::NOTIFY_DEFAULT,
+			Participant::NOTIFY_ALWAYS,
+			Participant::NOTIFY_MENTION,
+			Participant::NOTIFY_NEVER,
+		], true)) {
+			return new DataResponse(['error' => 'level'], Http::STATUS_BAD_REQUEST);
+		}
+
+		try {
+			$thread = $this->ensureThread($messageId);
+		} catch (NotFoundException) {
+			return new DataResponse(['error' => 'message'], Http::STATUS_NOT_FOUND);
+		} catch (\InvalidArgumentException) {
+			return new DataResponse(['error' => 'message'], Http::STATUS_BAD_REQUEST);
+		}
+
+		$threadAttendee = $this->threadService->addAttendeeToThread($this->participant->getAttendee(), $thread, $level);
+		$attendees = [$thread->getId() => $threadAttendee];
+		$list = $this->prepareListOfThreads([$thread], $attendees);
+
+		/** @var TalkThreadInfo $threadInfo */
+		$threadInfo = array_shift($list);
+		return new DataResponse($threadInfo);
+	}
+
+	/**
+	 * @throws NotFoundException
+	 * @throws \InvalidArgumentException
+	 */
+	protected function ensureThread(int $messageId): Thread {
+		// Todo: What if the root already expired
+		$comment = $this->chatManager->getTopMostComment($this->room, (string)$messageId);
 
 		$threadId = (int)$comment->getId();
 
 		$threadMessage = $this->messageParser->createMessage($this->room, $this->participant, $comment, $this->l);
 		$this->messageParser->parseMessage($threadMessage);
 		if ($threadMessage->getMessageType() === ChatManager::VERB_SYSTEM) {
-			return new DataResponse(['error' => 'message'], Http::STATUS_BAD_REQUEST);
+			throw new \InvalidArgumentException('message');
 		}
 
 		try {
-			$thread = $this->threadService->findByThreadId($threadId);
-			$threadAttendee = $this->threadService->addAttendeeToThread($this->participant->getAttendee(), $thread);
-			$attendees = [$thread->getId() => $threadAttendee];
-
-			$list = $this->prepareListOfThreads([$thread], $attendees);
-			/** @var TalkThreadInfo $threadInfo */
-			$threadInfo = array_shift($list);
-			return new DataResponse($threadInfo);
+			return $this->threadService->findByThreadId($threadId);
 		} catch (DoesNotExistException) {
 		}
 
@@ -252,12 +321,6 @@ class ThreadController extends AEnvironmentAwareOCSController {
 			true
 		);
 
-		$threadAttendee = $this->threadService->addAttendeeToThread($this->participant->getAttendee(), $thread);
-		$attendees = [$thread->getId() => $threadAttendee];
-
-		$list = $this->prepareListOfThreads([$thread], $attendees);
-		/** @var TalkThreadInfo $threadInfo */
-		$threadInfo = array_shift($list);
-		return new DataResponse($threadInfo);
+		return $thread;
 	}
 }

--- a/lib/Controller/ThreadController.php
+++ b/lib/Controller/ThreadController.php
@@ -227,7 +227,7 @@ class ThreadController extends AEnvironmentAwareOCSController {
 	}
 
 	/**
-	 * Create a thread out of a message or reply chain
+	 * Set notification level for a specific thread
 	 *
 	 * Required capability: `threads`
 	 *
@@ -237,7 +237,7 @@ class ThreadController extends AEnvironmentAwareOCSController {
 	 * @psalm-param Participant::NOTIFY_* $level
 	 * @return DataResponse<Http::STATUS_OK, TalkThreadInfo, array{}>|DataResponse<Http::STATUS_BAD_REQUEST|Http::STATUS_NOT_FOUND, array{error: 'level'|'message'|'status'|'top-most'}, array{}>
 	 *
-	 * 200: Thread successfully created
+	 * 200: Successfully set notification level for thread
 	 * 400: Root message is a system message and therefor not supported or notification level was invalid
 	 * 404: Message or top most message not found
 	 */
@@ -277,7 +277,7 @@ class ThreadController extends AEnvironmentAwareOCSController {
 			return new DataResponse(['error' => 'message'], Http::STATUS_BAD_REQUEST);
 		}
 
-		$threadAttendee = $this->threadService->addAttendeeToThread($this->participant->getAttendee(), $thread, $level);
+		$threadAttendee = $this->threadService->setNotificationLevel($this->participant->getAttendee(), $thread, $level);
 		$attendees = [$thread->getId() => $threadAttendee];
 		$list = $this->prepareListOfThreads([$thread], $attendees);
 

--- a/lib/Federation/Proxy/TalkV1/Controller/ThreadController.php
+++ b/lib/Federation/Proxy/TalkV1/Controller/ThreadController.php
@@ -151,8 +151,9 @@ class ThreadController {
 	 * @return DataResponse<Http::STATUS_OK, TalkThreadInfo, array{}>|DataResponse<Http::STATUS_BAD_REQUEST|Http::STATUS_NOT_FOUND, array{error: 'level'|'message'|'status'|'top-most'}, array{}>
 	 * @throws CannotReachRemoteException
 	 *
-	 * 200: Thread info returned
-	 * 404: Thread not found
+	 * 200: Successfully set notification level for thread
+	 * 400: Root message is a system message and therefor not supported or notification level was invalid
+	 * 404: Message or top most message not found
 	 */
 	public function setNotificationLevel(Room $room, Participant $participant, int $messageId, int $level): DataResponse {
 		$proxy = $this->proxy->post(
@@ -171,7 +172,7 @@ class ThreadController {
 				$statusCode = $this->proxy->logUnexpectedStatusCode(__METHOD__, $statusCode);
 				$data = ['error' => 'status'];
 			} else {
-				/** @var array{error: 'message'|'top-most'} $data */
+				/** @var array{error: 'level'|'message'|'top-most'} $data */
 				$data = $this->proxy->getOCSData($proxy, [
 					Http::STATUS_BAD_REQUEST,
 					Http::STATUS_NOT_FOUND,

--- a/lib/Model/ThreadAttendeeMapper.php
+++ b/lib/Model/ThreadAttendeeMapper.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace OCA\Talk\Model;
 
+use OCA\Talk\Participant;
 use OCP\AppFramework\Db\QBMapper;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
@@ -36,23 +37,44 @@ class ThreadAttendeeMapper extends QBMapper {
 	}
 
 	/**
-	 * @param int $attendeeId
 	 * @param list<int> $threadIds
 	 * @return list<ThreadAttendee>
 	 */
-	public function findAttendeeByThreadIds(int $attendeeId, array $threadIds): array {
+	public function findAttendeeByThreadIds(string $actorType, string $actorId, array $threadIds): array {
 		$query = $this->db->getQueryBuilder();
 		$query->select('*')
 			->from($this->getTableName())
 			->where($query->expr()->eq(
-				'attendee_id',
-				$query->createNamedParameter($attendeeId, IQueryBuilder::PARAM_INT),
-				IQueryBuilder::PARAM_INT,
+				'actor_type',
+				$query->createNamedParameter($actorType),
+			))
+			->andWhere($query->expr()->eq(
+				'actor_id',
+				$query->createNamedParameter($actorId),
 			))
 			->andWhere($query->expr()->in(
 				'thread_id',
 				$query->createNamedParameter($threadIds, IQueryBuilder::PARAM_INT_ARRAY),
 				IQueryBuilder::PARAM_INT_ARRAY,
+			));
+
+		return $this->findEntities($query);
+	}
+
+	/**
+	 * @return list<ThreadAttendee>
+	 */
+	public function findAttendeesForNotification(int $threadId): array {
+		$query = $this->db->getQueryBuilder();
+		$query->select('*')
+			->from($this->getTableName())
+			->where($query->expr()->eq(
+				'thread_id',
+				$query->createNamedParameter($threadId, IQueryBuilder::PARAM_INT),
+			))
+			->andWhere($query->expr()->neq(
+				'notification_level',
+				$query->createNamedParameter(Participant::NOTIFY_DEFAULT, IQueryBuilder::PARAM_INT),
 			));
 
 		return $this->findEntities($query);

--- a/lib/Model/ThreadAttendeeMapper.php
+++ b/lib/Model/ThreadAttendeeMapper.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace OCA\Talk\Model;
 
 use OCA\Talk\Participant;
+use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Db\QBMapper;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
@@ -59,6 +60,29 @@ class ThreadAttendeeMapper extends QBMapper {
 			));
 
 		return $this->findEntities($query);
+	}
+
+	/**
+	 * @throws DoesNotExistException if the item does not exist
+	 */
+	public function findAttendeeByThreadId(string $actorType, string $actorId, int $threadId): ThreadAttendee {
+		$query = $this->db->getQueryBuilder();
+		$query->select('*')
+			->from($this->getTableName())
+			->where($query->expr()->eq(
+				'actor_type',
+				$query->createNamedParameter($actorType),
+			))
+			->andWhere($query->expr()->eq(
+				'actor_id',
+				$query->createNamedParameter($actorId),
+			))
+			->andWhere($query->expr()->eq(
+				'thread_id',
+				$query->createNamedParameter($threadId),
+			));
+
+		return $this->findEntity($query);
 	}
 
 	/**

--- a/lib/Service/ThreadService.php
+++ b/lib/Service/ThreadService.php
@@ -119,7 +119,7 @@ class ThreadService {
 		$query->executeStatement();
 	}
 
-	public function updateLastMessageInfoAfterReply(Thread $thread, int $lastMessageId): void {
+	public function updateLastMessageInfoAfterReply(int $threadId, int $lastMessageId): void {
 		$dateTime = $this->timeFactory->getDateTime();
 
 		$query = $this->connection->getQueryBuilder();
@@ -127,12 +127,8 @@ class ThreadService {
 			->set('num_replies', $query->func()->add('num_replies', $query->expr()->literal(1)))
 			->set('last_message_id', $query->createNamedParameter($lastMessageId))
 			->set('last_activity', $query->createNamedParameter($dateTime, IQueryBuilder::PARAM_DATETIME_MUTABLE))
-			->where($query->expr()->eq('id', $query->createNamedParameter($thread->getId())));
+			->where($query->expr()->eq('id', $query->createNamedParameter($threadId)));
 		$query->executeStatement();
-
-		$thread->setNumReplies($thread->getNumReplies() + 1);
-		$thread->setLastMessageId($lastMessageId);
-		$thread->setLastActivity($dateTime);
 	}
 
 	public function deleteByRoom(Room $room): void {

--- a/lib/Service/ThreadService.php
+++ b/lib/Service/ThreadService.php
@@ -75,10 +75,23 @@ class ThreadService {
 	 * @return array<int, ThreadAttendee> Key is the thread id
 	 */
 	public function findAttendeeByThreadIds(Attendee $attendee, array $threadIds): array {
-		$attendees = $this->threadAttendeeMapper->findAttendeeByThreadIds($attendee->getId(), $threadIds);
+		$attendees = $this->threadAttendeeMapper->findAttendeeByThreadIds($attendee->getActorType(), $attendee->getActorId(), $threadIds);
 		$threadAttendees = [];
 		foreach ($attendees as $threadAttendee) {
 			$threadAttendees[$threadAttendee->getThreadId()] = $threadAttendee;
+		}
+
+		return $threadAttendees;
+	}
+
+	/**
+	 * @return array<int, ThreadAttendee> Key is the attendee id
+	 */
+	public function findAttendeesForNotificationByThreadId(int $threadId): array {
+		$attendees = $this->threadAttendeeMapper->findAttendeesForNotification($threadId);
+		$threadAttendees = [];
+		foreach ($attendees as $threadAttendee) {
+			$threadAttendees[$threadAttendee->getAttendeeId()] = $threadAttendee;
 		}
 
 		return $threadAttendees;

--- a/lib/Service/ThreadService.php
+++ b/lib/Service/ThreadService.php
@@ -84,7 +84,7 @@ class ThreadService {
 		return $threadAttendees;
 	}
 
-	public function addAttendeeToThread(Attendee $attendee, Thread $thread): ThreadAttendee {
+	public function addAttendeeToThread(Attendee $attendee, Thread $thread, int $level): ThreadAttendee {
 		$threadAttendee = new ThreadAttendee();
 		$threadAttendee->setThreadId($thread->getId());
 		$threadAttendee->setRoomId($thread->getRoomId());
@@ -92,7 +92,7 @@ class ThreadService {
 		$threadAttendee->setAttendeeId($attendee->getId());
 		$threadAttendee->setActorType($attendee->getActorType());
 		$threadAttendee->setActorId($attendee->getActorId());
-		$threadAttendee->setNotificationLevel($attendee->getNotificationLevel());
+		$threadAttendee->setNotificationLevel($level);
 
 		try {
 			$this->threadAttendeeMapper->insert($threadAttendee);

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -21275,7 +21275,7 @@
         "/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/threads/{messageId}/notify": {
             "post": {
                 "operationId": "thread-set-notification-level",
-                "summary": "Create a thread out of a message or reply chain",
+                "summary": "Set notification level for a specific thread",
                 "description": "Required capability: `threads`",
                 "tags": [
                     "thread"
@@ -21363,7 +21363,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Thread successfully created",
+                        "description": "Successfully set notification level for thread",
                         "content": {
                             "application/json": {
                                 "schema": {

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -21272,6 +21272,217 @@
                 }
             }
         },
+        "/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/threads/{messageId}/notify": {
+            "post": {
+                "operationId": "thread-set-notification-level",
+                "summary": "Create a thread out of a message or reply chain",
+                "description": "Required capability: `threads`",
+                "tags": [
+                    "thread"
+                ],
+                "security": [
+                    {},
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "level"
+                                ],
+                                "properties": {
+                                    "level": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "New level"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v1"
+                            ],
+                            "default": "v1"
+                        }
+                    },
+                    {
+                        "name": "token",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^[a-z0-9]{4,30}$"
+                        }
+                    },
+                    {
+                        "name": "messageId",
+                        "in": "path",
+                        "description": "The message to create a thread for (Doesn't have to be the root)",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64",
+                            "minimum": 0
+                        }
+                    },
+                    {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Thread successfully created",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "$ref": "#/components/schemas/ThreadInfo"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Root message is a system message and therefor not supported or notification level was invalid",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "error"
+                                                    ],
+                                                    "properties": {
+                                                        "error": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "level",
+                                                                "message",
+                                                                "status",
+                                                                "top-most"
+                                                            ]
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Message or top most message not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "error"
+                                                    ],
+                                                    "properties": {
+                                                        "error": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "level",
+                                                                "message",
+                                                                "status",
+                                                                "top-most"
+                                                            ]
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/ocs/v2.php/apps/spreed/api/{apiVersion}/proxy/new/user-avatar/{size}": {
             "get": {
                 "operationId": "avatar-get-user-proxy-avatar-without-room",

--- a/openapi.json
+++ b/openapi.json
@@ -21176,6 +21176,217 @@
                     }
                 }
             }
+        },
+        "/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/threads/{messageId}/notify": {
+            "post": {
+                "operationId": "thread-set-notification-level",
+                "summary": "Create a thread out of a message or reply chain",
+                "description": "Required capability: `threads`",
+                "tags": [
+                    "thread"
+                ],
+                "security": [
+                    {},
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "level"
+                                ],
+                                "properties": {
+                                    "level": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "New level"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v1"
+                            ],
+                            "default": "v1"
+                        }
+                    },
+                    {
+                        "name": "token",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^[a-z0-9]{4,30}$"
+                        }
+                    },
+                    {
+                        "name": "messageId",
+                        "in": "path",
+                        "description": "The message to create a thread for (Doesn't have to be the root)",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64",
+                            "minimum": 0
+                        }
+                    },
+                    {
+                        "name": "x-nextcloud-federation",
+                        "in": "header",
+                        "description": "Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Thread successfully created",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "$ref": "#/components/schemas/ThreadInfo"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Root message is a system message and therefor not supported or notification level was invalid",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "error"
+                                                    ],
+                                                    "properties": {
+                                                        "error": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "level",
+                                                                "message",
+                                                                "status",
+                                                                "top-most"
+                                                            ]
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Message or top most message not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "error"
+                                                    ],
+                                                    "properties": {
+                                                        "error": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "level",
+                                                                "message",
+                                                                "status",
+                                                                "top-most"
+                                                            ]
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     },
     "tags": []

--- a/openapi.json
+++ b/openapi.json
@@ -21180,7 +21180,7 @@
         "/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/threads/{messageId}/notify": {
             "post": {
                 "operationId": "thread-set-notification-level",
-                "summary": "Create a thread out of a message or reply chain",
+                "summary": "Set notification level for a specific thread",
                 "description": "Required capability: `threads`",
                 "tags": [
                     "thread"
@@ -21268,7 +21268,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Thread successfully created",
+                        "description": "Successfully set notification level for thread",
                         "content": {
                             "application/json": {
                                 "schema": {

--- a/src/types/openapi/openapi-full.ts
+++ b/src/types/openapi/openapi-full.ts
@@ -1663,7 +1663,7 @@ export type paths = {
         get?: never;
         put?: never;
         /**
-         * Create a thread out of a message or reply chain
+         * Set notification level for a specific thread
          * @description Required capability: `threads`
          */
         post: operations["thread-set-notification-level"];
@@ -10436,7 +10436,7 @@ export interface operations {
             };
         };
         responses: {
-            /** @description Thread successfully created */
+            /** @description Successfully set notification level for thread */
             200: {
                 headers: {
                     [name: string]: unknown;

--- a/src/types/openapi/openapi-full.ts
+++ b/src/types/openapi/openapi-full.ts
@@ -1653,6 +1653,26 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
+    "/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/threads/{messageId}/notify": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Create a thread out of a message or reply chain
+         * @description Required capability: `threads`
+         */
+        post: operations["thread-set-notification-level"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/ocs/v2.php/apps/spreed/api/{apiVersion}/proxy/new/user-avatar/{size}": {
         parameters: {
             query?: never;
@@ -10380,6 +10400,85 @@ export interface operations {
                             data: {
                                 /** @enum {string} */
                                 error: "message" | "status" | "top-most";
+                            };
+                        };
+                    };
+                };
+            };
+        };
+    };
+    "thread-set-notification-level": {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
+                /** @description Required to be true for the API request to pass */
+                "OCS-APIRequest": boolean;
+            };
+            path: {
+                apiVersion: "v1";
+                token: string;
+                /** @description The message to create a thread for (Doesn't have to be the root) */
+                messageId: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /**
+                     * Format: int64
+                     * @description New level
+                     */
+                    level: number;
+                };
+            };
+        };
+        responses: {
+            /** @description Thread successfully created */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: components["schemas"]["ThreadInfo"];
+                        };
+                    };
+                };
+            };
+            /** @description Root message is a system message and therefor not supported or notification level was invalid */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: {
+                                /** @enum {string} */
+                                error: "level" | "message" | "status" | "top-most";
+                            };
+                        };
+                    };
+                };
+            };
+            /** @description Message or top most message not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: {
+                                /** @enum {string} */
+                                error: "level" | "message" | "status" | "top-most";
                             };
                         };
                     };

--- a/src/types/openapi/openapi.ts
+++ b/src/types/openapi/openapi.ts
@@ -1663,7 +1663,7 @@ export type paths = {
         get?: never;
         put?: never;
         /**
-         * Create a thread out of a message or reply chain
+         * Set notification level for a specific thread
          * @description Required capability: `threads`
          */
         post: operations["thread-set-notification-level"];
@@ -9898,7 +9898,7 @@ export interface operations {
             };
         };
         responses: {
-            /** @description Thread successfully created */
+            /** @description Successfully set notification level for thread */
             200: {
                 headers: {
                     [name: string]: unknown;

--- a/src/types/openapi/openapi.ts
+++ b/src/types/openapi/openapi.ts
@@ -1653,6 +1653,26 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
+    "/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/threads/{messageId}/notify": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Create a thread out of a message or reply chain
+         * @description Required capability: `threads`
+         */
+        post: operations["thread-set-notification-level"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 };
 export type webhooks = Record<string, never>;
 export type components = {
@@ -9842,6 +9862,85 @@ export interface operations {
                             data: {
                                 /** @enum {string} */
                                 error: "message" | "status" | "top-most";
+                            };
+                        };
+                    };
+                };
+            };
+        };
+    };
+    "thread-set-notification-level": {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request */
+                "x-nextcloud-federation"?: string;
+                /** @description Required to be true for the API request to pass */
+                "OCS-APIRequest": boolean;
+            };
+            path: {
+                apiVersion: "v1";
+                token: string;
+                /** @description The message to create a thread for (Doesn't have to be the root) */
+                messageId: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /**
+                     * Format: int64
+                     * @description New level
+                     */
+                    level: number;
+                };
+            };
+        };
+        responses: {
+            /** @description Thread successfully created */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: components["schemas"]["ThreadInfo"];
+                        };
+                    };
+                };
+            };
+            /** @description Root message is a system message and therefor not supported or notification level was invalid */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: {
+                                /** @enum {string} */
+                                error: "level" | "message" | "status" | "top-most";
+                            };
+                        };
+                    };
+                };
+            };
+            /** @description Message or top most message not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: {
+                                /** @enum {string} */
+                                error: "level" | "message" | "status" | "top-most";
                             };
                         };
                     };

--- a/tests/integration/features/chat-4/threads.feature
+++ b/tests/integration/features/chat-4/threads.feature
@@ -20,8 +20,8 @@ Feature: chat-4/threads
     And user "participant1" adds user "participant2" to room "room" with 200 (v4)
     And user "participant1" sends message "Message 1" to room "room" with 201
     And user "participant1" creates thread "Message 1" in room "room" with 200
-      | t.id      | t.numReplies | t.lastMessage | firstMessage | lastMessage |
-      | Message 1 | 0            | 0             | Message 1    | NULL        |
+      | t.id      | t.numReplies | t.lastMessage | a.notificationLevel | firstMessage | lastMessage |
+      | Message 1 | 0            | 0             | 0                   | Message 1    | NULL        |
 
   Scenario: Create thread on root with reply
     Given user "participant1" creates room "room" (v4)
@@ -31,8 +31,8 @@ Feature: chat-4/threads
     And user "participant1" sends message "Message 1" to room "room" with 201
     And user "participant2" sends reply "Message 1-1" on message "Message 1" to room "room" with 201
     And user "participant1" creates thread "Message 1" in room "room" with 200
-      | t.id      | t.numReplies | t.lastMessage | firstMessage | lastMessage |
-      | Message 1 | 1            | Message 1-1   | Message 1    | Message 1-1 |
+      | t.id      | t.numReplies | t.lastMessage | a.notificationLevel | firstMessage | lastMessage |
+      | Message 1 | 1            | Message 1-1   | 0                   | Message 1    | Message 1-1 |
 
   Scenario: Create thread on reply
     Given user "participant1" creates room "room" (v4)
@@ -42,8 +42,8 @@ Feature: chat-4/threads
     And user "participant1" sends message "Message 1" to room "room" with 201
     And user "participant2" sends reply "Message 1-1" on message "Message 1" to room "room" with 201
     And user "participant1" creates thread "Message 1-1" in room "room" with 200
-      | t.id      | t.numReplies | t.lastMessage | firstMessage | lastMessage |
-      | Message 1 | 1            | Message 1-1   | Message 1    | Message 1-1 |
+      | t.id      | t.numReplies | t.lastMessage | a.notificationLevel | firstMessage | lastMessage |
+      | Message 1 | 1            | Message 1-1   | 0                   | Message 1    | Message 1-1 |
 
   Scenario: Creating a thread again does not conflict nor duplicate
     Given user "participant1" creates room "room" (v4)
@@ -54,11 +54,11 @@ Feature: chat-4/threads
     When user "participant1" creates thread "Message 1" in room "room" with 200
     When user "participant2" creates thread "Message 1" in room "room" with 200
     Then user "participant1" sees the following recent threads in room "room" with 200
-      | t.id      | t.numReplies | t.lastMessage | firstMessage | lastMessage |
-      | Message 1 | 0            | 0             | Message 1    | NULL        |
+      | t.id      | t.numReplies | t.lastMessage | a.notificationLevel | firstMessage | lastMessage |
+      | Message 1 | 0            | 0             | 0                   | Message 1    | NULL        |
     Then user "participant2" sees the following recent threads in room "room" with 200
-      | t.id      | t.numReplies | t.lastMessage | firstMessage | lastMessage |
-      | Message 1 | 0            | 0             | Message 1    | NULL        |
+      | t.id      | t.numReplies | t.lastMessage | a.notificationLevel | firstMessage | lastMessage |
+      | Message 1 | 0            | 0             | 0                   | Message 1    | NULL        |
 
   Scenario: Recent threads are sorted by last activity
     Given user "participant1" creates room "room" (v4)
@@ -69,15 +69,37 @@ Feature: chat-4/threads
     And user "participant2" sends message "Message 2" to room "room" with 201
     When user "participant2" creates thread "Message 2" in room "room" with 200
     Then user "participant1" sees the following recent threads in room "room" with 200
-      | t.id      | t.numReplies | t.lastMessage | firstMessage | lastMessage |
-      | Message 2 | 0            | 0             | Message 2    | NULL        |
+      | t.id      | t.numReplies | t.lastMessage | a.notificationLevel | firstMessage | lastMessage |
+      | Message 2 | 0            | 0             | 0                   | Message 2    | NULL        |
     When user "participant1" creates thread "Message 1" in room "room" with 200
     Then user "participant1" sees the following recent threads in room "room" with 200
-      | t.id      | t.numReplies | t.lastMessage | firstMessage | lastMessage |
-      | Message 1 | 0            | 0             | Message 1    | NULL        |
-      | Message 2 | 0            | 0             | Message 2    | NULL        |
+      | t.id      | t.numReplies | t.lastMessage | a.notificationLevel | firstMessage | lastMessage |
+      | Message 1 | 0            | 0             | 0                   | Message 1    | NULL        |
+      | Message 2 | 0            | 0             | 0                   | Message 2    | NULL        |
     When user "participant1" sends reply "Message 2-1" on message "Message 2" to room "room" with 201
     Then user "participant2" sees the following recent threads in room "room" with 200
-      | t.id      | t.numReplies | t.lastMessage | firstMessage | lastMessage |
-      | Message 2 | 1            | Message 2-1   | Message 2    | Message 2-1 |
-      | Message 1 | 0            | 0             | Message 1    | NULL        |
+      | t.id      | t.numReplies | t.lastMessage | a.notificationLevel | firstMessage | lastMessage |
+      | Message 2 | 1            | Message 2-1   | 0                   | Message 2    | Message 2-1 |
+      | Message 1 | 0            | 0             | 0                   | Message 1    | NULL        |
+
+  Scenario: Create thread on reply
+    Given user "participant1" creates room "room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    And user "participant1" adds user "participant2" to room "room" with 200 (v4)
+    And user "participant1" sends message "Message 1" to room "room" with 201
+    And user "participant1" creates thread "Message 1" in room "room" with 200
+      | t.id      | t.numReplies | t.lastMessage | a.notificationLevel | firstMessage | lastMessage |
+      | Message 1 | 0            | 0             | 0                   | Message 1    | NULL        |
+    And user "participant1" subscribes to thread "Message 1" in room "room" with notification level 1 with 200
+      | t.id      | t.numReplies | t.lastMessage | a.notificationLevel | firstMessage | lastMessage |
+      | Message 1 | 0            | 0             | 1                   | Message 1    | NULL        |
+    And user "participant1" subscribes to thread "Message 1" in room "room" with notification level 2 with 200
+      | t.id      | t.numReplies | t.lastMessage | a.notificationLevel | firstMessage | lastMessage |
+      | Message 1 | 0            | 0             | 2                   | Message 1    | NULL        |
+    And user "participant1" subscribes to thread "Message 1" in room "room" with notification level 3 with 200
+      | t.id      | t.numReplies | t.lastMessage | a.notificationLevel | firstMessage | lastMessage |
+      | Message 1 | 0            | 0             | 3                   | Message 1    | NULL        |
+    And user "participant1" subscribes to thread "Message 1" in room "room" with notification level 0 with 200
+      | t.id      | t.numReplies | t.lastMessage | a.notificationLevel | firstMessage | lastMessage |
+      | Message 1 | 0            | 0             | 0                   | Message 1    | NULL        |

--- a/tests/php/Chat/NotifierTest.php
+++ b/tests/php/Chat/NotifierTest.php
@@ -17,6 +17,7 @@ use OCA\Talk\Model\Session;
 use OCA\Talk\Participant;
 use OCA\Talk\Room;
 use OCA\Talk\Service\ParticipantService;
+use OCA\Talk\Service\ThreadService;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Comments\IComment;
 use OCP\IConfig;
@@ -33,6 +34,7 @@ class NotifierTest extends TestCase {
 	protected IUserManager&MockObject $userManager;
 	protected IGroupManager&MockObject $groupManager;
 	protected ParticipantService&MockObject $participantService;
+	protected ThreadService&MockObject $threadService;
 	protected IConfig&MockObject $config;
 	protected ITimeFactory&MockObject $timeFactory;
 	protected Util&MockObject $util;
@@ -51,6 +53,7 @@ class NotifierTest extends TestCase {
 		$this->groupManager = $this->createMock(IGroupManager::class);
 
 		$this->participantService = $this->createMock(ParticipantService::class);
+		$this->threadService = $this->createMock(ThreadService::class);
 		$this->config = $this->createMock(IConfig::class);
 		$this->timeFactory = $this->createMock(ITimeFactory::class);
 		$this->util = $this->createMock(Util::class);
@@ -68,6 +71,7 @@ class NotifierTest extends TestCase {
 					$this->userManager,
 					$this->groupManager,
 					$this->participantService,
+					$this->threadService,
 					$this->config,
 					$this->timeFactory,
 					$this->util,
@@ -80,6 +84,7 @@ class NotifierTest extends TestCase {
 			$this->userManager,
 			$this->groupManager,
 			$this->participantService,
+			$this->threadService,
 			$this->config,
 			$this->timeFactory,
 			$this->util


### PR DESCRIPTION
### ☑️ Resolves

* Ref #9679 

## 🛠️ API Checklist

### 🚧 Tasks

- [x] Allow to subscribe with a different notification level to threads
    - Value is not used for notifications yet, will be a follow up
    - Integration test will follow when that is implemented
- [x] Improve performance by dropping a SELECT query every time we reply to a thread

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
