### PR TITLE
feat: support chat relay in frontend

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -22,6 +22,11 @@ export const CONFIG = {
 		 * to allow join the call without page reload
 		 */
 		RECOVER_SESSION: 2,
+		/**
+		 * Since 22.0.3
+		 * Send chat messages via the High performance-backend / websocket
+		 */
+		CHAT_RELAY: 4,
 	},
 } as const
 

--- a/src/services/EventBus.ts
+++ b/src/services/EventBus.ts
@@ -21,6 +21,7 @@ import mitt from 'mitt'
 export type Events = {
 	[key: EventType]: unknown
 	'audio-player-ended': number
+	'signaling-message-received': { token: string, message: ChatMessage }
 	'conversations-received': { singleConversation?: Conversation, fromBrowserStorage?: boolean }
 	'session-conflict-confirmation': string
 	'deleted-session-detected': void
@@ -53,6 +54,7 @@ export type Events = {
 	'signaling-users-joined': [StandaloneSignalingJoinSession[]]
 	'signaling-users-left': [string[]]
 	'signaling-all-users-changed-in-call-to-disconnected': void
+	'signaling-supported-features': string[]
 	'smart-picker-open': void
 	'switch-to-conversation': { token: string }
 	'talk:poll-added': { token: string, message: ChatMessage }

--- a/src/utils/signaling.js
+++ b/src/utils/signaling.js
@@ -1113,6 +1113,7 @@ Signaling.Standalone.prototype.helloResponseReceived = function(data) {
 		for (i = 0; i < features.length; i++) {
 			this.features[features[i]] = true
 		}
+		this._trigger('supportedFeatures', features)
 	}
 
 	if (!this.settings.helloAuthParams.internal
@@ -1430,8 +1431,12 @@ Signaling.Standalone.prototype.processRoomEvent = function(data) {
 Signaling.Standalone.prototype.processRoomMessageEvent = function(token, data) {
 	switch (data.type) {
 		case 'chat':
-		// FIXME this is not listened to
-			EventBus.emit('should-refresh-chat-messages')
+			if ('comment' in data.chat) {
+				EventBus.emit('signaling-message-received', { token, message: { ...data.chat.comment, token } })
+			} else {
+				// TOREMOVE after HPB next release
+				EventBus.emit('should-refresh-chat-messages')
+			}
 			break
 		case 'recording':
 			EventBus.emit('signaling-recording-status-changed', [token, data.recording.status])


### PR DESCRIPTION
### ☑️ Resolves

- Part of #624 
- To test and while you don't have the latest master from signaling, overwrite its feature like:
```
this.features['chat-relay'] = true // TEMPORARY Always supported by standalone signaling server.

```

in `Signaling.Standalone.prototype.helloResponseReceived `

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
