### PR TITLE
Use new lighter taskProcessingManager::getAvailableTaskTypeIds method

### DIFF
--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -352,11 +352,11 @@ class Capabilities implements IPublicCapability {
 			$capabilities['config']['call']['can-enable-sip'] = $this->talkConfig->canUserEnableSIP($user);
 		}
 
-		$supportedTaskTypes = $this->taskProcessingManager->getAvailableTaskTypes();
-		if (isset($supportedTaskTypes[TextToTextSummary::ID])) {
+		$supportedTaskTypeIds = $this->taskProcessingManager->getAvailableTaskTypeIds();
+		if (in_array(TextToTextSummary::ID, $supportedTaskTypeIds, true)) {
 			$capabilities['features'][] = 'chat-summary-api';
 		}
-		if (isset($supportedTaskTypes[TextToTextTranslate::ID])) {
+		if (in_array(TextToTextTranslate::ID, $supportedTaskTypeIds, true)) {
 			$capabilities['config']['chat']['has-translation-task-providers'] = true;
 		}
 

--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -556,8 +556,8 @@ class ChatController extends AEnvironmentAwareOCSController {
 	): DataResponse {
 		$fromMessageId = max(0, $fromMessageId);
 
-		$supportedTaskTypes = $this->taskProcessingManager->getAvailableTaskTypes();
-		if (!isset($supportedTaskTypes[TextToTextSummary::ID])) {
+		$supportedTaskTypeIds = $this->taskProcessingManager->getAvailableTaskTypeIds();
+		if (!in_array(TextToTextSummary::ID, $supportedTaskTypeIds, true)) {
 			return new DataResponse([
 				'error' => ChatSummaryException::REASON_AI_ERROR,
 			], Http::STATUS_BAD_REQUEST);

--- a/lib/Service/RecordingService.php
+++ b/lib/Service/RecordingService.php
@@ -157,8 +157,8 @@ class RecordingService {
 			return;
 		}
 
-		$supportedTaskTypes = $this->taskProcessingManager->getAvailableTaskTypes();
-		if (!isset($supportedTaskTypes[AudioToText::ID])) {
+		$supportedTaskTypeIds = $this->taskProcessingManager->getAvailableTaskTypeIds();
+		if (!in_array(AudioToText::ID, $supportedTaskTypeIds, true)) {
 			$this->logger->error('Can not transcribe call recording as no Audio2Text task provider is available');
 			return;
 		}
@@ -258,8 +258,8 @@ class RecordingService {
 			return;
 		}
 
-		$supportedTaskTypes = $this->taskProcessingManager->getAvailableTaskTypes();
-		if (!isset($supportedTaskTypes[TextToTextSummary::ID])) {
+		$supportedTaskTypeIds = $this->taskProcessingManager->getAvailableTaskTypeIds();
+		if (!in_array(TextToTextSummary::ID, $supportedTaskTypeIds, true)) {
 			$this->logger->error('Can not summarize call recording as no TextToTextSummary task provider is available');
 			return;
 		}

--- a/tests/php/CapabilitiesTest.php
+++ b/tests/php/CapabilitiesTest.php
@@ -263,8 +263,8 @@ class CapabilitiesTest extends TestCase {
 		$user->method('getQuota')
 			->willReturn($quota);
 
-		$this->taskProcessingManager->method('getAvailableTaskTypes')
-			->willReturn([TextToTextSummary::ID => true]);
+		$this->taskProcessingManager->method('getAvailableTaskTypeIds')
+			->willReturn([TextToTextSummary::ID]);
 
 		$this->serverConfig->expects($this->any())
 			->method('getAppValue')
@@ -509,8 +509,8 @@ class CapabilitiesTest extends TestCase {
 	public function testCapabilitiesTranslationsTaskProviders(): void {
 		$capabilities = $this->getCapabilities();
 
-		$this->taskProcessingManager->method('getAvailableTaskTypes')
-			->willReturn([TextToTextTranslate::ID => true]);
+		$this->taskProcessingManager->method('getAvailableTaskTypeIds')
+			->willReturn([TextToTextTranslate::ID]);
 
 		$data = json_decode(json_encode($capabilities->getCapabilities(), JSON_THROW_ON_ERROR), true);
 		$this->assertEquals(true, $data['spreed']['config']['chat']['has-translation-task-providers']);
@@ -519,8 +519,8 @@ class CapabilitiesTest extends TestCase {
 	public function testSummaryTaskProviders(): void {
 		$capabilities = $this->getCapabilities();
 
-		$this->taskProcessingManager->method('getAvailableTaskTypes')
-			->willReturn([TextToTextFormalization::ID => true]);
+		$this->taskProcessingManager->method('getAvailableTaskTypeIds')
+			->willReturn([TextToTextFormalization::ID]);
 
 		$data = json_decode(json_encode($capabilities->getCapabilities(), JSON_THROW_ON_ERROR), true);
 		$this->assertNotContains('chat-summary-api', $data['spreed']['features']);


### PR DESCRIPTION
Use new lighter `taskProcessingManager::getAvailableTaskTypeIds()` method to check which feature is available.

When calling `taskProcessingManager::getAvailableTaskTypes()` the manager gets a full description of the task type. This description includes some data that is provided by the preferred provider for the task type like the default values and the multiselect values. Those values are cached but when there is no cache hit (task processing cache and provider-specific cache, some of them are obtained with a network request (like the model list in integration_openai). So if one just needs to know the list of available task types without any extra detail, one can now use `taskProcessingManager::getAvailableTaskTypeIds()` which returns a list of strings and does not get any extra info from the providers.

This method is fairly recent so it's not included yet in nextcloud/ocp. Should we adjust the psalm baseline or wait until nextcloud/ocp is up-to-date? Or even ignore the psalm failure?

This can be backported to stable32 as the new method is there. See https://github.com/nextcloud/server/pull/54917 and https://github.com/nextcloud/documentation/pull/13608

### ☑️ Resolves

* Slow capabilities computation

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required


