### PR TITLE
fix(Lobby): make guest names visible for moderators when lobby is active

### DIFF
--- a/src/components/SetGuestUsername.vue
+++ b/src/components/SetGuestUsername.vue
@@ -52,6 +52,7 @@ import { getGuestNickname } from '@nextcloud/auth'
 import { subscribe, unsubscribe } from '@nextcloud/event-bus'
 import { t } from '@nextcloud/l10n'
 import { generateUrl } from '@nextcloud/router'
+import debounce from 'debounce'
 import escapeHtml from 'escape-html'
 import { computed, nextTick, onBeforeUnmount, ref, useTemplateRef, watch } from 'vue'
 import NcButton from '@nextcloud/vue/components/NcButton'
@@ -85,6 +86,7 @@ const actorDisplayName = computed<string>(() => actorStore.displayName || guestU
 const displayNameLabel = computed(() => t('spreed', 'Display name: {name}', {
 	name: `<strong>${escapeHtml(actorDisplayName.value)}</strong>`,
 }, { escape: false }))
+const debounceUpdateDisplayName = debounce(updateDisplayName, 500)
 
 watch(actorDisplayName, (newValue) => {
 	guestUserName.value = newValue
@@ -145,6 +147,7 @@ function toggleEdit() {
 
 // One-way binding to parent component
 watch(guestUserName, (newValue) => {
+	debounceUpdateDisplayName()
 	emit('update', newValue)
 }, { immediate: true })
 </script>


### PR DESCRIPTION

### ☑️ Resolves

* Fix #16108 

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="765" height="681" alt="image" src="https://github.com/user-attachments/assets/f9134d9d-7fb7-4df6-bc0b-019cd3a78337" /> | <img width="776" height="796" alt="image" src="https://github.com/user-attachments/assets/58012431-4fd5-42a1-b0f4-830c511f8d24" />

<!-- ☀️ Light theme | 🌑 Dark Theme -->



### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
