### PR TITLE
fix(router): emit 'route-change' after navigation

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -400,18 +400,22 @@ export default {
 						return
 					}
 				}
-				// Update current token in the token store
-				this.tokenStore.updateToken(to.params.token)
 			}
 
+			next()
+		}
+
+		this.$router.afterEach((to, from) => {
+			/**
+			 * Update current token in the token store
+			 */
+			this.tokenStore.updateToken(to.params.token ?? '')
 			/**
 			 * Fires a global event that tells the whole app that the route has changed. The event
 			 * carries the from and to objects as payload
 			 */
 			EventBus.emit('route-change', { from, to })
-
-			next()
-		}
+		})
 
 		/**
 		 * Global before guard, this is called whenever a navigation is triggered.

--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -957,9 +957,6 @@ export default {
 			}
 			if (from.name === 'conversation') {
 				this.$store.dispatch('leaveConversation', { token: from.params.token })
-				if (to.name !== 'conversation') {
-					this.tokenStore.updateToken('')
-				}
 			}
 			if (to.name === 'conversation') {
 				this.abortSearch()

--- a/src/composables/useGetMessages.ts
+++ b/src/composables/useGetMessages.ts
@@ -223,7 +223,6 @@ export function useGetMessagesProvider() {
 		}
 
 		const focusMessageId = getMessageIdFromHash(to.hash)
-		const threadId = +(to.query.threadId ?? 0)
 		if (from.hash !== to.hash && focusMessageId !== null) {
 			// the hash changed, need to focus/highlight another message
 			contextMessageId.value = focusMessageId
@@ -235,7 +234,7 @@ export function useGetMessagesProvider() {
 			contextMessageId.value = conversationLastMessageId.value
 		}
 
-		await checkContextAndFocusMessage(to.params.token, contextMessageId.value, threadId)
+		await checkContextAndFocusMessage(to.params.token, contextMessageId.value, contextThreadId.value)
 	}
 
 	/**


### PR DESCRIPTION
### ☑️ Resolves

* Follow-up to #15704
* Wait for router navigation to successfully complete before emitting an event seems more reasonable:
	* `token` and `threadId` are updated globally according to route
	* navigation can be no longer interrupted
	* all current use cases are side-effects, which are safe to run after navigation:
		* SearchMessageTab, ThreadsTab - change sidebar tab, safe to do after
		* LeftSidebar - leave-join to signaling happens here, but safe to after
		* useGetMessages - defining a context, the place where it's important to do after 🟢 

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
