### PR TITLE
fix: replace moment.calendar() with Intl formatters

### DIFF
--- a/src/components/CalendarEventsDialog.vue
+++ b/src/components/CalendarEventsDialog.vue
@@ -8,7 +8,6 @@ import type { Conversation, Participant } from '../types/index.ts'
 
 import { showSuccess } from '@nextcloud/dialogs'
 import { n, t } from '@nextcloud/l10n'
-import moment from '@nextcloud/moment'
 import { useIsMobile } from '@nextcloud/vue/composables/useIsMobile'
 import { usernameToColor } from '@nextcloud/vue/functions/usernameToColor'
 import debounce from 'debounce'
@@ -33,6 +32,7 @@ import SelectableParticipant from './BreakoutRoomsEditor/SelectableParticipant.v
 import CalendarEventSmall from './UIShared/CalendarEventSmall.vue'
 import ContactSelectionBubble from './UIShared/ContactSelectionBubble.vue'
 import SearchBox from './UIShared/SearchBox.vue'
+import StaticDateTime from './UIShared/StaticDateTime.vue'
 import TransitionWrapper from './UIShared/TransitionWrapper.vue'
 import { ATTENDEE, CONVERSATION } from '../constants.ts'
 import { hasTalkFeature } from '../services/CapabilitiesManager.ts'
@@ -69,7 +69,7 @@ const upcomingEvents = computed(() => {
 		.sort((a, b) => (a.start && b.start) ? (a.start - b.start) : 0)
 		.map((event) => {
 			const start = event.start
-				? (event.start <= now) ? t('spreed', 'Now') : moment(event.start * 1000).calendar()
+				? (event.start <= now) ? t('spreed', 'Now') : event.start * 1000
 				: ''
 			const color = calendars.value[event.calendarUri]?.color ?? usernameToColor(event.calendarUri).color
 
@@ -356,7 +356,7 @@ async function submitNewMeeting() {
 						<span class="upcoming-meeting__header">
 							{{ t('spreed', 'Next meeting') }}
 						</span>
-						<span> {{ upcomingEvents[0].start }} </span>
+						<StaticDateTime :time="upcomingEvents[0].start" calendar />
 					</template>
 				</NcButton>
 			</template>

--- a/src/components/RightSidebar/RightSidebarContent.vue
+++ b/src/components/RightSidebar/RightSidebarContent.vue
@@ -11,7 +11,6 @@ import type {
 } from '../../types/index.ts'
 
 import { t } from '@nextcloud/l10n'
-import moment from '@nextcloud/moment'
 import { generateUrl } from '@nextcloud/router'
 import { useIsDarkTheme } from '@nextcloud/vue/composables/useIsDarkTheme'
 import { computed, ref, watch } from 'vue'
@@ -38,7 +37,7 @@ import { convertToUnix } from '../../utils/formattedTime.ts'
 type MutualEvent = {
 	uri: DashboardEvent['eventLink']
 	name: DashboardEvent['eventName']
-	start: string
+	start: string | number
 	href: DashboardEvent['eventLink']
 	color: string
 }
@@ -139,7 +138,7 @@ const mutualEventsInformation = computed<MutualEvent[]>(() => {
 	const now = convertToUnix(Date.now())
 	return groupwareStore.mutualEvents[token.value].map((event) => {
 		const start = event.start
-			? (event.start <= now) ? t('spreed', 'Now') : moment(event.start * 1000).calendar()
+			? (event.start <= now) ? t('spreed', 'Now') : event.start * 1000
 			: ''
 		return {
 			uri: event.eventLink,

--- a/src/components/UIShared/CalendarEventSmall.vue
+++ b/src/components/UIShared/CalendarEventSmall.vue
@@ -6,10 +6,11 @@
 <script setup lang="ts">
 import { t } from '@nextcloud/l10n'
 import IconReload from 'vue-material-design-icons/Reload.vue'
+import StaticDateTime from './StaticDateTime.vue'
 
 const props = defineProps<{
 	name: string | null
-	start: string | null
+	start: string | number
 	color: string
 	isRecurring?: boolean
 	href?: string
@@ -31,7 +32,7 @@ const props = defineProps<{
 					<span class="calendar-event__header-text">{{ name }}</span>
 					<IconReload v-if="isRecurring" :size="13" />
 				</span>
-				<span>{{ start }}</span>
+				<StaticDateTime :time="start" calendar />
 			</span>
 		</a>
 	</li>


### PR DESCRIPTION
### ☑️ Resolves

* Ref #14434
* Extracted from #14492
* Trade-offs:
  * we're losing prefixes like 'Today `at` 3:00 PM'
  * for 6+ days, we're using the same format as date separators (and not DD.MM.YYYY)



## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="351" height="260" alt="2025-09-30_14h08_29" src="https://github.com/user-attachments/assets/e0eaab0e-e2eb-46ae-a604-667609632547" /> | <img width="350" height="266" alt="2025-09-30_14h07_31" src="https://github.com/user-attachments/assets/4d06fe98-8be7-4840-872d-09288ec1b28b" />
<img width="424" height="280" alt="2025-09-30_14h09_08" src="https://github.com/user-attachments/assets/6bcccaa3-ea8c-426e-aed5-38b5f45c84a3" /> | <img width="412" height="263" alt="2025-09-30_14h10_57" src="https://github.com/user-attachments/assets/35f26fd9-5ee9-410d-b5c3-c9a97c1229ac" />
<img width="417" height="263" alt="2025-09-30_14h09_42" src="https://github.com/user-attachments/assets/08b9e601-2a6d-4fdd-8e78-e3851f0cf4e8" /> | <img width="415" height="262" alt="2025-09-30_14h10_29" src="https://github.com/user-attachments/assets/e679a0c1-e4fa-4028-a248-29336bbc2010" />
6+ days | --
<img width="418" height="262" alt="image" src="https://github.com/user-attachments/assets/b6a50f8a-cfa4-494c-9cfb-36d4edb03fcd" /> | <img width="415" height="258" alt="image" src="https://github.com/user-attachments/assets/538dd862-5c91-48e4-b097-317efa78a5a0" />
<img width="297" height="401" alt="2025-10-01_14h36_34" src="https://github.com/user-attachments/assets/d2f4cd9a-0119-400f-b909-ee1dfcc0dfd2" /> | <img width="292" height="398" alt="2025-10-01_14h38_15" src="https://github.com/user-attachments/assets/9730cb04-ebc3-4e58-8750-9b2dca400c72" />


### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team