### PR TITLE
fix(l10n): Remove redundant "Talk" prefix from "Talk home"

### DIFF
--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -140,7 +140,7 @@
 				<NcAppNavigationItem
 					class="navigation-item"
 					:to="{ name: 'root' }"
-					:name="t('spreed', 'Talk home')"
+					:name="HOME_BUTTON_LABEL"
 					@click="refreshTalkDashboard">
 					<template #icon>
 						<IconHomeOutline :size="20" />
@@ -339,6 +339,7 @@ const canModerateSipDialOut = hasTalkFeature('local', 'sip-support-dialout')
 	&& getTalkConfig('local', 'call', 'can-enable-sip')
 const canNoteToSelf = hasTalkFeature('local', 'note-to-self')
 const supportsArchive = hasTalkFeature('local', 'archived-conversations-v2')
+const HOME_BUTTON_LABEL = t('spreed', 'Home') // TRANSLATORS: The main home view
 const FILTER_LABELS = {
 	unread: t('spreed', 'Unread'),
 	mentions: t('spreed', 'Mentions'),
@@ -422,6 +423,7 @@ export default {
 			showArchived,
 			showThreadsList,
 			settingsStore,
+			HOME_BUTTON_LABEL,
 			FILTER_LABELS,
 			actorStore: useActorStore(),
 			chatExtrasStore: useChatExtrasStore(),


### PR DESCRIPTION
This is just sort of redundant to have there. You are inside Talk :)

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="304" height="129" alt="image" src="https://github.com/user-attachments/assets/dffbd433-5dc5-4f51-b6c4-f2a8f1c0c292" /> | <img width="304" height="129" alt="image" src="https://github.com/user-attachments/assets/4a7f678e-d838-434e-93d5-2845f4ec4a1a" />


### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Not risky to browser differences / client
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required