### PR TITLE
fix(l10n): remove trailing dot in translated string

### DIFF
--- a/src/components/SettingsDialog/SettingsDialog.vue
+++ b/src/components/SettingsDialog/SettingsDialog.vue
@@ -174,6 +174,9 @@ import { useActorStore } from '../../stores/actor.ts'
 import { useSettingsStore } from '../../stores/settings.ts'
 import { useSoundsStore } from '../../stores/sounds.js'
 
+const disableKeyboardShortcuts = OCP.Accessibility.disableKeyboardShortcuts()
+const settingsUrl = generateUrl('/settings/user/notifications')
+
 const talkVersion = getTalkVersion()
 
 const supportTypingStatus = getTalkConfig('local', 'chat', 'typing-privacy') !== undefined
@@ -200,12 +203,15 @@ export default {
 	},
 
 	setup() {
+		const actorStore = useActorStore()
 		const settingsStore = useSettingsStore()
 		const soundsStore = useSoundsStore()
 		const { customSettingsSections } = useCustomSettings()
 
 		return {
 			IS_DESKTOP,
+			disableKeyboardShortcuts,
+			settingsUrl,
 			talkVersion,
 			settingsStore,
 			soundsStore,
@@ -214,7 +220,7 @@ export default {
 			supportStartWithoutMedia,
 			supportConversationsListStyle,
 			supportDefaultBlurVirtualBackground,
-			actorStore: useActorStore(),
+			actorStore,
 		}
 	},
 
@@ -256,14 +262,6 @@ export default {
 
 		conversationsListStyle() {
 			return this.settingsStore.conversationsListStyle !== CONVERSATION.LIST_STYLE.TWO_LINES
-		},
-
-		settingsUrl() {
-			return generateUrl('/settings/user/notifications')
-		},
-
-		disableKeyboardShortcuts() {
-			return OCP.Accessibility.disableKeyboardShortcuts()
 		},
 
 		hideMediaSettings() {


### PR DESCRIPTION
### ☑️ Resolves

* Follow-up to #16192
  * Remove dot in translated string
  * Cleanup and chores

## 🖌️ UI Checklist

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required