### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -311,12 +311,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "4556a0916442369994fdc6a7d4cd7c6e5e85d46d"
+                "reference": "64f0f74510b9c241b2aa930f9620eb8988d72c96"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/4556a0916442369994fdc6a7d4cd7c6e5e85d46d",
-                "reference": "4556a0916442369994fdc6a7d4cd7c6e5e85d46d",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/64f0f74510b9c241b2aa930f9620eb8988d72c96",
+                "reference": "64f0f74510b9c241b2aa930f9620eb8988d72c96",
                 "shasum": ""
             },
             "require": {
@@ -352,7 +352,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2025-10-15T00:49:40+00:00"
+            "time": "2025-10-17T00:49:00+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency