### PR TITLE
fix(MessagesList): allow wheel event for non-scrollable chats

### DIFF
--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -312,7 +312,7 @@ export default {
 				this.$nextTick(() => {
 					this.checkSticky()
 					// setting wheel event for non-scrollable chat
-					if (!this.isChatBeginningReached && this.checkChatNotScrollable()) {
+					if (this.checkChatNotScrollable()) {
 						this.$refs.scroller.addEventListener('wheel', this.handleWheelEvent, { passive: true })
 					}
 				})
@@ -658,8 +658,7 @@ export default {
 				this.setChatScrolledToBottom(false)
 			}
 
-			if ((scrollHeight > clientHeight && scrollTop < LOAD_HISTORY_THRESHOLD && this.isScrolling === 'up')
-				|| skipHeightCheck) {
+			if (this.isScrolling === 'up' && (skipHeightCheck || (scrollHeight > clientHeight && scrollTop < LOAD_HISTORY_THRESHOLD))) {
 				if (this.loadingOldMessages || this.isChatBeginningReached) {
 					// already loading, don't do it twice
 					return
@@ -672,8 +671,7 @@ export default {
 					})
 				}
 				this.setChatScrolledToBottom(false, { auto: true })
-			} else if ((scrollHeight > clientHeight && scrollOffsetFromBottom < LOAD_HISTORY_THRESHOLD && this.isScrolling === 'down')
-				|| skipHeightCheck) {
+			} else if (this.isScrolling === 'down' && (skipHeightCheck || (scrollHeight > clientHeight && scrollOffsetFromBottom < LOAD_HISTORY_THRESHOLD))) {
 				if (this.loadingNewMessages || this.isChatEndReached) {
 					// already loading, don't do it twice
 					return


### PR DESCRIPTION
### ☑️ Resolves

* Fix following scenario:
  * Have thread message (thread id: 100, message in thread: 102)
  * Post message in the chat (id: 103)
  * Open a thread and reload the page
  * Now it has threadBlocks: [100, 101, 102] and chatBlocks [103]
  * Post message in thread (104)
  * We don't know if it's attached to previous ones, so it results in [100, 101, 102], [104]
  * We can't see both  at the same moment, so best to fetch new messages from 102 -> get 104 (again) -> merge blocks
  * Can't do it with non-scrollable chat, as event listenere has not been added


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="352" height="80" alt="image" src="https://github.com/user-attachments/assets/509831cf-fec8-4a86-906a-f65c0d620ba2" /> | <img width="352" height="77" alt="image" src="https://github.com/user-attachments/assets/c7d7374f-cc77-4bb9-8f3c-3670ace818df" />


### 🚧 Tasks

- [ ] Show that you have unread messages / unrendered messages somehow (scroll to bottom button, if not on latest chat block)?

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
