### PR TITLE
[stable31] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -307,12 +307,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "4a55dcdbff0ae2062a8e3cdb905fc4d6076240b9"
+                "reference": "f2c9631628aa505923ea9da8e94cbbaccff42207"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/4a55dcdbff0ae2062a8e3cdb905fc4d6076240b9",
-                "reference": "4a55dcdbff0ae2062a8e3cdb905fc4d6076240b9",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/f2c9631628aa505923ea9da8e94cbbaccff42207",
+                "reference": "f2c9631628aa505923ea9da8e94cbbaccff42207",
                 "shasum": ""
             },
             "require": {
@@ -347,7 +347,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable31"
             },
-            "time": "2025-10-03T00:46:19+00:00"
+            "time": "2025-10-08T00:46:58+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency