### PR TITLE
chore(dependencies): bump @nextcloud/vue to stable v9.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@nextcloud/router": "^3.0.1",
         "@nextcloud/sharing": "^0.3.0",
         "@nextcloud/upload": "^2.0.0-rc.0",
-        "@nextcloud/vue": "^9.0.0-rc.9",
+        "@nextcloud/vue": "^9.0.0",
         "@vue-leaflet/vue-leaflet": "^0.10.1",
         "@vueuse/components": "^13.7.0",
         "@vueuse/core": "^13.7.0",
@@ -1586,17 +1586,17 @@
       }
     },
     "node_modules/@nextcloud/axios": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/axios/-/axios-2.5.1.tgz",
-      "integrity": "sha512-AA7BPF/rsOZWAiVxqlobGSdD67AEwjOnymZCKUIwEIBArKxYK7OQEqcILDjQwgj6G0e/Vg9Y8zTVsPZp+mlvwA==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@nextcloud/axios/-/axios-2.5.2.tgz",
+      "integrity": "sha512-8frJb77jNMbz00TjsSqs1PymY0nIEbNM4mVmwen2tXY7wNgRai6uXilIlXKOYB9jR/F/HKRj6B4vUwVwZbhdbw==",
+      "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@nextcloud/auth": "^2.3.0",
+        "@nextcloud/auth": "^2.5.1",
         "@nextcloud/router": "^3.0.1",
-        "axios": "^1.6.8"
+        "axios": "^1.12.2"
       },
       "engines": {
-        "node": "^20.0.0",
-        "npm": "^10.0.0"
+        "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
       }
     },
     "node_modules/@nextcloud/browser-storage": {
@@ -1926,18 +1926,6 @@
         "stylelint-config-recommended-vue": "^1.5.0"
       }
     },
-    "node_modules/@nextcloud/timezones": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/timezones/-/timezones-1.0.0.tgz",
-      "integrity": "sha512-9b7Wms2mzB4RAltf8s9dY40PcU5ova5QjQJw1Gty35e54alKyx33BqUOy4gEbkzmYSrW4aZcLcMrOO5Bj2eIzg==",
-      "license": "AGPL-3.0-or-later",
-      "dependencies": {
-        "ical.js": "^2.1.0"
-      },
-      "engines": {
-        "node": "^20 || ^22"
-      }
-    },
     "node_modules/@nextcloud/typings": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/@nextcloud/typings/-/typings-1.9.1.tgz",
@@ -1997,15 +1985,15 @@
       }
     },
     "node_modules/@nextcloud/vue": {
-      "version": "9.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-9.0.0-rc.9.tgz",
-      "integrity": "sha512-rrM0KmRMGK2u1y9VZNJwVA7IzzU1OMnPkqU5ii9j07F5uOjy4J97/Bu71maQ19nfZA8tFe6INKHuX5AgOPYkbg==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-9.0.0.tgz",
+      "integrity": "sha512-zEz1NObKuMuWBCSbDxGtfkM6ZYKpYyFGCStuBF+/N4Wh4LBp2Z6QY14A311nuMOwSM2W2i16MMpYvIYGguUTkA==",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@ckpack/vue-color": "^1.6.0",
         "@floating-ui/dom": "^1.7.4",
         "@nextcloud/auth": "^2.5.2",
-        "@nextcloud/axios": "^2.5.1",
+        "@nextcloud/axios": "^2.5.2",
         "@nextcloud/browser-storage": "^0.4.0",
         "@nextcloud/capabilities": "^1.2.0",
         "@nextcloud/event-bus": "^3.3.2",
@@ -2014,7 +2002,6 @@
         "@nextcloud/logger": "^3.0.2",
         "@nextcloud/router": "^3.0.1",
         "@nextcloud/sharing": "^0.3.0",
-        "@nextcloud/timezones": "^1.0.0",
         "@vuepic/vue-datepicker": "^11.0.2",
         "@vueuse/components": "^13.9.0",
         "@vueuse/core": "^13.9.0",
@@ -2022,7 +2009,7 @@
         "clone": "^2.1.2",
         "crypto-browserify": "^3.12.1",
         "debounce": "^2.2.0",
-        "dompurify": "^3.2.6",
+        "dompurify": "^3.2.7",
         "emoji-mart-vue-fast": "^15.0.5",
         "escape-html": "^1.0.3",
         "floating-vue": "^5.2.2",
@@ -4348,9 +4335,10 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.1.tgz",
-      "integrity": "sha512-Kn4kbSXpkFHCGE6rBFNwIv0GQs4AvDT80jlveJDKFxjbTYMUeB4QtsdPCv6H8Cm19Je7IU6VFtRl2zWZI0rudQ==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
+      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.4",
@@ -6146,9 +6134,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
-      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
+      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -8347,12 +8335,6 @@
       "engines": {
         "node": ">=10.18"
       }
-    },
-    "node_modules/ical.js": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ical.js/-/ical.js-2.2.1.tgz",
-      "integrity": "sha512-yK/UlPbEs316igb/tjRgbFA8ZV75rCsBJp/hWOatpyaPNlgw0dGDmU+FoicOcwX4xXkeXOkYiOmCqNPFpNPkQg==",
-      "license": "MPL-2.0"
     },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
@@ -16842,13 +16824,13 @@
       }
     },
     "@nextcloud/axios": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/axios/-/axios-2.5.1.tgz",
-      "integrity": "sha512-AA7BPF/rsOZWAiVxqlobGSdD67AEwjOnymZCKUIwEIBArKxYK7OQEqcILDjQwgj6G0e/Vg9Y8zTVsPZp+mlvwA==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@nextcloud/axios/-/axios-2.5.2.tgz",
+      "integrity": "sha512-8frJb77jNMbz00TjsSqs1PymY0nIEbNM4mVmwen2tXY7wNgRai6uXilIlXKOYB9jR/F/HKRj6B4vUwVwZbhdbw==",
       "requires": {
-        "@nextcloud/auth": "^2.3.0",
+        "@nextcloud/auth": "^2.5.1",
         "@nextcloud/router": "^3.0.1",
-        "axios": "^1.6.8"
+        "axios": "^1.12.2"
       }
     },
     "@nextcloud/browser-storage": {
@@ -17078,14 +17060,6 @@
         "stylelint-use-logical": "^2.1.2"
       }
     },
-    "@nextcloud/timezones": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/timezones/-/timezones-1.0.0.tgz",
-      "integrity": "sha512-9b7Wms2mzB4RAltf8s9dY40PcU5ova5QjQJw1Gty35e54alKyx33BqUOy4gEbkzmYSrW4aZcLcMrOO5Bj2eIzg==",
-      "requires": {
-        "ical.js": "^2.1.0"
-      }
-    },
     "@nextcloud/typings": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/@nextcloud/typings/-/typings-1.9.1.tgz",
@@ -17132,14 +17106,14 @@
       }
     },
     "@nextcloud/vue": {
-      "version": "9.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-9.0.0-rc.9.tgz",
-      "integrity": "sha512-rrM0KmRMGK2u1y9VZNJwVA7IzzU1OMnPkqU5ii9j07F5uOjy4J97/Bu71maQ19nfZA8tFe6INKHuX5AgOPYkbg==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-9.0.0.tgz",
+      "integrity": "sha512-zEz1NObKuMuWBCSbDxGtfkM6ZYKpYyFGCStuBF+/N4Wh4LBp2Z6QY14A311nuMOwSM2W2i16MMpYvIYGguUTkA==",
       "requires": {
         "@ckpack/vue-color": "^1.6.0",
         "@floating-ui/dom": "^1.7.4",
         "@nextcloud/auth": "^2.5.2",
-        "@nextcloud/axios": "^2.5.1",
+        "@nextcloud/axios": "^2.5.2",
         "@nextcloud/browser-storage": "^0.4.0",
         "@nextcloud/capabilities": "^1.2.0",
         "@nextcloud/event-bus": "^3.3.2",
@@ -17148,7 +17122,6 @@
         "@nextcloud/logger": "^3.0.2",
         "@nextcloud/router": "^3.0.1",
         "@nextcloud/sharing": "^0.3.0",
-        "@nextcloud/timezones": "^1.0.0",
         "@vuepic/vue-datepicker": "^11.0.2",
         "@vueuse/components": "^13.9.0",
         "@vueuse/core": "^13.9.0",
@@ -17156,7 +17129,7 @@
         "clone": "^2.1.2",
         "crypto-browserify": "^3.12.1",
         "debounce": "^2.2.0",
-        "dompurify": "^3.2.6",
+        "dompurify": "^3.2.7",
         "emoji-mart-vue-fast": "^15.0.5",
         "escape-html": "^1.0.3",
         "floating-vue": "^5.2.2",
@@ -18839,9 +18812,9 @@
       }
     },
     "axios": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.1.tgz",
-      "integrity": "sha512-Kn4kbSXpkFHCGE6rBFNwIv0GQs4AvDT80jlveJDKFxjbTYMUeB4QtsdPCv6H8Cm19Je7IU6VFtRl2zWZI0rudQ==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
       "requires": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.4",
@@ -20103,9 +20076,9 @@
       }
     },
     "dompurify": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
-      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
+      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
       "requires": {
         "@types/trusted-types": "^2.0.7"
       }
@@ -21687,11 +21660,6 @@
       "integrity": "sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==",
       "dev": true,
       "peer": true
-    },
-    "ical.js": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ical.js/-/ical.js-2.2.1.tgz",
-      "integrity": "sha512-yK/UlPbEs316igb/tjRgbFA8ZV75rCsBJp/hWOatpyaPNlgw0dGDmU+FoicOcwX4xXkeXOkYiOmCqNPFpNPkQg=="
     },
     "iconv-lite": {
       "version": "0.4.24",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@nextcloud/router": "^3.0.1",
     "@nextcloud/sharing": "^0.3.0",
     "@nextcloud/upload": "^2.0.0-rc.0",
-    "@nextcloud/vue": "^9.0.0-rc.9",
+    "@nextcloud/vue": "^9.0.0",
     "@vue-leaflet/vue-leaflet": "^0.10.1",
     "@vueuse/components": "^13.7.0",
     "@vueuse/core": "^13.7.0",

--- a/src/components/CalendarEventsDialog.vue
+++ b/src/components/CalendarEventsDialog.vue
@@ -343,8 +343,7 @@ async function submitNewMeeting() {
 			:container="container"
 			:popper-hide-triggers="hideTriggers"
 			:no-focus-trap="!canScheduleMeeting && upcomingEvents.length === 0"
-			popup-role="dialog"
-			close-on-click-outside>
+			popup-role="dialog">
 			<template #trigger>
 				<NcButton
 					class="upcoming-meeting"

--- a/src/components/MediaSettings/MediaSettings.vue
+++ b/src/components/MediaSettings/MediaSettings.vue
@@ -99,7 +99,6 @@
 						<NcPopover
 							v-else
 							:title="t('spreed', 'Show more info')"
-							close-on-click-outside
 							no-focus-trap>
 							<template #trigger>
 								<NcButton
@@ -133,7 +132,6 @@
 						<NcPopover
 							v-else
 							:title="t('spreed', 'Show more info')"
-							close-on-click-outside
 							no-focus-trap>
 							<template #trigger>
 								<NcButton


### PR DESCRIPTION
### ☑️ Resolves

* Bump library to stable
* Remove deprecated prop (NcPopover close-on-click-outside)


### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required