### PR TITLE
fix: don't reset automatically threads list

### DIFF
--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -164,7 +164,7 @@
 					<NcAppNavigationItem
 						class="navigation-item"
 						:name="t('spreed', 'Back to conversations')"
-						@click.prevent="showThreadsList = false; showArchived = false">
+						@click.prevent="handleBackToConversations">
 						<template #icon>
 							<IconArrowLeft class="bidirectional-icon" :size="20" />
 						</template>
@@ -177,7 +177,7 @@
 					v-else-if="supportThreads && !showThreadsList && !isSearching && !isFiltered"
 					class="navigation-item"
 					:name="t('spreed', 'Followed threads')"
-					@click.prevent="showThreadsList = true; showArchived = false">
+					@click.prevent="handleShowThreadsList">
 					<template #icon>
 						<IconForumOutline :size="20" />
 					</template>
@@ -488,6 +488,7 @@ export default {
 			isCurrentTabLeader: false,
 			isFocused: false,
 			isNavigating: false,
+			fallbackConversationToken: null,
 		}
 	},
 
@@ -1006,6 +1007,7 @@ export default {
 				// this is triggered when the hash in the URL changes
 				if (!to.query?.threadId) {
 					this.showThreadsList = false
+					this.fallbackConversationToken = null
 				}
 				return
 			}
@@ -1041,6 +1043,24 @@ export default {
 			if (this.$route.name === 'root') {
 				event.preventDefault()
 				EventBus.emit('refresh-talk-dashboard')
+			}
+		},
+
+		handleShowThreadsList() {
+			this.showThreadsList = true
+			this.showArchived = false
+			this.fallbackConversationToken = this.$route.params?.token
+		},
+
+		handleBackToConversations() {
+			this.showThreadsList = false
+			this.showArchived = false
+			if (this.fallbackConversationToken) {
+				this.$router.push({
+					name: 'conversation',
+					params: { token: this.fallbackConversationToken },
+				}).catch((err) => console.debug(`Error while pushing the fallback conversation's route: ${err}`))
+				this.fallbackConversationToken = null
 			}
 		},
 	},

--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -1004,6 +1004,9 @@ export default {
 				&& to.name === 'conversation'
 				&& from.params.token === to.params.token) {
 				// this is triggered when the hash in the URL changes
+				if (!to.query?.threadId) {
+					this.showThreadsList = false
+				}
 				return
 			}
 			if (from.name === 'conversation') {
@@ -1013,7 +1016,6 @@ export default {
 				this.abortSearch()
 				this.$store.dispatch('joinConversation', { token: to.params.token })
 				this.showArchived = this.$store.getters.conversation(to.params.token)?.isArchived ?? false
-				this.showThreadsList = false
 				this.scrollToConversation(to.params.token)
 			}
 			if (this.isMobile) {


### PR DESCRIPTION
### ☑️ Resolves

- When clicking on thread item and you are not in the same conversation, LS suddenly jumps and shows conversations list with the new conversation joined
- When returning from threads navigation, it feels a bit lost on where you are as thread items don't show which conversation you are in. Best is to return the conversation you were joined in before navigation. 

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
Screenshot before | Screenshot after

<!-- ☀️ Light theme | 🌑 Dark Theme -->


### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required

