### PR TITLE
fix(NewMessageNewFileDialog): validate filename before creating

### DIFF
--- a/src/components/NewMessage/NewMessageNewFileDialog.vue
+++ b/src/components/NewMessage/NewMessageNewFileDialog.vue
@@ -42,7 +42,7 @@
 		<template #actions>
 			<NcButton
 				variant="primary"
-				:disabled="loading"
+				:disabled="loading || !!newFileError"
 				@click="handleCreateNewFile">
 				<template v-if="loading" #icon>
 					<NcLoadingIcon />
@@ -55,6 +55,7 @@
 
 <script>
 import { showError } from '@nextcloud/dialogs'
+import { validateFilename } from '@nextcloud/files'
 import { t } from '@nextcloud/l10n'
 import NcButton from '@nextcloud/vue/components/NcButton'
 import NcDialog from '@nextcloud/vue/components/NcDialog'
@@ -62,7 +63,7 @@ import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
 import NcTextField from '@nextcloud/vue/components/NcTextField'
 import NewMessageTemplatePreview from './NewMessageTemplatePreview.vue'
 import { useViewer } from '../../composables/useViewer.js'
-import { createNewFile, shareFile } from '../../services/filesSharingServices.ts'
+import { createNewFile } from '../../services/filesSharingServices.ts'
 
 export default {
 	name: 'NewMessageNewFileDialog',
@@ -157,6 +158,16 @@ export default {
 			handler(value) {
 				this.newFileTitle = value.label + value.extension
 			},
+		},
+
+		newFileTitle(value) {
+			try {
+				validateFilename(value)
+				this.newFileError = ''
+			} catch (e) {
+				console.error(e)
+				this.newFileError = e.message
+			}
 		},
 
 		selectedTemplate: {

--- a/src/test-setup.js
+++ b/src/test-setup.js
@@ -26,6 +26,10 @@ vi.mock('@nextcloud/dialogs', () => ({
 	TOAST_PERMANENT_TIMEOUT: -1,
 }))
 
+vi.mock('@nextcloud/files', () => ({
+	validateFileName: vi.fn(),
+}))
+
 vi.mock('@nextcloud/files/dav', () => ({
 	defaultRemoteURL: () => 'https://nextcloud.local/remote.php/dav',
 }))


### PR DESCRIPTION
### ☑️ Resolves

* Prevent sending an invalid name suggsetion to the server


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

<img width="376" height="122" alt="2025-09-15_12h25_52" src="https://github.com/user-attachments/assets/a82f74f2-8b11-43be-8785-cb1187a73077" />
<img width="371" height="150" alt="2025-09-15_12h26_08" src="https://github.com/user-attachments/assets/a1f0bf08-2a50-4138-a75c-cbdea97036c9" />

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required