### PR TITLE
fix(TalkDashboard): show unread mentions content

### DIFF
--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -529,15 +529,6 @@ export default {
 				this.isNavigating = true
 			}
 		},
-
-		isCompact(value) {
-			if (!value) {
-				// Last messages are likely missing from the store, need to fetch with modifiedSince=0
-				this.roomListModifiedBefore = 0
-				this.forceFullRoomListRefreshAfterXLoops = 10
-				this.fetchConversations()
-			}
-		},
 	},
 
 	beforeMount() {
@@ -855,7 +846,6 @@ export default {
 			try {
 				const response = await this.$store.dispatch('fetchConversations', {
 					modifiedSince: this.roomListModifiedBefore,
-					includeLastMessage: this.isCompact ? 0 : 1,
 				})
 
 				// We can only support this with the HPB as otherwise rooms,


### PR DESCRIPTION
### ☑️ Resolves

* Ref discussion from #15114
  * As mentioned in the issue, skipping lastMessage brings more issues than benefits. A lot of components relies on this data:
    * Dashboard content
    * Message polling logic
    * New messages asterisk
    * Messages processing
  * Server-wide, it doubles request size that is made with 30-sec interval (IMO, modified since should be optimized instead)

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="205" height="115" alt="2025-08-20_10h29_36" src="https://github.com/user-attachments/assets/15de09c5-bd74-4ab0-af61-0d8709e53234" /> | <img width="207" height="111" alt="2025-08-20_10h29_57" src="https://github.com/user-attachments/assets/ebd9e9ac-957a-4acb-883a-236cb4ab24f5" />
16.4 kB transferred for 160 rooms | 34.9 kB transferred for 160 rooms

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client