### PR TITLE
style(BottomBar): increase selector specificity for tertiary buttons

### DIFF
--- a/src/components/CallView/BottomBar.vue
+++ b/src/components/CallView/BottomBar.vue
@@ -328,6 +328,10 @@ useHotKey('r', toggleHandRaised)
 	justify-content: space-between;
 	padding: 0 calc(var(--default-grid-baseline) * 2);
 	z-index: 10;
+
+	:deep(.button-vue--tertiary) {
+		background-color: var(--color-primary-light);
+	}
 }
 
 .bottom-bar-call-controls {
@@ -335,9 +339,5 @@ useHotKey('r', toggleHandRaised)
 	align-items: center;
 	flex-direction: row;
 	gap: var(--default-grid-baseline);
-}
-
-:deep(.button-vue--tertiary) {
-	background-color: var(--color-primary-light);
 }
 </style>


### PR DESCRIPTION
### ☑️ Resolves

* Fix UI appearance of call buttons
  * Selector should always be specified higher, if its' overriding styles

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
Screenshot before | Screenshot after
<img width="217" height="42" alt="2025-09-04_16h48_53" src="https://github.com/user-attachments/assets/91da71bd-ed79-4dc1-877f-efcef74b7219" /> | <img width="216" height="40" alt="2025-09-04_16h47_33" src="https://github.com/user-attachments/assets/226401d7-92fb-4f15-b4db-3f88eae59075" />

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required