### PR TITLE
fix(messagesStore): harden check for lastMessage

### DIFF
--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -1217,7 +1217,7 @@ const actions = {
 			// New message should be appended to the most recent block without gaps
 			const chatStore = useChatStore()
 			const conversation = context.rootGetters.conversation(token)
-			const conversationLastMessageId = (conversation && 'id' in conversation.lastMessage)
+			const conversationLastMessageId = (conversation?.lastMessage && 'id' in conversation.lastMessage)
 				? conversation.lastMessage.id
 				: chatStore.getLastKnownId(token, { threadId: temporaryMessage.threadId })
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix error
<img width="722" height="56" alt="image" src="https://github.com/user-attachments/assets/f24cd29e-08fc-4096-92bb-7c15c70dbaed" />


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts


### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required