### PR TITLE
fix(MessagesList): scroll to bottom when joining the call

### DIFF
--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -346,6 +346,11 @@ export default {
 
 		this.resizeObserver = new ResizeObserver(this.updateSize)
 		this.resizeObserver.observe(this.$refs.scroller)
+
+		// Scroll to bottom when joining / leaving the call -> remounting component
+		if (!this.isInitialisingMessages) {
+			this.scrollToBottom({ smooth: false, force: true })
+		}
 	},
 
 	beforeUnmount() {


### PR DESCRIPTION
### ☑️ Resolves

* Fix chat at the top when remounting the chat component to a new place

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts


### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client