### PR TITLE
fix: do not use route outside of integration apps

### DIFF
--- a/src/FilesSidebarTabApp.vue
+++ b/src/FilesSidebarTabApp.vue
@@ -34,7 +34,6 @@ import { t } from '@nextcloud/l10n'
 import { defineAsyncComponent, defineComponent, h } from 'vue'
 import NcButton from '@nextcloud/vue/components/NcButton'
 import LoadingComponent from './components/LoadingComponent.vue'
-import { useGetToken } from './composables/useGetToken.ts'
 import { useSessionIssueHandler } from './composables/useSessionIssueHandler.ts'
 import { EventBus } from './services/EventBus.ts'
 import { getFileConversation } from './services/filesIntegrationServices.ts'
@@ -64,7 +63,6 @@ export default {
 		return {
 			isLeavingAfterSessionIssue: useSessionIssueHandler(),
 			actorStore: useActorStore(),
-			token: useGetToken(),
 			tokenStore: useTokenStore(),
 		}
 	},
@@ -83,6 +81,10 @@ export default {
 	},
 
 	computed: {
+		token() {
+			return this.tokenStore.token
+		},
+
 		fileInfo() {
 			return this.Talk.fileInfo || {}
 		},

--- a/src/PublicShareAuthSidebar.vue
+++ b/src/PublicShareAuthSidebar.vue
@@ -36,7 +36,6 @@ import InternalSignalingHint from './components/RightSidebar/InternalSignalingHi
 import TopBar from './components/TopBar/TopBar.vue'
 import TransitionWrapper from './components/UIShared/TransitionWrapper.vue'
 import { useGetMessagesProvider } from './composables/useGetMessages.ts'
-import { useGetToken } from './composables/useGetToken.ts'
 import { useHashCheck } from './composables/useHashCheck.js'
 import { useSessionIssueHandler } from './composables/useSessionIssueHandler.ts'
 import { EventBus } from './services/EventBus.ts'
@@ -69,7 +68,6 @@ export default {
 		return {
 			isLeavingAfterSessionIssue: useSessionIssueHandler(),
 			actorStore: useActorStore(),
-			token: useGetToken(),
 			tokenStore: useTokenStore(),
 		}
 	},
@@ -83,6 +81,10 @@ export default {
 	},
 
 	computed: {
+		token() {
+			return this.tokenStore.token
+		},
+
 		conversation() {
 			return this.$store.getters.conversation(this.token)
 		},

--- a/src/PublicShareSidebar.vue
+++ b/src/PublicShareSidebar.vue
@@ -50,7 +50,6 @@ import CallButton from './components/TopBar/CallButton.vue'
 import TopBar from './components/TopBar/TopBar.vue'
 import TransitionWrapper from './components/UIShared/TransitionWrapper.vue'
 import { useGetMessagesProvider } from './composables/useGetMessages.ts'
-import { useGetToken } from './composables/useGetToken.ts'
 import { useHashCheck } from './composables/useHashCheck.js'
 import { useIsInCall } from './composables/useIsInCall.js'
 import { useSessionIssueHandler } from './composables/useSessionIssueHandler.ts'
@@ -101,7 +100,6 @@ export default {
 			isInCall: useIsInCall(),
 			isLeavingAfterSessionIssue: useSessionIssueHandler(),
 			actorStore: useActorStore(),
-			token: useGetToken(),
 			tokenStore: useTokenStore(),
 		}
 	},
@@ -115,6 +113,10 @@ export default {
 	},
 
 	computed: {
+		token() {
+			return this.tokenStore.token
+		},
+
 		conversation() {
 			return this.$store.getters.conversation(this.token)
 		},


### PR DESCRIPTION
### ☑️ Resolves

* Regression from #15704
* Composable value can't be used, if we don't navigate to the conversation yet (which is after initialisation of sidebars)

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
Sidebar doesn't open | It works


### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
