### PR TITLE
fix(chat): improve mixed bidi content render

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/MessageBody.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/MessageBody.vue
@@ -610,8 +610,29 @@ export default {
 			}
 
 			:deep(.rich-text--wrapper) {
-				text-align: start;
+				// NcRichText is used with dir="auto", so internal text direction may vary
+				// But we want to keep the alignment consistent with the rest of the UI
+				text-align: inherit;
+
 				@include markdown;
+			}
+
+			// FIXME: Should it be in the upstream NcRichText component?
+			// NcRichText is used with dir="auto", so internal text direction may vary
+			// But we want to keep the alignment consistent with the rest of the UI
+			// So we need to override the direction for task lists using the current direction, not its own direction
+			&:dir(rtl) :deep(ul.contains-task-list) {
+				direction: rtl;
+			}
+
+			&:dir(ltr) :deep(ul.contains-task-list) {
+				direction: ltr;
+			}
+
+			// Overriding direction above breaks text direction
+			// Restoring it back
+			:deep(ul.contains-task-list) .checkbox-content__wrapper {
+				unicode-bidi: plaintext;
 			}
 		}
 	}
@@ -679,10 +700,6 @@ export default {
 
 .call-button {
 	margin: 0 auto;
-}
-
-:deep(.rich-text--wrapper) {
-	direction: inherit;
 }
 
 // Always render code blocks LTR


### PR DESCRIPTION
### ☑️ Resolves

* Fix https://github.com/nextcloud/spreed/issues/15562
* `direction` was disabled on chat to keep the content aligned with the entire UI
* But it breaks displaying text with mixed LTR/RTL content
* Instead: keep the direction enabled but override text-alignment
* And add a dirty fix for checkboxes...

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="898" height="64" alt="image" src="https://github.com/user-attachments/assets/c13df723-0979-4421-9d61-78058f29665b" /> | <img width="907" height="72" alt="image" src="https://github.com/user-attachments/assets/fbd84f81-1bb7-476c-8890-b1298f3ef464" />
<img width="893" height="128" alt="image" src="https://github.com/user-attachments/assets/3a73752d-7580-4d3f-ba37-3b462871cfe1" /> | <img width="898" height="138" alt="image" src="https://github.com/user-attachments/assets/0c8a5838-da72-49f8-a364-59dc359200d7" />


### Still works in RTL

🏚️ Before | 🏡 After
-- | --
<img width="905" height="67" alt="image" src="https://github.com/user-attachments/assets/0a170e2c-879a-4ff5-b9d1-860c19b28f7e" /> | <img width="900" height="65" alt="image" src="https://github.com/user-attachments/assets/afacaa02-2984-4811-bdb0-fb71290c97c2" />
<img width="902" height="134" alt="image" src="https://github.com/user-attachments/assets/5e3f5915-a21d-49d4-9e1f-f3d81352aabe" /> | <img width="904" height="144" alt="image" src="https://github.com/user-attachments/assets/60f6d46f-88b8-4c18-a788-9ef5572f0e83" />

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required