### PR TITLE
fix(useGetMessages): always start message polling

### DIFF
--- a/src/composables/useGetMessages.ts
+++ b/src/composables/useGetMessages.ts
@@ -318,23 +318,22 @@ export function useGetMessagesProvider() {
 				}
 
 				await getMessageContext(token, contextMessageId.value, contextThreadId.value)
-
-				// If last message is not present in the initial context,
-				// add it as most recent chat block to start long polling from it
-				if (conversation.value?.lastMessage && 'id' in conversation.value.lastMessage
-					&& !chatStore.hasMessage(token, { messageId: conversation.value.lastMessage.id })) {
-					await store.dispatch('processMessage', { token, message: conversation.value.lastMessage })
-					chatStore.processChatBlocks(token, [conversation.value.lastMessage])
-				}
-
-				// Fallback for sensitive and federated conversations: if there is still no chat block created,
-				// ensure polling starts at least from the last read message by the user
-				if (!chatStore.chatBlocks[token]) {
-					chatStore.chatBlocks[token] = [new Set([conversation.value!.lastReadMessage])]
-				}
 			} catch (exception) {
 				console.debug(exception)
-				return
+			}
+
+			// If last message is not present in the initial context,
+			// add it as most recent chat block to start long polling from it
+			if (conversation.value?.lastMessage && 'id' in conversation.value.lastMessage
+				&& !chatStore.hasMessage(token, { messageId: conversation.value.lastMessage.id })) {
+				await store.dispatch('processMessage', { token, message: conversation.value.lastMessage })
+				chatStore.processChatBlocks(token, [conversation.value.lastMessage])
+			}
+
+			// Fallback for sensitive and federated conversations: if there is still no chat block created,
+			// ensure polling starts at least from the last read message by the user
+			if (!chatStore.chatBlocks[token]) {
+				chatStore.chatBlocks[token] = [new Set([conversation.value!.lastReadMessage])]
 			}
 		} else {
 			await checkContextAndFocusMessage(token, contextMessageId.value, contextThreadId.value, focusMessageId !== null)


### PR DESCRIPTION
### ☑️ Resolves

* Might help with #15868

One of the cases to reproduce (may be something else):
  - add `sleep(5)` to `ChatController#getMessageContext`
  - join the room
  - post a message before contextRequest was finished loading
  - contextId shifted to a new message
  - contextRequest 1 is cancelled, polling is never started
  - contextRequest2 is started, no more new messages
 
 With this PR:
 - use the same fallback to last read message + long polling
 - if context request was cancelled, we at least have:
  - lastMessage to show in the chat
  - lastReadMessageId to start polling from it


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required