### PR TITLE
fix(virtual-bg): change the video segmentation dimensions to square, …

### DIFF
--- a/src/utils/media/pipeline/VirtualBackground.js
+++ b/src/utils/media/pipeline/VirtualBackground.js
@@ -127,8 +127,8 @@ export default class VirtualBackground extends TrackSinkSource {
 
 	_initVideoStreamBackgroundEffect() {
 		const segmentationDimensions = {
-			modelLandscape: {
-				height: 144,
+			modelSquare: {
+				height: 256,
 				width: 256,
 			},
 		}
@@ -144,7 +144,7 @@ export default class VirtualBackground extends TrackSinkSource {
 			blurValue: VIRTUAL_BACKGROUND.BLUR_STRENGTH.DEFAULT,
 		}
 		const options = {
-			...segmentationDimensions.modelLandscape,
+			...segmentationDimensions.modelSquare,
 			virtualBackground,
 			webGL,
 		}


### PR DESCRIPTION
…since we are now using the square model

This is only used when falling back to CPU compositing
