### PR TITLE
fix(threads): show main chat after activity in a thread view on a fresh reload

### DIFF
--- a/src/composables/useGetMessages.ts
+++ b/src/composables/useGetMessages.ts
@@ -259,8 +259,9 @@ export function useGetMessagesProvider() {
 		if (!chatStore.hasMessage(token, { messageId, threadId })) {
 			// message not found in the list, need to fetch it first
 			await getMessageContext(token, messageId, threadId)
-		} else if (chatStore.getFirstKnownId(token, { messageId, threadId }) === messageId) {
-			// message is the first one in the block, try to get some messages above
+		} else if (chatStore.getFirstKnownId(token, { messageId, threadId }) === messageId
+			|| store.getters.message(token, messageId)?.threadId !== threadId) {
+			// message is the first one in the block or does not belong to the current context, try to get some messages above
 			isInitialisingMessages.value = true
 			await getOldMessages(token, true, { messageId, threadId })
 			isInitialisingMessages.value = false

--- a/src/stores/chat.ts
+++ b/src/stores/chat.ts
@@ -253,7 +253,7 @@ export const useChatStore = defineStore('chat', () => {
 						for (const messageId of chatBlockWithMergeBy) {
 							const message = store.state.messagesStore.messages[token][messageId]
 							if (message && message.threadId === +threadId) {
-								threadIdSetsToUpdate[threadId].add(messageId)
+								threadIdSetsToUpdate[message.threadId].add(messageId)
 								break
 							}
 						}


### PR DESCRIPTION
### ☑️ Resolves

* Steps to reproduce:
* type message
* create a thread and type a message inside thread
* Reload on the thread view
* Type some messages in thread view
* Return to the main chat
-> You will see emtpy chat

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
Screenshot before | Screenshot after

<!-- ☀️ Light theme | 🌑 Dark Theme -->

### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
