### PR TITLE
fix(SearchConversationsResults): fix compact list styles

### DIFF
--- a/src/components/LeftSidebar/ConversationsList/ConversationsListVirtual.vue
+++ b/src/components/LeftSidebar/ConversationsList/ConversationsListVirtual.vue
@@ -152,6 +152,7 @@ export default {
 
 <style lang="scss" scoped>
 // Overwrite NcListItem styles
+// TOREMOVE: get rid of it or find better approach
 :deep(.list-item) {
 	outline-offset: -2px;
 }

--- a/src/components/LeftSidebar/SearchConversationsResults/SearchConversationsResults.vue
+++ b/src/components/LeftSidebar/SearchConversationsResults/SearchConversationsResults.vue
@@ -329,3 +329,29 @@ const iconSize = computed(() => isCompact.value ? AVATAR.SIZE.COMPACT : AVATAR.S
 		</template>
 	</RecycleScroller>
 </template>
+
+<style lang="scss" scoped>
+// Overwrite NcListItem styles
+// TOREMOVE: get rid of it or find better approach
+:deep(.list-item) {
+	outline-offset: -2px;
+}
+
+/* Overwrite NcListItem styles for compact view */
+:deep(.list-item--compact) {
+	padding-block: 0 !important;
+}
+
+:deep(.list-item--compact:not(:has(.list-item-content__subname))) {
+	--list-item-height: calc(var(--clickable-area-small, 24px) + 4px) !important;
+}
+
+:deep(.list-item--compact .button-vue--size-normal) {
+	--button-size: var(--clickable-area-small, 24px);
+	--button-radius: var(--border-radius);
+}
+
+:deep(.list-item--compact .list-item-content__actions) {
+	height: var(--clickable-area-small, 24px);
+}
+</style>


### PR DESCRIPTION
### ☑️ Resolves

* Fix styles for search results in compact mode

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="207" height="160" alt="2025-11-14_16h25_21" src="https://github.com/user-attachments/assets/135fd2bc-ba36-44e7-810e-95a5c8fe6d4c" /> | <img width="209" height="136" alt="2025-11-14_16h24_40" src="https://github.com/user-attachments/assets/7c79efd6-b13e-477f-b1e1-1cd50bc6904c" />

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
