### PR TITLE
test(federation): Add a test to change call notification settings in …

### DIFF
--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -1350,6 +1350,25 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 		$this->assertStatusCode($this->response, 200);
 	}
 
+	#[Then('/^user "([^"]*)" sets call notifications to (enabled|disabled) for room "([^"]*)" \((v4)\)$/')]
+	public function userSetsCallNotificationLevelForRoom(string $user, string $level, string $identifier, string $apiVersion): void {
+		$this->setCurrentUser($user);
+
+		$intLevel = 1; // default
+		if ($level === 'disabled') {
+			$intLevel = 0;
+		}
+
+		$this->sendRequest(
+			'POST', '/apps/spreed/api/' . $apiVersion . '/room/' . self::$identifierToToken[$identifier] . '/notify-calls',
+			new TableNode([
+				['level', $intLevel],
+			])
+		);
+
+		$this->assertStatusCode($this->response, 200);
+	}
+
 	#[Then('/^user "([^"]*)" leaves room "([^"]*)" with (\d+) \((v4)\)$/')]
 	public function userExitsRoom(string $user, string $identifier, int $statusCode, string $apiVersion): void {
 		$this->setCurrentUser($user);

--- a/tests/integration/features/federation/call.feature
+++ b/tests/integration/features/federation/call.feature
@@ -317,6 +317,26 @@ Feature: federation/call
     And user "participant1" has the following notifications
       | app | object_type | object_id | subject |
 
+  Scenario: Turning off call notifications also works
+    Given user "participant1" creates room "room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    And user "participant1" adds federated_user "participant2" to room "room" with 200 (v4)
+    And using server "REMOTE"
+    And user "participant2" has the following invitations (v1)
+      | remoteServerUrl | remoteToken | state | inviterCloudId     | inviterDisplayName       |
+      | LOCAL           | room        | 0     | participant1@LOCAL | participant1-displayname |
+    And user "participant2" accepts invite to room "room" of server "LOCAL" with 200 (v1)
+      | id          | name | type | remoteServer | remoteToken |
+      | LOCAL::room | room | 2    | LOCAL        | room        |
+    And user "participant2" sets call notifications to disabled for room "LOCAL::room" (v4)
+    And using server "LOCAL"
+    And user "participant1" joins room "room" with 200 (v4)
+    When user "participant1" joins call "room" with 200 (v4)
+    And using server "REMOTE"
+    And user "participant2" has the following notifications
+      | app | object_type | object_id | subject |
+
   Scenario: missed silent call by federated user does not trigger call notification
     Given user "participant1" creates room "room" (v4)
       | roomType | 2 |


### PR DESCRIPTION
…federated conversations


### ☑️ Resolves

* Fix #15510 

## 🛠️ API Checklist

- Main was fixed in https://github.com/nextcloud/spreed/pull/15172 but the backport forgotten
- Patch necessary for 31 and 30:
```diff
diff --git a/lib/Controller/RoomController.php b/lib/Controller/RoomController.php
index e08a59772..f77527814 100644
--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -860,6 +860,7 @@ class RoomController extends AEnvironmentAwareOCSController {
         * 200: Call notification level updated successfully
         * 400: Updating call notification level is not possible
         */
+       #[FederationSupported]
        #[NoAdminRequired]
        #[RequireLoggedInParticipant]
        public function setNotificationCalls(int $level): DataResponse {
```

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
