### PR TITLE
fix(ConversationsSearchListVirtual): adjust item height

### DIFF
--- a/src/components/LeftSidebar/ConversationsList/ConversationsSearchListVirtual.vue
+++ b/src/components/LeftSidebar/ConversationsList/ConversationsSearchListVirtual.vue
@@ -23,10 +23,11 @@
 import { RecycleScroller } from 'vue-virtual-scroller'
 import LoadingPlaceholder from '../../UIShared/LoadingPlaceholder.vue'
 import ConversationSearchResult from './ConversationSearchResult.vue'
+import { AVATAR } from '../../../constants.ts'
 
 import 'vue-virtual-scroller/dist/vue-virtual-scroller.css'
 
-const CONVERSATION_ITEM_SIZE = 66
+const CONVERSATION_ITEM_SIZE = AVATAR.SIZE.DEFAULT + 2 * 4 + 2 * 2
 
 export default {
 	name: 'ConversationsSearchListVirtual',


### PR DESCRIPTION
### ☑️ Resolves

* Fix UI bug with virtual scroller list


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="310" height="300" alt="2025-09-04_15h35_54" src="https://github.com/user-attachments/assets/a916c72e-a335-4cd7-b269-9e185cc11d44" /> | <img width="308" height="301" alt="2025-09-04_15h36_12" src="https://github.com/user-attachments/assets/4c112c71-f836-4329-a630-7f29941ff7a5" />

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required

