### PR TITLE
fix(threads): Count shared files as thread replies and last message

### DIFF
--- a/lib/Chat/SystemMessage/Listener.php
+++ b/lib/Chat/SystemMessage/Listener.php
@@ -424,9 +424,10 @@ class Listener implements IEventListener {
 			replyTo: $replyTo,
 			threadId: $threadId,
 		);
+		$messageId = (int)$comment->getId();
 
 		if ($threadTitle !== '' && $comment->getTopmostParentId() === '0') {
-			$thread = $this->threadService->createThread($room, (int)$comment->getId(), $threadTitle);
+			$thread = $this->threadService->createThread($room, $messageId, $threadTitle);
 			try {
 				// Add to subscribed threads list
 				$participant = $this->participantService->getParticipant($room, $this->getUserId());
@@ -437,11 +438,24 @@ class Listener implements IEventListener {
 			$this->sendSystemMessage(
 				$room,
 				'thread_created',
-				['thread' => (int)$comment->getId(), 'title' => $thread->getName()],
+				['thread' => $messageId, 'title' => $thread->getName()],
 				shouldSkipLastMessageUpdate: true,
 				silent: true,
 				parent: $comment,
 			);
+		} else {
+			$threadId = (int)$comment->getTopmostParentId();
+			if ($threadId !== 0) {
+				$isThread = $this->threadService->updateLastMessageInfoAfterReply($threadId, $messageId);
+				if ($isThread) {
+					try {
+						// Add to subscribed threads list
+						$participant = $this->participantService->getParticipant($room, $this->getUserId());
+						$this->threadService->ensureIsThreadAttendee($participant->getAttendee(), $threadId);
+					} catch (ParticipantNotFoundException) {
+					}
+				}
+			}
 		}
 	}
 

--- a/lib/Service/ThreadService.php
+++ b/lib/Service/ThreadService.php
@@ -207,7 +207,7 @@ class ThreadService {
 		$query->executeStatement();
 	}
 
-	public function updateLastMessageInfoAfterReply(int $threadId, int $lastMessageId): void {
+	public function updateLastMessageInfoAfterReply(int $threadId, int $lastMessageId): bool {
 		$dateTime = $this->timeFactory->getDateTime();
 
 		$query = $this->connection->getQueryBuilder();
@@ -216,7 +216,7 @@ class ThreadService {
 			->set('last_message_id', $query->createNamedParameter($lastMessageId))
 			->set('last_activity', $query->createNamedParameter($dateTime, IQueryBuilder::PARAM_DATETIME_MUTABLE))
 			->where($query->expr()->eq('id', $query->createNamedParameter($threadId)));
-		$query->executeStatement();
+		return (bool)$query->executeStatement();
 	}
 
 	public function deleteByRoom(Room $room): void {

--- a/tests/integration/features/bootstrap/SharingContext.php
+++ b/tests/integration/features/bootstrap/SharingContext.php
@@ -615,7 +615,7 @@ class SharingContext implements Context {
 				if ($key === 'expireDate' && $value !== 'invalid date') {
 					$value = date('Y-m-d', strtotime($value));
 				}
-				if ($key === 'talkMetaData.replyTo') {
+				if ($key === 'talkMetaData.replyTo' || $key === 'talkMetaData.threadId') {
 					$value = FeatureContext::getMessageIdForText($value);
 				}
 				if (str_starts_with($key, 'talkMetaData.')) {

--- a/tests/integration/features/chat-4/threads.feature
+++ b/tests/integration/features/chat-4/threads.feature
@@ -195,3 +195,48 @@ Feature: chat-4/threads
     Then user "participant1" sees 1 number of subscribed threads with 1 offset
       | t.id      | t.token | t.title  | t.numReplies | t.lastMessage | a.notificationLevel | firstMessage | lastMessage |
       | Message 1 | room1   | Thread 1 | 1            | Message 1-1   | 0                   | Message 1    | Message 1-1 |
+
+  Scenario: Reply with an attachment
+    Given user "participant1" creates room "room1" (v4)
+      | roomType | 2 |
+      | roomName | room1 |
+    And user "participant1" adds user "participant2" to room "room1" with 200 (v4)
+    And user "participant1" sends thread "Thread 1" with message "Message 1" to room "room1" with 201
+    When user "participant2" shares "welcome.txt" with room "room1"
+      | talkMetaData.caption      | Message 2 |
+      | talkMetaData.replyTo      | Message 1 |
+    Then user "participant1" sees the following messages in room "room1" with 200
+      | room  | actorType | actorId      | actorDisplayName         | message   | messageParameters | parentMessage |
+      | room1 | users     | participant2 | participant2-displayname | Message 2 | "IGNORE"          | Message 1     |
+      | room1 | users     | participant1 | participant1-displayname | Message 1 | []                |               |
+    Then user "participant1" sees the following recent threads in room "room1" with 200
+      | t.id      | t.token | t.title  | t.numReplies | t.lastMessage | a.notificationLevel | firstMessage | lastMessage |
+      | Message 1 | room1   | Thread 1 | 1            | Message 2     | 0                   | Message 1    | Message 2   |
+    And user "participant1" has the following notifications
+      | app    | object_type | object_id       | subject                                                                |
+      | spreed | chat        | room1/Message 2 | participant2-displayname replied to your message in conversation room1 |
+    Then user "participant2" sees the following subscribed threads
+      | t.id      | t.token | t.title  | t.numReplies | t.lastMessage | a.notificationLevel | firstMessage | lastMessage |
+      | Message 1 | room1   | Thread 1 | 1            | Message 2     | 0                   | Message 1    | Message 2   |
+
+  Scenario: Post a message with an attachment (not replying)
+    Given user "participant1" creates room "room1" (v4)
+      | roomType | 2 |
+      | roomName | room1 |
+    And user "participant1" adds user "participant2" to room "room1" with 200 (v4)
+    And user "participant1" sends thread "Thread 1" with message "Message 1" to room "room1" with 201
+    When user "participant2" shares "welcome.txt" with room "room1"
+      | talkMetaData.caption      | Message 2 |
+      | talkMetaData.threadId     | Message 1 |
+    Then user "participant1" sees the following messages in room "room1" with 200
+      | room  | actorType | actorId      | actorDisplayName         | message   | messageParameters | parentMessage |
+      | room1 | users     | participant2 | participant2-displayname | Message 2 | "IGNORE"          | Message 1     |
+      | room1 | users     | participant1 | participant1-displayname | Message 1 | []                |               |
+    Then user "participant1" sees the following recent threads in room "room1" with 200
+      | t.id      | t.token | t.title  | t.numReplies | t.lastMessage | a.notificationLevel | firstMessage | lastMessage |
+      | Message 1 | room1   | Thread 1 | 1            | Message 2     | 0                   | Message 1    | Message 2   |
+    And user "participant1" has the following notifications
+      | app | object_type | object_id | subject |
+    Then user "participant2" sees the following subscribed threads
+      | t.id      | t.token | t.title  | t.numReplies | t.lastMessage | a.notificationLevel | firstMessage | lastMessage |
+      | Message 1 | room1   | Thread 1 | 1            | Message 2     | 0                   | Message 1    | Message 2   |


### PR DESCRIPTION
## 🛠️ API Checklist
- [x] Make sure shared files count as replies and update the threads last message

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
