### PR TITLE
fix(sounds): do not pause playing audio on speaker change

### DIFF
--- a/src/composables/useDevices.js
+++ b/src/composables/useDevices.js
@@ -200,7 +200,7 @@ export const useDevices = createSharedComposable(function() {
 		updateAudioStream()
 		updateVideoStream()
 
-		if (mediaDevicesManager.attributes.audioOutputId !== undefined) {
+		if (mediaDevicesManager.attributes.audioOutputId !== soundsStore.audioOutputDeviceId) {
 			soundsStore.setGeneralAudioOutput(mediaDevicesManager.attributes.audioOutputId)
 		}
 	}

--- a/src/stores/sounds.js
+++ b/src/stores/sounds.js
@@ -38,6 +38,7 @@ export const useSoundsStore = defineStore('sounds', {
 			leave: null,
 			wait: null,
 		},
+		audioOutputDeviceId: undefined,
 	}),
 
 	actions: {
@@ -123,6 +124,7 @@ export const useSoundsStore = defineStore('sounds', {
 			} catch (error) {
 				console.error(error)
 			}
+			this.audioOutputDeviceId = deviceId
 		},
 	},
 })


### PR DESCRIPTION
### ☑️ Resolves

- Fix sound stop when joining call
  - output is already set at the device checker, no need to set it again
- Might still sound abruptly, but it is not actually needed
- Proper A-B fix would be to separate useDevices

## 🖌️ UI Checklist

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [x] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
