### PR TITLE
test(threads): Add an integration test for returned thread info

### DIFF
--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -2647,6 +2647,8 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 		$includeReactionsSelf = in_array('reactionsSelf', $formData->getRow(0), true);
 		$includeLastEdit = in_array('lastEditActorId', $formData->getRow(0), true);
 		$includeMessageType = in_array('messageType', $formData->getRow(0), true);
+		$includeThreadTitle = in_array('threadTitle', $formData->getRow(0), true);
+		$includeThreadReplies = in_array('threadReplies', $formData->getRow(0), true);
 
 		$expected = $formData->getHash();
 		$count = count($expected);
@@ -2707,9 +2709,21 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 					$messages[$i]['message']
 				);
 			}
+
+			if (isset($messages[$i]['threadTitle']) && $messages[$i]['threadTitle'] === 'NULL') {
+				$messages[$i]['threadTitle'] = null;
+			}
+
+			if (isset($messages[$i]['threadReplies'])) {
+				if ($messages[$i]['threadReplies'] !== 'NULL') {
+					$messages[$i]['threadReplies'] = (int)$messages[$i]['threadReplies'];
+				} else {
+					$messages[$i]['threadReplies'] = null;
+				}
+			}
 		}
 
-		Assert::assertEquals($expected, array_map(function ($message, $expected) use ($includeParents, $includeReferenceId, $includeReactions, $includeReactionsSelf, $includeLastEdit, $includeMessageType) {
+		Assert::assertEquals($expected, array_map(function ($message, $expected) use ($includeParents, $includeReferenceId, $includeReactions, $includeReactionsSelf, $includeLastEdit, $includeMessageType, $includeThreadTitle, $includeThreadReplies) {
 			$data = [
 				'room' => self::$tokenToIdentifier[$message['token']],
 				'actorType' => $message['actorType'],
@@ -2751,6 +2765,13 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 				if (($message['lastEditActorType'] ?? '') === 'guests') {
 					$data['lastEditActorId'] = self::$sessionIdToUser[$message['lastEditActorId']];
 				}
+			}
+
+			if ($includeThreadTitle) {
+				$data['threadTitle'] = $message['threadTitle'] ?? null;
+			}
+			if ($includeThreadReplies) {
+				$data['threadReplies'] = $message['threadReplies'] ?? null;
 			}
 
 			return $data;

--- a/tests/integration/features/chat-4/threads.feature
+++ b/tests/integration/features/chat-4/threads.feature
@@ -24,9 +24,9 @@ Feature: chat-4/threads
       | t.id      | t.title  | t.numReplies | t.lastMessage | a.notificationLevel | firstMessage | lastMessage |
       | Message 1 | Thread 1 | 1            |  Message 1-1  | 0                   | Message 1    | Message 1-1 |
     Then user "participant1" sees the following messages in room "room" with 200
-      | room | actorType | actorId      | actorDisplayName         | message     | messageParameters | parentMessage |
-      | room | users     | participant2 | participant2-displayname | Message 1-1 | []                | Message 1     |
-      | room | users     | participant1 | participant1-displayname | Message 1   | []                |               |
+      | room | actorType | actorId      | actorDisplayName         | message     | messageParameters | parentMessage | threadTitle | threadReplies |
+      | room | users     | participant2 | participant2-displayname | Message 1-1 | []                | Message 1     | Thread 1    | 1             |
+      | room | users     | participant1 | participant1-displayname | Message 1   | []                |               | Thread 1    | 1             |
     Then user "participant1" sees the following system messages in room "room" with 200
       | room | actorType     | actorId      | systemMessage        | message                        | silent | messageParameters |
       | room | users         | participant1 | thread_created       | You created thread {title} | true   | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname","mention-id":"participant1"},"title":{"type":"highlight","id":THREAD_ID(Thread 1),"name":"Thread 1"}} |


### PR DESCRIPTION
### ☑️ Resolves

* Test for #15776 and #15782 

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
