### PR TITLE
fix(chat): attach actual parent message to file uploads

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
@@ -225,10 +225,10 @@ export default {
 
 		// This is used to decide which outer element type to use
 		filePreviewElement() {
-			if (this.isUploadEditor || this.isTemporaryUpload) {
-				return 'div'
-			} else if (this.isVoiceMessage && !this.isSharedItems) {
+			if (this.isVoiceMessage && !this.isSharedItems) {
 				return AudioPlayer
+			} else if (this.isUploadEditor || this.isTemporaryUpload) {
+				return 'div'
 			}
 			return 'a'
 		},

--- a/src/components/NewMessage/NewMessageUploadEditor.vue
+++ b/src/components/NewMessage/NewMessageUploadEditor.vue
@@ -211,6 +211,7 @@ export default {
 						threadId: temporaryMessage.threadId,
 						threadTitle: temporaryMessage.threadTitle,
 						silent: temporaryMessage.silent,
+						parent: temporaryMessage.parent,
 					},
 				})
 			} else {

--- a/src/store/fileUploadStore.js
+++ b/src/store/fileUploadStore.js
@@ -316,6 +316,7 @@ const actions = {
 			// Store the previously created temporary message
 			const message = {
 				...uploadedFile.temporaryMessage,
+				parent: options?.parent ? options.parent : uploadedFile.temporaryMessage.parent,
 				message: index === lastIndex && caption ? caption : '{file}',
 			}
 			// Add temporary messages (files) to the messages list
@@ -456,7 +457,7 @@ const actions = {
 				continue
 			}
 			const [index, shareableFile] = share
-			const { id, messageType, parent, referenceId } = shareableFile.temporaryMessage || {}
+			const { id, messageType, referenceId } = shareableFile.temporaryMessage || {}
 
 			const talkMetaData = JSON.stringify(Object.assign(
 				messageType !== MESSAGE.TYPE.COMMENT ? { messageType } : {},
@@ -464,7 +465,7 @@ const actions = {
 				options?.silent ? { silent: options.silent } : {},
 				options?.threadId ? { threadId: options.threadId } : {},
 				options?.threadTitle ? { threadTitle: options.threadTitle } : {},
-				parent ? { replyTo: parent.id } : {},
+				options?.parent ? { replyTo: options.parent.id } : {},
 			))
 
 			await context.dispatch('shareFile', { token, path: shareableFile.sharePath, index, uploadId, id, referenceId, talkMetaData })


### PR DESCRIPTION
### ☑️ Resolves

* Ref https://github.com/nextcloud/talk-ios/issues/2188
	* temporary message is created, when file is just uploaded/pasted/dropped on the chat, and not sent yet
	* parent message might be dismissed by then (in the dialog)
	* Should be checked when sending
* Fix appearance for temporary voice message

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="443" height="107" alt="image" src="https://github.com/user-attachments/assets/8032302f-6c32-4793-b780-b96d23723316" /> | <img width="441" height="112" alt="image" src="https://github.com/user-attachments/assets/fa97423f-f379-427a-b4f3-da574d9d2d89" />
<img width="400" height="180" alt="image" src="https://github.com/user-attachments/assets/a74da638-93a1-4e08-9b22-5224d6da034f" /> | <img width="403" height="124" alt="image" src="https://github.com/user-attachments/assets/c5a36bc3-a021-474a-b834-13cef13585d3" />


### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
