### PR TITLE
fix(VideoStreamBackgroundEffect): make imports supported by Talk Desktop

### DIFF
--- a/rspack.config.js
+++ b/rspack.config.js
@@ -5,7 +5,6 @@
 
 const browserslistConfig = require('@nextcloud/browserslist-config')
 const { defineConfig } = require('@rspack/cli')
-const { CopyRspackPlugin } = require('@rspack/core')
 const { CssExtractRspackPlugin, LightningCssMinimizerRspackPlugin, DefinePlugin, ProgressPlugin, SwcJsMinimizerRspackPlugin } = require('@rspack/core')
 const NodePolyfillPlugin = require('@rspack/plugin-node-polyfill')
 const browserslist = require('browserslist')
@@ -204,20 +203,6 @@ module.exports = defineConfig((env) => {
 				filename: '../css/talk-[name].css',
 				chunkFilename: '../css/chunks/[id].chunk.css',
 				ignoreOrder: true,
-			}),
-
-			// Bundle wasm and tflite files required for virtual background feature
-			new CopyRspackPlugin({
-				patterns: [
-					{
-						from: path.resolve(__dirname, 'node_modules', '@mediapipe/tasks-vision', 'wasm'),
-						to: path.resolve(__dirname, 'js'),
-					},
-					{
-						from: path.resolve(__dirname, 'src', 'utils', 'media', 'effects', 'virtual-background', 'vendor', 'models', 'selfie_segmenter.tflite'),
-						to: path.resolve(__dirname, 'js'),
-					},
-				],
 			}),
 		],
 

--- a/src/utils/media/effects/virtual-background/VideoStreamBackgroundEffect.js
+++ b/src/utils/media/effects/virtual-background/VideoStreamBackgroundEffect.js
@@ -97,7 +97,29 @@ export default class VideoStreamBackgroundEffect {
 			 * Checks inside, if SIMD is supported to load the appropriate fileset
 			 */
 			if (!_WasmFileset) {
-				_WasmFileset = await FilesetResolver.forVisionTasks(generateFilePath('spreed', '', 'js'))
+				if (await FilesetResolver.isSimdSupported()) {
+					_WasmFileset = {
+						wasmLoaderPath: new URL(
+							'../../../../../node_modules/@mediapipe/tasks-vision/wasm/vision_wasm_internal.js',
+							import.meta.url,
+						).pathname,
+						wasmBinaryPath: new URL(
+							'../../../../../node_modules/@mediapipe/tasks-vision/wasm/vision_wasm_internal.wasm',
+							import.meta.url,
+						).pathname,
+					}
+				} else {
+					_WasmFileset = {
+						wasmLoaderPath: new URL(
+							'../../../../../node_modules/@mediapipe/tasks-vision/wasm/vision_wasm_nosimd_internal.js',
+							import.meta.url,
+						).pathname,
+						wasmBinaryPath: new URL(
+							'../../../../../node_modules/@mediapipe/tasks-vision/wasm/vision_wasm_nosimd_internal.wasm',
+							import.meta.url,
+						).pathname,
+					}
+				}
 			}
 
 			/**
@@ -105,7 +127,10 @@ export default class VideoStreamBackgroundEffect {
 			 */
 			this._imageSegmenter = await ImageSegmenter.createFromOptions(_WasmFileset, {
 				baseOptions: {
-					modelAssetPath: generateFilePath('spreed', 'js', 'selfie_segmenter.tflite'),
+					modelAssetPath: new URL(
+						'./vendor/models/selfie_segmenter.tflite',
+						import.meta.url,
+					).pathname,
 					delegate: 'GPU',
 				},
 				runningMode: 'VIDEO',


### PR DESCRIPTION
### ☑️ Resolves

* Follow-up to #16145
* Not dependent on tool (webpack / rspack)
* No need for copy plugin
* Works with Desktop client without tweaks

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required