### PR TITLE
fix(CalendarEventsDialog): Style upcoming meetings as tertiary

### DIFF
--- a/src/components/CalendarEventsDialog.vue
+++ b/src/components/CalendarEventsDialog.vue
@@ -349,7 +349,7 @@ async function submitNewMeeting() {
 					class="upcoming-meeting"
 					:title="t('spreed', 'Upcoming meetings')"
 					:aria-label="t('spreed', 'Upcoming meetings')"
-					:variant="tertiary">
+					variant="tertiary">
 					<template #icon>
 						<IconCalendarBlankOutline :size="20" />
 					</template>


### PR DESCRIPTION
This fixes the low padding and generally weird style for a status button that was there previously.

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="370" height="64" alt="image" src="https://github.com/user-attachments/assets/c03fc2b5-8582-451c-b0aa-310b94107981" /> | <img width="370" height="64" alt="image" src="https://github.com/user-attachments/assets/ef7ceb29-1224-4c69-b5fd-0db72f1390fd" />

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required

(PS: This is just a quick one-liner so I did not actually test it as I don't have a dev env set up for Talk, please tell me if something doesn't work haha)