### PR TITLE
fix(PollViewer): fix mispositioned icons

### DIFF
--- a/src/components/PollViewer/PollVotersDetails.vue
+++ b/src/components/PollViewer/PollVotersDetails.vue
@@ -94,7 +94,7 @@ export default {
 	max-width: 30%;
 	margin-inline-end: 8px;
 
-	& &__button,
+	& &__button.button-vue:has(.button-vue__text:empty),
 	&__button :deep(.button-vue__icon) {
 		min-height: auto;
 		height: auto;
@@ -109,7 +109,7 @@ export default {
 	&__popover {
 		padding: 8px;
 		max-height: 400px;
-		overflow-y: scroll;
+		overflow-y: auto;
 	}
 
 	&__display-name {


### PR DESCRIPTION
### ☑️ Resolves

* Fix regression from overriden styles
  * selector specificity is too low now, increasing according to upstream lib


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="183" height="188" alt="image" src="https://github.com/user-attachments/assets/3213fb36-eee8-4492-bf91-93ef3472dc5e" /> | <img width="207" height="159" alt="image" src="https://github.com/user-attachments/assets/77fdb1e6-67e9-408d-8079-f23307aa85a7" />


### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
