### PR TITLE
fix(l10n): Put translator comment on correct line

### DIFF
--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -339,7 +339,7 @@ const canModerateSipDialOut = hasTalkFeature('local', 'sip-support-dialout')
 	&& getTalkConfig('local', 'call', 'can-enable-sip')
 const canNoteToSelf = hasTalkFeature('local', 'note-to-self')
 const supportsArchive = hasTalkFeature('local', 'archived-conversations-v2')
-// TRANSLATORS: The main home view
+// TRANSLATORS The main home view
 const HOME_BUTTON_LABEL = t('spreed', 'Home')
 const FILTER_LABELS = {
 	unread: t('spreed', 'Unread'),


### PR DESCRIPTION
See https://github.com/nextcloud/spreed/pull/15710#discussion_r2295706986