### PR TITLE
fix(icons): make phone dial out icon more relatable and adjust filter icon size

### DIFF
--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -37,7 +37,7 @@
 						class="filters"
 						:class="{ 'hidden-visually': isSearching }">
 						<template #icon>
-							<IconFilterOutline :size="15" />
+							<IconFilterOutline :size="20" />
 						</template>
 						<NcActionCaption :name="t('spreed', 'Filter conversations by')" />
 

--- a/src/components/RightSidebar/Participants/Participant.vue
+++ b/src/components/RightSidebar/Participants/Participant.vue
@@ -55,7 +55,7 @@
 					:disabled="disabled"
 					@click="dialOutPhoneNumber">
 					<template #icon>
-						<IconPhoneOutline :size="20" />
+						<IconPhoneDialOutline :size="20" />
 					</template>
 				</NcButton>
 				<template v-else>
@@ -160,7 +160,7 @@
 					close-after-click
 					@click="dialOutPhoneNumber">
 					<template #icon>
-						<IconPhoneOutline :size="20" />
+						<IconPhoneDialOutline :size="20" />
 					</template>
 					{{ t('spreed', 'Dial out phone number') }}
 				</NcActionButton>
@@ -334,9 +334,9 @@ import IconLockOutline from 'vue-material-design-icons/LockOutline.vue'
 import IconLockReset from 'vue-material-design-icons/LockReset.vue'
 import IconMicrophoneOutline from 'vue-material-design-icons/MicrophoneOutline.vue'
 import IconPencilOutline from 'vue-material-design-icons/PencilOutline.vue'
+import IconPhoneDialOutline from 'vue-material-design-icons/PhoneDialOutline.vue'
 import IconPhoneHangupOutline from 'vue-material-design-icons/PhoneHangupOutline.vue'
 import IconPhoneInTalkOutline from 'vue-material-design-icons/PhoneInTalkOutline.vue'
-import IconPhoneOutline from 'vue-material-design-icons/PhoneOutline.vue'
 import IconPhonePausedOutline from 'vue-material-design-icons/PhonePausedOutline.vue'
 import IconTune from 'vue-material-design-icons/Tune.vue'
 import IconVideoOutline from 'vue-material-design-icons/VideoOutline.vue'
@@ -393,7 +393,7 @@ export default {
 		IconLockReset,
 		IconMicrophoneOutline,
 		IconPencilOutline,
-		IconPhoneOutline,
+		IconPhoneDialOutline,
 		IconPhoneInTalkOutline,
 		IconPhoneHangupOutline,
 		IconPhonePausedOutline,
@@ -581,7 +581,7 @@ export default {
 			} if (this.participant.inCall & PARTICIPANT.CALL_FLAG.WITH_VIDEO) {
 				return { icon: IconVideoOutline, size: 20, title: t('spreed', 'Joined with video') }
 			} else if (this.participant.inCall & PARTICIPANT.CALL_FLAG.WITH_PHONE) {
-				return { icon: IconPhoneOutline, size: 20, title: t('spreed', 'Joined via phone') }
+				return { icon: IconPhoneDialOutline, size: 20, title: t('spreed', 'Joined via phone') }
 			} else {
 				return { icon: IconMicrophoneOutline, size: 20, title: t('spreed', 'Joined with audio') }
 			}


### PR DESCRIPTION
### ☑️ Resolves

* Fix #15609

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

LS | Participant
-- | --
<img width="594" height="84" alt="image" src="https://github.com/user-attachments/assets/dd78a4bf-713c-4ae8-a2ee-c255d50fd80a" /> | <img width="444" height="226" alt="image" src="https://github.com/user-attachments/assets/e60438f1-ca6d-41a1-b13f-1a69bb37da06" />

<!-- ☀️ Light theme | 🌑 Dark Theme -->


### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required

