### PR TITLE
fix: Don't transfer sample rooms

### DIFF
--- a/lib/Command/User/TransferOwnership.php
+++ b/lib/Command/User/TransferOwnership.php
@@ -85,6 +85,11 @@ class TransferOwnership extends Base {
 				continue;
 			}
 
+			if ($room->getObjectType() === Room::OBJECT_TYPE_SAMPLE) {
+				// Skip sample rooms
+				continue;
+			}
+
 			if ($room->isFederatedConversation()) {
 				$federatedRooms++;
 				continue;


### PR DESCRIPTION
## 🛠️ API Checklist

I noticed that `occ talk:user:transfer-ownership` also transfers sample rooms. We should not do that. At the same time, I wonder if other types should also be excluded here?!

Regarding tests, not really sure how to create a sample room easily, as we block it on api level and we currently don't have tests for that.

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x]  🔖 Capability is added or not needed 
