### PR TITLE
fix(guests): ease display name submission requirement flow

### DIFF
--- a/src/components/LobbyScreen.vue
+++ b/src/components/LobbyScreen.vue
@@ -40,7 +40,6 @@ import moment from '@nextcloud/moment'
 import NcRichText from '@nextcloud/vue/components/NcRichText'
 import RoomService from 'vue-material-design-icons/RoomService.vue'
 import MediaSettings from '../components/MediaSettings/MediaSettings.vue'
-import GuestWelcomeWindow from './GuestWelcomeWindow.vue'
 import { useGetToken } from '../composables/useGetToken.ts'
 import { futureRelativeTime, ONE_DAY_IN_MS } from '../utils/formattedTime.ts'
 

--- a/src/components/MediaSettings/MediaSettings.vue
+++ b/src/components/MediaSettings/MediaSettings.vue
@@ -171,7 +171,9 @@
 					</MediaSettingsTabs>
 
 					<!-- Guest display name setting-->
-					<SetGuestUsername v-if="isGuest" compact />
+					<SetGuestUsername v-if="isGuest"
+						compact
+						@update:guest-username="guestUserName = $event" />
 
 					<!-- Moderator options before starting a call-->
 					<NcCheckboxRadioSwitch v-if="showStartRecordingOption"
@@ -382,6 +384,7 @@ export default {
 			skipBlurVirtualBackground: false,
 			mediaLoading: false,
 			isDeviceCheck: false,
+			guestUserName: '',
 		}
 	},
 
@@ -557,7 +560,7 @@ export default {
 
 		disabledCallButton() {
 			return (this.isRecordingConsentRequired && !this.recordingConsentGiven)
-				|| (this.isGuest && !this.actorStore.displayName.length)
+				|| (this.isGuest && !this.guestUserName.length)
 		},
 
 		forceShowMediaSettings() {

--- a/src/components/SetGuestUsername.vue
+++ b/src/components/SetGuestUsername.vue
@@ -24,11 +24,11 @@
 				:placeholder="t('spreed', 'Guest')"
 				class="username-form__input"
 				:label="t('spreed', 'Display name (required)')"
-				:show-trailing-button="!!guestUserName"
+				:show-trailing-button="!!guestUserName && !compact"
 				trailing-button-icon="arrowEnd"
 				:trailing-button-label="t('spreed', 'Save name')"
-				@trailing-button-click="updateDisplayName"
-				@keydown.enter="updateDisplayName"
+				@trailing-button-click="!compact ? updateDisplayName() : null"
+				@keydown.enter="!compact ? updateDisplayName() : null"
 				@keydown.esc="toggleEdit" />
 		</div>
 
@@ -63,8 +63,10 @@ import { useActorStore } from '../stores/actor.ts'
 import { useGuestNameStore } from '../stores/guestName.js'
 
 const { compact = false } = defineProps<{
-	compact: boolean
+	compact?: boolean
 }>()
+
+const emit = defineEmits(['update:guest-username'])
 const loginUrl = `${generateUrl('/login')}?redirect_url=${encodeURIComponent(window.location.pathname)}`
 
 const actorStore = useActorStore()
@@ -104,6 +106,7 @@ EventBus.once('joined-conversation', () => {
 subscribe('user:info:changed', updateDisplayNameFromPublicEvent)
 onBeforeUnmount(() => {
 	unsubscribe('user:info:changed', updateDisplayNameFromPublicEvent)
+	updateDisplayName()
 })
 
 /** Update guest username from public page user menu */
@@ -129,6 +132,12 @@ function toggleEdit() {
 		})
 	}
 }
+
+// One-way binding to parent component
+watch(guestUserName, (newValue) => {
+	emit('update:guest-username', newValue)
+})
+emit('update:guest-username', guestUserName.value)
 </script>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
### ☑️ Resolves

* Setting displayname in media settings was a bit ambiguious as you have to hit enter or click on the arrow button. It is more clear if the displayname is submitted with closing media settings. 
* I don't prefer debounce update because it will interfer with guest welcome window and allow empty submission

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

<!-- ☀️ Light theme | 🌑 Dark Theme -->

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required