### PR TITLE
fix(chat): Suggest to mention self

### DIFF
--- a/lib/Chat/AutoComplete/SearchPlugin.php
+++ b/lib/Chat/AutoComplete/SearchPlugin.php
@@ -122,11 +122,6 @@ class SearchPlugin implements ISearchPlugin {
 		$matches = $exactMatches = [];
 		foreach ($users as $userId => $displayName) {
 			$userId = (string)$userId;
-			if ($this->userId !== '' && $this->userId === $userId) {
-				// Do not suggest the current user
-				continue;
-			}
-
 			if ($searchResult->hasResult($type, $userId)) {
 				continue;
 			}
@@ -174,11 +169,6 @@ class SearchPlugin implements ISearchPlugin {
 
 		$matches = $exactMatches = [];
 		foreach ($cloudIds as $cloudId => $displayName) {
-			if ($this->federationAuthenticator->getCloudId() === $cloudId) {
-				// Do not suggest the current user
-				continue;
-			}
-
 			if ($searchResult->hasResult($type, $cloudId)) {
 				continue;
 			}

--- a/lib/Chat/AutoComplete/SearchPlugin.php
+++ b/lib/Chat/AutoComplete/SearchPlugin.php
@@ -267,19 +267,8 @@ class SearchPlugin implements ISearchPlugin {
 		}
 
 		$search = strtolower($search);
-		$currentSessionHash = null;
-		if (!$this->userId) {
-			// Best effort: Might not work on guests that reloaded but not worth too much performance impact atm.
-			$currentSessionHash = sha1($this->talkSession->getSessionForRoom($this->room->getToken()));
-		}
-
 		$matches = $exactMatches = [];
 		foreach ($attendees as $attendee) {
-			if ($currentSessionHash === $attendee->getActorId()) {
-				// Do not suggest the current guest
-				continue;
-			}
-
 			$name = $attendee->getDisplayName() ?: $this->l->t('Guest');
 			if ($search === '') {
 				$matches[] = $this->createGuestResult($attendee->getActorId(), $name);

--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -1667,10 +1667,13 @@ class ChatController extends AEnvironmentAwareOCSController {
 		$results = array_merge_recursive($exactMatches, $results);
 
 		$this->autoCompleteManager->registerSorter(Sorter::class);
+		/** @psalm-suppress InvalidArgument */
 		$this->autoCompleteManager->runSorters(['talk_chat_participants'], $results, [
 			'itemType' => 'chat',
 			'itemId' => (string)$this->room->getId(),
 			'search' => $search,
+			'selfUserId' => $this->userId,
+			'selfCloudId' => $this->userId === null ? $this->federationAuthenticator->getCloudId() : null,
 		]);
 
 		$statuses = [];

--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -1636,7 +1636,12 @@ class ParticipantService {
 		$helper = new SelectHelper();
 		$helper->selectAttendeesTable($query);
 		$query->from('talk_attendees', 'a')
-			->where($query->expr()->eq('a.room_id', $query->createNamedParameter($room->getId(), IQueryBuilder::PARAM_INT)));
+			->leftJoin('a', 'talk_sessions', 's', $query->expr()->eq('a.id', 's.attendee_id'))
+			->where($query->expr()->eq('a.room_id', $query->createNamedParameter($room->getId(), IQueryBuilder::PARAM_INT)))
+			->andWhere($query->expr()->orX(
+				$query->expr()->neq('a.actor_type', $query->createNamedParameter(Attendee::ACTOR_GUESTS)),
+				$query->expr()->isNotNull('s.id'),
+			));
 
 		return $this->getParticipantsFromQuery($query, $room);
 	}

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -1229,7 +1229,7 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 
 	#[Then('/^user "([^"]*)" joins room "([^"]*)" with (\d+) \((v4)\) session name "([^"]*)"$/')]
 	public function userJoinsRoomWithNamedSession(string $user, string $identifier, int $statusCode, string $apiVersion, string $sessionName, ?TableNode $formData = null): void {
-		$this->setCurrentUser($user, $identifier);
+		$this->setCurrentUser($user);
 
 		$this->sendRequest(
 			'POST', '/apps/spreed/api/' . $apiVersion . '/room/' . self::$identifierToToken[$identifier] . '/participants/active',

--- a/tests/integration/features/chat-2/mentions.feature
+++ b/tests/integration/features/chat-2/mentions.feature
@@ -13,6 +13,7 @@ Feature: chat/mentions
     Then user "participant1" gets the following candidate mentions in room "one-to-one room" for "" with 200
       | id           | label                    | source | mentionId    |
       | participant2 | participant2-displayname | users  | participant2 |
+      | participant1 | participant1-displayname | users  | participant1 |
     And user "participant2" gets the following candidate mentions in room "one-to-one room" for "" with 404
     When user "participant2" creates room "one-to-one room" with 200 (v4)
       | roomType | 1 |
@@ -20,6 +21,7 @@ Feature: chat/mentions
     And user "participant2" gets the following candidate mentions in room "one-to-one room" for "" with 200
       | id           | label                    | source | mentionId    |
       | participant1 | participant1-displayname | users  | participant1 |
+      | participant2 | participant2-displayname | users  | participant2 |
 
   Scenario: get matched mentions in a one-to-one room
     When user "participant1" creates room "one-to-one room" (v4)
@@ -28,6 +30,7 @@ Feature: chat/mentions
     Then user "participant1" gets the following candidate mentions in room "one-to-one room" for "part" with 200
       | id           | label                    | source | mentionId    |
       | participant2 | participant2-displayname | users  | participant2 |
+      | participant1 | participant1-displayname | users  | participant1 |
     And user "participant2" gets the following candidate mentions in room "one-to-one room" for "part" with 404
     When user "participant2" creates room "one-to-one room" with 200 (v4)
       | roomType | 1 |
@@ -35,6 +38,7 @@ Feature: chat/mentions
     And user "participant2" gets the following candidate mentions in room "one-to-one room" for "part" with 200
       | id           | label                    | source | mentionId    |
       | participant1 | participant1-displayname | users  | participant1 |
+      | participant2 | participant2-displayname | users  | participant2 |
 
   Scenario: get unmatched mentions in a one-to-one room
     When user "participant1" creates room "one-to-one room" (v4)
@@ -53,8 +57,6 @@ Feature: chat/mentions
       | invite   | participant2 |
     Then user "participant3" gets the following candidate mentions in room "one-to-one room" for "" with 404
 
-
-
   Scenario: get mentions in a group room with no other participant
     When user "participant1" creates room "group room" (v4)
       | roomType | 2 |
@@ -62,6 +64,7 @@ Feature: chat/mentions
     Then user "participant1" gets the following candidate mentions in room "group room" for "" with 200
       | id           | label                    | source | mentionId    | details           |
       | all          | room                     | calls  | all          |                   |
+      | participant1 | participant1-displayname | users  | participant1 |                   |
 
   Scenario: get mentions in a group room
     When user "participant1" creates room "group room" (v4)
@@ -74,16 +77,19 @@ Feature: chat/mentions
       | all          | room                     | calls  | all          |
       | participant2 | participant2-displayname | users  | participant2 |
       | participant3 | participant3-displayname | users  | participant3 |
+      | participant1 | participant1-displayname | users  | participant1 |
     And user "participant2" gets the following candidate mentions in room "group room" for "" with 200
       | id           | label                    | source | mentionId    |
       | all          | room                     | calls  | all          |
       | participant1 | participant1-displayname | users  | participant1 |
       | participant3 | participant3-displayname | users  | participant3 |
+      | participant2 | participant2-displayname | users  | participant2 |
     And user "participant3" gets the following candidate mentions in room "group room" for "" with 200
       | id           | label                    | source | mentionId    |
       | all          | room                     | calls  | all          |
       | participant1 | participant1-displayname | users  | participant1 |
       | participant2 | participant2-displayname | users  | participant2 |
+      | participant3 | participant3-displayname | users  | participant3 |
 
   Scenario: get matched mentions in a group room
     Given team "1234" exists
@@ -98,14 +104,17 @@ Feature: chat/mentions
       | id           | label                    | source | mentionId    |
       | participant2 | participant2-displayname | users  | participant2 |
       | participant3 | participant3-displayname | users  | participant3 |
+      | participant1 | participant1-displayname | users  | participant1 |
     And user "participant2" gets the following candidate mentions in room "group room" for "part" with 200
       | id           | label                    | source | mentionId    |
       | participant1 | participant1-displayname | users  | participant1 |
       | participant3 | participant3-displayname | users  | participant3 |
+      | participant2 | participant2-displayname | users  | participant2 |
     And user "participant3" gets the following candidate mentions in room "group room" for "part" with 200
       | id           | label                    | source | mentionId    |
       | participant1 | participant1-displayname | users  | participant1 |
       | participant2 | participant2-displayname | users  | participant2 |
+      | participant3 | participant3-displayname | users  | participant3 |
     And user "participant1" gets the following candidate mentions in room "group room" for "1234" with 200
       | id           | label                    | source  | mentionId    |
       | 1234         | 1234                     | teams   | team/1234    |
@@ -134,8 +143,6 @@ Feature: chat/mentions
     And user "participant1" adds user "participant3" to room "group room" with 200 (v4)
     Then user "participant4" gets the following candidate mentions in room "group room" for "" with 404
 
-
-
   Scenario: get mentions in a public room with no other participant
     When user "participant1" creates room "public room" (v4)
       | roomType | 3 |
@@ -143,6 +150,7 @@ Feature: chat/mentions
     Then user "participant1" gets the following candidate mentions in room "public room" for "" with 200
       | id           | label                    | source | mentionId    |
       | all          | room                     | calls  | all          |
+      | participant1 | participant1-displayname | users  | participant1 |
 
   Scenario: get mentions in a public room
     When user "participant1" creates room "public room" (v4)
@@ -156,18 +164,21 @@ Feature: chat/mentions
       | all          | room                     | calls  | all          |
       | participant2 | participant2-displayname | users  | participant2 |
       | participant3 | participant3-displayname | users  | participant3 |
+      | participant1 | participant1-displayname | users  | participant1 |
       | GUEST_ID     | Guest                    | guests | GUEST_ID     |
     And user "participant2" gets the following candidate mentions in room "public room" for "" with 200
       | id           | label                    | source | mentionId    |
       | all          | room                     | calls  | all          |
       | participant1 | participant1-displayname | users  | participant1 |
       | participant3 | participant3-displayname | users  | participant3 |
+      | participant2 | participant2-displayname | users  | participant2 |
       | GUEST_ID     | Guest                    | guests | GUEST_ID     |
     And user "participant3" gets the following candidate mentions in room "public room" for "" with 200
       | id           | label                    | source | mentionId    |
       | all          | room                     | calls  | all          |
       | participant1 | participant1-displayname | users  | participant1 |
       | participant2 | participant2-displayname | users  | participant2 |
+      | participant3 | participant3-displayname | users  | participant3 |
       | GUEST_ID     | Guest                    | guests | GUEST_ID     |
     And user "guest" gets the following candidate mentions in room "public room" for "" with 200
       | id           | label                    | source | mentionId    |
@@ -175,6 +186,7 @@ Feature: chat/mentions
       | participant1 | participant1-displayname | users  | participant1 |
       | participant2 | participant2-displayname | users  | participant2 |
       | participant3 | participant3-displayname | users  | participant3 |
+      | GUEST_ID     | Guest                    | guests | GUEST_ID     |
 
   Scenario: get matched mentions in a public room
     When user "participant1" creates room "public room" (v4)
@@ -187,14 +199,17 @@ Feature: chat/mentions
       | id           | label                    | source | mentionId    |
       | participant2 | participant2-displayname | users  | participant2 |
       | participant3 | participant3-displayname | users  | participant3 |
+      | participant1 | participant1-displayname | users  | participant1 |
     And user "participant2" gets the following candidate mentions in room "public room" for "part" with 200
       | id           | label                    | source | mentionId    |
       | participant1 | participant1-displayname | users  | participant1 |
       | participant3 | participant3-displayname | users  | participant3 |
+      | participant2 | participant2-displayname | users  | participant2 |
     And user "participant3" gets the following candidate mentions in room "public room" for "part" with 200
       | id           | label                    | source | mentionId    |
       | participant1 | participant1-displayname | users  | participant1 |
       | participant2 | participant2-displayname | users  | participant2 |
+      | participant3 | participant3-displayname | users  | participant3 |
     And user "guest" gets the following candidate mentions in room "public room" for "part" with 200
       | id           | label                    | source | mentionId    |
       | participant1 | participant1-displayname | users  | participant1 |
@@ -224,8 +239,10 @@ Feature: chat/mentions
     And user "guest1" gets the following candidate mentions in room "public room" for "uest" with 200
       | id           | label                    | source | mentionId    |
       | GUEST_ID     | Guest                    | guests | GUEST_ID     |
+      | GUEST_ID     | Guest                    | guests | GUEST_ID     |
     And user "guest2" gets the following candidate mentions in room "public room" for "uest" with 200
       | id           | label                    | source | mentionId    |
+      | GUEST_ID     | Guest                    | guests | GUEST_ID     |
       | GUEST_ID     | Guest                    | guests | GUEST_ID     |
 
   Scenario: get matched named guest mentions in a public room
@@ -247,6 +264,8 @@ Feature: chat/mentions
       | id           | label                    | source | mentionId    |
       | GUEST_ID     | FooBar                   | guests | GUEST_ID     |
     And user "guest1" gets the following candidate mentions in room "public room" for "oob" with 200
+      | id           | label                    | source | mentionId    |
+      | GUEST_ID     | FooBar                   | guests | GUEST_ID     |
     And user "guest2" gets the following candidate mentions in room "public room" for "oob" with 200
       | id           | label                    | source | mentionId    |
       | GUEST_ID     | FooBar                   | guests | GUEST_ID     |
@@ -286,6 +305,7 @@ Feature: chat/mentions
       | id           | label                    | source | mentionId    |
       | all          | welcome.txt              | calls  | all          |
       | participant2 | participant2-displayname | users  | participant2 |
+      | participant1 | participant1-displayname | users  | participant1 |
     And user "participant2" gets the following candidate mentions in room "file welcome.txt room" for "" with 404
 
   Scenario: get mentions in a file room
@@ -300,10 +320,12 @@ Feature: chat/mentions
       | id           | label                    | source | mentionId    |
       | all          | welcome (2).txt          | calls  | all          |
       | participant2 | participant2-displayname | users  | participant2 |
+      | participant1 | participant1-displayname | users  | participant1 |
     And user "participant2" gets the following candidate mentions in room "file welcome (2).txt room" for "" with 200
       | id           | label                    | source | mentionId    |
       | all          | welcome (2).txt          | calls  | all          |
       | participant1 | participant1-displayname | users  | participant1 |
+      | participant2 | participant2-displayname | users  | participant2 |
 
   Scenario: get matched mentions in a file room
     Given user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
@@ -316,9 +338,11 @@ Feature: chat/mentions
     Then user "participant1" gets the following candidate mentions in room "file welcome (2).txt room" for "part" with 200
       | id           | label                    | source | mentionId    |
       | participant2 | participant2-displayname | users  | participant2 |
+      | participant1 | participant1-displayname | users  | participant1 |
     And user "participant2" gets the following candidate mentions in room "file welcome (2).txt room" for "part" with 200
       | id           | label                    | source | mentionId    |
       | participant1 | participant1-displayname | users  | participant1 |
+      | participant2 | participant2-displayname | users  | participant2 |
 
   Scenario: get unmatched mentions in a file room
     Given user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
@@ -365,6 +389,7 @@ Feature: chat/mentions
       | id           | label                    | source | mentionId    |
       | all          | welcome.txt              | calls  | all          |
       | participant2 | participant2-displayname | users  | participant2 |
+      | participant1 | participant1-displayname | users  | participant1 |
     And user "participant2" gets the following candidate mentions in room "file last share room" for "" with 404
     And user "participant3" gets the following candidate mentions in room "file last share room" for "" with 404
     And user "guest" gets the following candidate mentions in room "file last share room" for "" with 404
@@ -398,6 +423,7 @@ Feature: chat/mentions
       | participant2 | participant2-displayname | users  | participant2 |
       | participant4 | participant4-displayname | users  | participant4 |
       | participant3 | participant3-displayname | users  | participant3 |
+      | participant1 | participant1-displayname | users  | participant1 |
       | GUEST_ID     | Guest                    | guests | GUEST_ID     |
     And user "participant2" gets the following candidate mentions in room "file last share room" for "" with 200
       | id           | label                    | source | mentionId    |
@@ -405,6 +431,7 @@ Feature: chat/mentions
       | participant1 | participant1-displayname | users  | participant1 |
       | participant4 | participant4-displayname | users  | participant4 |
       | participant3 | participant3-displayname | users  | participant3 |
+      | participant2 | participant2-displayname | users  | participant2 |
       | GUEST_ID     | Guest                    | guests | GUEST_ID     |
     # Self-joined users can not mention users with access to the file that have
     # not joined the room.
@@ -413,6 +440,7 @@ Feature: chat/mentions
       | all          | welcome.txt              | calls  | all          |
       | participant1 | participant1-displayname | users  | participant1 |
       | participant2 | participant2-displayname | users  | participant2 |
+      | participant3 | participant3-displayname | users  | participant3 |
       | GUEST_ID     | Guest                    | guests | GUEST_ID     |
     # Guests can not mention users with access to the file that have not joined
     # the room.
@@ -422,6 +450,7 @@ Feature: chat/mentions
       | participant1 | participant1-displayname | users  | participant1 |
       | participant2 | participant2-displayname | users  | participant2 |
       | participant3 | participant3-displayname | users  | participant3 |
+      | GUEST_ID     | Guest                    | guests | GUEST_ID     |
 
   Scenario: get matched mentions in a room for a file shared by link
     Given user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
@@ -451,17 +480,20 @@ Feature: chat/mentions
       | participant2 | participant2-displayname | users  | participant2 |
       | participant4 | participant4-displayname | users  | participant4 |
       | participant3 | participant3-displayname | users  | participant3 |
+      | participant1 | participant1-displayname | users  | participant1 |
     And user "participant2" gets the following candidate mentions in room "file last share room" for "part" with 200
       | id           | label                    | source | mentionId    |
       | participant1 | participant1-displayname | users  | participant1 |
       | participant4 | participant4-displayname | users  | participant4 |
       | participant3 | participant3-displayname | users  | participant3 |
+      | participant2 | participant2-displayname | users  | participant2 |
     # Self-joined users can not mention users with access to the file that have
     # not joined the room.
     And user "participant3" gets the following candidate mentions in room "file last share room" for "part" with 200
       | id           | label                    | source | mentionId    |
       | participant1 | participant1-displayname | users  | participant1 |
       | participant2 | participant2-displayname | users  | participant2 |
+      | participant3 | participant3-displayname | users  | participant3 |
     # Guests can not mention users with access to the file that have not joined
     # the room.
     And user "guest" gets the following candidate mentions in room "file last share room" for "part" with 200
@@ -666,15 +698,19 @@ Feature: chat/mentions
       | id           | label                    | source | mentionId    |
       | all          | room                     | calls  | all          |
       | participant2 | participant2-displayname | users  | participant2 |
+      | participant1 | participant1-displayname | users  | participant1 |
     And user "participant2" gets the following candidate mentions in room "group room" for "" with 200
       | id           | label                    | source | mentionId    |
       | all          | room                     | calls  | all          |
       | participant1 | participant1-displayname | users  | participant1 |
+      | participant2 | participant2-displayname | users  | participant2 |
     When user "participant1" sets mention permissions for room "group room" to moderators with 200 (v4)
     Then user "participant1" gets the following candidate mentions in room "group room" for "" with 200
       | id           | label                    | source | mentionId    |
       | all          | room                     | calls  | all          |
       | participant2 | participant2-displayname | users  | participant2 |
+      | participant1 | participant1-displayname | users  | participant1 |
     And user "participant2" gets the following candidate mentions in room "group room" for "" with 200
       | id           | label                    | source | mentionId    |
       | participant1 | participant1-displayname | users  | participant1 |
+      | participant2 | participant2-displayname | users  | participant2 |

--- a/tests/integration/features/chat-2/mentions.feature
+++ b/tests/integration/features/chat-2/mentions.feature
@@ -244,6 +244,10 @@ Feature: chat/mentions
       | id           | label                    | source | mentionId    |
       | GUEST_ID     | Guest                    | guests | GUEST_ID     |
       | GUEST_ID     | Guest                    | guests | GUEST_ID     |
+    And user "guest2" leaves room "public room" with 200 (v4)
+    Then user "participant1" gets the following candidate mentions in room "public room" for "uest" with 200
+      | id           | label                    | source | mentionId    |
+      | GUEST_ID     | Guest                    | guests | GUEST_ID     |
 
   Scenario: get matched named guest mentions in a public room
     When user "participant1" creates room "public room" (v4)

--- a/tests/integration/features/federation/chat.feature
+++ b/tests/integration/features/federation/chat.feature
@@ -30,16 +30,18 @@ Feature: federation/chat
       | LOCAL::room | 2    |
     And using server "LOCAL"
     And user "participant1" gets the following candidate mentions in room "room" for "" with 200
-      | source          | id                               | label                    | mentionId                                        |
-      | calls           | all                              | room                     | all                                              |
-      | federated_users | participant2@{$REMOTE_URL}       | participant2-displayname | federated_user/participant2@{$REMOTE_URL}  |
-      | users           | participant3                     | participant3-displayname | participant3                                     |
+      | source          | id                               | label                    | mentionId                                 |
+      | calls           | all                              | room                     | all                                       |
+      | federated_users | participant2@{$REMOTE_URL}       | participant2-displayname | federated_user/participant2@{$REMOTE_URL} |
+      | users           | participant1                     | participant1-displayname | participant1                              |
+      | users           | participant3                     | participant3-displayname | participant3                              |
     Given using server "REMOTE"
     And user "participant2" gets the following candidate mentions in room "LOCAL::room" for "" with 200
       | source          | id                        | label                    | mentionId    |
       | calls           | all                       | room                     | all          |
       | federated_users | participant1@{$LOCAL_URL} | participant1-displayname | participant1 |
       | federated_users | participant3@{$LOCAL_URL} | participant3-displayname | participant3 |
+      | users           | participant2              | participant2-displayname | federated_user/participant2@{$REMOTE_URL} |
 
   Scenario: Get mention suggestions (translating federated users of the same server to local users)
     Given user "participant1" creates room "room" (v4)
@@ -67,6 +69,7 @@ Feature: federation/chat
     And user "participant1" gets the following candidate mentions in room "room" for "" with 200
       | source          | id                         | label                    | mentionId                                 |
       | calls           | all                        | room                     | all                                       |
+      | users           | participant1               | participant1-displayname | participant1                              |
       | federated_users | participant2@{$REMOTE_URL} | participant2-displayname | federated_user/participant2@{$REMOTE_URL} |
       | federated_users | participant3@{$REMOTE_URL} | participant3-displayname | federated_user/participant3@{$REMOTE_URL} |
     Given using server "REMOTE"
@@ -75,6 +78,7 @@ Feature: federation/chat
       | calls           | all                       | room                     | all                                       |
       | federated_users | participant1@{$LOCAL_URL} | participant1-displayname | participant1                              |
       | users           | participant3              | participant3-displayname | federated_user/participant3@{$REMOTE_URL} |
+      | users           | participant2              | participant2-displayname | federated_user/participant2@{$REMOTE_URL} |
 
   Scenario: Basic chatting including posting, getting, editing and deleting
     Given user "participant1" creates room "room" (v4)

--- a/tests/php/Chat/AutoComplete/SearchPluginTest.php
+++ b/tests/php/Chat/AutoComplete/SearchPluginTest.php
@@ -159,7 +159,7 @@ class SearchPluginTest extends TestCase {
 				'foo' => '',
 				'test' => 'Te st',
 				'test1' => 'Te st 1',
-			], [['test1' => 'Te st 1']], [['test' => 'Te st']]],
+			], [['test1' => 'Te st 1']], [['current' => 'test'], ['test' => 'Te st']]],
 			['test', [
 				'foo' => 'Test',
 				'bar' => 'test One',


### PR DESCRIPTION
- Since bots, todo lists and other things became more popular it makes sense to add the self-user also as a mention suggestion
- Ignore guests from mention suggestions that disconnected
  They will have a new session ID when reconnecting so the highlight
  does not work anyway and participants are better of quoting them.


### ☑️ Resolves

* Fix #15597 
* Fix #15366

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
