### PR TITLE
fix: redirect to thread from notification link

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -431,6 +431,10 @@ export default {
 		 * first navigation will be made from initial state { name : undefined }
 		 */
 		this.$router.beforeEach((to, from, next) => {
+			if (to.fullPath === from.fullPath) {
+				// Block duplicated navigation
+				return
+			}
 			if (from.name === 'conversation' && to.name === 'conversation' && from.params.token === to.params.token) {
 				// Navigating within the same conversation
 				beforeRouteChangeListener(to, from, next)

--- a/src/App.vue
+++ b/src/App.vue
@@ -49,6 +49,7 @@ import { useDocumentTitle } from './composables/useDocumentTitle.ts'
 import { useGetMessagesProvider } from './composables/useGetMessages.ts'
 import { useGetToken } from './composables/useGetToken.ts'
 import { useHashCheck } from './composables/useHashCheck.js'
+import { useInterceptNotifications } from './composables/useInterceptNotifications.ts'
 import { useIsInCall } from './composables/useIsInCall.js'
 import { useSessionIssueHandler } from './composables/useSessionIssueHandler.ts'
 import { CONVERSATION, PARTICIPANT } from './constants.ts'
@@ -57,7 +58,6 @@ import { EventBus } from './services/EventBus.ts'
 import { leaveConversationSync } from './services/participantsService.js'
 import { useActorStore } from './stores/actor.ts'
 import { useCallViewStore } from './stores/callView.ts'
-import { useFederationStore } from './stores/federation.ts'
 import { useSidebarStore } from './stores/sidebar.ts'
 import { useTokenStore } from './stores/token.ts'
 import { checkBrowser } from './utils/browserCheck.ts'
@@ -80,6 +80,8 @@ export default {
 		useDocumentTitle()
 		// Provide context for MessagesList mounted in different places
 		useGetMessagesProvider()
+		// Intercept some notifications and handle them in the Talk app
+		useInterceptNotifications()
 		// Add provided value to check if we're in the main app or plugin
 		provide('Talk:isMainApp', true)
 		useDocumentFullscreen()
@@ -92,7 +94,6 @@ export default {
 			isMobile: useIsMobile(),
 			isNextcloudTalkHashDirty: useHashCheck(),
 			supportSessionState: useActiveSession(),
-			federationStore: useFederationStore(),
 			callViewStore: useCallViewStore(),
 			sidebarStore: useSidebarStore(),
 			actorStore: useActorStore(),
@@ -226,8 +227,6 @@ export default {
 		if (!getCurrentUser()) {
 			EventBus.off('should-refresh-conversations', this.debounceRefreshCurrentConversation)
 		}
-
-		unsubscribe('notifications:action:execute', this.interceptNotificationActions)
 
 		window.removeEventListener('beforeunload', this.preventUnload)
 
@@ -468,120 +467,10 @@ export default {
 		if (!IS_DESKTOP) {
 			checkBrowser()
 		}
-
-		subscribe('notifications:action:execute', this.interceptNotificationActions)
-		subscribe('notifications:notification:received', this.interceptNotificationReceived)
 	},
 
 	methods: {
 		t,
-		/**
-		 * Intercept clicking actions on notifications and open the conversation without a page reload instead
-		 *
-		 * @param {object} event The event object provided by the notifications app
-		 * @param {object} event.notification The notification object
-		 * @param {string} event.notification.app The app ID of the app providing the notification
-		 * @param {object} event.action The action that was clicked
-		 * @param {string} event.action.url The URL the action is aiming at
-		 * @param {string} event.action.type The request type used for the action
-		 * @param {boolean} event.cancelAction Option to cancel the action so no page reload is happening
-		 */
-		async interceptNotificationActions(event) {
-			if (event.notification.app !== 'spreed') {
-				return
-			}
-
-			switch (event.action.type) {
-				case 'WEB': {
-					const load = event.action.url.split('/call/').pop()
-					if (!load) {
-						return
-					}
-
-					const [token, hash] = load.split('#')
-					this.$router.push({
-						name: 'conversation',
-						hash: hash ? `#${hash}` : '',
-						params: {
-							token,
-						},
-					})
-
-					event.cancelAction = true
-					break
-				}
-				case 'POST': {
-				// Federation invitation handling
-					if (event.notification.objectType === 'remote_talk_share') {
-						try {
-							event.cancelAction = true
-							this.federationStore.addInvitationFromNotification(event.notification)
-							const conversation = await this.federationStore.acceptShare(event.notification.objectId)
-							if (conversation.token) {
-								this.$store.dispatch('addConversation', conversation)
-								this.$router.push({ name: 'conversation', params: { token: conversation.token } })
-							}
-						} catch (error) {
-							console.error(error)
-						}
-					}
-					break
-				}
-				case 'DELETE': {
-				// Federation invitation handling
-					if (event.notification.objectType === 'remote_talk_share') {
-						try {
-							event.cancelAction = true
-							this.federationStore.addInvitationFromNotification(event.notification)
-							await this.federationStore.rejectShare(event.notification.objectId)
-						} catch (error) {
-							console.error(error)
-						}
-					}
-					break
-				}
-				default: break
-			}
-		},
-
-		/**
-		 * Intercept …
-		 *
-		 * @param {object} event The event object provided by the notifications app
-		 * @param {object} event.notification The notification object
-		 * @param {string} event.notification.app The app ID of the app providing the notification
-		 */
-		interceptNotificationReceived(event) {
-			if (event.notification.app !== 'spreed') {
-				return
-			}
-
-			switch (event.notification.objectType) {
-				case 'chat': {
-					if (event.notification.subjectRichParameters?.reaction) {
-					// Ignore reaction notifications in case of one-to-one and always-notify
-						return
-					}
-
-					this.$store.dispatch('updateConversationLastMessageFromNotification', {
-						notification: event.notification,
-					})
-					break
-				}
-				case 'call': {
-					this.$store.dispatch('updateCallStateFromNotification', {
-						notification: event.notification,
-					})
-					break
-				}
-				// Federation invitation handling
-				case 'remote_talk_share': {
-					this.federationStore.addInvitationFromNotification(event.notification)
-					break
-				}
-				default: break
-			}
-		},
 
 		refreshCurrentConversation() {
 			this.fetchSingleConversation(this.token)

--- a/src/composables/useInterceptNotifications.ts
+++ b/src/composables/useInterceptNotifications.ts
@@ -1,0 +1,146 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { Notification, NotificationEvent, NotificationInvite } from '../types/index.ts'
+
+import { subscribe, unsubscribe } from '@nextcloud/event-bus'
+import { onBeforeUnmount } from 'vue'
+import { useRouter } from 'vue-router'
+import { useStore } from 'vuex'
+import { useFederationStore } from '../stores/federation.ts'
+
+/**
+ * Type guard to check if a notification is a Talk federation invitation
+ *
+ * @param notification - notification object
+ */
+function isNotificationInvite(notification: Notification): notification is NotificationInvite {
+	return notification.objectType === 'remote_talk_share'
+}
+
+/**
+ * Composable to intercept notifications and handle them via Talk app
+ */
+export function useInterceptNotifications() {
+	const router = useRouter()
+	const store = useStore()
+	const federationStore = useFederationStore()
+
+	subscribe('notifications:action:execute', interceptNotificationActions)
+	subscribe('notifications:notification:received', interceptNotificationReceived)
+
+	onBeforeUnmount(() => {
+		unsubscribe('notifications:action:execute', interceptNotificationActions)
+		unsubscribe('notifications:notification:received', interceptNotificationReceived)
+	})
+
+	/**
+	 * Intercept clicking actions on notifications and open the conversation without a page reload instead
+	 *
+	 * @param event The event object provided by the notifications app
+	 * @param event.notification The notification object
+	 * @param event.notification.app The app ID of the app providing the notification
+	 * @param event.action The action that was clicked
+	 * @param event.action.url The URL the action is aiming at
+	 * @param event.action.type The request type used for the action
+	 * @param event.cancelAction Option to cancel the action so no page reload is happening
+	 */
+	async function interceptNotificationActions(event: NotificationEvent) {
+		if (event.notification.app !== 'spreed') {
+			return
+		}
+
+		switch (event.action.type) {
+			case 'WEB': {
+				const load = event.action.url.split('/call/').pop()
+				if (!load) {
+					return
+				}
+
+				const [token, hash] = load.split('#')
+				await router.push({
+					name: 'conversation',
+					hash: hash ? `#${hash}` : '',
+					params: {
+						token,
+					},
+				})
+
+				event.cancelAction = true
+				break
+			}
+			case 'POST': {
+				// Federation invitation handling
+				if (isNotificationInvite(event.notification)) {
+					try {
+						event.cancelAction = true
+						federationStore.addInvitationFromNotification(event.notification)
+						const conversation = await federationStore.acceptShare(event.notification.objectId)
+						if (conversation?.token) {
+							await store.dispatch('addConversation', conversation)
+							await router.push({ name: 'conversation', params: { token: conversation.token } })
+						}
+					} catch (error) {
+						console.error(error)
+					}
+				}
+				break
+			}
+			case 'DELETE': {
+				// Federation invitation handling
+				if (isNotificationInvite(event.notification)) {
+					try {
+						event.cancelAction = true
+						federationStore.addInvitationFromNotification(event.notification)
+						await federationStore.rejectShare(event.notification.objectId)
+					} catch (error) {
+						console.error(error)
+					}
+				}
+				break
+			}
+			default: break
+		}
+	}
+
+	/**
+	 * Intercept …
+	 *
+	 * @param event The event object provided by the notifications app
+	 * @param event.notification The notification object
+	 * @param event.notification.app The app ID of the app providing the notification
+	 */
+	async function interceptNotificationReceived(event: NotificationEvent) {
+		if (event.notification.app !== 'spreed') {
+			return
+		}
+
+		switch (event.notification.objectType) {
+			case 'chat': {
+				if (event.notification.subjectRichParameters?.reaction) {
+					// Ignore reaction notifications in case of one-to-one and always-notify
+					return
+				}
+
+				await store.dispatch('updateConversationLastMessageFromNotification', {
+					notification: event.notification,
+				})
+				break
+			}
+			case 'call': {
+				await store.dispatch('updateCallStateFromNotification', {
+					notification: event.notification,
+				})
+				break
+			}
+			// Federation invitation handling
+			case 'remote_talk_share': {
+				federationStore.addInvitationFromNotification(event.notification as NotificationInvite)
+				break
+			}
+			default: break
+		}
+	}
+}

--- a/src/composables/useInterceptNotifications.ts
+++ b/src/composables/useInterceptNotifications.ts
@@ -54,19 +54,14 @@ export function useInterceptNotifications() {
 
 		switch (event.action.type) {
 			case 'WEB': {
-				const load = event.action.url.split('/call/').pop()
-				if (!load) {
+				const conversationRouteIndex = event.action.url.indexOf('/call')
+				if (conversationRouteIndex === -1) {
+					// Proceed with default behaviour (open given link)
 					return
 				}
 
-				const [token, hash] = load.split('#')
-				await router.push({
-					name: 'conversation',
-					hash: hash ? `#${hash}` : '',
-					params: {
-						token,
-					},
-				})
+				const conversationRouteLocationRaw = event.action.url.substring(conversationRouteIndex)
+				await router.push(conversationRouteLocationRaw)
 
 				event.cancelAction = true
 				break

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -77,10 +77,11 @@ export type InitialState = {
 }
 
 // Notifications
+type NotificationActionType = 'WEB' | 'POST' | 'DELETE' | string & {}
 type NotificationAction = {
 	label: string
 	link: string
-	type: 'WEB' | 'POST' | 'DELETE' | string
+	type: NotificationActionType
 	primary: boolean
 }
 
@@ -103,6 +104,15 @@ export type Notification<T = Record<string, RichObject & Record<string, unknown>
 	icon: string
 	shouldNotify: true
 	actions: NotificationAction[]
+}
+
+export type NotificationEvent = {
+	action: {
+		type: NotificationAction['type']
+		url: NotificationAction['link']
+	}
+	notification: Notification
+	cancelAction: boolean
 }
 
 // Signaling

--- a/src/types/vendor/@nextcloud/event-bus.d.ts
+++ b/src/types/vendor/@nextcloud/event-bus.d.ts
@@ -2,11 +2,14 @@
  * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+import type { NotificationEvent } from '../../index.ts'
 
 declare module '@nextcloud/event-bus' {
 	import type { NextcloudUser } from '@nextcloud/auth'
 	export interface NextcloudEvents {
 		'user:info:changed': NextcloudUser
+		'notifications:action:execute': NotificationEvent
+		'notifications:notification:received': NotificationEvent
 	}
 }
 export {}


### PR DESCRIPTION
### ☑️ Resolves

* Fix clicking on "View chat" notification action when someone sent a message in a thread
  * extract notification interceptors from App.vue to composable
  * fix parsing the action link to conversation route
  * block duplicate navigation
    * ⚠️ Vue Router is running listeners in `popStateHandler` and don't catch `NavigationFailureType["duplicated"]` errors - should be done on app side


## 🖌️ UI Checklist

 - trigger notification leading to a thread
 - click 'View chat'
 - see thread and not 'Not found'

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop ❓ 
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required