### PR TITLE
fix(MessagesList): drop unused methods

### DIFF
--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -988,32 +988,6 @@ export default {
 			return true // element found
 		},
 
-		/**
-		 * gets the last known message id.
-		 *
-		 * @return {string} The last known message id.
-		 */
-		getLastKnownMessageId() {
-			let i = this.messagesList.length - 1
-
-			while (i >= 0) {
-				if (!this.messagesList[i].id.toString().startsWith('temp-')) {
-					return this.messagesList[i].id
-				}
-				i--
-			}
-			return '0'
-		},
-
-		/**
-		 * gets the first message's id.
-		 *
-		 * @return {string}
-		 */
-		getFirstKnownMessageId() {
-			return this.messagesList[0].id.toString()
-		},
-
 		setChatScrolledToBottom(value, { auto = false } = {}) {
 			let isScrolledToBottom = value
 			if (auto) {


### PR DESCRIPTION
### ☑️ Resolves

* Methods are some leftovers from time before `getters.getFirstKnownMessageId` and `getters.getLastKnownMessageId`

## 🖌️ UI Checklist

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Not risky to browser differences / client