### PR TITLE
fix: Use short datetime style in search

### DIFF
--- a/src/components/RightSidebar/SearchMessages/SearchMessageItem.vue
+++ b/src/components/RightSidebar/SearchMessages/SearchMessageItem.vue
@@ -120,7 +120,7 @@ function handleResultClick() {
 			<NcDateTime
 				:timestamp="timestamp * 1000"
 				class="search-results__date"
-				relative-time="narrow"
+				relative-time="short"
 				ignore-seconds />
 		</template>
 	</NcListItem>


### PR DESCRIPTION
### ☑️ Resolves

* Fix https://github.com/nextcloud/spreed/issues/16229

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img  height="450" alt="Bildschirmfoto 2025-10-29 um 22 34 07" src="https://github.com/user-attachments/assets/94efff90-13c4-403d-b1f0-29e9f09d8e35" /> |  <img height="450" alt="Bildschirmfoto 2025-10-29 um 22 35 54" src="https://github.com/user-attachments/assets/5d2983af-9c7a-4380-abbe-895637d71e6a" />


### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required

