### PR TITLE
fix: Use normal subtitles icon instead of outline when enabled

### DIFF
--- a/src/components/CallView/BottomBar.vue
+++ b/src/components/CallView/BottomBar.vue
@@ -18,6 +18,7 @@ import IconFullscreen from 'vue-material-design-icons/Fullscreen.vue'
 import IconFullscreenExit from 'vue-material-design-icons/FullscreenExit.vue'
 import IconHandBackLeft from 'vue-material-design-icons/HandBackLeft.vue' // Filled for better indication
 import IconHandBackLeftOutline from 'vue-material-design-icons/HandBackLeftOutline.vue'
+import IconSubtitles from 'vue-material-design-icons/Subtitles.vue'
 import IconSubtitlesOutline from 'vue-material-design-icons/SubtitlesOutline.vue'
 import IconViewGalleryOutline from 'vue-material-design-icons/ViewGalleryOutline.vue'
 import IconViewGridOutline from 'vue-material-design-icons/ViewGridOutline.vue'
@@ -280,6 +281,8 @@ useHotKey('r', toggleHandRaised)
 				@click="toggleLiveTranscription">
 				<template #icon>
 					<NcLoadingIcon v-if="isLiveTranscriptionLoading"
+						:size="20" />
+					<IconSubtitles v-else-if="callViewStore.isLiveTranscriptionEnabled"
 						:size="20" />
 					<IconSubtitlesOutline v-else
 						:size="20" />

--- a/src/components/CallView/BottomBar.vue
+++ b/src/components/CallView/BottomBar.vue
@@ -279,9 +279,9 @@ useHotKey('r', toggleHandRaised)
 				:disabled="isLiveTranscriptionLoading"
 				@click="toggleLiveTranscription">
 				<template #icon>
-					<IconSubtitlesOutline v-if="!isLiveTranscriptionLoading"
+					<NcLoadingIcon v-if="isLiveTranscriptionLoading"
 						:size="20" />
-					<NcLoadingIcon v-else
+					<IconSubtitlesOutline v-else
 						:size="20" />
 				</template>
 			</NcButton>


### PR DESCRIPTION
Similarly to the icon in the raise hand button, when the live transcription button is enabled now the normal icon is used instead of the outline one.

I am not sure if this is needed or not, but just in case :-) If it is not needed feel free to close ;-)

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="158" height="50" alt="LiveTranscription-Button-Disabled" src="https://github.com/user-attachments/assets/98b0651a-682e-4b8c-b787-1320f4bd2c2e" /> | <img width="158" height="50" alt="LiveTranscription-Button-Disabled" src="https://github.com/user-attachments/assets/98b0651a-682e-4b8c-b787-1320f4bd2c2e" />
<img width="158" height="50" alt="LiveTranscription-Button-Enabled-Before" src="https://github.com/user-attachments/assets/b5ffff59-b74f-4bf2-a585-f2edcf3da473" /> | <img width="158" height="50" alt="LiveTranscription-Button-Enabled-After" src="https://github.com/user-attachments/assets/01d54f01-14f9-4b88-8b51-c11c9c6387a5" />
