### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -311,12 +311,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "1baa9849e11228754ed6027612e4e140cb855185"
+                "reference": "c7def7e86eb5cb9f73056405f699c26b73930ba8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/1baa9849e11228754ed6027612e4e140cb855185",
-                "reference": "1baa9849e11228754ed6027612e4e140cb855185",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/c7def7e86eb5cb9f73056405f699c26b73930ba8",
+                "reference": "c7def7e86eb5cb9f73056405f699c26b73930ba8",
                 "shasum": ""
             },
             "require": {
@@ -352,7 +352,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2025-08-22T00:50:40+00:00"
+            "time": "2025-08-28T00:48:45+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency