### PR TITLE
Release v21.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 21.1.4 – 2025-08-28
+### Added
+- feat(sip): Allow to send the direct dial-in number of users on out-going calls
+  [#15701](https://github.com/nextcloud/spreed/issues/15701)
+- feat(settings): Add a config for the unread message threshold for the AI summary
+  [#15734](https://github.com/nextcloud/spreed/issues/15734)
+
+### Changed
+- Update translations
+- Update dependencies
+
+### Fixed
+- fix(dashboard): Fix events without an end date
+  [#15732](https://github.com/nextcloud/spreed/issues/15732)
+- fix(chat): Suggest mentioning yourself, it's useful with bots and todos
+  [#15656](https://github.com/nextcloud/spreed/issues/15656)
+- fix(chat): Fix search interaction when scrolling away and clicking on a result again
+  [#15706](https://github.com/nextcloud/spreed/issues/15706)
+- fix(chat): Fix support for at-all in captions when sharing a file
+  [#15744](https://github.com/nextcloud/spreed/issues/15744)
+
 ## 21.1.3 – 2025-08-06
 ### Changed
 - Update translations

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -18,7 +18,7 @@
 * 🌉 **Sync with other chat solutions** With [Matterbridge](https://github.com/42wim/matterbridge/) being integrated in Talk, you can easily sync a lot of other chat solutions to Nextcloud Talk and vice-versa.
 ]]></description>
 
-	<version>21.1.3</version>
+	<version>21.1.4</version>
 	<licence>agpl</licence>
 
 	<author>Anna Larch</author>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "talk",
-  "version": "21.1.3",
+  "version": "21.1.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "talk",
-      "version": "21.1.3",
+      "version": "21.1.4",
       "license": "agpl",
       "dependencies": {
         "@linusborg/vue-simple-portal": "^0.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "talk",
-  "version": "21.1.3",
+  "version": "21.1.4",
   "private": true,
   "description": "",
   "license": "agpl",


### PR DESCRIPTION
## 21.1.4 – 2025-08-28
### Added
- feat(sip): Allow to send the direct dial-in number of users on out-going calls [#15701](https://github.com/nextcloud/spreed/issues/15701)
- feat(settings): Add a config for the unread message threshold for the AI summary [#15734](https://github.com/nextcloud/spreed/issues/15734)

### Changed
- Update translations
- Update dependencies

### Fixed
- fix(dashboard): Fix events without an end date [#15732](https://github.com/nextcloud/spreed/issues/15732)
- fix(chat): Suggest mentioning yourself, it's useful with bots and todos [#15656](https://github.com/nextcloud/spreed/issues/15656)
- fix(chat): Fix search interaction when scrolling away and clicking on a result again [#15706](https://github.com/nextcloud/spreed/issues/15706)
- fix(chat): Fix support for at-all in captions when sharing a file [#15744](https://github.com/nextcloud/spreed/issues/15744)
