### PR TITLE
fix(App): prevent guest from joining the room twice

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -240,12 +240,10 @@ export default {
 		if (!getCurrentUser()) {
 			/**
 			 * When guest opens a public conversation, we wait for it to be fetched,
-			 * then joining and setting the 30 seconds interval to update information
+			 * then setting the 30 seconds interval to update information.
+			 * Joining is handled by router (initial navigation to 'conversation')
 			 */
 			EventBus.once('conversations-received', (params) => {
-				if (params.singleConversation) {
-					this.$store.dispatch('joinConversation', { token: params.singleConversation.token })
-				}
 				setInterval(() => {
 					this.refreshCurrentConversation()
 				}, 30_000)


### PR DESCRIPTION
### ☑️ Resolves

* Fix second session appeared for guest
 * logic is now controlled by Vue-router


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="519" height="227" alt="2025-10-16_12h37_03" src="https://github.com/user-attachments/assets/4212109c-8b05-40d3-99c8-cb20e0e69dfb" /> | <img width="513" height="232" alt="2025-10-16_12h36_39" src="https://github.com/user-attachments/assets/17ea0fed-c6ca-40eb-9e93-9742ef36fc96" />

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client