### PR TITLE
fix(NewMessage): limit 'set cursor to the end' to editing

### DIFF
--- a/src/components/NewMessage/NewMessage.vue
+++ b/src/components/NewMessage/NewMessage.vue
@@ -582,6 +582,11 @@ export default {
 			} else {
 				this.text = this.chatInput
 			}
+
+			this.$nextTick(() => {
+				// set cursor at the end
+				selectRange(getRangeAtEnd(this.getContenteditable()), this.getContenteditable())
+			})
 		},
 
 		parentMessage(newValue) {
@@ -978,8 +983,7 @@ export default {
 		},
 
 		restoreSelectionRange() {
-			// If nothing to restore, set cursor at the end
-			selectRange(this.preservedSelectionRange ?? getRangeAtEnd(this.getContenteditable()), this.getContenteditable())
+			selectRange(this.preservedSelectionRange, this.getContenteditable())
 			this.preservedSelectionRange = null
 		},
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix regression from #16152
  * Cursor was also set when briefly unfocus tab / bring from background
  * Now only limited to editing messages, as per original issue


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

### 🚧 Tasks

- [ ] Need manual testing
- [ ] Probably https://github.com/nextcloud-libraries/nextcloud-vue/pull/4924 might interfere on Linux, but not Windows (Firefox and Chrome)

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required