### PR TITLE
fix(Recording): wait for router to be initialized

### DIFF
--- a/src/Recording.vue
+++ b/src/Recording.vue
@@ -43,19 +43,35 @@ onBeforeMount(async () => {
 	<CallView :token="token" is-recording />
 </template>
 
-<style lang="scss" scoped>
+<style lang="scss">
+/** Hide public footer gap from recording */
+#body-public {
+	--footer-height: 0 !important;
+}
+
+/** Hide public interface from recording */
+#header .header-end {
+	display: none !important;
+}
+
 /* The CallView descendants expect border-box to be set, as in the normal UI the
  * CallView is a descendant of NcContent, which applies the border-box to all
  * its descendants.
  */
 #call-container {
-	:deep(*) {
+	--wrapper-padding: 0 !important;
+
+	* {
 		box-sizing: border-box;
 	}
 
-	:deep(#videos) {
+	#videos {
 		inset: 0;
 		height: 100%;
+	}
+
+	.video-container {
+		width: 100%;
 	}
 }
 </style>


### PR DESCRIPTION
### ☑️ Resolves

* Fix recording UI
  * join sounds are no longer played
  * server public interface is hidden
  * component refactored to script setup

How to test:
 - setup recording server 
 - comment this code in PHP:
https://github.com/nextcloud/spreed/blob/e706405aedfdb59515445b1c83f12de2099dfb52/lib/Controller/PageController.php#L308-L313
 - open `<your-instance>/call/<token>/recording` page
 - put snippet in browser console:
 ```js
const TOKEN = location.href.split('/').at(-2)
const RECORDING_SERVER_SECRET = '<THE-SECRET-OF-THE-RECORDING-SERVER>'
const INTERNAL_HPB_SECRET = '<THE-INTERNAL-SECRET-OF-THE-SIGNALING-SERVER>'
 
 signalingSettings = await OCA.Talk.signalingGetSettingsForRecording(
    TOKEN,
    '1234567890123456789012345678901234567890123',
    Array.from(new Uint8Array(await crypto.subtle.sign(
        'HMAC',
         await crypto.subtle.importKey(
            'raw',
            (new TextEncoder().encode(RECORDING_SERVER_SECRET)).buffer,
            {
                name: 'HMAC',
                hash: { name: 'SHA-256', },
            },
            true,
            ['sign']
        ),
        new TextEncoder().encode('1234567890123456789012345678901234567890123')
    ))).map(b => b.toString(16).padStart(2, '0')).join('')
)

OCA.Talk.signalingJoinCallForRecording(
    TOKEN,
    signalingSettings,
    {
        random: '1234567890123456789012345678901234567890123',
        token: Array.from(new Uint8Array(await crypto.subtle.sign(
            'HMAC',
            await crypto.subtle.importKey(
                'raw',
                (new TextEncoder().encode(INTERNAL_HPB_SECRET)).buffer,
                {
                    name: 'HMAC',
                    hash: { name: 'SHA-256', },
                },
                true,
                ['sign']
            ),
            new TextEncoder().encode('1234567890123456789012345678901234567890123')
        ))).map(b => b.toString(16).padStart(2, '0')).join(''),
        backend: signalingSettings.server,
    }
)
```

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="775" height="390" alt="image" src="https://github.com/user-attachments/assets/c41a2863-bfb6-4c4a-8997-5322c7a93bda" /> | <img width="775" height="390" alt="image" src="https://github.com/user-attachments/assets/d39d0765-07db-404c-9521-2ea01b1e6156" />

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client