### PR TITLE
fix: support call bottom bar squeezing on small screens

### DIFF
--- a/src/components/TopBar/CallButton.vue
+++ b/src/components/TopBar/CallButton.vue
@@ -57,7 +57,7 @@
 		v-else-if="showLeaveCallButton && (canEndForAll || isBreakoutRoom)"
 		class="leave-call leave-call-actions--split"
 		:disabled="loading"
-		force-name
+		:force-name="showButtonText"
 		placement="top-end"
 		:aria-label="leaveCallActionsLabel"
 		:inline="1"
@@ -67,20 +67,26 @@
 		</template>
 		<NcActionButton
 			v-if="isBreakoutRoom"
+			:aria-label="backToMainRoomLabel"
 			@click="switchToParentRoom">
 			<template #icon>
 				<IconArrowLeft class="bidirectional-icon" :size="20" />
 			</template>
-			{{ backToMainRoomLabel }}
+			<template v-if="showButtonText" #default>
+				{{ backToMainRoomLabel }}
+			</template>
 		</NcActionButton>
 		<NcActionButton
 			class="leave-call-button--split"
+			:aria-label="leaveCallLabel"
 			@click="leaveCall(false)">
 			<template #icon>
 				<NcLoadingIcon v-if="loading" :size="20" />
 				<IconPhoneHangupOutline v-else :size="20" />
 			</template>
-			{{ leaveCallLabel }}
+			<template v-if="showButtonText || isBreakoutRoom" #default>
+				{{ leaveCallLabel }}
+			</template>
 		</NcActionButton>
 		<NcActionButton v-if="canEndForAll" @click="leaveCall(true)">
 			<template #icon>

--- a/src/components/TopBar/TopBarMediaControls.vue
+++ b/src/components/TopBar/TopBarMediaControls.vue
@@ -62,6 +62,7 @@
 			variant="tertiary" />
 
 		<NcButton
+			v-if="!hideVirtualBackgroundShortcut"
 			:aria-label="t('spreed', 'Select virtual background')"
 			:title="t('spreed', 'Select virtual background')"
 			variant="tertiary"
@@ -171,6 +172,11 @@ export default {
 		},
 
 		isSidebar: {
+			type: Boolean,
+			default: false,
+		},
+
+		hideVirtualBackgroundShortcut: {
 			type: Boolean,
 			default: false,
 		},


### PR DESCRIPTION
### ☑️ Resolves

* Fix bottom bar exceeding call view when the screen is small

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
Screenshot before | <img width="485"  alt="image" src="https://github.com/user-attachments/assets/d9f1f5e7-a741-413b-9000-31a338441554" />


<!-- ☀️ Light theme | 🌑 Dark Theme -->

### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
