### PR TITLE
fix(CalendarEventsDialog): don't let popovers overlap

### DIFF
--- a/src/components/CalendarEventsDialog.vue
+++ b/src/components/CalendarEventsDialog.vue
@@ -314,7 +314,8 @@ async function submitNewMeeting() {
 		<NcPopover :container="container"
 			:popper-hide-triggers="hideTriggers"
 			:no-focus-trap="!canScheduleMeeting && upcomingEvents.length === 0"
-			popup-role="dialog">
+			popup-role="dialog"
+			close-on-click-outside>
 			<template #trigger>
 				<NcButton class="upcoming-meeting"
 					:title="t('spreed', 'Upcoming meetings')"

--- a/src/components/ExtendOneToOneDialog.vue
+++ b/src/components/ExtendOneToOneDialog.vue
@@ -72,7 +72,8 @@ async function extendOneToOneConversation() {
 
 <template>
 	<NcPopover :container="container"
-		popup-role="dialog">
+		popup-role="dialog"
+		close-on-click-outside>
 		<template #trigger>
 			<NcButton variant="tertiary"
 				:title="t('spreed', 'Start a group conversation')"


### PR DESCRIPTION
### ☑️ Resolves


<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
Before| Screenshot after

<!-- ☀️ Light theme | 🌑 Dark Theme -->

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required