### PR TITLE
fix(MediaDevicesManager): update devices list in UI

### DIFF
--- a/src/utils/webrtc/MediaDevicesManager.js
+++ b/src/utils/webrtc/MediaDevicesManager.js
@@ -360,7 +360,7 @@ MediaDevicesManager.prototype = {
 	_removeDevice(removedDevice) {
 		const removedDeviceIndex = this.attributes.devices.findIndex((oldDevice) => oldDevice.deviceId === removedDevice.deviceId && oldDevice.kind === removedDevice.kind)
 		if (removedDeviceIndex >= 0) {
-			this.attributes.devices.splice(removedDeviceIndex, 1)
+			this.attributes.devices = this.attributes.devices.splice(removedDeviceIndex, 1)
 		}
 		if (removedDevice.kind === 'audioinput' && removedDevice.deviceId === this.attributes.audioInputId) {
 			this.attributes.audioInputId = undefined
@@ -417,7 +417,7 @@ MediaDevicesManager.prototype = {
 
 		// Always refresh the known device with the latest values.
 		this._knownDevices[addedDevice.kind + '-' + addedDevice.deviceId] = addedDevice
-		this.attributes.devices.push(addedDevice)
+		this.attributes.devices = [...this.attributes.devices, addedDevice]
 	},
 
 	/**


### PR DESCRIPTION
### ☑️ Resolves

* Fix reactivity in devices update
  * attributes.devices gets new values, but subscribed components do not receive it
  * stable31 (Vue 2) is fine
* Ref #12366


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏡 After

https://github.com/user-attachments/assets/17befd06-5bb4-4e61-8b55-15e108c2cc23

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] ⛑️ Tests are included or not possible