### PR TITLE
[stable32] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -311,12 +311,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "251d379ae2c80830880d49e1070926f89bc48669"
+                "reference": "cca045524d2e0de868069207c7a8a1ad845f6027"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/251d379ae2c80830880d49e1070926f89bc48669",
-                "reference": "251d379ae2c80830880d49e1070926f89bc48669",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/cca045524d2e0de868069207c7a8a1ad845f6027",
+                "reference": "cca045524d2e0de868069207c7a8a1ad845f6027",
                 "shasum": ""
             },
             "require": {
@@ -351,7 +351,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable32"
             },
-            "time": "2025-10-03T00:46:18+00:00"
+            "time": "2025-10-07T00:47:13+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency