### PR TITLE
[stable32] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -311,12 +311,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "fc0f7a56ddd9a6278f2aa5a4c3c050d6f70928db"
+                "reference": "5f0db0fc0e5f09a4c8ac06ebc5dedefd21d53603"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/fc0f7a56ddd9a6278f2aa5a4c3c050d6f70928db",
-                "reference": "fc0f7a56ddd9a6278f2aa5a4c3c050d6f70928db",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/5f0db0fc0e5f09a4c8ac06ebc5dedefd21d53603",
+                "reference": "5f0db0fc0e5f09a4c8ac06ebc5dedefd21d53603",
                 "shasum": ""
             },
             "require": {
@@ -351,7 +351,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable32"
             },
-            "time": "2025-09-06T00:45:35+00:00"
+            "time": "2025-09-10T00:46:52+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency