### PR TITLE
fix(LeftSidebar): allow to search for strings with diacritics

### DIFF
--- a/src/components/LeftSidebar/SearchConversationsResults/SearchConversationsResults.vue
+++ b/src/components/LeftSidebar/SearchConversationsResults/SearchConversationsResults.vue
@@ -75,9 +75,12 @@ const searchResultsVirtual = computed(() => {
 	// Initialize
 	const virtualList = []
 
-	const lowerSearchText = props.searchText.toLowerCase()
-	const searchResultsConversationList = props.conversationsList.filter((conversation) => conversation.displayName.toLowerCase().includes(lowerSearchText)
-		|| conversation.name.toLowerCase().includes(lowerSearchText))
+	// Normalize strings for search (remove diacritics and case, e.g. 'Jérôme' -> 'jerome')
+	const normalizer = (rawString: string) => rawString.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '')
+
+	const lowerSearchText = normalizer(props.searchText)
+	const searchResultsConversationList = props.conversationsList.filter((conversation) => normalizer(conversation.displayName).includes(lowerSearchText)
+		|| normalizer(conversation.name).includes(lowerSearchText))
 
 	// Add conversations section
 	virtualList.push({ type: 'caption', id: 'conversations_caption', name: t('spreed', 'Conversations') })


### PR DESCRIPTION
### ☑️ Resolves

* Fix #15890


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
Screenshot before | <img width="280" height="221" alt="image" src="https://github.com/user-attachments/assets/cb9d75be-6c6e-4c00-8c7a-c83f483c9b95" />

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required