### PR TITLE
style(ReactionMenu): fix reactions to be shown in 2 lines

### DIFF
--- a/src/components/TopBar/ReactionMenu.vue
+++ b/src/components/TopBar/ReactionMenu.vue
@@ -117,10 +117,11 @@ export default {
 <style lang="scss" scoped>
 .reaction {
 	&__group {
+		// Override NcActionButtonGroup styles to fit reactions in a compact way
 		:deep(.nc-button-group-content) {
 			flex-wrap: wrap;
 			justify-content: flex-start;
-			gap: 0;
+			gap: 0 !important;
 			width: calc(var(--reactions-in-single-row) * var(--default-clickable-area))
 		}
 	}


### PR DESCRIPTION
### ☑️ Resolves

* Fix overriden changes from upstream (for NcActionButtonGroup)

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="162" height="109" alt="2025-09-09_12h10_46" src="https://github.com/user-attachments/assets/a980bc98-d5b8-4d5f-b653-6b543a7e8292" /> | <img width="171" height="90" alt="2025-09-09_12h10_38" src="https://github.com/user-attachments/assets/6966adbe-64c8-4e4d-8e03-29e6df1a8bba" />

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required