### PR TITLE
docs: Adjust second docs link for snap installation

### DIFF
--- a/docs/quick-install.md
+++ b/docs/quick-install.md
@@ -48,7 +48,7 @@ Packages for installing the High-performance backend for Ubuntu, Debian und Red 
 * **Requirements:** Docker
 * **Link:** [help.nextcloud.com/t/high-performance-backend-for-talk-on-nextcloud-with-docker/215828](https://help.nextcloud.com/t/high-performance-backend-for-talk-on-nextcloud-with-docker/215828)
 
-Thanks to the Nextcloud snap team, who created a [how to](https://github.com/nextcloud-snap/nextcloud-snap/wiki/How-to-configure-talk-HPB-with-Docker) for installing the High-performance backend using the Talk container from Nextcloud AIO in a Docker Stack. While provided "as-is" it might help you to setup the High-performance backend for your use-case. Please note that it does not require a Nextcloud snap installation! 
+Thanks to the Nextcloud snap team, who created a [how to](https://help.nextcloud.com/t/high-performance-backend-for-talk-on-nextcloud-with-docker/215828) for installing the High-performance backend using the Talk container from Nextcloud AIO in a Docker Stack. While provided "as-is" it might help you to setup the High-performance backend for your use-case. Please note that it does not require a Nextcloud snap installation! 
 
 ### Docker container
 


### PR DESCRIPTION
* Follow up to https://github.com/nextcloud/spreed/pull/15724

Noticed a few seconds after merge that we have 2 links :-( 