### PR TITLE
fix(CalendarEventsDialog): adjust start/end dates to their counterparts

### DIFF
--- a/src/components/CalendarEventsDialog.vue
+++ b/src/components/CalendarEventsDialog.vue
@@ -11,6 +11,7 @@ import { n, t } from '@nextcloud/l10n'
 import moment from '@nextcloud/moment'
 import { useIsMobile } from '@nextcloud/vue/composables/useIsMobile'
 import { usernameToColor } from '@nextcloud/vue/functions/usernameToColor'
+import debounce from 'debounce'
 import { computed, onBeforeMount, provide, ref, watch } from 'vue'
 import { useStore } from 'vuex'
 import NcButton from '@nextcloud/vue/components/NcButton'
@@ -36,7 +37,7 @@ import TransitionWrapper from './UIShared/TransitionWrapper.vue'
 import { ATTENDEE, CONVERSATION } from '../constants.ts'
 import { hasTalkFeature } from '../services/CapabilitiesManager.ts'
 import { useGroupwareStore } from '../stores/groupware.ts'
-import { convertToUnix } from '../utils/formattedTime.ts'
+import { convertToUnix, ONE_HOUR_IN_MS } from '../utils/formattedTime.ts'
 import { getDisplayNameWithFallback } from '../utils/getDisplayName.ts'
 
 const props = defineProps<{
@@ -197,6 +198,8 @@ const inviteLabel = computed(() => {
 		: t('spreed', 'Invite all users and emails in this conversation')
 })
 
+const debounceAdjustCurrentTimeRange = debounce(adjustCurrentTimeRange, 500)
+
 onBeforeMount(() => {
 	getCalendars()
 })
@@ -227,6 +230,27 @@ watch(participants, (value) => {
 		selectedAttendeeIds.value = value.map((participant: Participant) => participant.attendeeId)
 	}
 })
+
+watch(selectedDateTimeStart, () => debounceAdjustCurrentTimeRange('end'))
+watch(selectedDateTimeEnd, () => debounceAdjustCurrentTimeRange('start'))
+
+/**
+ * Autocorrect end date, if start date is after end date (or vice versa)
+ *
+ * @param direction counterpart to be adjusted
+ */
+function adjustCurrentTimeRange(direction: 'start' | 'end') {
+	if (selectedDateTimeStart.value < selectedDateTimeEnd.value) {
+		// All good, no adjustment needed
+		return
+	} else if (direction === 'end') {
+		// Keep the end time 1 hour ahead
+		selectedDateTimeEnd.value = new Date(selectedDateTimeStart.value.getTime() + ONE_HOUR_IN_MS)
+	} else {
+		// Keep the start time 1 hour behind
+		selectedDateTimeStart.value = new Date(selectedDateTimeEnd.value.getTime() - ONE_HOUR_IN_MS)
+	}
+}
 
 /**
  * Returns Date object with N hours from now at the start of hour


### PR DESCRIPTION
### ☑️ Resolves

* Fix inconsistent datetime for meeting shortcut in Talk (start date larger than end date, second is not adjusted)
* Default interval in 1 hour is maintained
* Debounce included for small input lag (e.g. user wanted to enter '12', and not '1')


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏡 After

https://github.com/user-attachments/assets/21b34d0c-7abd-4e10-a794-ebc6b9555299

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
