### PR TITLE
fix(NewMessage): don't show typing indicator when editing a message

### DIFF
--- a/src/components/NewMessage/NewMessage.vue
+++ b/src/components/NewMessage/NewMessage.vue
@@ -656,7 +656,7 @@ export default {
 
 		handleTyping() {
 			// Enable signal sending, only if indicator for this input is on
-			if (!this.showTypingStatus) {
+			if (!this.showTypingStatus || this.messageToEdit) {
 				return
 			}
 


### PR DESCRIPTION
### ☑️ Resolves

* When seeing typing indicator, you expect a new message to be shown. Showing typing for editing existing messages is confusing.

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->


### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required

