### PR TITLE
feat(Quote): add a shortcut to threaded view from replies

### DIFF
--- a/src/components/Quote.vue
+++ b/src/components/Quote.vue
@@ -198,7 +198,6 @@ function handleQuoteClick() {
 		<NcButton v-if="canCancel"
 			class="quote__close"
 			variant="tertiary"
-			size="small"
 			:title="t('spreed', 'Cancel quote')"
 			:aria-label="t('spreed', 'Cancel quote')"
 			@click="handleAbort">
@@ -214,15 +213,15 @@ function handleQuoteClick() {
 
 .quote {
 	position: relative;
-	padding-block: calc(0.5 * var(--default-grid-baseline));
-	padding-inline: calc(1.5 * var(--default-grid-baseline)) var(--default-clickable-area);
+	padding-block: var(--default-grid-baseline);
+	padding-inline: calc(2 * var(--default-grid-baseline)) var(--default-clickable-area);
+	margin-bottom: var(--default-grid-baseline);
 	display: flex;
 	gap: var(--default-grid-baseline);
 	max-width: $messages-text-max-width;
-	min-height: var(--clickable-area-small);
+	min-height: var(--default-clickable-area);
 	border-radius: var(--border-radius-large);
 	border: 2px solid var(--color-border);
-	font-size: var(--font-size-small);
 	color: var(--color-text-maxcontrast);
 	background-color: var(--color-main-background);
 	overflow: hidden;
@@ -280,7 +279,7 @@ function handleQuoteClick() {
 		&-author {
 			display: flex;
 			align-items: center;
-			gap: calc(0.5 * var(--default-grid-baseline));
+			gap: var(--default-grid-baseline);
 
 			&-info {
 				flex-shrink: 0;

--- a/src/components/Quote.vue
+++ b/src/components/Quote.vue
@@ -13,6 +13,7 @@ import { useRoute } from 'vue-router'
 import NcButton from '@nextcloud/vue/components/NcButton'
 import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
 import IconClose from 'vue-material-design-icons/Close.vue'
+import IconForumOutline from 'vue-material-design-icons/ForumOutline.vue'
 import IconPencilOutline from 'vue-material-design-icons/PencilOutline.vue'
 import AvatarWrapper from './AvatarWrapper/AvatarWrapper.vue'
 import { useGetThreadId } from '../composables/useGetThreadId.ts'
@@ -104,12 +105,22 @@ const shortenedQuoteMessage = computed(() => {
 	return simpleQuotedMessage.value.length >= 250 ? simpleQuotedMessage.value.substring(0, 250) + '…' : simpleQuotedMessage.value
 })
 
+const showThreadShortcut = computed(() => {
+	return !threadId.value && isExistingMessage(message) && message.isThread && message.threadId
+})
+
 /**
  * Check whether message to quote (parent) existing on server
  * Otherwise server returns ['id' => (int)$parentId, 'deleted' => true]
  */
 function isExistingMessage(message: ChatMessage | DeletedParentMessage): message is ChatMessage {
 	return 'messageType' in message
+}
+
+function goToThread() {
+	if (isExistingMessage(message) && message.threadId) {
+		threadId.value = message.threadId
+	}
 }
 
 /**
@@ -196,13 +207,23 @@ function handleQuoteClick() {
 		</span>
 
 		<NcButton v-if="canCancel"
-			class="quote__close"
+			class="quote__button"
 			variant="tertiary"
 			:title="t('spreed', 'Cancel quote')"
 			:aria-label="t('spreed', 'Cancel quote')"
 			@click="handleAbort">
 			<template #icon>
 				<IconClose :size="20" />
+			</template>
+		</NcButton>
+		<NcButton v-else-if="showThreadShortcut"
+			class="quote__button"
+			variant="tertiary"
+			:title="t('spreed', 'Go to thread')"
+			:aria-label="t('spreed', 'Go to thread')"
+			@click.stop.prevent="goToThread">
+			<template #icon>
+				<IconForumOutline :size="20" />
 			</template>
 		</NcButton>
 	</component>
@@ -302,10 +323,12 @@ function handleQuoteClick() {
 		}
 	}
 
-	&__close {
+	&__button {
 		position: absolute !important;
 		top: 0;
 		inset-inline-end: 0;
+		height: 100%;
+		border-radius: 0 !important;
 	}
 }
 

--- a/src/components/RightSidebar/Threads/ThreadItem.vue
+++ b/src/components/RightSidebar/Threads/ThreadItem.vue
@@ -12,7 +12,6 @@ import type {
 import { t } from '@nextcloud/l10n'
 import { computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import { useStore } from 'vuex'
 import NcActionButton from '@nextcloud/vue/components/NcActionButton'
 import NcDateTime from '@nextcloud/vue/components/NcDateTime'
 import NcListItem from '@nextcloud/vue/components/NcListItem'
@@ -26,7 +25,6 @@ const { thread } = defineProps<{ thread: ThreadInfo }>()
 
 const router = useRouter()
 const route = useRoute()
-const store = useStore()
 
 const threadAuthor = computed(() => getDisplayNameWithFallback(thread.first.actorDisplayName, thread.first.actorType, true))
 const lastActivity = computed(() => thread.thread.lastActivity * 1000)
@@ -147,7 +145,7 @@ const timeFormat = computed<Intl.DateTimeFormatOptions>(() => {
 	}
 
 	&.list-item__wrapper--active .thread__details-replies {
-		color: var(--color-primary-text);
+		color: var(--color-primary-element-text);
 		background-color: transparent;
 	}
 }


### PR DESCRIPTION
### ☑️ Resolves

* Fix #15512
* Give some space
* Add a shortcut button to thread view from a quote (if this message is already a thread)

⚠️ Screenshots are made against unreleased vue-library (messages do not have margin-bottom)

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="578" height="243" alt="2025-07-15_15h44_34" src="https://github.com/user-attachments/assets/88bd5647-78d7-4a33-ae5b-b9c98bb969da" /> | <img width="579" height="277" alt="2025-07-15_15h39_58" src="https://github.com/user-attachments/assets/b82e7b16-34ce-4b81-98c9-c8e3cc6f6963" />
<img width="165" height="328" alt="2025-07-15_15h49_52" src="https://github.com/user-attachments/assets/00b4e7ba-1a01-4dfd-9195-a6ec44c4c422" /> | <img width="198" height="329" alt="2025-07-15_15h50_02" src="https://github.com/user-attachments/assets/e1817daf-f45d-491c-b8ff-0bd264c6d642" />

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required