### PR TITLE
fix(threads): show thread icon in LeftSidebar

### DIFF
--- a/src/utils/getMessageIcon.ts
+++ b/src/utils/getMessageIcon.ts
@@ -8,6 +8,7 @@ import type { Conversation } from '../types/index.ts'
 import IconCardTextOutline from 'vue-material-design-icons/CardTextOutline.vue'
 import IconContactsOutline from 'vue-material-design-icons/ContactsOutline.vue'
 import IconFileOutline from 'vue-material-design-icons/FileOutline.vue'
+import IconForumOutline from 'vue-material-design-icons/ForumOutline.vue'
 import IconImageOutline from 'vue-material-design-icons/ImageOutline.vue'
 import IconMapMarkerOutline from 'vue-material-design-icons/MapMarkerOutline.vue'
 import IconMicrophoneOutline from 'vue-material-design-icons/MicrophoneOutline.vue'
@@ -24,6 +25,11 @@ export function getMessageIcon(lastMessage: Conversation['lastMessage']): Compon
 	if (!lastMessage || Array.isArray(lastMessage)) {
 		return null
 	}
+
+	if ('threadId' in lastMessage && lastMessage.isThread) {
+		return IconForumOutline
+	}
+
 	const file = lastMessage.messageParameters?.file
 	if (file) {
 		if (file.mimetype?.startsWith('video')) {


### PR DESCRIPTION
### ☑️ Resolves

* Indicate that a last message is in the thread
* Do not merge until #16009, needs a consistent response body for `lastMessage`

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

<img width="199" height="39" alt="2025-09-25_11h43_40" src="https://github.com/user-attachments/assets/e4b40de4-3369-4b60-a030-f650016d50cf" />


### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
