### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -311,12 +311,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "24cda0e45962869f9911f427711ac7018fac02fe"
+                "reference": "8ec87be7ab634f12a403fca7165319587a6cb218"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/24cda0e45962869f9911f427711ac7018fac02fe",
-                "reference": "24cda0e45962869f9911f427711ac7018fac02fe",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/8ec87be7ab634f12a403fca7165319587a6cb218",
+                "reference": "8ec87be7ab634f12a403fca7165319587a6cb218",
                 "shasum": ""
             },
             "require": {
@@ -352,7 +352,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2025-07-25T10:09:46+00:00"
+            "time": "2025-07-26T00:55:00+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency