### PR TITLE
fix(call): apply selected device state after closing dialog in call

### DIFF
--- a/src/components/CallView/shared/LocalAudioControlButton.vue
+++ b/src/components/CallView/shared/LocalAudioControlButton.vue
@@ -77,7 +77,7 @@
 </template>
 
 <script>
-import { emit, subscribe, unsubscribe } from '@nextcloud/event-bus'
+import { emit } from '@nextcloud/event-bus'
 import { t } from '@nextcloud/l10n'
 import { useHotKey } from '@nextcloud/vue/composables/useHotKey'
 import { onBeforeUnmount, ref, watch } from 'vue'
@@ -91,7 +91,6 @@ import IconChevronUp from 'vue-material-design-icons/ChevronUp.vue'
 import VolumeIndicator from '../../UIShared/VolumeIndicator.vue'
 import { useDevices } from '../../../composables/useDevices.js'
 import { PARTICIPANT } from '../../../constants.ts'
-import BrowserStorage from '../../../services/BrowserStorage.js'
 import SpeakingWhileMutedWarner from '../../../utils/webrtc/SpeakingWhileMutedWarner.js'
 
 export default {
@@ -259,14 +258,6 @@ export default {
 		useHotKey(' ', this.toggleAudio, { push: true })
 	},
 
-	mounted() {
-		subscribe('local-audio-control-button:toggle-audio', this.updateDeviceState)
-	},
-
-	beforeUnmount() {
-		unsubscribe('local-audio-control-button:toggle-audio', this.updateDeviceState)
-	},
-
 	methods: {
 		t,
 		toggleAudio() {
@@ -276,14 +267,6 @@ export default {
 			}
 
 			if (this.model.attributes.audioEnabled) {
-				this.model.disableAudio()
-			} else {
-				this.model.enableAudio()
-			}
-		},
-
-		updateDeviceState() {
-			if (BrowserStorage.getItem('audioDisabled_' + this.token) === 'true') {
 				this.model.disableAudio()
 			} else {
 				this.model.enableAudio()

--- a/src/components/CallView/shared/LocalVideoControlButton.vue
+++ b/src/components/CallView/shared/LocalVideoControlButton.vue
@@ -45,7 +45,7 @@
 </template>
 
 <script>
-import { emit, subscribe, unsubscribe } from '@nextcloud/event-bus'
+import { emit } from '@nextcloud/event-bus'
 import { t } from '@nextcloud/l10n'
 import { useHotKey } from '@nextcloud/vue/composables/useHotKey'
 import NcActionButton from '@nextcloud/vue/components/NcActionButton'
@@ -57,7 +57,6 @@ import IconVideo from 'vue-material-design-icons/Video.vue' // Filled for better
 import IconVideoOffOutline from 'vue-material-design-icons/VideoOffOutline.vue'
 import { useDevices } from '../../../composables/useDevices.js'
 import { PARTICIPANT } from '../../../constants.ts'
-import BrowserStorage from '../../../services/BrowserStorage.js'
 
 export default {
 	name: 'LocalVideoControlButton',
@@ -183,14 +182,6 @@ export default {
 		useHotKey('v', this.toggleVideo)
 	},
 
-	mounted() {
-		subscribe('local-video-control-button:toggle-video', this.updateDeviceState)
-	},
-
-	beforeUnmount() {
-		unsubscribe('local-video-control-button:toggle-video', this.updateDeviceState)
-	},
-
 	methods: {
 		t,
 		toggleVideo() {
@@ -200,14 +191,6 @@ export default {
 			}
 
 			if (this.model.attributes.videoEnabled) {
-				this.model.disableVideo()
-			} else {
-				this.model.enableVideo()
-			}
-		},
-
-		updateDeviceState() {
-			if (BrowserStorage.getItem('videoDisabled_' + this.token)) {
 				this.model.disableVideo()
 			} else {
 				this.model.enableVideo()

--- a/src/components/MediaSettings/MediaSettings.vue
+++ b/src/components/MediaSettings/MediaSettings.vue
@@ -381,7 +381,6 @@ export default {
 			audioStreamError,
 			videoStreamError,
 			virtualBackground,
-			model: localMediaModel,
 			tabs,
 			dialogHeaderId,
 			supportStartWithoutMedia,
@@ -731,7 +730,7 @@ export default {
 				BrowserStorage.setItem('audioDisabled_' + this.token, 'true')
 				this.audioOn = false
 			}
-			this.audioDeviceStateChanged = !this.audioDeviceStateChanged
+			this.audioDeviceStateChanged = true
 		},
 
 		toggleVideo() {
@@ -742,7 +741,7 @@ export default {
 				BrowserStorage.setItem('videoDisabled_' + this.token, 'true')
 				this.videoOn = false
 			}
-			this.videoDeviceStateChanged = !this.videoDeviceStateChanged
+			this.videoDeviceStateChanged = true
 		},
 
 		setNotifyCall(value) {
@@ -757,11 +756,21 @@ export default {
 			if (this.updatedBackground) {
 				this.handleUpdateBackground(this.updatedBackground)
 			}
-			if (this.audioDeviceStateChanged) {
-				emit('local-audio-control-button:toggle-audio')
+
+			if (this.audioDeviceStateChanged && this.isInCall) {
+				if (this.audioOn) {
+					localMediaModel.enableAudio()
+				} else {
+					localMediaModel.disableAudio()
+				}
 			}
-			if (this.videoDeviceStateChanged) {
-				emit('local-video-control-button:toggle-video')
+
+			if (this.videoDeviceStateChanged && this.isInCall) {
+				if (this.videoOn) {
+					localMediaModel.enableVideo()
+				} else {
+					localMediaModel.disableVideo()
+				}
 			}
 
 			this.close()
@@ -874,6 +883,7 @@ export default {
 
 		handleAudioInputIdChange(audioInputId) {
 			this.audioInputId = audioInputId
+			this.audioDeviceStateChanged = true
 			this.updatePreferences('audioinput')
 		},
 
@@ -884,6 +894,7 @@ export default {
 
 		handleVideoInputIdChange(videoInputId) {
 			this.videoInputId = videoInputId
+			this.videoDeviceStateChanged = true
 			this.updatePreferences('videoinput')
 		},
 


### PR DESCRIPTION
### ☑️ Resolves

* Extracted from #15680
* Fix device state after closing 'Check devices' dialog:
  * with input id change, device is muted and toggled outside of component
  * instead of toggle methods in buttons, directly change state in the model after close

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts


### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
