### PR TITLE
fix(NewMessage): set cursor to the end when focus

### DIFF
--- a/src/components/NewMessage/NewMessage.vue
+++ b/src/components/NewMessage/NewMessage.vue
@@ -238,7 +238,12 @@ import { useSettingsStore } from '../../stores/settings.ts'
 import { useTokenStore } from '../../stores/token.ts'
 import { fetchClipboardContent } from '../../utils/clipboard.js'
 import { ONE_DAY_IN_MS } from '../../utils/formattedTime.ts'
-import { getCurrentSelectionRange, insertTextInElement, selectRange } from '../../utils/selectionRange.ts'
+import {
+	getCurrentSelectionRange,
+	getRangeAtEnd,
+	insertTextInElement,
+	selectRange,
+} from '../../utils/selectionRange.ts'
 import { parseSpecialSymbols } from '../../utils/textParse.ts'
 
 export default {
@@ -973,7 +978,8 @@ export default {
 		},
 
 		restoreSelectionRange() {
-			selectRange(this.preservedSelectionRange, this.getContenteditable())
+			// If nothing to restore, set cursor at the end
+			selectRange(this.preservedSelectionRange ?? getRangeAtEnd(this.getContenteditable()), this.getContenteditable())
 			this.preservedSelectionRange = null
 		},
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix #16151

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏡 After

https://github.com/user-attachments/assets/eb20b76d-30b3-4860-9552-024a87f29e56


### 🚧 Tasks

- [ ] Check why `this.restoreSelection()` with `this.preservedSelectionRange !== null` still set cursor at the end

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required