### PR TITLE
fix(reactions): set expiry of reaction message to parent message expiry

### DIFF
--- a/lib/Chat/ReactionManager.php
+++ b/lib/Chat/ReactionManager.php
@@ -63,6 +63,7 @@ class ReactionManager {
 		} catch (NotFoundException $e) {
 		}
 
+		/** @var IComment $comment */
 		$comment = $this->commentsManager->create(
 			$actorType,
 			$actorId,
@@ -72,6 +73,7 @@ class ReactionManager {
 		$comment->setParentId($parentMessage->getId());
 		$comment->setMessage($reaction);
 		$comment->setVerb(ChatManager::VERB_REACTION);
+		$comment->setExpireDate($parentMessage->getExpireDate());
 
 		$event = new BeforeReactionAddedEvent($chat, $parentMessage, $actorType, $actorId, $actorDisplayName, $reaction);
 		$this->dispatcher->dispatchTyped($event);


### PR DESCRIPTION
### ☑️ Resolves

* Fixes #11298

<!--
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
░░░███████░░░█████████░░█████░
░░███░░░███░░░███░░░███░░███░░
░░█████████░░░████████░░░███░░
░░███░░░███░░░███░░░░░░░░███░░
░█████░█████░█████░░░░░░█████░
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching frontend/UI code
-->

## 🛠️ API Checklist

### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not possible
- [ ] 📘 API documentation in `docs/` has been updated or is not required
- [ ] 🔖 Capability is added or not needed 
