### PR TITLE
fix(chat): Fix guests in a fully empty chat

### DIFF
--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -811,9 +811,14 @@ class ChatController extends AEnvironmentAwareOCSController {
 		}
 
 		$currentUser = $this->userManager->get($this->userId);
-		$commentsHistory = $this->chatManager->getHistory($this->room, $messageId, $limit, true, $threadId);
-		$commentsHistory = array_reverse($commentsHistory);
-		$commentsFuture = $this->chatManager->waitForNewMessages($this->room, $messageId, $limit, 0, $currentUser, false);
+		if ($messageId === 0) {
+			// Guest in a fully expired chat, no history, just loading the chat from beginning for now
+			$commentsHistory = $commentsFuture = [];
+		} else {
+			$commentsHistory = $this->chatManager->getHistory($this->room, $messageId, $limit, true, $threadId);
+			$commentsHistory = array_reverse($commentsHistory);
+			$commentsFuture = $this->chatManager->waitForNewMessages($this->room, $messageId, $limit, 0, $currentUser, false);
+		}
 
 		return $this->prepareCommentsAsDataResponse(array_merge($commentsHistory, $commentsFuture));
 	}

--- a/lib/Service/RoomFormatter.php
+++ b/lib/Service/RoomFormatter.php
@@ -418,6 +418,11 @@ class RoomFormatter {
 			}
 		}
 
+		if ($roomData['lastReadMessage'] === 0) {
+			// Guest in a fully expired chat, no history, just loading the chat from beginning for now
+			$roomData['lastReadMessage'] = ChatManager::UNREAD_FIRST_MESSAGE;
+		}
+
 		if ($currentUser instanceof IUser
 			&& $attendee->getActorType() === Attendee::ACTOR_USERS
 			&& $roomData['lastReadMessage'] === ChatManager::UNREAD_FIRST_MESSAGE


### PR DESCRIPTION
### ☑️ Resolves

* Create a chat
* Make it public
* Configure message expiration
* Purge the chat history
* Join as a guest in a private window

Before | After
---|---
See loading animation for ever | See empty content
<img width="987" height="603" alt="grafik" src="https://github.com/user-attachments/assets/20bbdae3-a117-4ea1-80c5-dfa46eb5c646" /> | <img width="987" height="603" alt="grafik" src="https://github.com/user-attachments/assets/447fd4b6-4f7d-49d8-8304-81a6a219e0ae" />


### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
