### PR TITLE
fix(call): do not open navigation in mobile, when call ends

### DIFF
--- a/src/components/TopBar/CallButton.vue
+++ b/src/components/TopBar/CallButton.vue
@@ -424,9 +424,11 @@ export default {
 			this.loading = true
 
 			// Open navigation
-			emit('toggle-navigation', {
-				open: true,
-			})
+			if (!this.isMobile) {
+				emit('toggle-navigation', {
+					open: true,
+				})
+			}
 			await this.$store.dispatch('leaveCall', {
 				token: this.token,
 				participantIdentifier: this.actorStore.participantIdentifier,


### PR DESCRIPTION
### ☑️ Resolves

* Fix redundant navigation opening on narrow windows

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![2025-08-18_10h39_06](https://github.com/user-attachments/assets/2ea8b242-f709-4621-acef-25ed0c1f2a70) | ![2025-08-18_10h41_30](https://github.com/user-attachments/assets/a441c926-737e-4500-9b3c-6d5da150ab77)


### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client