### PR TITLE
Use material symbol variant of delete icon

### DIFF
--- a/src/components/AdminSettings/RecordingServer.vue
+++ b/src/components/AdminSettings/RecordingServer.vue
@@ -26,7 +26,7 @@
 			:aria-label="t('spreed', 'Delete this server')"
 			@click="removeServer">
 			<template #icon>
-				<IconDeleteOutline :size="20" />
+				<IconTrashCanOutline :size="20" />
 			</template>
 		</NcButton>
 
@@ -57,8 +57,8 @@ import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
 import NcTextField from '@nextcloud/vue/components/NcTextField'
 import IconAlertCircleOutline from 'vue-material-design-icons/AlertCircleOutline.vue'
 import IconCheck from 'vue-material-design-icons/Check.vue'
-import IconDeleteOutline from 'vue-material-design-icons/DeleteOutline.vue'
 import IconReload from 'vue-material-design-icons/Reload.vue'
+import IconTrashCanOutline from 'vue-material-design-icons/TrashCanOutline.vue'
 import { getWelcomeMessage } from '../../services/recordingService.js'
 
 export default {
@@ -67,7 +67,7 @@ export default {
 	components: {
 		IconAlertCircleOutline,
 		IconCheck,
-		IconDeleteOutline,
+		IconTrashCanOutline,
 		IconReload,
 		NcButton,
 		NcCheckboxRadioSwitch,

--- a/src/components/AdminSettings/SignalingServer.vue
+++ b/src/components/AdminSettings/SignalingServer.vue
@@ -25,7 +25,7 @@
 			:aria-label="t('spreed', 'Delete this server')"
 			@click="removeServer">
 			<template #icon>
-				<IconDeleteOutline :size="20" />
+				<IconTrashCanOutline :size="20" />
 			</template>
 		</NcButton>
 
@@ -71,8 +71,8 @@ import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
 import NcTextField from '@nextcloud/vue/components/NcTextField'
 import IconAlertCircleOutline from 'vue-material-design-icons/AlertCircleOutline.vue'
 import IconCheck from 'vue-material-design-icons/Check.vue'
-import IconDeleteOutline from 'vue-material-design-icons/DeleteOutline.vue'
 import IconReload from 'vue-material-design-icons/Reload.vue'
+import IconTrashCanOutline from 'vue-material-design-icons/TrashCanOutline.vue'
 import { EventBus } from '../../services/EventBus.ts'
 import { fetchSignalingSettings, getWelcomeMessage } from '../../services/signalingService.js'
 import { createConnection } from '../../utils/SignalingStandaloneTest.js'
@@ -83,7 +83,7 @@ export default {
 	components: {
 		IconAlertCircleOutline,
 		IconCheck,
-		IconDeleteOutline,
+		IconTrashCanOutline,
 		IconReload,
 		NcButton,
 		NcCheckboxRadioSwitch,

--- a/src/components/AdminSettings/StunServer.vue
+++ b/src/components/AdminSettings/StunServer.vue
@@ -30,7 +30,7 @@
 			:aria-label="t('spreed', 'Delete this server')"
 			@click="removeServer">
 			<template #icon>
-				<IconDeleteOutline :size="20" />
+				<IconTrashCanOutline :size="20" />
 			</template>
 		</NcButton>
 	</li>
@@ -41,14 +41,14 @@ import { t } from '@nextcloud/l10n'
 import NcButton from '@nextcloud/vue/components/NcButton'
 import NcTextField from '@nextcloud/vue/components/NcTextField'
 import IconAlertCircleOutline from 'vue-material-design-icons/AlertCircleOutline.vue'
-import IconDeleteOutline from 'vue-material-design-icons/DeleteOutline.vue'
+import IconTrashCanOutline from 'vue-material-design-icons/TrashCanOutline.vue'
 
 export default {
 	name: 'StunServer',
 
 	components: {
 		IconAlertCircleOutline,
-		IconDeleteOutline,
+		IconTrashCanOutline,
 		NcButton,
 		NcTextField,
 	},

--- a/src/components/AdminSettings/TurnServer.vue
+++ b/src/components/AdminSettings/TurnServer.vue
@@ -65,7 +65,7 @@
 			:aria-label="t('spreed', 'Delete this server')"
 			@click="removeServer">
 			<template #icon>
-				<IconDeleteOutline :size="20" />
+				<IconTrashCanOutline :size="20" />
 			</template>
 		</NcButton>
 	</li>
@@ -84,8 +84,8 @@ import NcSelect from '@nextcloud/vue/components/NcSelect'
 import NcTextField from '@nextcloud/vue/components/NcTextField'
 import IconAlertCircleOutline from 'vue-material-design-icons/AlertCircleOutline.vue'
 import IconCheck from 'vue-material-design-icons/Check.vue'
-import IconDeleteOutline from 'vue-material-design-icons/DeleteOutline.vue'
 import IconPulse from 'vue-material-design-icons/Pulse.vue'
+import IconTrashCanOutline from 'vue-material-design-icons/TrashCanOutline.vue'
 import { isCertificateValid } from '../../services/certificateService.ts'
 import { convertToUnix } from '../../utils/formattedTime.ts'
 
@@ -96,7 +96,7 @@ export default {
 		NcLoadingIcon,
 		IconAlertCircleOutline,
 		IconCheck,
-		IconDeleteOutline,
+		IconTrashCanOutline,
 		NcButton,
 		NcSelect,
 		NcTextField,

--- a/src/components/BreakoutRoomsEditor/BreakoutRoomsParticipantsEditor.vue
+++ b/src/components/BreakoutRoomsEditor/BreakoutRoomsParticipantsEditor.vue
@@ -34,7 +34,7 @@
 				variant="error"
 				@click="toggleShowDialog">
 				<template #icon>
-					<IconDeleteOutline :size="20" />
+					<IconTrashCanOutline :size="20" />
 				</template>
 				{{ deleteButtonLabel }}
 			</NcButton>
@@ -97,9 +97,9 @@ import NcActions from '@nextcloud/vue/components/NcActions'
 import NcButton from '@nextcloud/vue/components/NcButton'
 import NcDialog from '@nextcloud/vue/components/NcDialog'
 import IconArrowLeft from 'vue-material-design-icons/ArrowLeft.vue'
-import IconDeleteOutline from 'vue-material-design-icons/DeleteOutline.vue'
 import DotsCircle from 'vue-material-design-icons/DotsCircle.vue'
 import Reload from 'vue-material-design-icons/Reload.vue'
+import IconTrashCanOutline from 'vue-material-design-icons/TrashCanOutline.vue'
 import BreakoutRoomItem from '../RightSidebar/BreakoutRooms/BreakoutRoomItem.vue'
 import SelectableParticipant from './SelectableParticipant.vue'
 import { ATTENDEE, CONVERSATION, PARTICIPANT } from '../../constants.ts'
@@ -117,7 +117,7 @@ export default {
 		SelectableParticipant,
 		NcButton,
 		IconArrowLeft,
-		IconDeleteOutline,
+		IconTrashCanOutline,
 		NcDialog,
 	},
 

--- a/src/components/ConversationSettings/ConversationAvatarEditor.vue
+++ b/src/components/ConversationSettings/ConversationAvatarEditor.vue
@@ -70,7 +70,7 @@
 						:aria-label="t('spreed', 'Remove conversation picture')"
 						@click="removeAvatar">
 						<template #icon>
-							<IconDeleteOutline :size="20" />
+							<IconTrashCanOutline :size="20" />
 						</template>
 					</NcButton>
 				</div>
@@ -108,10 +108,10 @@ import NcButton from '@nextcloud/vue/components/NcButton'
 import NcColorPicker from '@nextcloud/vue/components/NcColorPicker'
 import NcEmojiPicker from '@nextcloud/vue/components/NcEmojiPicker'
 import NcIconSvgWrapper from '@nextcloud/vue/components/NcIconSvgWrapper'
-import IconDeleteOutline from 'vue-material-design-icons/DeleteOutline.vue'
 import IconEmoticonOutline from 'vue-material-design-icons/EmoticonOutline.vue'
 import IconFolder from 'vue-material-design-icons/Folder.vue' // Filled as in Files app icon
 import IconPaletteOutline from 'vue-material-design-icons/PaletteOutline.vue'
+import IconTrashCanOutline from 'vue-material-design-icons/TrashCanOutline.vue'
 import ConversationIcon from '../ConversationIcon.vue'
 import IconFileUpload from '../../../img/material-icons/file-upload.svg?raw'
 import { AVATAR } from '../../constants.ts'
@@ -131,7 +131,7 @@ export default {
 		NcIconSvgWrapper,
 		VueCropper,
 		// Icons
-		IconDeleteOutline,
+		IconTrashCanOutline,
 		IconEmoticonOutline,
 		IconFolder,
 		IconPaletteOutline,

--- a/src/components/ConversationSettings/Matterbridge/BridgePart.vue
+++ b/src/components/ConversationSettings/Matterbridge/BridgePart.vue
@@ -29,7 +29,7 @@
 				</NcActionLink>
 				<NcActionButton v-if="editable" close-after-click @click="$emit('deletePart')">
 					<template #icon>
-						<IconDeleteOutline :size="20" />
+						<IconTrashCanOutline :size="20" />
 					</template>
 					{{ t('spreed', 'Delete') }}
 				</NcActionButton>
@@ -77,15 +77,15 @@ import NcActionButton from '@nextcloud/vue/components/NcActionButton'
 import NcActionLink from '@nextcloud/vue/components/NcActionLink'
 import NcActions from '@nextcloud/vue/components/NcActions'
 import IconCheck from 'vue-material-design-icons/Check.vue'
-import IconDeleteOutline from 'vue-material-design-icons/DeleteOutline.vue'
 import IconInformationOutline from 'vue-material-design-icons/InformationOutline.vue'
 import IconPencilOutline from 'vue-material-design-icons/PencilOutline.vue'
+import IconTrashCanOutline from 'vue-material-design-icons/TrashCanOutline.vue'
 
 export default {
 	name: 'BridgePart',
 	components: {
 		IconCheck,
-		IconDeleteOutline,
+		IconTrashCanOutline,
 		IconInformationOutline,
 		IconPencilOutline,
 		NcActionButton,

--- a/src/components/LeftSidebar/ConversationsList/Conversation.vue
+++ b/src/components/LeftSidebar/ConversationsList/Conversation.vue
@@ -123,7 +123,7 @@
 					class="critical"
 					@click="isDeleteDialogOpen = true">
 					<template #icon>
-						<IconDeleteOutline :size="16" />
+						<IconTrashCanOutline :size="16" />
 					</template>
 					{{ t('spreed', 'Delete conversation') }}
 				</NcActionButton>
@@ -277,7 +277,6 @@ import IconArrowRight from 'vue-material-design-icons/ArrowRight.vue'
 import IconBellOutline from 'vue-material-design-icons/BellOutline.vue'
 import IconCogOutline from 'vue-material-design-icons/CogOutline.vue'
 import IconContentCopy from 'vue-material-design-icons/ContentCopy.vue'
-import IconDeleteOutline from 'vue-material-design-icons/DeleteOutline.vue'
 import IconExitToApp from 'vue-material-design-icons/ExitToApp.vue'
 import IconEyeOffOutline from 'vue-material-design-icons/EyeOffOutline.vue'
 import IconEyeOutline from 'vue-material-design-icons/EyeOutline.vue'
@@ -285,6 +284,7 @@ import IconMessageAlertOutline from 'vue-material-design-icons/MessageAlertOutli
 import IconPhoneRingOutline from 'vue-material-design-icons/PhoneRingOutline.vue'
 import IconShieldLockOutline from 'vue-material-design-icons/ShieldLockOutline.vue'
 import IconStar from 'vue-material-design-icons/Star.vue' // Filled for better indication
+import IconTrashCanOutline from 'vue-material-design-icons/TrashCanOutline.vue'
 import IconVideo from 'vue-material-design-icons/Video.vue' // Filled for better indication
 import ConversationIcon from './../../ConversationIcon.vue'
 import IconVolumeHighOutline from '../../../../img/material-icons/volume-high-outline.svg?raw'
@@ -317,7 +317,7 @@ export default {
 		IconBellOutline,
 		IconCogOutline,
 		IconContentCopy,
-		IconDeleteOutline,
+		IconTrashCanOutline,
 		IconExitToApp,
 		IconEyeOutline,
 		IconEyeOffOutline,

--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
@@ -201,7 +201,7 @@
 							close-after-click
 							@click.stop="handleDelete">
 							<template #icon>
-								<IconDeleteOutline :size="16" />
+								<IconTrashCanOutline :size="16" />
 							</template>
 							{{ t('spreed', 'Delete') }}
 						</NcActionButton>
@@ -331,7 +331,6 @@ import IconClockEditOutline from 'vue-material-design-icons/ClockEditOutline.vue
 import IconClockOutline from 'vue-material-design-icons/ClockOutline.vue'
 import IconCloseCircleOutline from 'vue-material-design-icons/CloseCircleOutline.vue'
 import IconContentCopy from 'vue-material-design-icons/ContentCopy.vue'
-import IconDeleteOutline from 'vue-material-design-icons/DeleteOutline.vue'
 import IconEmoticonOutline from 'vue-material-design-icons/EmoticonOutline.vue'
 import IconEyeOffOutline from 'vue-material-design-icons/EyeOffOutline.vue'
 import IconFileOutline from 'vue-material-design-icons/FileOutline.vue'
@@ -341,6 +340,7 @@ import IconOpenInNew from 'vue-material-design-icons/OpenInNew.vue'
 import IconPencilOutline from 'vue-material-design-icons/PencilOutline.vue'
 import IconPlus from 'vue-material-design-icons/Plus.vue'
 import IconTranslate from 'vue-material-design-icons/Translate.vue'
+import IconTrashCanOutline from 'vue-material-design-icons/TrashCanOutline.vue'
 import IconFileDownload from '../../../../../../img/material-icons/file-download.svg?raw'
 import { useGetThreadId } from '../../../../../composables/useGetThreadId.ts'
 import { useMessageInfo } from '../../../../../composables/useMessageInfo.ts'
@@ -380,7 +380,7 @@ export default {
 		IconClockEditOutline,
 		IconClockOutline,
 		IconContentCopy,
-		IconDeleteOutline,
+		IconTrashCanOutline,
 		IconEmoticonOutline,
 		IconEyeOffOutline,
 		IconFileOutline,

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/Poll.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/Poll.vue
@@ -22,7 +22,7 @@
 				:aria-label="t('spreed', 'Delete poll draft')"
 				@click.stop="deleteDraft">
 				<template #icon>
-					<IconDeleteOutline :size="20" />
+					<IconTrashCanOutline :size="20" />
 				</template>
 			</NcButton>
 		</span>
@@ -58,9 +58,9 @@
 import { n, t } from '@nextcloud/l10n'
 import { vIntersectionObserver as IntersectionObserver } from '@vueuse/components'
 import NcButton from '@nextcloud/vue/components/NcButton'
-import IconDeleteOutline from 'vue-material-design-icons/DeleteOutline.vue'
 import IconPencilOutline from 'vue-material-design-icons/PencilOutline.vue'
 import IconPoll from 'vue-material-design-icons/Poll.vue'
+import IconTrashCanOutline from 'vue-material-design-icons/TrashCanOutline.vue'
 import { POLL } from '../../../../../constants.ts'
 import { hasTalkFeature } from '../../../../../services/CapabilitiesManager.ts'
 import { usePollsStore } from '../../../../../stores/polls.ts'
@@ -70,7 +70,7 @@ export default {
 
 	components: {
 		NcButton,
-		IconDeleteOutline,
+		IconTrashCanOutline,
 		IconPencilOutline,
 		IconPoll,
 	},

--- a/src/components/RightSidebar/Participants/Participant.vue
+++ b/src/components/RightSidebar/Participants/Participant.vue
@@ -261,7 +261,7 @@
 				close-after-click
 				@click="isRemoveDialogOpen = true">
 				<template #icon>
-					<IconDeleteOutline :size="20" />
+					<IconTrashCanOutline :size="20" />
 				</template>
 				{{ removeParticipantLabel }}
 			</NcActionButton>
@@ -326,7 +326,6 @@ import IconAccountPlusOutline from 'vue-material-design-icons/AccountPlusOutline
 import IconBellOutline from 'vue-material-design-icons/BellOutline.vue'
 import IconContentCopy from 'vue-material-design-icons/ContentCopy.vue'
 import IconCrownOutline from 'vue-material-design-icons/CrownOutline.vue'
-import IconDeleteOutline from 'vue-material-design-icons/DeleteOutline.vue'
 import IconEmailOutline from 'vue-material-design-icons/EmailOutline.vue'
 import IconHandBackLeft from 'vue-material-design-icons/HandBackLeft.vue' // Filled for better indication
 import IconLockOpenVariantOutline from 'vue-material-design-icons/LockOpenVariantOutline.vue'
@@ -338,6 +337,7 @@ import IconPhoneDialOutline from 'vue-material-design-icons/PhoneDialOutline.vue
 import IconPhoneHangupOutline from 'vue-material-design-icons/PhoneHangupOutline.vue'
 import IconPhoneInTalkOutline from 'vue-material-design-icons/PhoneInTalkOutline.vue'
 import IconPhonePausedOutline from 'vue-material-design-icons/PhonePausedOutline.vue'
+import IconTrashCanOutline from 'vue-material-design-icons/TrashCanOutline.vue'
 import IconTune from 'vue-material-design-icons/Tune.vue'
 import IconVideoOutline from 'vue-material-design-icons/VideoOutline.vue'
 import AvatarWrapper from '../../AvatarWrapper/AvatarWrapper.vue'
@@ -385,7 +385,7 @@ export default {
 		IconBellOutline,
 		IconContentCopy,
 		IconCrownOutline,
-		IconDeleteOutline,
+		IconTrashCanOutline,
 		IconEmailOutline,
 		IconHandBackLeft,
 		IconLockOutline,

--- a/src/components/UIShared/ConversationActionsShortcut.vue
+++ b/src/components/UIShared/ConversationActionsShortcut.vue
@@ -13,7 +13,7 @@ import { useRoute, useRouter } from 'vue-router'
 import { useStore } from 'vuex'
 import NcButton from '@nextcloud/vue/components/NcButton'
 import IconCheckUnderline from 'vue-material-design-icons/CheckUnderline.vue'
-import IconDeleteOutline from 'vue-material-design-icons/DeleteOutline.vue'
+import IconTrashCanOutline from 'vue-material-design-icons/TrashCanOutline.vue'
 import ConfirmDialog from '../../components/UIShared/ConfirmDialog.vue'
 import { CONVERSATION } from '../../constants.ts'
 import { getTalkConfig, hasTalkFeature } from '../../services/CapabilitiesManager.ts'
@@ -113,7 +113,7 @@ async function showConfirmationDialog() {
 			<NcButton variant="error"
 				@click="showConfirmationDialog">
 				<template #icon>
-					<IconDeleteOutline />
+					<IconTrashCanOutline />
 				</template>
 				{{ t('spreed', 'Delete now') }}
 			</NcButton>


### PR DESCRIPTION
### ☑️ Resolves

* Ref #15473


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
Screenshot before | <img width="226" height="46" alt="image" src="https://github.com/user-attachments/assets/89a07191-1c60-430f-8f54-fefaed91deda" />

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
