### PR TITLE
fix(MediaSettings): fix modal width

### DIFF
--- a/src/components/MediaSettings/MediaSettings.vue
+++ b/src/components/MediaSettings/MediaSettings.vue
@@ -994,8 +994,9 @@ export default {
 	max-width: 450px;
 }
 
+// Override NcModal styles for large horizontal layout
 :deep(.modal-wrapper--large > .modal-container) {
-	width: unset;
+	width: unset !important;
 }
 
 </style>

--- a/src/components/MediaSettings/MediaSettings.vue
+++ b/src/components/MediaSettings/MediaSettings.vue
@@ -677,6 +677,9 @@ export default {
 			if (page === 'device-check') {
 				this.isDeviceCheck = true
 				this.tabContent = 'devices'
+			} else if (page === 'backgrounds') {
+				this.isDeviceCheck = true
+				this.tabContent = 'backgrounds'
 			}
 		},
 

--- a/src/components/TopBar/TopBarMediaControls.vue
+++ b/src/components/TopBar/TopBarMediaControls.vue
@@ -55,6 +55,16 @@
 			:show-devices="!isSidebar"
 			variant="tertiary" />
 
+		<NcButton
+			:aria-label="t('spreed', 'Select virtual background')"
+			:title="t('spreed', 'Select virtual background')"
+			variant="tertiary"
+			@click.stop="emit('talk:media-settings:show', 'backgrounds')">
+			<template #icon>
+				<NcIconSvgWrapper :svg="IconBackground" :size="20" />
+			</template>
+		</NcButton>
+
 		<NcActions v-if="!isSidebar && isScreensharing"
 			id="screensharing-button"
 			v-model:open="screenSharingMenuOpen"
@@ -103,6 +113,7 @@ import escapeHtml from 'escape-html'
 import NcActionButton from '@nextcloud/vue/components/NcActionButton'
 import NcActions from '@nextcloud/vue/components/NcActions'
 import NcButton from '@nextcloud/vue/components/NcButton'
+import NcIconSvgWrapper from '@nextcloud/vue/components/NcIconSvgWrapper'
 import NcPopover from '@nextcloud/vue/components/NcPopover'
 import IconMonitor from 'vue-material-design-icons/Monitor.vue'
 import IconMonitorOff from 'vue-material-design-icons/MonitorOff.vue'
@@ -110,6 +121,7 @@ import IconMonitorShare from 'vue-material-design-icons/MonitorShare.vue'
 import IconNetworkStrength2Alert from 'vue-material-design-icons/NetworkStrength2Alert.vue'
 import LocalAudioControlButton from '../CallView/shared/LocalAudioControlButton.vue'
 import LocalVideoControlButton from '../CallView/shared/LocalVideoControlButton.vue'
+import IconBackground from '../../../img/material-icons/replace-background.svg?raw'
 import { useIsInCall } from '../../composables/useIsInCall.js'
 import { PARTICIPANT } from '../../constants.ts'
 import { CONNECTION_QUALITY } from '../../utils/webrtc/analyzers/PeerConnectionAnalyzer.js'
@@ -125,6 +137,7 @@ export default {
 		NcActionButton,
 		NcActions,
 		NcButton,
+		NcIconSvgWrapper,
 		NcPopover,
 		// Icons
 		IconMonitor,
@@ -157,6 +170,7 @@ export default {
 
 	setup() {
 		return {
+			IconBackground,
 			isInCall: useIsInCall(),
 			callAnalyzer,
 		}
@@ -361,6 +375,8 @@ export default {
 	},
 
 	methods: {
+		emit,
+
 		t,
 
 		toggleScreenSharingMenu() {


### PR DESCRIPTION
### ☑️ Resolves

* Adds a button to quickly open 'virtual backgrounds'


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

<img width="321" height="56" alt="image" src="https://github.com/user-attachments/assets/c71ca903-5850-4d05-87f2-ac7b7eae7c78" />
### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
