### PR TITLE
fix: use memory router for Talk integration

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -36,6 +36,7 @@ Screenshot before | Screenshot after
   - [ ] Firefox
   - [ ] Safari
   - [ ] Talk Desktop
+  - [ ] Integrations with Files sidebar and other apps
   - [ ] Not risky to browser differences / client
 - [ ] 🖌️ Design was reviewed, approved or inspired by the design team
 - [ ] ⛑️ Tests are included or not possible

--- a/src/App.vue
+++ b/src/App.vue
@@ -46,7 +46,6 @@ import { useHashCheck } from './composables/useHashCheck.js'
 import { useIsInCall } from './composables/useIsInCall.js'
 import { useSessionIssueHandler } from './composables/useSessionIssueHandler.ts'
 import { CONVERSATION, PARTICIPANT } from './constants.ts'
-import Router from './router/router.ts'
 import BrowserStorage from './services/BrowserStorage.js'
 import { EventBus } from './services/EventBus.ts'
 import { leaveConversationSync } from './services/participantsService.js'
@@ -413,7 +412,7 @@ export default {
 		 * When app is initializing and router is not ready yet,
 		 * first navigation will be made from initial state { name : undefined }
 		 */
-		Router.beforeEach((to, from, next) => {
+		this.$router.beforeEach((to, from, next) => {
 			if (from.name === 'conversation' && to.name === 'conversation' && from.params.token === to.params.token) {
 				// Navigating within the same conversation
 				beforeRouteChangeListener(to, from, next)

--- a/src/FilesSidebarTabApp.vue
+++ b/src/FilesSidebarTabApp.vue
@@ -178,6 +178,7 @@ export default {
 			// if this conversation is joined again.
 			await this.$store.dispatch('purgeParticipantsStore', this.token)
 
+			await this.$router.push({ name: 'conversation', params: { token: this.token } })
 			await this.$store.dispatch('joinConversation', { token: this.token })
 
 			// The current participant (which is automatically set when fetching

--- a/src/PublicShareAuthSidebar.vue
+++ b/src/PublicShareAuthSidebar.vue
@@ -14,7 +14,7 @@
 				<TopBar is-in-call is-sidebar />
 				<CallView :token="token" is-sidebar />
 				<InternalSignalingHint />
-				<ChatView is-sidebar />
+				<RouterView />
 				<PollManager />
 				<PollViewer />
 				<MediaSettings v-model:recording-consent-given="recordingConsentGiven" />
@@ -29,7 +29,6 @@ import { emit } from '@nextcloud/event-bus'
 import { loadState } from '@nextcloud/initial-state'
 import { t } from '@nextcloud/l10n'
 import CallView from './components/CallView/CallView.vue'
-import ChatView from './components/ChatView.vue'
 import MediaSettings from './components/MediaSettings/MediaSettings.vue'
 import PollManager from './components/PollViewer/PollManager.vue'
 import PollViewer from './components/PollViewer/PollViewer.vue'
@@ -56,7 +55,6 @@ export default {
 	components: {
 		InternalSignalingHint,
 		CallView,
-		ChatView,
 		MediaSettings,
 		PollManager,
 		PollViewer,
@@ -136,6 +134,7 @@ export default {
 				this.actorStore.setDisplayName(guestNickname)
 			}
 
+			await this.$router.push({ name: 'conversation', params: { token: this.token } })
 			await this.$store.dispatch('joinConversation', { token: this.token })
 
 			// Add guest name to the store, only possible after joining the conversation

--- a/src/PublicShareSidebar.vue
+++ b/src/PublicShareSidebar.vue
@@ -25,7 +25,7 @@
 				<InternalSignalingHint />
 				<CallButton v-if="!isInCall" class="call-button" />
 				<CallFailedDialog v-if="connectionFailed" :token="token" />
-				<ChatView is-sidebar />
+				<RouterView />
 				<PollManager />
 				<PollViewer />
 				<MediaSettings v-model:recording-consent-given="recordingConsentGiven" />
@@ -42,7 +42,6 @@ import NcButton from '@nextcloud/vue/components/NcButton'
 import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
 import CallFailedDialog from './components/CallView/CallFailedDialog.vue'
 import CallView from './components/CallView/CallView.vue'
-import ChatView from './components/ChatView.vue'
 import MediaSettings from './components/MediaSettings/MediaSettings.vue'
 import PollManager from './components/PollViewer/PollManager.vue'
 import PollViewer from './components/PollViewer/PollViewer.vue'
@@ -73,7 +72,6 @@ export default {
 		CallButton,
 		CallFailedDialog,
 		CallView,
-		ChatView,
 		MediaSettings,
 		NcButton,
 		NcLoadingIcon,
@@ -173,6 +171,7 @@ export default {
 			try {
 				await this.getPublicShareConversationData()
 
+				await this.$router.push({ name: 'conversation', params: { token: this.token } })
 				await this.$store.dispatch('joinConversation', { token: this.token })
 			} catch (exception) {
 				this.joiningConversation = false

--- a/src/main.js
+++ b/src/main.js
@@ -8,7 +8,7 @@ import { emit } from '@nextcloud/event-bus'
 import { generateFilePath } from '@nextcloud/router'
 import { createApp, reactive, watch } from 'vue'
 import App from './App.vue'
-import router from './router/router.ts'
+import { createTalkRouter } from './router/router.ts'
 import { SettingsAPI } from './services/SettingsAPI.ts'
 import store from './store/index.js'
 import pinia from './stores/pinia.ts'
@@ -31,6 +31,8 @@ if (!IS_DESKTOP) {
 	// We do not want the index.php since we're loading files
 	__webpack_public_path__ = generateFilePath('spreed', '', 'js/')
 }
+
+const router = createTalkRouter()
 
 const instance = createApp(App, { fileInfo: null })
 	.use(store)

--- a/src/mainFilesSidebar.js
+++ b/src/mainFilesSidebar.js
@@ -8,6 +8,7 @@ import { generateFilePath } from '@nextcloud/router'
 import { createApp, reactive } from 'vue'
 import FilesSidebarCallViewApp from './FilesSidebarCallViewApp.vue'
 import FilesSidebarTabApp from './FilesSidebarTabApp.vue'
+import { createMemoryRouter } from './router/router.ts'
 import store from './store/index.js'
 import pinia from './stores/pinia.ts'
 import { NextcloudGlobalsVuePlugin } from './utils/NextcloudGlobalsVuePlugin.js'
@@ -27,14 +28,18 @@ __webpack_nonce__ = getCSPNonce()
 // We do not want the index.php since we're loading files
 __webpack_public_path__ = generateFilePath('spreed', '', 'js/')
 
+const router = createMemoryRouter()
+
 const newCallView = () => createApp(FilesSidebarCallViewApp)
 	.use(store)
 	.use(pinia)
+	.use(router)
 	.use(NextcloudGlobalsVuePlugin)
 
 const newTab = () => createApp(FilesSidebarTabApp)
 	.use(store)
 	.use(pinia)
+	.use(router)
 	.use(NextcloudGlobalsVuePlugin)
 
 if (!window.OCA.Talk) {

--- a/src/mainPublicShareAuthSidebar.js
+++ b/src/mainPublicShareAuthSidebar.js
@@ -8,6 +8,7 @@ import { generateFilePath } from '@nextcloud/router'
 import { createApp } from 'vue'
 import PublicShareAuthRequestPasswordButton from './PublicShareAuthRequestPasswordButton.vue'
 import PublicShareAuthSidebar from './PublicShareAuthSidebar.vue'
+import { createMemoryRouter } from './router/router.ts'
 import store from './store/index.js'
 import pinia from './stores/pinia.ts'
 import { NextcloudGlobalsVuePlugin } from './utils/NextcloudGlobalsVuePlugin.js'
@@ -87,14 +88,18 @@ function getShareToken() {
 	return shareTokenElement.value
 }
 
+const router = createMemoryRouter()
+
 createApp(PublicShareAuthRequestPasswordButton, { shareToken: getShareToken() })
 	.use(pinia)
 	.use(store)
+	.use(router)
 	.use(NextcloudGlobalsVuePlugin)
 	.mount('#request-password')
 
 createApp(PublicShareAuthSidebar)
 	.use(pinia)
 	.use(store)
+	.use(router)
 	.use(NextcloudGlobalsVuePlugin)
 	.mount(document.querySelector('#talk-sidebar'))

--- a/src/mainPublicShareSidebar.js
+++ b/src/mainPublicShareSidebar.js
@@ -9,6 +9,7 @@ import { getSharingToken } from '@nextcloud/sharing/public'
 import { createApp, reactive } from 'vue'
 import PublicShareSidebar from './PublicShareSidebar.vue'
 import PublicShareSidebarTrigger from './PublicShareSidebarTrigger.vue'
+import { createMemoryRouter } from './router/router.ts'
 import store from './store/index.js'
 import pinia from './stores/pinia.ts'
 import { NextcloudGlobalsVuePlugin } from './utils/NextcloudGlobalsVuePlugin.js'
@@ -69,12 +70,15 @@ function addTalkSidebar() {
 	talkSidebarElement.setAttribute('id', 'talk-sidebar')
 	document.getElementById('content-vue').appendChild(talkSidebarElement)
 
+	const router = createMemoryRouter()
+
 	createApp(PublicShareSidebar, {
 		shareToken: getSharingToken(),
 		state: sidebarState,
 	})
 		.use(pinia)
 		.use(store)
+		.use(router)
 		.use(NextcloudGlobalsVuePlugin)
 		.mount(document.querySelector('#talk-sidebar'))
 }

--- a/src/mainRecording.js
+++ b/src/mainRecording.js
@@ -8,7 +8,7 @@ import { getCSPNonce } from '@nextcloud/auth'
 import { generateFilePath } from '@nextcloud/router'
 import { createApp, reactive } from 'vue'
 import Recording from './Recording.vue'
-import router from './router/router.ts'
+import { createTalkRouter } from './router/router.ts'
 import store from './store/index.js'
 import pinia from './stores/pinia.ts'
 import { NextcloudGlobalsVuePlugin } from './utils/NextcloudGlobalsVuePlugin.js'
@@ -38,6 +38,8 @@ window.store = store
 if (!window.OCA.Talk) {
 	window.OCA.Talk = reactive({})
 }
+
+const router = createTalkRouter()
 
 const instance = createApp(Recording)
 	.use(pinia)

--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -3,8 +3,14 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import type { RouteRecordRaw } from 'vue-router'
+
 import { generateUrl, getRootUrl } from '@nextcloud/router'
-import { createRouter, createWebHashHistory, createWebHistory } from 'vue-router'
+import {
+	createRouter,
+	createWebHashHistory,
+	createWebHistory,
+} from 'vue-router'
 import CallView from '../components/CallView/CallView.vue'
 import ForbiddenView from '../views/ForbiddenView.vue'
 import MainView from '../views/MainView.vue'
@@ -27,13 +33,11 @@ function generateTalkWebBasePath(): string {
 	})
 }
 
-export default createRouter({
-	// On desktop (Electron) app is open via file:// protocol - History API is not available and no base path
-	history: !IS_DESKTOP ? createWebHistory(generateTalkWebBasePath()) : createWebHashHistory(''),
-
-	linkActiveClass: 'active',
-
-	routes: [
+/**
+ * Returns a router object for the main app (Talk, Talk Recording, Talk Desktop)
+ */
+export function createTalkRouter() {
+	const routes: RouteRecordRaw[] = [
 		{
 			path: '/apps/spreed',
 			name: 'root',
@@ -70,5 +74,12 @@ export default createRouter({
 			component: CallView,
 			props: true,
 		},
-	],
-})
+	]
+
+	return createRouter({
+		// On desktop (Electron) app is open via file:// protocol - History API is not available and no base path
+		history: !IS_DESKTOP ? createWebHistory(generateTalkWebBasePath()) : createWebHashHistory(''),
+		linkActiveClass: 'active',
+		routes,
+	})
+}

--- a/src/views/FilesSidebarChatView.vue
+++ b/src/views/FilesSidebarChatView.vue
@@ -8,7 +8,7 @@
 		<InternalSignalingHint />
 		<CallButton v-if="!isInCall" class="talk-tab__call-button" />
 		<CallFailedDialog v-if="connectionFailed" :token="token" />
-		<ChatView class="talk-tab__chat-view" is-sidebar />
+		<RouterView class="talk-tab__chat-view" />
 		<PollManager />
 		<PollViewer />
 		<MediaSettings v-model:recording-consent-given="recordingConsentGiven" />
@@ -18,7 +18,6 @@
 <script>
 
 import CallFailedDialog from '../components/CallView/CallFailedDialog.vue'
-import ChatView from '../components/ChatView.vue'
 import MediaSettings from '../components/MediaSettings/MediaSettings.vue'
 import PollManager from '../components/PollViewer/PollManager.vue'
 import PollViewer from '../components/PollViewer/PollViewer.vue'
@@ -36,7 +35,6 @@ export default {
 		InternalSignalingHint,
 		CallButton,
 		CallFailedDialog,
-		ChatView,
 		MediaSettings,
 		PollManager,
 		PollViewer,


### PR DESCRIPTION
### ☑️ Resolves

* Fix #15573
  * testing with Files Sidebar (from files, public, public auth)
  * integration route is matching message actual URL


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="447" height="40" alt="image" src="https://github.com/user-attachments/assets/c47f20d6-6ff4-43b5-a3b3-8c26a24bb4e9" /> | All clean
<img width="370" height="31" alt="image" src="https://github.com/user-attachments/assets/2b7f5c55-c807-47eb-9185-6728bef7f167" /> | All clean

🏡 After

https://github.com/user-attachments/assets/916600a3-339c-4935-9e42-07a4663cee7b



### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Integrations with Files sidebar and other apps 🆕 
  - [ ] Not risky to browser differences / client
- [ ] ⛑️ Tests are included or not possible