### PR TITLE
fix: Fix marking null peer objects as raw

### DIFF
--- a/src/utils/webrtc/models/CallParticipantModel.js
+++ b/src/utils/webrtc/models/CallParticipantModel.js
@@ -220,7 +220,7 @@ CallParticipantModel.prototype = {
 			this.get('peer').off('remoteVideoBlocked', this._handleRemoteVideoBlockedBound)
 		}
 
-		this.set('peer', markRaw(peer))
+		this.set('peer', peer ? markRaw(peer) : null)
 
 		// Special case when the participant has no streams.
 		if (!this.get('peer')) {
@@ -339,7 +339,7 @@ CallParticipantModel.prototype = {
 			console.warn('Mismatch between stored peer ID and ID of given screen peer: ', this.get('peerId'), screenPeer.id)
 		}
 
-		this.set('screenPeer', markRaw(screenPeer))
+		this.set('screenPeer', screenPeer ? markRaw(screenPeer) : null)
 
 		// Reset state that depends on the screen Peer object.
 		this._handlePeerStreamAdded(this.get('screenPeer'))


### PR DESCRIPTION
Fixes a regression introduced in 282ba881a3be6d53d227fac0738858f08668e0f0

`peer` can be null if the participant is not a publisher, so `markRaw` should not be used in that case.

`screenPeer` is not currently set to null, but it was also guarded for consistency.

Note that `markRaw` is not used for the [peer](https://github.com/nextcloud/spreed/blob/0709f7438a74903bc2c4a1be5f355d89b1afb90c/src/utils/webrtc/models/LocalCallParticipantModel.js#L79) or [screen peer](https://github.com/nextcloud/spreed/blob/0709f7438a74903bc2c4a1be5f355d89b1afb90c/src/utils/webrtc/models/LocalCallParticipantModel.js#L104) attributes in `LocalCallParticipant`. I do not know if that is on purpose or if it should be used there too.

## How to reproduce

- Setup the HPB
- Create a public conversation
- Start a call
- Open the browser console
- In a private window, join the conversation
- Join the call with no audio nor video devices (so only as a listener)

### Result with this pull request

No error is shown in the browser console, and the guest is eventually shown as connected in the call view

### Result without this pull request

An error is shown in the browser console, and a loading spinner is indefinitely shown on the guest in the call view
