### PR TITLE
fix(chat): improve check for last message context

### DIFF
--- a/src/stores/chat.ts
+++ b/src/stores/chat.ts
@@ -46,6 +46,20 @@ function checkIfIntersect(parentBlock: Set<number>, childBlock: Set<number>): bo
 }
 
 /**
+ * Check, if message belongs to the current context (main chat or thread)
+ *
+ * @param message
+ * @param threadId
+ */
+function checkIfBelongsToContext(message: ChatMessage, threadId?: number): boolean {
+	return threadId
+		// In thread context, only thread messages with given threadId are allowed
+		? threadId === message.threadId
+		// In main context, only non-thread messages, topmost thread messages and temporary messages are allowed
+		: (!message.isThread || message.id === message.threadId || message.id.toString().startsWith('temp-'))
+}
+
+/**
  * Return an array of only numeric ids from given set
  * (temporary messages have a string id)
  *
@@ -113,10 +127,7 @@ export const useChatStore = defineStore('chat', () => {
 				// - completely deleted (expired) message
 				// - thread message in general view (apart from the topmost one)
 				if (message && !isHiddenSystemMessage(message)
-					&& (threadId
-						? threadId === message.threadId
-						: (!message.isThread || message.id === message.threadId || message.id.toString().startsWith('temp-'))
-					)
+					&& checkIfBelongsToContext(message, threadId)
 				) {
 					acc.push(message)
 				}

--- a/src/stores/chat.ts
+++ b/src/stores/chat.ts
@@ -227,6 +227,31 @@ export const useChatStore = defineStore('chat', () => {
 	}
 
 	/**
+	 * Returns nearest known message id, belonging to current context
+	 *
+	 * @param token
+	 * @param payload
+	 * @param payload.messageId
+	 * @param payload.threadId
+	 */
+	function getNearestKnownContextId(
+		token: string,
+		{ messageId = 0, threadId = 0 }: GetMessagesListOptions = { messageId: 0, threadId: 0 },
+	): number | undefined {
+		const message = store.state.messagesStore.messages[token][messageId]
+		if (!message) {
+			return undefined
+		}
+
+		if (checkIfBelongsToContext(message, threadId)) {
+			return messageId
+		}
+
+		// Get last item from prepared messages list (already represents current context)
+		return getMessagesList(token, { messageId, threadId }).at(-1)?.id
+	}
+
+	/**
 	 * Populate chat blocks from given arrays of messages
 	 * If blocks already exist, try to extend them
 	 *
@@ -511,6 +536,7 @@ export const useChatStore = defineStore('chat', () => {
 		hasMessage,
 		getFirstKnownId,
 		getLastKnownId,
+		getNearestKnownContextId,
 		processChatBlocks,
 		addMessageToChatBlocks,
 		removeMessagesFromChatBlocks,


### PR DESCRIPTION
### ☑️ Resolves

* Fix regression from #16012 
* in main context, `threadId` is always 0, and `store.getters.message(token, messageId)?.threadId !== threadId` is always true



## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before 

https://github.com/user-attachments/assets/0de1759b-0a5d-4ae4-b163-785a9c8e6584

🏡 After

https://github.com/user-attachments/assets/7c043c9d-f512-4c3a-8b28-445b7ee0cd63



### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [x] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client