### PR TITLE
Revert "fix(NcRichText): adjust the direction of interactive items"

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/MessageBody.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/MessageBody.vue
@@ -586,10 +586,6 @@ export default {
 	}
 }
 
-:deep(.rich-text--wrapper) {
-	direction: inherit;
-}
-
 // Always render code blocks LTR
 :deep(.rich-text--wrapper) pre {
 	direction: ltr;


### PR DESCRIPTION
### ☑️ Resolves

* Fix #15562
  * This reverts commit 4fe885e4e338ad229607ed64e9254e61c914b257.


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="817" height="170" alt="2025-07-20_19h19_55" src="https://github.com/user-attachments/assets/cc0b1594-8978-45f9-8792-9cff038013e0" /> | <img width="808" height="163" alt="2025-07-20_19h20_11" src="https://github.com/user-attachments/assets/dbd02e65-bef9-45d4-9c39-c538da8e8873" />

### 🚧 Tasks

- [ ] Remember, why it was added

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Not risky to browser differences / client