### PR TITLE
feat(SettingsDialog): refactor settings and shortcuts to new design

### DIFF
--- a/src/components/SettingsDialog/SettingsDialog.vue
+++ b/src/components/SettingsDialog/SettingsDialog.vue
@@ -7,15 +7,13 @@
 	<NcAppSettingsDialog
 		v-model:open="showSettings"
 		:name="t('spreed', 'Talk settings')"
-		show-navigation
-		legacy>
+		show-navigation>
 		<!-- Custom settings sections registered via OCA.Talk.Settings -->
 		<NcAppSettingsSection
 			v-for="{ id, name, element } in customSettingsSections"
 			:id="id"
 			:key="id"
-			:name="name"
-			class="app-settings-section">
+			:name="name">
 			<component :is="element" />
 		</NcAppSettingsSection>
 
@@ -410,51 +408,10 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-
 .app-settings-section {
-	margin-bottom: 80px;
-
-	&:last-of-type {
-		margin-bottom: 0;
-	}
-
-	&__title {
-		overflow: hidden;
-		white-space: nowrap;
-		text-overflow: ellipsis;
-	}
-
-	&__hint {
-		color: var(--color-text-maxcontrast);
-		padding: 8px 0;
-	}
-
 	&__version {
 		margin-inline: var(--form-element-label-offset);
 		color: var(--color-text-maxcontrast);
 	}
-
-	&__wrapper {
-		display: flex;
-		align-items: center;
-		gap: 8px;
-	}
-
-	// Copy-pasted styles from NcInputField
-	&__input {
-		width: 300px;
-		height: var(--default-clickable-area);
-		line-height: var(--default-clickable-area);
-		padding-inline: 12px 6px;
-		border: var(--border-width-input, 2px) solid var(--color-border-maxcontrast);
-		border-radius: var(--border-radius-large);
-		font-size: var(--default-font-size);
-		text-overflow: ellipsis;
-		opacity: 0.7;
-		color: var(--color-main-text);
-		background-color: var(--color-main-background);
-		cursor: pointer;
-	}
 }
-
 </style>


### PR DESCRIPTION
### ☑️ Resolves

* Fix #16113

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

Before | After
-- | --
<img width="967" height="286" alt="image" src="https://github.com/user-attachments/assets/cb39ff17-0c91-4084-8753-92d9d01b879f" /> | <img width="562" height="237" alt="image" src="https://github.com/user-attachments/assets/1c3be8f7-dcb2-4946-9251-a0b83885eef7" />
<img width="847" height="423" alt="image" src="https://github.com/user-attachments/assets/210baee6-1988-47e8-aa22-6b452af8633b" /> | <img width="558" height="430" alt="image" src="https://github.com/user-attachments/assets/a39b4623-fb22-4475-8f5f-73d712e2076c" />
<img width="967" height="207" alt="image" src="https://github.com/user-attachments/assets/a39b0af5-cce7-4e3d-a547-3d94a5239920" /> | <img width="550" height="106" alt="image" src="https://github.com/user-attachments/assets/d0dc9967-49e4-4e1a-a4d8-4cf3f38cb124" />
<img width="713" height="751" alt="image" src="https://github.com/user-attachments/assets/73277149-5851-4483-939a-bc43fd69778a" /> | <img width="548" height="661" alt="image" src="https://github.com/user-attachments/assets/f9dbbb64-f39f-4d11-a1cd-12b95ad4bdcb" />

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required