### PR TITLE
fix: fix skewed position of user status

### DIFF
--- a/src/components/LeftSidebar/ConversationsList/ConversationsListVirtual.vue
+++ b/src/components/LeftSidebar/ConversationsList/ConversationsListVirtual.vue
@@ -153,15 +153,7 @@ export default {
 <style lang="scss" scoped>
 // Overwrite NcListItem styles
 :deep(.list-item) {
-	overflow: hidden;
 	outline-offset: -2px;
-
-	.avatardiv .avatardiv__user-status {
-		inset-inline-end: -2px !important;
-		bottom: -2px !important;
-		min-height: 11px !important;
-		min-width: 11px !important;
-	}
 }
 
 /* Overwrite NcListItem styles for compact view */


### PR DESCRIPTION
### ☑️ Resolves

* We no longer need those styles after https://github.com/nextcloud-libraries/nextcloud-vue/pull/6004

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="116" height="202" alt="image" src="https://github.com/user-attachments/assets/3bb881c0-73a9-4c77-9722-06dc5ed976bb" /> | <img width="119" height="212" alt="image" src="https://github.com/user-attachments/assets/aaf12ac6-4f26-4e7d-9b31-dffad9d365c8" />

<!-- ☀️ Light theme | 🌑 Dark Theme -->


### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
