### PR TITLE
[stable32] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -311,12 +311,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "48411c7277aaf2533565cb5e2c766ca164ad9709"
+                "reference": "2dd55a1fecc06ba4d01d5eea8583a33231b26e7d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/48411c7277aaf2533565cb5e2c766ca164ad9709",
-                "reference": "48411c7277aaf2533565cb5e2c766ca164ad9709",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/2dd55a1fecc06ba4d01d5eea8583a33231b26e7d",
+                "reference": "2dd55a1fecc06ba4d01d5eea8583a33231b26e7d",
                 "shasum": ""
             },
             "require": {
@@ -351,7 +351,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable32"
             },
-            "time": "2025-10-29T00:53:19+00:00"
+            "time": "2025-11-06T00:51:57+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency