### PR TITLE
fix(chat): imitate smooth scrolling and drop hash when scroll to bottom

### DIFF
--- a/src/components/ChatView.vue
+++ b/src/components/ChatView.vue
@@ -205,6 +205,7 @@ export default {
 		},
 
 		scrollToBottom() {
+			this.$router.replace({ hash: '' })
 			EventBus.emit('scroll-chat-to-bottom', { smooth: false, force: true })
 		},
 	},

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/MessageBody.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/MessageBody.vue
@@ -5,8 +5,6 @@
 
 <template>
 	<div ref="messageMain"
-		v-element-size="[onResize, { width: 0, height: 22.5 }]"
-		v-intersection-observer="onIntersectionObserver"
 		class="message-main">
 		<!-- System or deleted message body content -->
 		<div v-if="isSystemMessage || isDeletedMessage"
@@ -130,7 +128,6 @@
 import { showError, showSuccess } from '@nextcloud/dialogs'
 import { t } from '@nextcloud/l10n'
 import moment from '@nextcloud/moment'
-import { vElementSize as ElementSize, vIntersectionObserver as IntersectionObserver } from '@vueuse/components'
 import emojiRegex from 'emoji-regex'
 import { inject, toRefs } from 'vue'
 import NcButton from '@nextcloud/vue/components/NcButton'
@@ -179,11 +176,6 @@ export default {
 		CheckAllIcon,
 		ContentCopyIcon,
 		ReloadIcon,
-	},
-
-	directives: {
-		IntersectionObserver,
-		ElementSize,
 	},
 
 	props: {
@@ -238,8 +230,6 @@ export default {
 			showReloadButton: false,
 			currentCodeBlock: null,
 			copyButtonOffset: 0,
-			isVisible: false,
-			previousSize: { width: 0, height: 22.5 }, // default height of one-line message body without widgets
 		}
 	},
 
@@ -490,29 +480,6 @@ export default {
 			if (messageId === this.message.id) {
 				this.isEditing = value
 			}
-		},
-
-		onIntersectionObserver([{ isIntersecting }]) {
-			this.isVisible = isIntersecting
-		},
-
-		onResize({ width, height }) {
-			const oldWidth = this.previousSize?.width
-			const oldHeight = this.previousSize?.height
-			this.previousSize = { width, height }
-
-			if (!this.isVisible) {
-				return
-			}
-			if (oldWidth && oldWidth !== width) {
-				// Resizing messages list
-				return
-			}
-			if (height === 0) {
-				// component is unmounted
-				return
-			}
-			EventBus.emit('message-height-changed', { heightDiff: height - oldHeight })
 		},
 	},
 }

--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -905,6 +905,14 @@ export default {
 					newTop = this.$refs.scroller.scrollHeight
 					this.setChatScrolledToBottom(true)
 				}
+
+				if (options?.smooth && this.$refs.scroller.scrollTop < newTop - 1.5 * window.innerHeight) {
+					// Imitate scrolling the whole distance to the element
+					this.$refs.scroller.scrollTo({
+						top: newTop - 1.5 * window.innerHeight,
+						behavior: 'instant',
+					})
+				}
 				this.$refs.scroller.scrollTo({
 					top: newTop,
 					behavior: options?.smooth ? 'smooth' : 'auto',

--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -329,7 +329,6 @@ export default {
 		EventBus.on('scroll-chat-to-bottom', this.scrollToBottom)
 		EventBus.on('focus-message', this.focusMessage)
 		EventBus.on('route-change', this.onRouteChange)
-		EventBus.on('message-height-changed', this.onMessageHeightChanged)
 		window.addEventListener('focus', this.onWindowFocus)
 
 		this.resizeObserver = new ResizeObserver(this.updateSize)
@@ -344,7 +343,6 @@ export default {
 		EventBus.off('scroll-chat-to-bottom', this.scrollToBottom)
 		EventBus.off('focus-message', this.focusMessage)
 		EventBus.off('route-change', this.onRouteChange)
-		EventBus.off('message-height-changed', this.onMessageHeightChanged)
 
 		if (this.resizeObserver) {
 			this.resizeObserver.disconnect()
@@ -1086,11 +1084,6 @@ export default {
 
 		messagesGroupComponent(group) {
 			return group.isSystemMessagesGroup ? MessagesSystemGroup : MessagesGroup
-		},
-
-		onMessageHeightChanged({ heightDiff }) {
-			// scroll down by the height difference
-			this.$refs.scroller.scrollTop += heightDiff
 		},
 
 		updateTasksCount() {

--- a/src/services/EventBus.ts
+++ b/src/services/EventBus.ts
@@ -31,7 +31,6 @@ export type Events = {
 	'focus-message': number // TODO: listener method can receive ...[messageId, smooth, highlightAnimation]
 	'forbidden-route': { error: string }
 	'joined-conversation': { token: string }
-	'message-height-changed': { heightDiff: number }
 	'poll-drafts-open': { token: string, selector?: string }
 	'poll-editor-open': { token: string, id: number | null, fromDrafts: boolean, action?: string, selector?: string }
 	'refresh-peer-list': void


### PR DESCRIPTION
### ☑️ Resolves

* Fix scrolling to focused items
* Imitate smooth scrolling with 'instant scroll to almost visible > smooth'
* That way rendered references will not interfer with container height and scroll position
* Drop hash from route/URL when scrolling to bottom (via button click)

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After

https://github.com/user-attachments/assets/1fda29a3-87d1-4d0a-83fb-b8a9ec5b1fd2


### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
