### PR TITLE
chore(deps): bump @nextcloud/vue library from v9.0.0-rc.3 to v9.0.0-rc.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@nextcloud/router": "^3.0.1",
         "@nextcloud/sharing": "^0.2.4",
         "@nextcloud/upload": "^2.0.0-rc.0",
-        "@nextcloud/vue": "^9.0.0-rc.3",
+        "@nextcloud/vue": "^9.0.0-rc.4",
         "@vue-leaflet/vue-leaflet": "^0.10.1",
         "@vueuse/components": "^13.4.0",
         "@vueuse/core": "^13.4.0",
@@ -3888,9 +3888,9 @@
       }
     },
     "node_modules/@nextcloud/vue": {
-      "version": "9.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-9.0.0-rc.3.tgz",
-      "integrity": "sha512-80eW36oUZIYwcwCQX58Aubao8ZXZS2ms0+tyYmkTCpVait9/eT9BmbwmvVxqD8y966572CSyyZf0DCsScLxqVQ==",
+      "version": "9.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-9.0.0-rc.4.tgz",
+      "integrity": "sha512-r9DGvFEKBXe6PBOEN/68btirU96iYz3yrjdw3Mi76pUhaow/LY8VV3OCFbhJU8BtU+bG5rTs+anonl4Y2t3Zfg==",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@ckpack/vue-color": "^1.6.0",
@@ -3901,7 +3901,7 @@
         "@nextcloud/capabilities": "^1.2.0",
         "@nextcloud/event-bus": "^3.3.2",
         "@nextcloud/initial-state": "^2.2.0",
-        "@nextcloud/l10n": "^3.2.0",
+        "@nextcloud/l10n": "^3.4.0",
         "@nextcloud/logger": "^3.0.2",
         "@nextcloud/router": "^3.0.1",
         "@nextcloud/sharing": "^0.2.4",
@@ -22184,9 +22184,9 @@
       }
     },
     "@nextcloud/vue": {
-      "version": "9.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-9.0.0-rc.3.tgz",
-      "integrity": "sha512-80eW36oUZIYwcwCQX58Aubao8ZXZS2ms0+tyYmkTCpVait9/eT9BmbwmvVxqD8y966572CSyyZf0DCsScLxqVQ==",
+      "version": "9.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-9.0.0-rc.4.tgz",
+      "integrity": "sha512-r9DGvFEKBXe6PBOEN/68btirU96iYz3yrjdw3Mi76pUhaow/LY8VV3OCFbhJU8BtU+bG5rTs+anonl4Y2t3Zfg==",
       "requires": {
         "@ckpack/vue-color": "^1.6.0",
         "@floating-ui/dom": "^1.6.13",
@@ -22196,7 +22196,7 @@
         "@nextcloud/capabilities": "^1.2.0",
         "@nextcloud/event-bus": "^3.3.2",
         "@nextcloud/initial-state": "^2.2.0",
-        "@nextcloud/l10n": "^3.2.0",
+        "@nextcloud/l10n": "^3.4.0",
         "@nextcloud/logger": "^3.0.2",
         "@nextcloud/router": "^3.0.1",
         "@nextcloud/sharing": "^0.2.4",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@nextcloud/router": "^3.0.1",
     "@nextcloud/sharing": "^0.2.4",
     "@nextcloud/upload": "^2.0.0-rc.0",
-    "@nextcloud/vue": "^9.0.0-rc.3",
+    "@nextcloud/vue": "^9.0.0-rc.4",
     "@vue-leaflet/vue-leaflet": "^0.10.1",
     "@vueuse/components": "^13.4.0",
     "@vueuse/core": "^13.4.0",


### PR DESCRIPTION
### ☑️ Resolves

* Fix markdown styles, hot keys with non-latin layout and other things

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts


### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required