### PR TITLE
fix(RecycleScroller): reuse items for better performance

### DIFF
--- a/src/components/LeftSidebar/ConversationsList/Conversation.vue
+++ b/src/components/LeftSidebar/ConversationsList/Conversation.vue
@@ -6,7 +6,6 @@
 <template>
 	<NcListItem
 		ref="listItem"
-		:key="item.token"
 		:name="item.displayName"
 		:title="item.displayName"
 		:data-nav-id="`conversation_${item.token}`"
@@ -27,6 +26,7 @@
 		@update:menu-open="handleActionsMenuOpen">
 		<template #icon>
 			<ConversationIcon
+				:key="item.token"
 				:item="item"
 				:hide-favorite="compact"
 				:hide-call="compact"

--- a/src/components/LeftSidebar/ConversationsList/ConversationSearchResult.vue
+++ b/src/components/LeftSidebar/ConversationsList/ConversationSearchResult.vue
@@ -5,7 +5,6 @@
 
 <template>
 	<NcListItem
-		:key="item.token"
 		:name="item.displayName"
 		:title="item.displayName"
 		:active="item.token === selectedRoom?.token"
@@ -14,7 +13,11 @@
 		:counter-type="counterType"
 		@click="onClick">
 		<template #icon>
-			<ConversationIcon :item="item" :hide-favorite="!item?.attendeeId" :hide-call="!item?.attendeeId" />
+			<ConversationIcon
+				:key="item.token"
+				:item="item"
+				:hide-favorite="!item?.attendeeId"
+				:hide-call="!item?.attendeeId" />
 		</template>
 		<template v-if="conversationInformation.message" #subname>
 			<span class="conversation__subname" :title="conversationInformation.title">

--- a/src/components/LeftSidebar/SearchConversationsResults/SearchConversationsResults.vue
+++ b/src/components/LeftSidebar/SearchConversationsResults/SearchConversationsResults.vue
@@ -218,7 +218,6 @@ const iconSize = computed(() => isCompact.value ? AVATAR.SIZE.COMPACT : AVATAR.S
 		<template #default="{ item }">
 			<Conversation
 				v-if="item.type === 'conversation'"
-				:key="`conversation_${item.id}`"
 				:ref="`conversation-${item.object.token}`"
 				:item="item.object"
 				:compact="isCompact"
@@ -238,7 +237,6 @@ const iconSize = computed(() => isCompact.value ? AVATAR.SIZE.COMPACT : AVATAR.S
 			</NcListItem>
 			<Conversation
 				v-else-if="item.type === 'open_conversation'"
-				:key="`open-conversation_${item.id}`"
 				:item="item.object"
 				is-search-result
 				:compact="isCompact"
@@ -257,13 +255,14 @@ const iconSize = computed(() => isCompact.value ? AVATAR.SIZE.COMPACT : AVATAR.S
 				:hint="item.hint" />
 			<NcListItem
 				v-else-if="item.type === 'user'"
-				:key="`user_${item.id}`"
 				:data-nav-id="`user_${item.id}`"
 				:name="item.object.label"
 				:compact="isCompact"
 				@click="emit('create-and-join-conversation', item.object)">
 				<template #icon>
-					<AvatarWrapper v-bind="item.icon" />
+					<AvatarWrapper
+						:key="`user_${item.id}`"
+						v-bind="item.icon" />
 				</template>
 				<template v-if="!isCompact" #subname>
 					{{ t('spreed', 'New private conversation') }}
@@ -271,13 +270,15 @@ const iconSize = computed(() => isCompact.value ? AVATAR.SIZE.COMPACT : AVATAR.S
 			</NcListItem>
 			<NcListItem
 				v-else-if="item.type === 'group'"
-				:key="`group_${item.id}`"
 				:data-nav-id="`group_${item.id}`"
 				:name="item.object.label"
 				:compact="isCompact"
 				@click="emit('create-and-join-conversation', item.object)">
 				<template #icon>
-					<ConversationIcon :item="item.icon" :size="iconSize" />
+					<ConversationIcon
+						:key="`group_${item.id}`"
+						:item="item.icon"
+						:size="iconSize" />
 				</template>
 				<template v-if="!isCompact" #subname>
 					{{ t('spreed', 'New group conversation') }}
@@ -285,13 +286,15 @@ const iconSize = computed(() => isCompact.value ? AVATAR.SIZE.COMPACT : AVATAR.S
 			</NcListItem>
 			<NcListItem
 				v-else-if="item.type === 'circle'"
-				:key="`circle_${item.id}`"
 				:data-nav-id="`circle_${item.id}`"
 				:name="item.object.label"
 				:compact="isCompact"
 				@click="emit('create-and-join-conversation', item.object)">
 				<template #icon>
-					<ConversationIcon :item="item.icon" :size="iconSize" />
+					<ConversationIcon
+						:key="`circle_${item.id}`"
+						:item="item.icon"
+						:size="iconSize" />
 				</template>
 				<template v-if="!isCompact" #subname>
 					{{ t('spreed', 'New group conversation') }}
@@ -299,13 +302,14 @@ const iconSize = computed(() => isCompact.value ? AVATAR.SIZE.COMPACT : AVATAR.S
 			</NcListItem>
 			<NcListItem
 				v-else-if="item.type === 'federated'"
-				:key="`federated_${item.id}`"
 				:data-nav-id="`federated_${item.id}`"
 				:name="item.object.label"
 				:compact="isCompact"
 				@click="emit('create-and-join-conversation', item.object)">
 				<template #icon>
-					<AvatarWrapper v-bind="item.icon" />
+					<AvatarWrapper
+						:key="`federated_${item.id}`"
+						v-bind="item.icon" />
 				</template>
 				<template v-if="!isCompact" #subname>
 					{{ t('spreed', 'New group conversation') }}

--- a/src/components/RightSidebar/Participants/Participant.vue
+++ b/src/components/RightSidebar/Participants/Participant.vue
@@ -17,6 +17,7 @@
 		<template #icon>
 			<AvatarWrapper
 				:id="participant.actorId"
+				:key="participant.attendeeId"
 				:token="token"
 				:name="displayName"
 				:source="participant.actorType"
@@ -809,6 +810,16 @@ export default {
 	},
 
 	watch: {
+		attendeeId() {
+			// Reset state when the participant data changes (in virtual scroller)
+			this.permissionsEditor = false
+			this.isRemoveDialogOpen = false
+			this.isBanParticipant = false
+			this.internalNote = ''
+			this.disabled = false
+			this.isLoading = false
+		},
+
 		phoneCallStatus(value) {
 			if (!value || !(value === 'ringing' || value === 'accepted')) {
 				this.disabled = false

--- a/src/components/RightSidebar/Participants/ParticipantsListVirtual.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsListVirtual.vue
@@ -11,7 +11,7 @@
 		:item-size="PARTICIPANT_ITEM_SIZE"
 		key-field="attendeeId">
 		<template #default="{ item }">
-			<Participant :key="item.attendeeId" :participant="item" />
+			<Participant :participant="item" />
 		</template>
 		<template v-if="loading" #after>
 			<LoadingPlaceholder type="participants" :count="dummyParticipants" />


### PR DESCRIPTION
### ☑️ Resolves

* Fix performance issue with virtual scroller rendering (hopefully)
  * with key set on root (NcListItem), it causes re-rendering of the whole item component (app) -> leads to observer disonnecting and creating new one (lib) -> calls getBoundingClient rect (lib) -> recalculate styles


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
Screenshot before | Screenshot after

<!-- ☀️ Light theme | 🌑 Dark Theme -->

### 🚧 Tasks

- [x] check other similar components
- [ ] check internal state (put watcher for key to reset it, if needed)

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
