### PR TITLE
fix(setupcheck): Clear OpenSSL errors before executing

### DIFF
--- a/lib/Config.php
+++ b/lib/Config.php
@@ -583,6 +583,9 @@ class Config {
 	}
 
 	public function deriveSignalingTokenPublicKey(string $privateKey, string $alg): string {
+		// Clear any existing (unrelated) OpenSSL errors
+		while (openssl_error_string() !== false);
+
 		if (str_starts_with($alg, 'ES') || str_starts_with($alg, 'RS')) {
 			$opensslPrivateKey = openssl_pkey_get_private($privateKey);
 			$this->throwOnOpensslError();


### PR DESCRIPTION
## 🛠️ API Checklist

### 🚧 Tasks

The `deriveSignalingTokenPublicKey` method checks for OpenSSL errors and throws in case there are any. When run as part of the setup checks, it's possible that there are OpenSSL errors in other parts of the checks, but we still throw in `deriveSignalingTokenPublicKey` and indicate that the HPB setup is not correct. 

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
