### PR TITLE
fix(chat): fix flickering MessagesList

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -491,7 +491,8 @@ export default {
 		inset-inline-end: 0;
 		width: fit-content;
 		height: 100%;
-		padding: 8px 8px 0 0;
+		padding-top: var(--default-grid-baseline);
+		padding-inline-end: var(--default-grid-baseline);
 	}
 }
 

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/MessageBody.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/MessageBody.vue
@@ -495,6 +495,7 @@ export default {
 	grid-row-gap: var(--default-grid-baseline);
 	justify-content: space-between;
 	align-items: flex-start;
+	min-height: var(--clickable-area-small);
 	min-width: 100%;
 
 	&__text {

--- a/src/components/MessagesList/MessagesGroup/MessagesGroup.vue
+++ b/src/components/MessagesList/MessagesGroup/MessagesGroup.vue
@@ -45,8 +45,6 @@ export default {
 		Message,
 	},
 
-	inheritAttrs: false,
-
 	props: {
 		/**
 		 * The conversation token.

--- a/src/components/MessagesList/MessagesGroup/MessagesSystemGroup.vue
+++ b/src/components/MessagesList/MessagesGroup/MessagesSystemGroup.vue
@@ -43,8 +43,6 @@ export default {
 		Message,
 	},
 
-	inheritAttrs: false,
-
 	props: {
 		/**
 		 * The conversation token.

--- a/src/components/MessagesList/MessagesList.spec.js
+++ b/src/components/MessagesList/MessagesList.spec.js
@@ -234,7 +234,7 @@ describe('MessagesList.vue', () => {
 				isReplyable: true,
 			}])
 
-			const dateSeparators = wrapper.findAll('.messages-group__date')
+			const dateSeparators = wrapper.findAll('.messages-date')
 			expect(dateSeparators).toHaveLength(3)
 			expect(dateSeparators.at(0).text()).toBe('2 days ago, May 9, 2020')
 			expect(dateSeparators.at(1).text()).toBe('Yesterday, May 10, 2020')

--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -1095,6 +1095,11 @@ export default {
 	&__content {
 		max-width: $messages-list-max-width;
 		margin: 0 auto;
+
+		/* Safe margin to fit MessageButtonsBar on screen for last one-line message */
+		&:last-of-type {
+			margin-bottom: calc(var(--default-clickable-area) - var(--clickable-area-small) - var(--default-grid-baseline));
+		}
 	}
 
 	&__loading {
@@ -1142,10 +1147,6 @@ export default {
 		color: var(--color-text-maxcontrast);
 		background-color: var(--color-background-dark);
 		border-radius: var(--border-radius-element, var(--border-radius-pill));
-	}
-
-	&:last-child {
-		margin-bottom: 16px;
 	}
 }
 

--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -39,7 +39,7 @@
 					{{ dateSeparatorLabels[dateTimestamp] }}
 				</span>
 			</li>
-			<component :is="messagesGroupComponent(group)"
+			<component :is="messagesGroupComponent[group.type]"
 				v-for="group in list"
 				:key="group.id"
 				class="messages-group"
@@ -90,6 +90,11 @@ import { convertToUnix, ONE_DAY_IN_MS } from '../../utils/formattedTime.ts'
 
 const SCROLL_TOLERANCE = 10
 const LOAD_HISTORY_THRESHOLD = 800
+
+const messagesGroupComponent = {
+	system: MessagesSystemGroup,
+	default: MessagesGroup,
+}
 
 export default {
 	name: 'MessagesList',
@@ -146,6 +151,7 @@ export default {
 		const threadId = useGetThreadId()
 
 		return {
+			messagesGroupComponent,
 			isInCall: useIsInCall(),
 			chatExtrasStore: useChatExtrasStore(),
 			isChatVisible,
@@ -389,7 +395,7 @@ export default {
 						dateTimestamp,
 						previousMessageId: lastMessage?.id || 0,
 						nextMessageId: 0,
-						isSystemMessagesGroup: message.systemMessage.length !== 0,
+						type: message.systemMessage.length !== 0 ? 'system' : 'default',
 					}
 
 					// Update the previous group with the next message id
@@ -1030,10 +1036,6 @@ export default {
 					this.dateSeparatorLabels[dateTimestamp] = this.generateDateSeparator(dateTimestamp)
 				})
 			}, 2)
-		},
-
-		messagesGroupComponent(group) {
-			return group.isSystemMessagesGroup ? MessagesSystemGroup : MessagesGroup
 		},
 
 		updateTasksCount() {

--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -34,15 +34,14 @@
 			:data-date-timestamp="dateTimestamp"
 			class="scroller__content"
 			:class="{ 'has-sticky': dateTimestamp === stickyDate }">
-			<li :key="dateSeparatorLabels[dateTimestamp]" class="messages-group__date">
-				<span class="messages-group__date-text" role="heading" aria-level="3">
+			<li :key="dateSeparatorLabels[dateTimestamp]" class="messages-date">
+				<span class="messages-date__text" role="heading" aria-level="3">
 					{{ dateSeparatorLabels[dateTimestamp] }}
 				</span>
 			</li>
 			<component :is="messagesGroupComponent[group.type]"
 				v-for="group in list"
 				:key="group.id"
-				class="messages-group"
 				:token="token"
 				:messages="group.messages"
 				:previous-message-id="group.previousMessageId"
@@ -1125,20 +1124,18 @@ export default {
 	}
 }
 
-.messages-group {
-	&__date {
-		position: sticky;
-		top: 0;
-		display: grid;
-		grid-template-columns: minmax(0, $messages-text-max-width) $messages-info-width;
-		z-index: 2;
-		margin-inline-start: calc($messages-avatar-width);
-		margin-bottom: 5px;
-		padding-inline: var(--default-grid-baseline);
-		pointer-events: none;
-	}
+.messages-date {
+	position: sticky;
+	top: 0;
+	display: grid;
+	grid-template-columns: minmax(0, $messages-text-max-width) $messages-info-width;
+	z-index: 2;
+	margin-inline-start: calc($messages-avatar-width);
+	margin-bottom: 5px;
+	padding-inline: var(--default-grid-baseline);
+	pointer-events: none;
 
-	&__date-text {
+	&__text {
 		margin: 0 auto;
 		padding: var(--default-grid-baseline) calc(3 * var(--default-grid-baseline));
 		text-wrap: nowrap;
@@ -1152,13 +1149,13 @@ export default {
 	}
 }
 
-.has-sticky .messages-group__date {
+.has-sticky .messages-date {
 	transition: opacity 0.3s ease-in-out;
 	transition-delay: 2s;
 	opacity: 0;
 }
 
-.scroller--isScrolling .has-sticky .messages-group__date {
+.scroller--isScrolling .has-sticky .messages-date {
 	opacity: 1;
 	transition: opacity 0s;
 }


### PR DESCRIPTION
### ☑️ Resolves

* Fix flickering, when mouse hover a one-line message (height 32px), it shows buttons menu (height 34px), total height is changed,  message is not hovered anymore, buttons menu is hidden - ... - repeat until tired
  * Fix message height to be minimum of (24px+2*4px padding)
  * Reduce buttons menu top inline to 4px (align top border with Quote)
  * Add safe margin for minimum resulting difference (34px + 4px - 2 * 4px - 24px)
* Refactor template to not use function, and migrate to const object instead
* Previous fix doesn't work in Vue3 due to inheritAttrs: false. Initial problem was solved, so removing an option

Alternative: buttons should not exceed message height

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
Flickering | Stable
<img width="138" height="59" alt="image" src="https://github.com/user-attachments/assets/35ae7702-e52d-4d30-9498-9d3dae17dae8" /> <img width="139" height="58" alt="image" src="https://github.com/user-attachments/assets/20b36d00-8918-4302-9dbe-d548afcd26bc" /> | <img width="136" height="57" alt="image" src="https://github.com/user-attachments/assets/770aad8a-84a5-4960-a7af-a3f22531ffea" /> <img width="128" height="56" alt="image" src="https://github.com/user-attachments/assets/f4af33fa-cb39-441c-9b2b-e81c79611740" />


### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team