### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -311,12 +311,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "3f95535bb867f0458d3cd2bf9de87e6def9b156e"
+                "reference": "6096dced51d997d0e9bedefb6b428c09e6aeae09"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/3f95535bb867f0458d3cd2bf9de87e6def9b156e",
-                "reference": "3f95535bb867f0458d3cd2bf9de87e6def9b156e",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/6096dced51d997d0e9bedefb6b428c09e6aeae09",
+                "reference": "6096dced51d997d0e9bedefb6b428c09e6aeae09",
                 "shasum": ""
             },
             "require": {
@@ -352,7 +352,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2025-10-31T00:51:08+00:00"
+            "time": "2025-11-05T00:53:12+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency