### PR TITLE
Bugfix/noid/thread id in federated notifications

### DIFF
--- a/lib/Chat/ChatManager.php
+++ b/lib/Chat/ChatManager.php
@@ -22,6 +22,7 @@ use OCA\Talk\Exceptions\ParticipantNotFoundException;
 use OCA\Talk\Model\Attendee;
 use OCA\Talk\Model\Message;
 use OCA\Talk\Model\Poll;
+use OCA\Talk\Model\Thread;
 use OCA\Talk\Participant;
 use OCA\Talk\ResponseDefinitions;
 use OCA\Talk\Room;
@@ -402,7 +403,8 @@ class ChatManager {
 
 		if ($replyTo instanceof IComment) {
 			$comment->setParentId($replyTo->getId());
-		} elseif ($threadId !== 0) {
+			$threadId = (int)$replyTo->getTopmostParentId() ?: (int)$replyTo->getId();
+		} elseif ($threadId !== Thread::THREAD_NONE && $threadId !== Thread::THREAD_CREATE) {
 			$comment->setParentId((string)$threadId);
 		}
 
@@ -431,21 +433,26 @@ class ChatManager {
 		if ($chat->getMentionPermissions() === Room::MENTION_PERMISSIONS_EVERYONE || $participant?->hasModeratorPermissions()) {
 			$metadata[Message::METADATA_CAN_MENTION_ALL] = true;
 		}
+		if ($threadId !== Thread::THREAD_NONE) {
+			$metadata[Message::METADATA_THREAD_ID] = $threadId;
+		}
 		$comment->setMetaData($metadata);
 
 		$event = new BeforeChatMessageSentEvent($chat, $comment, $participant, $silent, $replyTo);
 		$this->dispatcher->dispatchTyped($event);
 
-		$threadId = 0;
 		$shouldFlush = $this->notificationManager->defer();
 		try {
 			$this->commentsManager->save($comment);
 			$messageId = (int)$comment->getId();
-			$threadId = (int)$comment->getTopmostParentId();
-			if ($threadId !== 0) {
+			if ($threadId === Thread::THREAD_CREATE) {
+				$metadata[Message::METADATA_THREAD_ID] = $messageId;
+				$comment->setMetaData($metadata);
+				$this->commentsManager->save($comment);
+			} elseif ($threadId !== Thread::THREAD_NONE) {
 				$isThread = $this->threadService->updateLastMessageInfoAfterReply($threadId, $messageId, $chat->getId());
 				if (!$isThread) {
-					$threadId = 0;
+					$threadId = Thread::THREAD_NONE;
 				} elseif ($participant instanceof Participant) {
 					// Add to subscribed threads list
 					$this->threadService->ensureIsThreadAttendee($participant->getAttendee(), $threadId);
@@ -495,7 +502,7 @@ class ChatManager {
 		} catch (NotFoundException $e) {
 		}
 		$this->cache->remove($chat->getToken());
-		if ($threadId !== 0) {
+		if ($threadId !== Thread::THREAD_NONE) {
 			$this->cache->remove($chat->getToken() . '/' . $threadId);
 		}
 		if ($shouldFlush) {

--- a/lib/Chat/SystemMessage/Listener.php
+++ b/lib/Chat/SystemMessage/Listener.php
@@ -431,7 +431,7 @@ class Listener implements IEventListener {
 			try {
 				// Add to subscribed threads list
 				$participant = $this->participantService->getParticipant($room, $this->getUserId());
-				$this->threadService->setNotificationLevel($participant->getAttendee(), $thread, Participant::NOTIFY_DEFAULT);
+				$this->threadService->setNotificationLevel($participant->getAttendee(), $thread->getId(), Participant::NOTIFY_DEFAULT);
 			} catch (ParticipantNotFoundException) {
 			}
 

--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -279,7 +279,7 @@ class ChatController extends AEnvironmentAwareOCSController {
 			if ($createThread) {
 				$thread = $this->threadService->createThread($this->room, (int)$comment->getId(), $threadTitle);
 				// Add to subscribed threads list
-				$this->threadService->setNotificationLevel($this->participant->getAttendee(), $thread, Participant::NOTIFY_DEFAULT);
+				$this->threadService->setNotificationLevel($this->participant->getAttendee(), $thread->getId(), Participant::NOTIFY_DEFAULT);
 
 				$this->chatManager->addSystemMessage(
 					$this->room,

--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -36,6 +36,7 @@ use OCA\Talk\Model\Bot;
 use OCA\Talk\Model\Message;
 use OCA\Talk\Model\Reminder;
 use OCA\Talk\Model\Session;
+use OCA\Talk\Model\Thread;
 use OCA\Talk\Participant;
 use OCA\Talk\ResponseDefinitions;
 use OCA\Talk\Room;
@@ -272,8 +273,10 @@ class ChatController extends AEnvironmentAwareOCSController {
 		$creationDateTime = $this->timeFactory->getDateTime('now', new \DateTimeZone('UTC'));
 
 		try {
+			$createThread = $replyTo === 0 && $threadTitle !== '';
+			$threadId = $createThread ? Thread::THREAD_CREATE : $threadId;
 			$comment = $this->chatManager->sendMessage($this->room, $this->participant, $actorType, $actorId, $message, $creationDateTime, $parent, $referenceId, $silent, threadId: $threadId);
-			if ($replyTo === 0 && $threadTitle !== '') {
+			if ($createThread) {
 				$thread = $this->threadService->createThread($this->room, (int)$comment->getId(), $threadTitle);
 				// Add to subscribed threads list
 				$this->threadService->setNotificationLevel($this->participant->getAttendee(), $thread, Participant::NOTIFY_DEFAULT);

--- a/lib/Model/Message.php
+++ b/lib/Model/Message.php
@@ -24,6 +24,7 @@ class Message {
 	public const METADATA_LAST_EDITED_TIME = 'last_edited_time';
 	public const METADATA_SILENT = 'silent';
 	public const METADATA_CAN_MENTION_ALL = 'can_mention_all';
+	public const METADATA_THREAD_ID = 'thread_id';
 
 	/** @var bool */
 	protected $visible = true;

--- a/lib/Model/Thread.php
+++ b/lib/Model/Thread.php
@@ -28,6 +28,8 @@ use OCP\DB\Types;
  * @psalm-import-type TalkThread from ResponseDefinitions
  */
 class Thread extends Entity {
+	public const THREAD_NONE = 0;
+	public const THREAD_CREATE = -1;
 	protected int $roomId = 0;
 	protected int $lastMessageId = 0;
 	protected int $numReplies = 0;

--- a/lib/Model/ThreadAttendeeMapper.php
+++ b/lib/Model/ThreadAttendeeMapper.php
@@ -65,7 +65,7 @@ class ThreadAttendeeMapper extends QBMapper {
 	/**
 	 * @throws DoesNotExistException if the item does not exist
 	 */
-	public function findAttendeeByThreadId(string $actorType, string $actorId, int $threadId): ThreadAttendee {
+	public function findAttendeeByThreadId(string $actorType, string $actorId, int $roomId, int $threadId): ThreadAttendee {
 		$query = $this->db->getQueryBuilder();
 		$query->select('*')
 			->from($this->getTableName())
@@ -76,6 +76,10 @@ class ThreadAttendeeMapper extends QBMapper {
 			->andWhere($query->expr()->eq(
 				'actor_id',
 				$query->createNamedParameter($actorId),
+			))
+			->andWhere($query->expr()->eq(
+				'room_id',
+				$query->createNamedParameter($roomId),
 			))
 			->andWhere($query->expr()->eq(
 				'thread_id',

--- a/lib/Service/ThreadService.php
+++ b/lib/Service/ThreadService.php
@@ -198,15 +198,15 @@ class ThreadService {
 		return $threadAttendees;
 	}
 
-	public function setNotificationLevel(Attendee $attendee, Thread $thread, int $level): ThreadAttendee {
+	public function setNotificationLevel(Attendee $attendee, int $threadId, int $level): ThreadAttendee {
 		try {
-			$threadAttendee = $this->threadAttendeeMapper->findAttendeeByThreadId($attendee->getActorType(), $attendee->getActorId(), $thread->getId());
+			$threadAttendee = $this->threadAttendeeMapper->findAttendeeByThreadId($attendee->getActorType(), $attendee->getActorId(), $attendee->getRoomId(), $threadId);
 			$threadAttendee->setNotificationLevel($level);
 			$this->threadAttendeeMapper->update($threadAttendee);
 		} catch (DoesNotExistException) {
 			$threadAttendee = new ThreadAttendee();
-			$threadAttendee->setThreadId($thread->getId());
-			$threadAttendee->setRoomId($thread->getRoomId());
+			$threadAttendee->setThreadId($threadId);
+			$threadAttendee->setRoomId($attendee->getRoomId());
 
 			$threadAttendee->setAttendeeId($attendee->getId());
 			$threadAttendee->setActorType($attendee->getActorType());
@@ -220,7 +220,7 @@ class ThreadService {
 
 	public function ensureIsThreadAttendee(Attendee $attendee, int $threadId): void {
 		try {
-			$this->threadAttendeeMapper->findAttendeeByThreadId($attendee->getActorType(), $attendee->getActorId(), $threadId);
+			$this->threadAttendeeMapper->findAttendeeByThreadId($attendee->getActorType(), $attendee->getActorId(), $attendee->getRoomId(), $threadId);
 		} catch (DoesNotExistException) {
 			$threadAttendee = new ThreadAttendee();
 			$threadAttendee->setThreadId($threadId);


### PR DESCRIPTION
## 🛠️ API Checklist
### 🚧 Tasks

- [x] Federated notifications are missing the thread id
- [ ] Federated users can thread notify level is not overwriting conversation level

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
