### PR TITLE
Fix: hide message expiration settings when not supported by server

### DIFF
--- a/src/components/ConversationSettings/ConversationSettingsDialog.vue
+++ b/src/components/ConversationSettings/ConversationSettingsDialog.vue
@@ -36,7 +36,7 @@
 				<MentionsSettings v-if="!isNoteToSelf && !isOneToOne" :token="token" :can-moderate="canFullModerate" />
 				<LinkShareSettings v-if="!isNoteToSelf" :token="token" :can-moderate="canFullModerate" />
 				<RecordingConsentSettings v-if="!isNoteToSelf && !isOneToOneFormer && recordingConsentAvailable" :token="token" :can-moderate="selfIsOwnerOrModerator" />
-				<ExpirationSettings v-if="!isOneToOneFormer" :token="token" :can-moderate="selfIsOwnerOrModerator" />
+				<ExpirationSettings v-if="!isOneToOneFormer && hasMessageExpirationFeature" :token="token" :can-moderate="selfIsOwnerOrModerator" />
 				<BanSettings v-if="supportBanV1 && canFullModerate" :token="token" />
 			</NcAppSettingsSection>
 
@@ -280,6 +280,10 @@ export default {
 
 		recordingConsentRequired() {
 			return this.conversation.recordingConsent === CALL.RECORDING_CONSENT.ENABLED
+		},
+
+		hasMessageExpirationFeature() {
+			return hasTalkFeature(this.token, 'message-expiration')
 		},
 	},
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix #11335

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="897" height="627" alt="before" src="https://github.com/user-attachments/assets/e113de90-0ccf-465e-8304-23a6ba0bcbba" /> | <img width="889" height="435" alt="after" src="https://github.com/user-attachments/assets/edae0da2-86e1-4e5a-9200-7e3214c7a488" />


<!-- ☀️ Light theme | 🌑 Dark Theme -->

### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [x] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required

Now the message expiration setting is not offered if it's not supported by the server.

Is this something you would expect in the [documentation](https://github.com/nextcloud/documentation/blob/master/user_manual/talk/talk_basics.rst#messages-expiration)?