### PR TITLE
fix: disable Esc hotkey for guests

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -209,7 +209,9 @@ export default {
 	created() {
 		window.addEventListener('beforeunload', this.preventUnload)
 		useHotKey('f', this.handleAppSearch, { ctrl: true, stop: true, prevent: true })
-		useHotKey('Escape', this.openRoot, { stop: true, prevent: true })
+		if (getCurrentUser()) {
+			useHotKey('Escape', this.openRoot, { stop: true, prevent: true })
+		}
 	},
 
 	beforeUnmount() {


### PR DESCRIPTION
### ☑️ Resolves

* Fix pressing Esc button loading dashboard / home page, when in public view


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="952" height="514" alt="2025-07-19_14h19_10" src="https://github.com/user-attachments/assets/37365661-9ac6-4d2f-893e-ac927f6cf0b9" /> | No navigation


### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Not risky to browser differences / client