### PR TITLE
feat(hpb-service): Configure STUN/TURN servers if included in HPB account

### DIFF
--- a/lib/BackgroundJob/CheckHostedSignalingServer.php
+++ b/lib/BackgroundJob/CheckHostedSignalingServer.php
@@ -68,16 +68,17 @@ class CheckHostedSignalingServer extends TimedJob {
 	}
 
 	private function updateStunTurnSettings(array $oldAccountInfo, array $accountInfo) {
-		if ($this->talkConfig->getStunServers() !== $accountInfo['stun']['servers']) {
-			if ($accountInfo['stun']['servers']) {
+		if (!empty($accountInfo['stun']['servers'])) {
+			if ($this->talkConfig->getStunServers() !== $accountInfo['stun']['servers']) {
 				// STUN servers were added / changed
 				$this->config->setAppValue('spreed', 'stun_servers', json_encode($accountInfo['stun']['servers']));
-			} elseif ($oldAccountInfo['stun']['servers']) {
-				// STUN servers are no longer available, reset to default.
-				$this->config->deleteAppValue('spreed', 'stun_servers');
 			}
+		} elseif (!empty($oldAccountInfo['stun']['servers'])) {
+			// STUN servers are no longer available, reset to default.
+			$this->config->deleteAppValue('spreed', 'stun_servers');
 		}
-		if ($accountInfo['turn']['servers']) {
+
+		if (!empty($accountInfo['turn']['servers'])) {
 			$newTurnServers = [];
 			foreach ($accountInfo['turn']['servers'] as $server) {
 				$newTurnServers[] = [
@@ -92,7 +93,7 @@ class CheckHostedSignalingServer extends TimedJob {
 				// TURN servers were added / changed
 				$this->config->setAppValue('spreed', 'turn_servers', json_encode($newTurnServers));
 			}
-		} elseif ($oldAccountInfo['turn']['servers']) {
+		} elseif (!empty($oldAccountInfo['turn']['servers'])) {
 			// TURN servers are no longer available, reset to default.
 			$this->config->deleteAppValue('spreed', 'turn_servers');
 		}

--- a/src/components/AdminSettings/HostedSignalingServer.vue
+++ b/src/components/AdminSettings/HostedSignalingServer.vue
@@ -13,6 +13,7 @@
 
 		<p class="settings-hint">
 			{{ t('spreed', 'Our partner Struktur AG provides a service where a hosted signaling server can be requested. For this you only need to fill out the form below and your Nextcloud will request it. Once the server is set up for you the credentials will be filled automatically. This will overwrite the existing signaling server settings.') }}
+			{{ t('spreed', 'If your high-performance backend account includes STUN and/or TURN functionality, the settings will be updated accordingly.') }}
 		</p>
 
 		<template v-if="!trialAccount.status">
@@ -102,6 +103,18 @@
 					<tr v-if="trialAccount.limits?.users">
 						<td>{{ t('spreed', 'Limits') }}</td>
 						<td>{{ n('spreed', '%n user', '%n users', trialAccount.limits.users) }}</td>
+					</tr>
+					<tr>
+						<td>{{ t('spreed', 'STUN included') }}</td>
+						<td>
+							{{ trialAccount.stun?.servers ? t('spreed', 'Yes') : t('spreed', 'No') }}
+						</td>
+					</tr>
+					<tr>
+						<td>{{ t('spreed', 'TURN included') }}</td>
+						<td>
+							{{ trialAccount.turn?.servers ? t('spreed', 'Yes') : t('spreed', 'No') }}
+						</td>
 					</tr>
 				</tbody>
 			</table>

--- a/tests/php/BackgroundJob/CheckHostedSignalingServerTest.php
+++ b/tests/php/BackgroundJob/CheckHostedSignalingServerTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace OCA\Talk\Tests\BackgroundJob;
 
 use OCA\Talk\BackgroundJob\CheckHostedSignalingServer;
+use OCA\Talk\Config;
 use OCA\Talk\Service\HostedSignalingServerService;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IConfig;
@@ -28,6 +29,7 @@ class CheckHostedSignalingServerTest extends TestCase {
 	protected IGroupManager&MockObject $groupManager;
 	protected IURLGenerator&MockObject $urlGenerator;
 	protected LoggerInterface&MockObject $logger;
+	protected Config&MockObject $talkConfig;
 
 	public function setUp(): void {
 		parent::setUp();
@@ -39,6 +41,7 @@ class CheckHostedSignalingServerTest extends TestCase {
 		$this->groupManager = $this->createMock(IGroupManager::class);
 		$this->urlGenerator = $this->createMock(IURLGenerator::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->talkConfig = $this->createMock(Config::class);
 	}
 
 	public function getBackgroundJob(): CheckHostedSignalingServer {
@@ -49,7 +52,8 @@ class CheckHostedSignalingServerTest extends TestCase {
 			$this->notificationManager,
 			$this->groupManager,
 			$this->urlGenerator,
-			$this->logger
+			$this->logger,
+			$this->talkConfig
 		);
 	}
 
@@ -92,6 +96,80 @@ class CheckHostedSignalingServerTest extends TestCase {
 
 		$expectedCalls = [
 			['spreed', 'signaling_servers', '{"servers":[{"server":"signaling-url","verify":true}],"secret":"signaling-secret"}'],
+			['spreed', 'hosted-signaling-server-account', json_encode($newStatus)],
+		];
+
+		$i = 0;
+		$this->config->expects($this->exactly(count($expectedCalls)))
+			->method('setAppValue')
+			->willReturnCallback(function () use ($expectedCalls, &$i): void {
+				$this->assertArrayHasKey($i, $expectedCalls);
+				$this->assertSame($expectedCalls[$i], func_get_args());
+				$i++;
+			});
+
+		$group = $this->createMock(IGroup::class);
+		$this->groupManager->expects($this->once())
+			->method('get')
+			->with('admin')
+			->willReturn($group);
+		$group->expects($this->once())
+			->method('getUsers')
+			->willReturn([]);
+
+		$this->hostedSignalingServerService->expects($this->once())
+			->method('fetchAccountInfo')
+			->willReturn($newStatus);
+
+		self::invokePrivate($backgroundJob, 'run', ['']);
+	}
+
+	public function testRunWithPendingToActiveIncludingStunAndTurn(): void {
+		$backgroundJob = $this->getBackgroundJob();
+		$newStatus = [
+			'status' => 'active',
+			'signaling' => [
+				'url' => 'signaling-url',
+				'secret' => 'signaling-secret',
+			],
+			'stun' => [
+				'servers' => [
+					'stun.domain.invalid:443',
+					'stun.domain.invalid:3478',
+				],
+			],
+			'turn' => [
+				'servers' => [
+					[
+						'server' => 'turn1.domain.invalid:443',
+						'secret' => 'turn-secret',
+						'schemes' => ['turns', 'turn'],
+						'protocols' => ['tcp', 'udp'],
+					],
+					[
+						'server' => 'turn2.domain.invalid:443',
+						'secret' => 'other-turn-secret',
+						'schemes' => ['turns'],
+						'protocols' => ['tcp'],
+					],
+				],
+			],
+		];
+
+		$this->config
+			->method('getAppValue')
+			->willReturnMap([
+				['spreed', 'hosted-signaling-server-account-id', '', 'my-account-id'],
+				['spreed', 'hosted-signaling-server-account', '{}', '{"status": "pending"}']
+			]);
+		$this->config->expects($this->once())
+			->method('deleteAppValue')
+			->with('spreed', 'signaling_mode');
+
+		$expectedCalls = [
+			['spreed', 'signaling_servers', '{"servers":[{"server":"signaling-url","verify":true}],"secret":"signaling-secret"}'],
+			['spreed', 'stun_servers', '["stun.domain.invalid:443","stun.domain.invalid:3478"]'],
+			['spreed', 'turn_servers', '[{"server":"turn1.domain.invalid:443","secret":"turn-secret","schemes":"turn,turns","protocols":"udp,tcp"},{"server":"turn2.domain.invalid:443","secret":"other-turn-secret","schemes":"turns","protocols":"tcp"}]'],
 			['spreed', 'hosted-signaling-server-account', json_encode($newStatus)],
 		];
 


### PR DESCRIPTION
With an upcoming release of the HPB service API, accounts will optionally include STUN-/TURN-server information for customers that don't want to host these themselves but get them through our offering.

This PR evaluates the additional fields and updates the Talk configuration accordingly.

Let me know if you don't already have access to the HPB service API documentation and want to set this up locally for testing.