### PR TITLE
fix(certificateService): Allow shortlived certificates

### DIFF
--- a/src/services/certificateService.ts
+++ b/src/services/certificateService.ts
@@ -38,10 +38,11 @@ async function isCertificateValid(host: certificateExpirationParams['host']): Pr
 			return false
 		} else if (expiration < 0) {
 			console.error('Certificate of', host, 'expired')
+			return false
 		} else {
 			console.info('Certificate of', host, 'is valid for', expiration, 'days')
+			return true
 		}
-		return expiration > 0
 	} catch (error) {
 		console.error(error)
 		return false


### PR DESCRIPTION
### ☑️ Resolves

I use step-ca in my homelab test setup and it only issues short lived certificates (24h). Due to the check only using days, the number of days until is always 0. In the backend side this is also checked correctly everywhere:
https://github.com/nextcloud/spreed/blob/3dbfbad07237902e6d399eb6bcf247f804c45145/lib/Controller/RecordingController.php#L80-L80
https://github.com/nextcloud/spreed/blob/3dbfbad07237902e6d399eb6bcf247f804c45145/lib/Signaling/Manager.php#L69-L69
In this frontend service there is the edge case for the value 0, because it logs that the certificate is valid (for 0 days), but it still returns false.

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [x] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required