### PR TITLE
style(TopBar): set fixed width for digit characters

### DIFF
--- a/src/components/TopBar/CallTime.vue
+++ b/src/components/TopBar/CallTime.vue
@@ -242,6 +242,8 @@ export default {
 		display: flex;
 		flex-direction: column;
 		align-items: center;
+		// Align characters width for any font
+		font-variant-numeric: tabular-nums;
 	}
 
 	&__placeholder {

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -95,6 +95,7 @@
 				v-if="isInCall && isModeratorOrUser"
 				:title="participantsInCallAriaLabel"
 				:aria-label="participantsInCallAriaLabel"
+				class="top-bar__participants-button"
 				variant="tertiary"
 				@click="openSidebar('participants')">
 				<template #icon>
@@ -417,6 +418,11 @@ export default {
 		top: 0;
 		inset-inline-start: 0;
 	}
+}
+
+.top-bar__participants-button {
+	// Align characters width for any font
+	font-variant-numeric: tabular-nums;
 }
 
 .conversation-header {


### PR DESCRIPTION
### ☑️ Resolves

* Fix 'components with digits' width for any font (should be reproducible with Inter)


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
Should be worse | Should be better

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required