### PR TITLE
chore: release Talk v22.0.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 22.0.0-beta.1 – 2025-08-21
+### Added
+- Implement threads feature [#15313](https://github.com/nextcloud/spreed/issues/15313)
+- Implement 'Busy' status in calls [#15465](https://github.com/nextcloud/spreed/issues/15465)
+- Update call interface design [#15025](https://github.com/nextcloud/spreed/issues/15025)
+
+### Fixed
+- Improve chat history browsing performance [#6046](https://github.com/nextcloud/spreed/issues/6046)
+
+### Changed
+- Migrate app to Vue3 [#9448](https://github.com/nextcloud/spreed/issues/9448)
+- Update dependencies
+- Update translations
+- Require Nextcloud 32 / Hub 25 Autumn
+
 ## 21.1.3 – 2025-08-06
 ### Changed
 - Update translations

--- a/Makefile
+++ b/Makefile
@@ -79,8 +79,7 @@ appstore:
 	--exclude=.drone.jsonnet \
 	--exclude=.drone.yml \
 	--exclude=.editorconfig \
-	--exclude=.eslintignore \
-	--exclude=.eslintrc.js \
+	--exclude=eslint.config.mjs \
 	--exclude=.git \
 	--exclude=.git-blame-ignore-revs \
 	--exclude=.gitattributes \

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -18,7 +18,7 @@
 * 🌉 **Sync with other chat solutions** With [Matterbridge](https://github.com/42wim/matterbridge/) being integrated in Talk, you can easily sync a lot of other chat solutions to Nextcloud Talk and vice-versa.
 ]]></description>
 
-	<version>22.0.0-dev.10</version>
+	<version>22.0.0-beta.1</version>
 	<licence>agpl</licence>
 
 	<author>Anna Larch</author>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "talk",
-  "version": "22.0.0-dev.0",
+  "version": "22.0.0-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "talk",
-      "version": "22.0.0-dev.0",
+      "version": "22.0.0-beta.1",
       "license": "agpl",
       "dependencies": {
         "@matrix-org/olm": "^3.2.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "talk",
-  "version": "22.0.0-dev.0",
+  "version": "22.0.0-beta.1",
   "private": true,
   "description": "",
   "license": "agpl",


### PR DESCRIPTION
## 22.0.0-beta.1 – 2025-08-21
### Added
- Implement threads feature [#15313](https://github.com/nextcloud/spreed/issues/15313)
- Implement 'Busy' status in calls [#15465](https://github.com/nextcloud/spreed/issues/15465)
- Update call interface design [#15025](https://github.com/nextcloud/spreed/issues/15025)

### Fixed
- Improve chat history browsing performance [#6046](https://github.com/nextcloud/spreed/issues/6046)

### Changed
- Migrate app to Vue3 [#9448](https://github.com/nextcloud/spreed/issues/9448)
- Update dependencies
- Update translations
- Require Nextcloud 32 / Hub 25 Autumn
