### PR TITLE
Support HPB service accounts without expiration

### DIFF
--- a/lib/Service/HostedSignalingServerService.php
+++ b/lib/Service/HostedSignalingServerService.php
@@ -62,11 +62,6 @@ class HostedSignalingServerService {
 				],
 				'timeout' => 10,
 			]);
-
-			// this is needed here because the deletion happens in a concurrent request
-			// and thus the cached value in the config object would trigger an UPDATE
-			// instead of an INSERT if there is another request to the API server
-			$this->config->deleteAppValue('spreed', 'hosted-signaling-server-nonce');
 		} catch (ClientException $e) {
 			$response = $e->getResponse();
 
@@ -182,6 +177,11 @@ class HostedSignalingServerService {
 			$this->logger->error('Failed to request hosted signaling server trial', ['exception' => $e]);
 			$message = $this->l10n->t('Failed to request trial because the trial server is unreachable. Please try again later.');
 			throw new HostedSignalingServerAPIException($message, ($e instanceof ServerException ? $e->getResponse()?->getStatusCode() : null) ?? Http::STATUS_INTERNAL_SERVER_ERROR);
+		} finally {
+			// this is needed here because the deletion happens in a concurrent request
+			// and thus the cached value in the config object would trigger an UPDATE
+			// instead of an INSERT if there is another request to the API server
+			$this->config->deleteAppValue('spreed', 'hosted-signaling-server-nonce');
 		}
 
 		$status = $response->getStatusCode();
@@ -234,11 +234,6 @@ class HostedSignalingServerService {
 				],
 				'timeout' => 10,
 			]);
-
-			// this is needed here because the delete happens in a concurrent request
-			// and thus the cached value in the config object would trigger an UPDATE
-			// instead of an INSERT if there is another request to the API server
-			$this->config->deleteAppValue('spreed', 'hosted-signaling-server-nonce');
 		} catch (ClientException $e) {
 			$response = $e->getResponse();
 
@@ -317,6 +312,11 @@ class HostedSignalingServerService {
 			$this->logger->error('Failed to request hosted signaling server trial', ['exception' => $e]);
 			$message = $this->l10n->t('Failed to fetch account information because the trial server is unreachable. Please check back later.');
 			throw new HostedSignalingServerAPIException($message, ($e instanceof ServerException ? $e->getResponse()?->getStatusCode() : null) ?? Http::STATUS_INTERNAL_SERVER_ERROR);
+		} finally {
+			// this is needed here because the delete happens in a concurrent request
+			// and thus the cached value in the config object would trigger an UPDATE
+			// instead of an INSERT if there is another request to the API server
+			$this->config->deleteAppValue('spreed', 'hosted-signaling-server-nonce');
 		}
 
 		$status = $response->getStatusCode();
@@ -388,11 +388,6 @@ class HostedSignalingServerService {
 				],
 				'timeout' => 10,
 			]);
-
-			// this is needed here because the delete happens in a concurrent request
-			// and thus the cached value in the config object would trigger an UPDATE
-			// instead of an INSERT if there is another request to the API server
-			$this->config->deleteAppValue('spreed', 'hosted-signaling-server-nonce');
 		} catch (ClientException $e) {
 			$response = $e->getResponse();
 
@@ -471,6 +466,11 @@ class HostedSignalingServerService {
 			$this->logger->error('Deleting the hosted signaling server account failed', ['exception' => $e]);
 			$message = $this->l10n->t('Failed to delete the account because the trial server is unreachable. Please check back later.');
 			throw new HostedSignalingServerAPIException($message, ($e instanceof ServerException ? $e->getResponse()?->getStatusCode() : null) ?? Http::STATUS_INTERNAL_SERVER_ERROR);
+		} finally {
+			// this is needed here because the delete happens in a concurrent request
+			// and thus the cached value in the config object would trigger an UPDATE
+			// instead of an INSERT if there is another request to the API server
+			$this->config->deleteAppValue('spreed', 'hosted-signaling-server-nonce');
 		}
 
 		$status = $response->getStatusCode();

--- a/src/components/AdminSettings/HostedSignalingServer.vue
+++ b/src/components/AdminSettings/HostedSignalingServer.vue
@@ -196,7 +196,7 @@ export default {
 		},
 
 		expiryDate() {
-			return moment(this.trialAccount.expires).format('L')
+			return this.trialAccount.expires ? moment(this.trialAccount.expires).format('L') : t('spreed', 'Never')
 		},
 
 		createdDate() {


### PR DESCRIPTION
While not very common, there are HPB service accounts without an expiration date, this should be supported in the UI. This introduces a new string for translation.

Also the nonce for HPB request authentication was only cleared in successful cases, this should also be done if a request failed. Without this I see occasional errors about `nonce_mismatch` in the log.