### PR TITLE
fix: Remove unread messages notification

### DIFF
--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -427,17 +427,6 @@ export default {
 			},
 		},
 
-		unreadMessagesCounter(newValue, oldValue) {
-			if (!this.isInCall || this.opened) {
-				return
-			}
-
-			// new messages arrived
-			if (newValue > 0 && oldValue === 0 && !this.hasUnreadMentions) {
-				this.notifyUnreadMessages(t('spreed', 'You have new unread messages in the chat.'))
-			}
-		},
-
 		hasUnreadMentions(newValue) {
 			if (!this.isInCall || this.opened) {
 				return


### PR DESCRIPTION
This is unnecessarily spamming the view when the chat tab is closed. Also, this is kind of a redundant with the blue dot on the message icon.

B | A
-- | --
<img width="293" height="59" alt="image" src="https://github.com/user-attachments/assets/49bf170e-f3bb-4e70-9c7c-9b4fdb0d32f1" /> | <img width="392" height="54" alt="2025-09-09_16h46_25" src="https://github.com/user-attachments/assets/eab88579-787b-46ab-8236-9833847d7892" />

