### PR TITLE
feat(LeftSidebar): add global Talk messages search

### DIFF
--- a/src/components/LeftSidebar/LeftSidebar.spec.js
+++ b/src/components/LeftSidebar/LeftSidebar.spec.js
@@ -28,6 +28,7 @@ vi.mock('../../services/conversationTagsService', () => ({
 }))
 vi.mock('../../services/coreService', () => ({
 	autocompleteQuery: vi.fn(),
+	searchMessages: vi.fn(),
 }))
 
 // short-circuit debounce

--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -377,6 +377,7 @@
 				:searchFilters="searchFilters"
 				:conversationsList="conversationsList"
 				:searchResults="searchResultsPossibleConversations"
+				:searchResultsMessages="searchResultsMessages"
 				:searchResultsListedConversations="searchResultsListedConversations"
 				@abortSearch="abortSearch"
 				@createNewConversation="createConversation"
@@ -515,6 +516,7 @@ const FILTER_LABELS = {
 }
 const SEARCH_FILTER_LABELS = {
 	conversations: t('spreed', 'Conversations'),
+	messages: t('spreed', 'Messages'),
 }
 const SORT_LABELS = {
 	// TRANSLATORS Navigation actions: sort conversations by recent activity / sort alphabetically
@@ -604,6 +606,7 @@ export default {
 			searchFilters,
 			searchResultsPossibleConversations,
 			searchResultsListedConversations,
+			searchResultsMessages,
 			searchResultsLoading,
 			search,
 			toggleFilter,
@@ -646,6 +649,7 @@ export default {
 			searchFilters,
 			searchResultsPossibleConversations,
 			searchResultsListedConversations,
+			searchResultsMessages,
 			searchResultsLoading,
 			search,
 			toggleFilter,

--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -231,6 +231,22 @@
 							:text="FILTER_LABELS[filter]"
 							@close="handleFilter(filter)" />
 					</TransitionWrapper>
+					<!-- Search filters -->
+					<div v-if="isSearching" class="conversations__search-filters">
+						<NcChip
+							v-for="filter in SEARCH_FILTERS"
+							:key="filter"
+							noClose
+							class="search-filter-chip"
+							:variant="searchFilters.includes(filter) ? 'primary' : 'secondary'"
+							:text="SEARCH_FILTER_LABELS[filter]"
+							role="button"
+							tabindex="0"
+							:aria-pressed="searchFilters.includes(filter)"
+							@click="handleSearchFilter(filter)"
+							@keydown.enter.prevent="handleSearchFilter(filter)"
+							@keydown.space.prevent="handleSearchFilter(filter)" />
+					</div>
 				</div>
 
 				<div v-if="!isSearching" class="navigation-buttons-container">
@@ -358,6 +374,7 @@
 				class="scroller"
 				:searchText="searchText"
 				:searchResultsLoading="searchResultsLoading"
+				:searchFilters="searchFilters"
 				:conversationsList="conversationsList"
 				:searchResults="searchResultsPossibleConversations"
 				:searchResultsListedConversations="searchResultsListedConversations"
@@ -474,7 +491,7 @@ import {
 	sortConversationsList,
 } from '../../utils/conversation.ts'
 import { requestTabLeadership } from '../../utils/requestTabLeadership.js'
-import { useSearchConversationsResults } from './SearchConversationsResults/useSearchConversationsResults.ts'
+import { SEARCH_FILTERS, useSearchConversationsResults } from './SearchConversationsResults/useSearchConversationsResults.ts'
 
 const isFederationEnabled = getTalkConfig('local', 'federation', 'enabled')
 const canModerateSipDialOut = hasTalkFeature('local', 'sip-support-dialout')
@@ -495,6 +512,9 @@ const FILTER_LABELS = {
 	mentions: t('spreed', 'Mentions'),
 	events: t('spreed', 'Meetings'),
 	default: '',
+}
+const SEARCH_FILTER_LABELS = {
+	conversations: t('spreed', 'Conversations'),
 }
 const SORT_LABELS = {
 	// TRANSLATORS Navigation actions: sort conversations by recent activity / sort alphabetically
@@ -581,10 +601,12 @@ export default {
 		const LIST_HEADING_ID = 'left-sidebar-list-heading'
 
 		const {
+			searchFilters,
 			searchResultsPossibleConversations,
 			searchResultsListedConversations,
 			searchResultsLoading,
 			search,
+			toggleFilter,
 			abortSearchRequests,
 		} = useSearchConversationsResults()
 
@@ -612,6 +634,8 @@ export default {
 			CONVERSATION,
 			HOME_BUTTON_LABEL,
 			FILTER_LABELS,
+			SEARCH_FILTERS,
+			SEARCH_FILTER_LABELS,
 			SORT_LABELS,
 			LIST_HEADING_ID,
 			actorStore: useActorStore(),
@@ -619,10 +643,12 @@ export default {
 			tokenStore: useTokenStore(),
 			tagsStore,
 
+			searchFilters,
 			searchResultsPossibleConversations,
 			searchResultsListedConversations,
 			searchResultsLoading,
 			search,
+			toggleFilter,
 			abortSearchRequests,
 		}
 	},
@@ -943,9 +969,22 @@ export default {
 			this.showThreadsList = false
 
 			this.resetNavigation()
-			// Re-initialize navigation only for successfull result
+			// Re-initialize navigation only for successful result
 			if (await this.search(this.searchText)) {
-				this.initializeNavigation()
+				this.$nextTick(() => this.initializeNavigation())
+			}
+		},
+
+		/**
+		 * Enable or disable a search filter, fetching or dropping its results
+		 *
+		 * @param {string} filter the toggled search filter
+		 */
+		async handleSearchFilter(filter) {
+			this.resetNavigation()
+			// Re-initialize navigation only for successful result
+			if (await this.toggleFilter(this.searchText, filter)) {
+				this.$nextTick(() => this.initializeNavigation())
 			}
 		},
 
@@ -1278,6 +1317,22 @@ export default {
 	display: flex;
 	flex-wrap: wrap;
 	gap: var(--default-grid-baseline);
+}
+
+.conversations__search-filters {
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--default-grid-baseline);
+	margin-block-start: var(--default-grid-baseline);
+
+	.search-filter-chip {
+		cursor: pointer;
+
+		// Overwrite NcChip styles: span inherits 'cursor: default'
+		:deep(.nc-chip__text) {
+			cursor: inherit;
+		}
+	}
 }
 
 .archived-conversations-bubble {

--- a/src/components/LeftSidebar/SearchConversationsResults/SearchConversationsResults.vue
+++ b/src/components/LeftSidebar/SearchConversationsResults/SearchConversationsResults.vue
@@ -4,7 +4,11 @@
 -->
 
 <script setup lang="ts">
-import type { Conversation, ParticipantSearchResult } from '../../../types/index.ts'
+import type {
+	Conversation,
+	ParticipantSearchResult,
+	UnifiedSearchResultEntryWithRouterLink,
+} from '../../../types/index.ts'
 
 import { t } from '@nextcloud/l10n'
 import { useVirtualList } from '@vueuse/core'
@@ -14,6 +18,7 @@ import NcListItem from '@nextcloud/vue/components/NcListItem'
 import IconChatPlusOutline from 'vue-material-design-icons/ChatPlusOutline.vue'
 import AvatarWrapper from '../../AvatarWrapper/AvatarWrapper.vue'
 import ConversationIcon from '../../ConversationIcon.vue'
+import SearchMessageItem from '../../RightSidebar/SearchMessages/SearchMessageItem.vue'
 import NavigationHint from '../../UIShared/NavigationHint.vue'
 import ConversationItem from '../ConversationsList/ConversationItem.vue'
 import { ATTENDEE, AVATAR, CONVERSATION } from '../../../constants.ts'
@@ -29,6 +34,7 @@ const props = defineProps<{
 	searchFilters: string[]
 	searchResultsListedConversations: Conversation[]
 	searchResults: ParticipantSearchResult[]
+	searchResultsMessages: UnifiedSearchResultEntryWithRouterLink[]
 }>()
 
 const emit = defineEmits<{
@@ -77,6 +83,7 @@ type VirtualListItem
 		| { type: 'hint', id: string, hint: string }
 		| { type: 'conversation', id: string, object: Conversation }
 		| { type: 'open_conversation', id: string, object: Conversation }
+		| { type: 'message', id: string, object: UnifiedSearchResultEntryWithRouterLink }
 		| { type: 'action', id: string, name: string, subname: string }
 		| { type: 'user' | 'group' | 'circle' | 'federated', id: string, object: ParticipantSearchResult, icon: Record<string, unknown> }
 
@@ -95,8 +102,9 @@ const searchResultsVirtual = computed<VirtualListItem[]>(() => {
 	})
 
 	const showConversations = props.searchFilters.includes('conversations')
+	const showMessages = props.searchFilters.includes('messages')
 
-	if (!showConversations) {
+	if (!showConversations && !showMessages) {
 		virtualList.push({ type: 'hint', id: 'hint_no_filters', hint: t('spreed', 'No matches found') })
 		return virtualList
 	}
@@ -119,19 +127,34 @@ const searchResultsVirtual = computed<VirtualListItem[]>(() => {
 		virtualList.push({ type: 'action', id: 'new_conversation', name: props.searchText, subname: t('spreed', 'New private conversation') })
 	}
 
-	// Add 'Loading' message if there are no results received from the server yet
-	if (showConversations && props.searchResultsLoading && !props.searchResultsListedConversations.length && !props.searchResults.length) {
-		virtualList.push({ type: 'caption', id: 'loading_results_caption', name: t('spreed', 'Other sources') })
-		virtualList.push({ type: 'hint', id: 'loading_results_hint', hint: t('spreed', 'Loading …') })
-		return virtualList
-	}
-
 	// Add open conversations section if any
 	if (showConversations && props.searchResultsListedConversations.length !== 0) {
 		virtualList.push({ type: 'caption', id: 'open_conversation_caption', name: t('spreed', 'Open conversations') })
 		props.searchResultsListedConversations.forEach((item: Conversation) => {
 			virtualList.push({ type: 'open_conversation', id: `open_conversation_${item.id}`, object: item })
 		})
+	}
+
+	if (showMessages) {
+		virtualList.push({ type: 'caption', id: 'messages_caption', name: t('spreed', 'Messages') })
+		if (props.searchResultsMessages.length === 0) {
+			virtualList.push({
+				type: 'hint',
+				id: 'hint_messages',
+				hint: props.searchResultsLoading ? t('spreed', 'Loading …') : t('spreed', 'No matches found'),
+			})
+		} else {
+			props.searchResultsMessages.forEach((item: UnifiedSearchResultEntryWithRouterLink) => {
+				virtualList.push({ type: 'message', id: `message_${item.attributes.messageId}`, object: item })
+			})
+		}
+	}
+
+	// Add 'Loading' message if there are no results received from the server yet
+	if (showConversations && props.searchResultsLoading && !props.searchResultsListedConversations.length && !props.searchResults.length) {
+		virtualList.push({ type: 'caption', id: 'loading_results_caption', name: t('spreed', 'Other sources') })
+		virtualList.push({ type: 'hint', id: 'loading_results_hint', hint: t('spreed', 'Loading …') })
+		return virtualList
 	}
 
 	// Categorize search results into different sections
@@ -275,6 +298,19 @@ const iconSize = computed(() => isCompact.value ? AVATAR.SIZE.COMPACT : AVATAR.S
 					v-else-if="item.data.type === 'open_conversation'"
 					:item="item.data.object"
 					isSearchResult
+					:compact="isCompact"
+					@click="emit('abortSearch')" />
+				<SearchMessageItem
+					v-else-if="item.data.type === 'message'"
+					:ref="`message-${item.data.object.attributes.conversation}`"
+					:messageId="+item.data.object.attributes.messageId"
+					:title="item.data.object.title"
+					:subline="item.data.object.subline"
+					:actorId="item.data.object.attributes.actorId"
+					:actorType="item.data.object.attributes.actorType"
+					:token="item.data.object.attributes.conversation"
+					:timestamp="+item.data.object.attributes.timestamp"
+					:to="item.data.object.to"
 					:compact="isCompact"
 					@click="emit('abortSearch')" />
 				<NcAppNavigationCaption

--- a/src/components/LeftSidebar/SearchConversationsResults/SearchConversationsResults.vue
+++ b/src/components/LeftSidebar/SearchConversationsResults/SearchConversationsResults.vue
@@ -91,16 +91,6 @@ const searchResultsVirtual = computed<VirtualListItem[]>(() => {
 	// Initialize
 	const virtualList: VirtualListItem[] = []
 
-	// Normalize strings for search (remove diacritics and case, e.g. 'Jérôme' -> 'jerome')
-	const normalizer = (rawString: string) => rawString.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '')
-
-	const searchTerms = normalizer(props.searchText).split(/\s+/).filter(Boolean)
-	const searchResultsConversationList = props.conversationsList.filter((conversation) => {
-		const displayName = normalizer(conversation.displayName)
-		const name = normalizer(conversation.name)
-		return searchTerms.every((term) => displayName.includes(term) || name.includes(term))
-	})
-
 	const showConversations = props.searchFilters.includes('conversations')
 	const showMessages = props.searchFilters.includes('messages')
 
@@ -111,15 +101,7 @@ const searchResultsVirtual = computed<VirtualListItem[]>(() => {
 
 	// Add conversations section
 	if (showConversations) {
-		virtualList.push({ type: 'caption', id: 'conversations_caption', name: t('spreed', 'Conversations') })
-		if (searchResultsConversationList.length === 0) {
-			virtualList.push({ type: 'hint', id: 'hint_conversations', hint: t('spreed', 'No matches found') })
-		} else {
-			sortConversationsList(searchResultsConversationList, settingsStore.groupMode, settingsStore.sortOrder)
-				.forEach((item: Conversation) => {
-					virtualList.push({ type: 'conversation', id: `conversation_${item.id}`, object: item })
-				})
-		}
+		virtualList.push(...getConversationsSection())
 	}
 
 	// Add "New Conversation" option if allowed
@@ -128,26 +110,12 @@ const searchResultsVirtual = computed<VirtualListItem[]>(() => {
 	}
 
 	// Add open conversations section if any
-	if (showConversations && props.searchResultsListedConversations.length !== 0) {
-		virtualList.push({ type: 'caption', id: 'open_conversation_caption', name: t('spreed', 'Open conversations') })
-		props.searchResultsListedConversations.forEach((item: Conversation) => {
-			virtualList.push({ type: 'open_conversation', id: `open_conversation_${item.id}`, object: item })
-		})
+	if (showConversations) {
+		virtualList.push(...getOpenConversationsSection())
 	}
 
 	if (showMessages) {
-		virtualList.push({ type: 'caption', id: 'messages_caption', name: t('spreed', 'Messages') })
-		if (props.searchResultsMessages.length === 0) {
-			virtualList.push({
-				type: 'hint',
-				id: 'hint_messages',
-				hint: props.searchResultsLoading ? t('spreed', 'Loading …') : t('spreed', 'No matches found'),
-			})
-		} else {
-			props.searchResultsMessages.forEach((item: UnifiedSearchResultEntryWithRouterLink) => {
-				virtualList.push({ type: 'message', id: `message_${item.attributes.messageId}`, object: item })
-			})
-		}
+		virtualList.push(...getMessagesSection())
 	}
 
 	// Add 'Loading' message if there are no results received from the server yet
@@ -159,46 +127,126 @@ const searchResultsVirtual = computed<VirtualListItem[]>(() => {
 
 	// Categorize search results into different sections
 	if (showConversations) {
-		const subList = props.searchResults.reduce<SubListType>((acc, result) => {
-			if (result.source === ATTENDEE.ACTOR_TYPE.USERS) {
-				acc.user.push(result)
-			} else if (result.source === ATTENDEE.ACTOR_TYPE.GROUPS && canStartConversations) {
-				acc.group.push(result)
-			} else if (result.source === ATTENDEE.ACTOR_TYPE.CIRCLES && canStartConversations) {
-				acc.circle.push(result)
-			} else if (result.source === ATTENDEE.ACTOR_TYPE.REMOTES && canStartConversations) {
-				acc.federated.push({ ...result, source: ATTENDEE.ACTOR_TYPE.FEDERATED_USERS })
-			}
-			return acc
-		}, {
-			user: [],
-			group: [],
-			circle: [],
-			federated: [],
-		})
-
-		// Iterate over sections and build the virtualList
-		sections.forEach((section) => {
-			if (subList[section.type].length > 0) {
-				virtualList.push(section.caption)
-				virtualList.push(...subList[section.type].map((match) => ({
-					type: section.type,
-					id: `${section.type}_${match.id}`,
-					object: match,
-					icon: iconData(match),
-				})))
-			}
-		})
-
-		// Add "No results" message if there are no results in any section
-		if (!subList.user.length || !subList.group.length || (!subList.circle.length && isCirclesEnabled) || !subList.federated.length) {
-			virtualList.push({ type: 'caption', id: 'no_results_caption', name: sourcesWithoutResults(subList) })
-			virtualList.push({ type: 'hint', id: 'no_results_hint', hint: t('spreed', 'No search results') })
-		}
+		virtualList.push(...getOtherSourcesSections())
 	}
 
 	return virtualList
 })
+
+/**
+ * Build the section with the joined conversations matching the search text
+ */
+function getConversationsSection(): VirtualListItem[] {
+	const items: VirtualListItem[] = []
+
+	// Normalize strings for search (remove diacritics and case, e.g. 'Jérôme' -> 'jerome')
+	const normalizer = (rawString: string) => rawString.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '')
+
+	const searchTerms = normalizer(props.searchText).split(/\s+/).filter(Boolean)
+	const searchResultsConversationList = props.conversationsList.filter((conversation) => {
+		const displayName = normalizer(conversation.displayName)
+		const name = normalizer(conversation.name)
+		return searchTerms.every((term) => displayName.includes(term) || name.includes(term))
+	})
+
+	items.push({ type: 'caption', id: 'conversations_caption', name: t('spreed', 'Conversations') })
+	if (searchResultsConversationList.length === 0) {
+		items.push({ type: 'hint', id: 'hint_conversations', hint: t('spreed', 'No matches found') })
+	} else {
+		sortConversationsList(searchResultsConversationList, settingsStore.groupMode, settingsStore.sortOrder)
+			.forEach((item: Conversation) => {
+				items.push({ type: 'conversation', id: `conversation_${item.id}`, object: item })
+			})
+	}
+
+	return items
+}
+
+/**
+ * Build the section with the open conversations (listable to registered users)
+ */
+function getOpenConversationsSection(): VirtualListItem[] {
+	const items: VirtualListItem[] = []
+
+	if (props.searchResultsListedConversations.length === 0) {
+		return items
+	}
+
+	items.push({ type: 'caption', id: 'open_conversation_caption', name: t('spreed', 'Open conversations') })
+	props.searchResultsListedConversations.forEach((item: Conversation) => {
+		items.push({ type: 'open_conversation', id: `open_conversation_${item.id}`, object: item })
+	})
+
+	return items
+}
+
+/**
+ * Build the section with the messages matching the search text
+ */
+function getMessagesSection(): VirtualListItem[] {
+	const items: VirtualListItem[] = []
+
+	items.push({ type: 'caption', id: 'messages_caption', name: t('spreed', 'Messages') })
+	if (props.searchResultsMessages.length === 0) {
+		items.push({
+			type: 'hint',
+			id: 'hint_messages',
+			hint: props.searchResultsLoading ? t('spreed', 'Loading …') : t('spreed', 'No matches found'),
+		})
+	} else {
+		props.searchResultsMessages.forEach((item: UnifiedSearchResultEntryWithRouterLink) => {
+			items.push({ type: 'message', id: `message_${item.attributes.messageId}`, object: item })
+		})
+	}
+
+	return items
+}
+
+/**
+ * Build the sections with the possible conversation results (users, groups, teams, federated users)
+ */
+function getOtherSourcesSections(): VirtualListItem[] {
+	const items: VirtualListItem[] = []
+
+	const subList = props.searchResults.reduce<SubListType>((acc, result) => {
+		if (result.source === ATTENDEE.ACTOR_TYPE.USERS) {
+			acc.user.push(result)
+		} else if (result.source === ATTENDEE.ACTOR_TYPE.GROUPS && canStartConversations) {
+			acc.group.push(result)
+		} else if (result.source === ATTENDEE.ACTOR_TYPE.CIRCLES && canStartConversations) {
+			acc.circle.push(result)
+		} else if (result.source === ATTENDEE.ACTOR_TYPE.REMOTES && canStartConversations) {
+			acc.federated.push({ ...result, source: ATTENDEE.ACTOR_TYPE.FEDERATED_USERS })
+		}
+		return acc
+	}, {
+		user: [],
+		group: [],
+		circle: [],
+		federated: [],
+	})
+
+	// Iterate over sections and build the list
+	sections.forEach((section) => {
+		if (subList[section.type].length > 0) {
+			items.push(section.caption)
+			items.push(...subList[section.type].map((match) => ({
+				type: section.type,
+				id: `${section.type}_${match.id}`,
+				object: match,
+				icon: iconData(match),
+			})))
+		}
+	})
+
+	// Add "No results" message if there are no results in any section
+	if (!subList.user.length || !subList.group.length || (!subList.circle.length && isCirclesEnabled) || !subList.federated.length) {
+		items.push({ type: 'caption', id: 'no_results_caption', name: sourcesWithoutResults(subList) })
+		items.push({ type: 'hint', id: 'no_results_hint', hint: t('spreed', 'No search results') })
+	}
+
+	return items
+}
 
 const { list, containerProps, wrapperProps } = useVirtualList<VirtualListItem>(searchResultsVirtual, {
 	itemHeight: () => itemHeight.value,

--- a/src/components/LeftSidebar/SearchConversationsResults/SearchConversationsResults.vue
+++ b/src/components/LeftSidebar/SearchConversationsResults/SearchConversationsResults.vue
@@ -26,6 +26,7 @@ const props = defineProps<{
 	searchText: string
 	conversationsList: Conversation[]
 	searchResultsLoading: boolean
+	searchFilters: string[]
 	searchResultsListedConversations: Conversation[]
 	searchResults: ParticipantSearchResult[]
 }>()
@@ -74,8 +75,8 @@ type SubListType = {
 type VirtualListItem
 	= | { type: 'caption', id: string, name: string }
 		| { type: 'hint', id: string, hint: string }
-		| { type: 'conversation', id: number, object: Conversation }
-		| { type: 'open_conversation', id: number, object: Conversation }
+		| { type: 'conversation', id: string, object: Conversation }
+		| { type: 'open_conversation', id: string, object: Conversation }
 		| { type: 'action', id: string, name: string, subname: string }
 		| { type: 'user' | 'group' | 'circle' | 'federated', id: string, object: ParticipantSearchResult, icon: Record<string, unknown> }
 
@@ -93,73 +94,84 @@ const searchResultsVirtual = computed<VirtualListItem[]>(() => {
 		return searchTerms.every((term) => displayName.includes(term) || name.includes(term))
 	})
 
+	const showConversations = props.searchFilters.includes('conversations')
+
+	if (!showConversations) {
+		virtualList.push({ type: 'hint', id: 'hint_no_filters', hint: t('spreed', 'No matches found') })
+		return virtualList
+	}
+
 	// Add conversations section
-	virtualList.push({ type: 'caption', id: 'conversations_caption', name: t('spreed', 'Conversations') })
-	if (searchResultsConversationList.length === 0) {
-		virtualList.push({ type: 'hint', id: 'hint_conversations', hint: t('spreed', 'No matches found') })
-	} else {
-		sortConversationsList(searchResultsConversationList, settingsStore.groupMode, settingsStore.sortOrder)
-			.forEach((item: Conversation) => {
-				virtualList.push({ type: 'conversation', id: item.id, object: item })
-			})
+	if (showConversations) {
+		virtualList.push({ type: 'caption', id: 'conversations_caption', name: t('spreed', 'Conversations') })
+		if (searchResultsConversationList.length === 0) {
+			virtualList.push({ type: 'hint', id: 'hint_conversations', hint: t('spreed', 'No matches found') })
+		} else {
+			sortConversationsList(searchResultsConversationList, settingsStore.groupMode, settingsStore.sortOrder)
+				.forEach((item: Conversation) => {
+					virtualList.push({ type: 'conversation', id: `conversation_${item.id}`, object: item })
+				})
+		}
 	}
 
 	// Add "New Conversation" option if allowed
-	if (canStartConversations) {
+	if (canStartConversations && showConversations) {
 		virtualList.push({ type: 'action', id: 'new_conversation', name: props.searchText, subname: t('spreed', 'New private conversation') })
 	}
 
 	// Add 'Loading' message if there are no results received from the server yet
-	if (props.searchResultsLoading && !props.searchResultsListedConversations.length && !props.searchResults.length) {
+	if (showConversations && props.searchResultsLoading && !props.searchResultsListedConversations.length && !props.searchResults.length) {
 		virtualList.push({ type: 'caption', id: 'loading_results_caption', name: t('spreed', 'Other sources') })
 		virtualList.push({ type: 'hint', id: 'loading_results_hint', hint: t('spreed', 'Loading …') })
 		return virtualList
 	}
 
 	// Add open conversations section if any
-	if (props.searchResultsListedConversations.length !== 0) {
+	if (showConversations && props.searchResultsListedConversations.length !== 0) {
 		virtualList.push({ type: 'caption', id: 'open_conversation_caption', name: t('spreed', 'Open conversations') })
 		props.searchResultsListedConversations.forEach((item: Conversation) => {
-			virtualList.push({ type: 'open_conversation', id: item.id, object: item })
+			virtualList.push({ type: 'open_conversation', id: `open_conversation_${item.id}`, object: item })
 		})
 	}
 
 	// Categorize search results into different sections
-	const subList = props.searchResults.reduce<SubListType>((acc, result) => {
-		if (result.source === ATTENDEE.ACTOR_TYPE.USERS) {
-			acc.user.push(result)
-		} else if (result.source === ATTENDEE.ACTOR_TYPE.GROUPS && canStartConversations) {
-			acc.group.push(result)
-		} else if (result.source === ATTENDEE.ACTOR_TYPE.CIRCLES && canStartConversations) {
-			acc.circle.push(result)
-		} else if (result.source === ATTENDEE.ACTOR_TYPE.REMOTES && canStartConversations) {
-			acc.federated.push({ ...result, source: ATTENDEE.ACTOR_TYPE.FEDERATED_USERS })
-		}
-		return acc
-	}, {
-		user: [],
-		group: [],
-		circle: [],
-		federated: [],
-	})
+	if (showConversations) {
+		const subList = props.searchResults.reduce<SubListType>((acc, result) => {
+			if (result.source === ATTENDEE.ACTOR_TYPE.USERS) {
+				acc.user.push(result)
+			} else if (result.source === ATTENDEE.ACTOR_TYPE.GROUPS && canStartConversations) {
+				acc.group.push(result)
+			} else if (result.source === ATTENDEE.ACTOR_TYPE.CIRCLES && canStartConversations) {
+				acc.circle.push(result)
+			} else if (result.source === ATTENDEE.ACTOR_TYPE.REMOTES && canStartConversations) {
+				acc.federated.push({ ...result, source: ATTENDEE.ACTOR_TYPE.FEDERATED_USERS })
+			}
+			return acc
+		}, {
+			user: [],
+			group: [],
+			circle: [],
+			federated: [],
+		})
 
-	// Iterate over sections and build the virtualList
-	sections.forEach((section) => {
-		if (subList[section.type].length > 0) {
-			virtualList.push(section.caption)
-			virtualList.push(...subList[section.type].map((match) => ({
-				type: section.type,
-				id: `${section.type}_${match.id}`,
-				object: match,
-				icon: iconData(match),
-			})))
-		}
-	})
+		// Iterate over sections and build the virtualList
+		sections.forEach((section) => {
+			if (subList[section.type].length > 0) {
+				virtualList.push(section.caption)
+				virtualList.push(...subList[section.type].map((match) => ({
+					type: section.type,
+					id: `${section.type}_${match.id}`,
+					object: match,
+					icon: iconData(match),
+				})))
+			}
+		})
 
-	// Add "No results" message if there are no results in any section
-	if (!subList.user.length || !subList.group.length || (!subList.circle.length && isCirclesEnabled) || !subList.federated.length) {
-		virtualList.push({ type: 'caption', id: 'no_results_caption', name: sourcesWithoutResults(subList) })
-		virtualList.push({ type: 'hint', id: 'no_results_hint', hint: t('spreed', 'No search results') })
+		// Add "No results" message if there are no results in any section
+		if (!subList.user.length || !subList.group.length || (!subList.circle.length && isCirclesEnabled) || !subList.federated.length) {
+			virtualList.push({ type: 'caption', id: 'no_results_caption', name: sourcesWithoutResults(subList) })
+			virtualList.push({ type: 'hint', id: 'no_results_hint', hint: t('spreed', 'No search results') })
+		}
 	}
 
 	return virtualList

--- a/src/components/LeftSidebar/SearchConversationsResults/useSearchConversationsResults.spec.js
+++ b/src/components/LeftSidebar/SearchConversationsResults/useSearchConversationsResults.spec.js
@@ -11,8 +11,9 @@ import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { h } from 'vue'
 import { createStore } from 'vuex'
 import { ATTENDEE, CONVERSATION } from '../../../constants.ts'
+import BrowserStorage from '../../../services/BrowserStorage.js'
 import { searchListedConversations } from '../../../services/conversationsService.ts'
-import { autocompleteQuery } from '../../../services/coreService.ts'
+import { autocompleteQuery, searchMessages } from '../../../services/coreService.ts'
 import { useActorStore } from '../../../stores/actor.ts'
 import { generateOCSResponse } from '../../../test-helpers.js'
 import { useSearchConversationsResults } from './useSearchConversationsResults.ts'
@@ -22,6 +23,13 @@ vi.mock('../../../services/conversationsService', () => ({
 }))
 vi.mock('../../../services/coreService', () => ({
 	autocompleteQuery: vi.fn(),
+	searchMessages: vi.fn(),
+}))
+vi.mock('../../../services/BrowserStorage.js', () => ({
+	default: {
+		getItem: vi.fn(),
+		setItem: vi.fn(),
+	},
 }))
 
 describe('useSearchConversationsResults', () => {
@@ -30,6 +38,7 @@ describe('useSearchConversationsResults', () => {
 	// Pending requests of each service, in the order they were created
 	let listedRequests
 	let possibleRequests
+	let messageRequests
 	// Whether aborting a request rejects it. Set to false to emulate requests
 	// that already left the pending state, so that aborting them has no effect
 	let abortRejectsRequests
@@ -56,6 +65,28 @@ describe('useSearchConversationsResults', () => {
 		}
 
 		return { promise, resolve, reject }
+	}
+
+	/**
+	 * Build a unified search entry for a message
+	 *
+	 * @param {string} messageId id of the message
+	 * @param {string} threadId id of the thread the message belongs to
+	 * @return {object} the unified search result entry
+	 */
+	function messageResult(messageId, threadId = messageId) {
+		return {
+			title: `message ${messageId}`,
+			subline: `message ${messageId}`,
+			attributes: {
+				conversation: 'token-1',
+				messageId,
+				threadId,
+				actorType: ATTENDEE.ACTOR_TYPE.USERS,
+				actorId: 'one',
+				timestamp: '1000',
+			},
+		}
 	}
 
 	/**
@@ -100,6 +131,7 @@ describe('useSearchConversationsResults', () => {
 
 	beforeEach(() => {
 		vi.clearAllMocks()
+		BrowserStorage.getItem.mockReturnValue(null)
 		setActivePinia(createPinia())
 		useActorStore().setCurrentUser({ uid: CURRENT_USER, displayName: CURRENT_USER })
 
@@ -114,6 +146,7 @@ describe('useSearchConversationsResults', () => {
 		// Tests that do not depend on the order arrange their responses with 'mock*ValueOnce'
 		listedRequests = []
 		possibleRequests = []
+		messageRequests = []
 		abortRejectsRequests = true
 		searchListedConversations.mockImplementation((query, options) => {
 			const request = createDeferred(options?.signal)
@@ -123,6 +156,11 @@ describe('useSearchConversationsResults', () => {
 		autocompleteQuery.mockImplementation((payload, options) => {
 			const request = createDeferred(options?.signal)
 			possibleRequests.push(request)
+			return request.promise
+		})
+		searchMessages.mockImplementation((payload, options) => {
+			const request = createDeferred(options?.signal)
+			messageRequests.push(request)
 			return request.promise
 		})
 	})
@@ -194,6 +232,229 @@ describe('useSearchConversationsResults', () => {
 				autocompleteResult('two', ATTENDEE.ACTOR_TYPE.USERS),
 				autocompleteResult('one', ATTENDEE.ACTOR_TYPE.GROUPS),
 			])
+		})
+	})
+
+	describe('search filters', () => {
+		test('restores valid saved filters', () => {
+			BrowserStorage.getItem.mockReturnValueOnce('messages,unknown')
+
+			const { composable } = mountComposable()
+
+			expect(BrowserStorage.getItem).toHaveBeenCalledWith('globalSearchFilters')
+			expect(composable.searchFilters.value).toEqual(['messages'])
+		})
+
+		test('persists changed filters', async () => {
+			const { composable } = mountComposable()
+
+			await composable.toggleFilter('', 'messages')
+
+			expect(BrowserStorage.setItem).toHaveBeenCalledWith('globalSearchFilters', 'conversations,messages')
+		})
+
+		test('requests only the enabled filters', async () => {
+			// Arrange
+			searchListedConversations.mockResolvedValueOnce(generateOCSResponse({ payload: [] }))
+			autocompleteQuery.mockResolvedValueOnce(generateOCSResponse({ payload: [] }))
+			const { composable } = mountComposable()
+
+			// Act: search in the conversations filter only
+			await composable.search('query')
+
+			// Assert: conversations and people belong to the same filter
+			expect(searchListedConversations).toHaveBeenCalledTimes(1)
+			expect(autocompleteQuery).toHaveBeenCalledTimes(1)
+			expect(searchMessages).not.toHaveBeenCalled()
+		})
+
+		test('applies message results with a router link to the message', async () => {
+			// Arrange
+			searchMessages.mockResolvedValueOnce(generateOCSResponse({
+				payload: { entries: [messageResult('101'), messageResult('102', '100')] },
+			}))
+			const { composable } = mountComposable()
+			composable.searchFilters.value = ['messages']
+
+			// Act: search in the messages filter only
+			await composable.search('query')
+
+			// Assert
+			expect(searchMessages).toHaveBeenCalledWith(
+				{ term: 'query', limit: expect.any(Number) },
+				expect.objectContaining({ signal: expect.any(AbortSignal) }),
+			)
+			expect(composable.searchResultsMessages.value).toEqual([
+				{
+					...messageResult('101'),
+					// A message of the main thread has no thread to route to
+					to: { name: 'conversation', hash: '#message_101', params: { token: 'token-1' }, query: { threadId: undefined } },
+				},
+				{
+					...messageResult('102', '100'),
+					to: { name: 'conversation', hash: '#message_102', params: { token: 'token-1' }, query: { threadId: '100' } },
+				},
+			])
+		})
+
+		test('drops the results of a filter that is no longer searched', async () => {
+			// Arrange: search in all filters
+			searchListedConversations.mockResolvedValueOnce(generateOCSResponse({ payload: [{ id: 1, token: 'listed' }] }))
+			autocompleteQuery.mockResolvedValueOnce(generateOCSResponse({ payload: [] }))
+			searchMessages.mockResolvedValueOnce(generateOCSResponse({ payload: { entries: [messageResult('101')] } }))
+			const { composable } = mountComposable()
+			composable.searchFilters.value = ['conversations', 'messages']
+			await composable.search('query')
+			expect(composable.searchResultsMessages.value).toHaveLength(1)
+
+			searchListedConversations.mockResolvedValueOnce(generateOCSResponse({ payload: [{ id: 1, token: 'listed' }] }))
+			autocompleteQuery.mockResolvedValueOnce(generateOCSResponse({ payload: [] }))
+
+			// Act: search again without the messages filter
+			composable.searchFilters.value = ['conversations']
+			await composable.search('query')
+
+			// Assert
+			expect(searchMessages).toHaveBeenCalledTimes(1)
+			expect(composable.searchResultsMessages.value).toEqual([])
+			expect(composable.searchResultsListedConversations.value).toEqual([{ id: 1, token: 'listed' }])
+		})
+
+		test('clears a single filter without invalidating the others', async () => {
+			// Arrange
+			const { composable } = mountComposable()
+
+			// Act: drop the messages filter while the other requests are still pending
+			composable.searchFilters.value = ['conversations', 'messages']
+			const search = composable.search('query')
+			composable.toggleFilter('query', 'messages')
+			listedRequests[0].resolve(generateOCSResponse({ payload: [{ id: 1, token: 'listed' }] }))
+			possibleRequests[0].resolve(generateOCSResponse({ payload: [autocompleteResult('one', ATTENDEE.ACTOR_TYPE.USERS)] }))
+
+			// Assert: the remaining filters are unaffected, only the dropped one reports as outdated
+			await expect(search).resolves.toBeFalsy()
+			expect(composable.searchResultsListedConversations.value).toEqual([{ id: 1, token: 'listed' }])
+			expect(composable.searchResultsPossibleConversations.value).toEqual([autocompleteResult('one', ATTENDEE.ACTOR_TYPE.USERS)])
+			expect(composable.searchResultsMessages.value).toEqual([])
+			// The outdated search does not stop loading, dropping the filter has to
+			expect(composable.searchResultsLoading.value).toBeFalsy()
+		})
+
+		test('searches a single filter without invalidating the others', async () => {
+			// Arrange
+			const { composable } = mountComposable()
+
+			// Act: enable the messages filter while the other requests are still pending
+			const search = composable.search('query')
+			const messagesSearch = composable.toggleFilter('query', 'messages')
+			messageRequests[0].resolve(generateOCSResponse({ payload: { entries: [messageResult('101')] } }))
+
+			// Assert
+			await expect(messagesSearch).resolves.toBeTruthy()
+			expect(composable.searchResultsMessages.value).toHaveLength(1)
+			// The other filters are still pending, so loading is kept
+			expect(composable.searchResultsLoading.value).toBeTruthy()
+
+			// Act: the other filters receive their results
+			listedRequests[0].resolve(generateOCSResponse({ payload: [{ id: 1, token: 'listed' }] }))
+			possibleRequests[0].resolve(generateOCSResponse({ payload: [] }))
+
+			// Assert
+			await expect(search).resolves.toBeTruthy()
+			expect(composable.searchResultsMessages.value).toHaveLength(1)
+			expect(composable.searchResultsListedConversations.value).toEqual([{ id: 1, token: 'listed' }])
+			expect(composable.searchResultsLoading.value).toBeFalsy()
+		})
+	})
+
+	describe('re-enabled filters', () => {
+		/**
+		 * Search in both filters and disable the messages one afterwards
+		 *
+		 * @param {string} query search text to look for
+		 * @return {object} the composable
+		 */
+		async function searchAndDisableMessages(query) {
+			searchListedConversations.mockResolvedValueOnce(generateOCSResponse({ payload: [] }))
+			autocompleteQuery.mockResolvedValueOnce(generateOCSResponse({ payload: [] }))
+			searchMessages.mockResolvedValueOnce(generateOCSResponse({ payload: { entries: [messageResult('101')] } }))
+			const { composable } = mountComposable()
+			composable.searchFilters.value = ['conversations', 'messages']
+			await composable.search(query)
+			await composable.toggleFilter(query, 'messages')
+
+			return composable
+		}
+
+		test('keeps the results of a disabled filter', async () => {
+			// Act: disable the messages filter after a successful search
+			const composable = await searchAndDisableMessages('query')
+
+			// Assert: the results are kept to be shown again, the consumer hides them meanwhile
+			expect(composable.searchFilters.value).toEqual(['conversations'])
+			expect(composable.searchResultsMessages.value).toHaveLength(1)
+		})
+
+		test('does not request again if the query did not change', async () => {
+			// Arrange
+			const composable = await searchAndDisableMessages('query')
+
+			// Act: enable the messages filter again, without searching in between
+			await expect(composable.toggleFilter('query', 'messages')).resolves.toBeTruthy()
+
+			// Assert: the results of the previous search are shown again
+			expect(searchMessages).toHaveBeenCalledTimes(1)
+			expect(composable.searchResultsMessages.value).toHaveLength(1)
+			expect(composable.searchResultsLoading.value).toBeFalsy()
+		})
+
+		test('requests again if the query changed meanwhile', async () => {
+			// Arrange
+			const composable = await searchAndDisableMessages('query')
+			searchListedConversations.mockResolvedValueOnce(generateOCSResponse({ payload: [] }))
+			autocompleteQuery.mockResolvedValueOnce(generateOCSResponse({ payload: [] }))
+			searchMessages.mockResolvedValueOnce(generateOCSResponse({ payload: { entries: [messageResult('102')] } }))
+
+			// Act: search for another query, then enable the messages filter again
+			await composable.search('another query')
+			await expect(composable.toggleFilter('another query', 'messages')).resolves.toBeTruthy()
+
+			// Assert
+			expect(searchMessages).toHaveBeenCalledTimes(2)
+			expect(searchMessages).toHaveBeenLastCalledWith({ term: 'another query', limit: expect.any(Number) }, expect.anything())
+			expect(composable.searchResultsMessages.value).toEqual([expect.objectContaining(messageResult('102'))])
+		})
+
+		test('requests again if the disabled filter had a pending request', async () => {
+			// Arrange
+			const { composable } = mountComposable()
+			composable.searchFilters.value = ['conversations', 'messages']
+
+			// Act: disable the messages filter while its request is still pending
+			composable.search('query')
+			await composable.toggleFilter('query', 'messages')
+			// and enable it again with an unchanged query
+			const messagesSearch = composable.toggleFilter('query', 'messages')
+			messageRequests[1].resolve(generateOCSResponse({ payload: { entries: [messageResult('101')] } }))
+
+			// Assert: results of the aborted request are incomplete and not reused
+			await expect(messagesSearch).resolves.toBeTruthy()
+			expect(searchMessages).toHaveBeenCalledTimes(2)
+			expect(composable.searchResultsMessages.value).toHaveLength(1)
+		})
+
+		test('requests again after the search was aborted', async () => {
+			// Arrange
+			const composable = await searchAndDisableMessages('query')
+			searchMessages.mockResolvedValueOnce(generateOCSResponse({ payload: { entries: [messageResult('102')] } }))
+
+			// Act: abort the search (the search box was cleared), then start over with the same query
+			composable.abortSearchRequests()
+			await expect(composable.toggleFilter('query', 'messages')).resolves.toBeTruthy()
+
+			// Assert
+			expect(searchMessages).toHaveBeenCalledTimes(2)
+			expect(composable.searchResultsMessages.value).toEqual([expect.objectContaining(messageResult('102'))])
 		})
 	})
 
@@ -312,6 +573,24 @@ describe('useSearchConversationsResults', () => {
 			expect(composable.searchResultsListedConversations.value).toEqual([])
 			expect(composable.searchResultsPossibleConversations.value).toEqual([autocompleteResult('one', ATTENDEE.ACTOR_TYPE.USERS)])
 			expect(composable.searchResultsLoading.value).toBeFalsy()
+		})
+
+		test('requests again when a re-enabled filter failed before', async () => {
+			// Arrange: the messages filter fails, then it is disabled
+			searchMessages.mockRejectedValueOnce(new Error('Unified search is not available'))
+			const { composable } = mountComposable()
+			composable.searchFilters.value = ['messages']
+			await composable.search('query')
+			await composable.toggleFilter('query', 'messages')
+
+			searchMessages.mockResolvedValueOnce(generateOCSResponse({ payload: { entries: [messageResult('101')] } }))
+
+			// Act: enable the filter again with an unchanged query
+			await expect(composable.toggleFilter('query', 'messages')).resolves.toBeTruthy()
+
+			// Assert: a failed search leaves nothing to show again
+			expect(searchMessages).toHaveBeenCalledTimes(2)
+			expect(composable.searchResultsMessages.value).toHaveLength(1)
 		})
 
 		test('does not report a failure of a superseded search', async () => {

--- a/src/components/LeftSidebar/SearchConversationsResults/useSearchConversationsResults.ts
+++ b/src/components/LeftSidebar/SearchConversationsResults/useSearchConversationsResults.ts
@@ -14,6 +14,7 @@ import { t } from '@nextcloud/l10n'
 import { onBeforeUnmount, ref } from 'vue'
 import { useStore } from 'vuex'
 import { ATTENDEE, CONVERSATION } from '../../../constants.ts'
+import BrowserStorage from '../../../services/BrowserStorage.js'
 import { getTalkConfig } from '../../../services/CapabilitiesManager.ts'
 import { searchListedConversations } from '../../../services/conversationsService.ts'
 import { autocompleteQuery } from '../../../services/coreService.ts'
@@ -21,6 +22,23 @@ import { useActorStore } from '../../../stores/actor.ts'
 import CancelableRequest from '../../../utils/CancelableRequest.ts'
 
 const canStartConversations = getTalkConfig('local', 'conversations', 'can-create')
+
+// Scope filters to search in
+export const SEARCH_FILTERS = ['conversations'] as const
+export type SearchFilter = typeof SEARCH_FILTERS[number]
+
+/**
+ * Restore user picked search filters from Browser storage (default - 'conversations')
+ */
+function restoreSearchFilters(): SearchFilter[] {
+	const storedFilters = BrowserStorage.getItem('globalSearchFilters')
+	if (!storedFilters) {
+		return [SEARCH_FILTERS[0]]
+	}
+
+	const filters = storedFilters.split(',')
+	return SEARCH_FILTERS.filter((filter) => filters.includes(filter))
+}
 
 /**
  * Composable to control logic for fetching search results:
@@ -33,6 +51,7 @@ export function useSearchConversationsResults() {
 	const actorStore = useActorStore()
 	const vuexStore = useStore()
 
+	const searchFilters = ref<SearchFilter[]>(restoreSearchFilters())
 	const searchResultsListedConversations = ref<Conversation[]>([])
 	const searchResultsPossibleConversations = ref<AutocompleteResult[]>([])
 	const searchResultsLoading = ref(true)
@@ -40,8 +59,18 @@ export function useSearchConversationsResults() {
 	let cancelSearchListedConversations: ReturnType<typeof CancelableRequest>['cancel'] | null = null
 	let cancelSearchPossibleConversations: ReturnType<typeof CancelableRequest>['cancel'] | null = null
 	// Generation counter - increases with every started or aborted search.
+	// Individual per filter.
 	// Results of a search are only applied with matching generation
-	let searchGeneration = 0
+	const searchGenerations: Record<SearchFilter, number> = {
+		conversations: 0,
+	}
+
+	// Query the stored results of each filter belong to, null if there are none.
+	// Results of a disabled filter are kept, so that re-enabling it with an
+	// unchanged query shows them again instead of requesting them anew
+	const fetchedQueries: Record<SearchFilter, string | null> = {
+		conversations: null,
+	}
 
 	onBeforeUnmount(() => {
 		abortSearchRequests()
@@ -66,7 +95,7 @@ export function useSearchConversationsResults() {
 				onlyUsers: !canStartConversations,
 			})
 
-			if (generation !== searchGeneration) {
+			if (generation !== searchGenerations.conversations) {
 				// Results are outdated
 				return
 			}
@@ -92,7 +121,7 @@ export function useSearchConversationsResults() {
 				return
 			}
 			console.error('Error searching for possible conversations', exception)
-			if (generation === searchGeneration) {
+			if (generation === searchGenerations.conversations) {
 				// Drop results of the failed search
 				searchResultsPossibleConversations.value = []
 			}
@@ -119,7 +148,7 @@ export function useSearchConversationsResults() {
 
 			const response = await request(query)
 
-			if (generation !== searchGeneration) {
+			if (generation !== searchGenerations.conversations) {
 				// Results are outdated
 				return
 			}
@@ -130,7 +159,7 @@ export function useSearchConversationsResults() {
 				return
 			}
 			console.error('Error searching for open conversations', exception)
-			if (generation === searchGeneration) {
+			if (generation === searchGenerations.conversations) {
 				// Drop results of the failed search
 				searchResultsListedConversations.value = []
 			}
@@ -143,52 +172,169 @@ export function useSearchConversationsResults() {
 	}
 
 	/**
-	 * Fetch and prepare results (in parallel)
+	 * Cancel the pending requests of a filter
 	 *
-	 * @param query search text
-	 * @return whether the results of this search were applied
+	 * @param filter filter to cancel the requests of
+	 * @return whether any request was pending
 	 */
-	async function search(query: string): Promise<boolean> {
-		const generation = ++searchGeneration
-		searchResultsLoading.value = true
-
-		const promiseResults = await Promise.allSettled([
-			fetchListedConversations(query, generation),
-			fetchPossibleConversations(query, generation),
-		])
-
-		if (generation !== searchGeneration) {
-			// Search was superseded by a newer one or aborted, do not proceed
-			return false
-		}
-
-		if (promiseResults.some((result) => result.status === 'rejected')) {
-			showError(t('spreed', 'An error occurred while performing the search'))
-		}
-
-		searchResultsLoading.value = false
-		return true
-	}
-
-	/**
-	 * Abort running requests and cleanup cancel functions
-	 */
-	function abortSearchRequests() {
-		// Invalidate a pending search, so that its results are not applied
-		searchGeneration++
+	function cancelFilterRequests(filter: SearchFilter): boolean {
+		const hasPendingRequests = cancelSearchListedConversations !== null
+			|| cancelSearchPossibleConversations !== null
 
 		cancelSearchListedConversations?.()
 		cancelSearchListedConversations = null
 
 		cancelSearchPossibleConversations?.()
 		cancelSearchPossibleConversations = null
+
+		return hasPendingRequests
+	}
+
+	/**
+	 * Stop searching in a filter, keeping its results to show them again
+	 * if it is re-enabled with an unchanged query
+	 *
+	 * @param filter filter to disable
+	 */
+	function disableFilter(filter: SearchFilter) {
+		searchGenerations[filter]++
+
+		if (cancelFilterRequests(filter)) {
+			// Results of the aborted requests are incomplete and cannot be reused
+			fetchedQueries[filter] = null
+		}
+	}
+
+	/**
+	 * Drop the results of a filter and invalidate its pending requests
+	 *
+	 * @param filter filter to clear
+	 */
+	function clearFilter(filter: SearchFilter) {
+		disableFilter(filter)
+		fetchedQueries[filter] = null
+
+		searchResultsListedConversations.value = []
+		searchResultsPossibleConversations.value = []
+	}
+
+	/**
+	 * Keep loading as long as any request is still waiting for its results
+	 */
+	function updateLoadingState() {
+		searchResultsLoading.value = cancelSearchListedConversations !== null
+			|| cancelSearchPossibleConversations !== null
+	}
+
+	/**
+	 * Fetch and prepare results (in parallel)
+	 * Run for enabled filters, drop results for disabled ones
+	 *
+	 * @param query search text
+	 * @return whether the results of this search were applied
+	 */
+	async function search(query: string): Promise<boolean> {
+		for (const filter of SEARCH_FILTERS) {
+			if (!searchFilters.value.includes(filter)) {
+				clearFilter(filter)
+			}
+		}
+
+		return await searchInFilters(query, [...searchFilters.value])
+	}
+
+	/**
+	 * Fetch and prepare results of the given filters
+	 *
+	 * @param query search text
+	 * @param filters filters to search in
+	 * @return whether the results of this search were applied
+	 */
+	async function searchInFilters(query: string, filters: SearchFilter[]): Promise<boolean> {
+		searchResultsLoading.value = true
+
+		const generations = filters.map((filter) => [filter, ++searchGenerations[filter]] as const)
+		const promiseResults = await Promise.all(generations.map(async ([filter, generation]) => {
+			const results = await Promise.allSettled([
+				fetchListedConversations(query, generation),
+				fetchPossibleConversations(query, generation),
+			])
+
+			if (generation === searchGenerations[filter]) {
+				// Only complete results of the current query can be shown again later
+				fetchedQueries[filter] = results.every((result) => result.status === 'fulfilled')
+					? query
+					: null
+			}
+
+			return results
+		}))
+
+		// A superseding search keeps loading with its own pending requests
+		updateLoadingState()
+
+		if (generations.some(([filter, generation]) => generation !== searchGenerations[filter])) {
+			// Search was superseded by a newer one or aborted, do not proceed
+			return false
+		}
+
+		if (promiseResults.flat().some((result) => result.status === 'rejected')) {
+			showError(t('spreed', 'An error occurred while performing the search'))
+		}
+
+		return true
+	}
+
+	/**
+	 * Enable or disable a filter, fetching or hiding its results.
+	 * The results of the other filters are kept, even if their search is still pending
+	 *
+	 * @param query search text
+	 * @param filter filter to toggle
+	 * @return whether the results were updated
+	 */
+	async function toggleFilter(query: string, filter: SearchFilter): Promise<boolean> {
+		const shouldRemoveFilter = searchFilters.value.includes(filter)
+		searchFilters.value = shouldRemoveFilter
+			? searchFilters.value.filter((item) => item !== filter)
+			: [...searchFilters.value, filter]
+		BrowserStorage.setItem('globalSearchFilters', searchFilters.value.join(','))
+
+		if (shouldRemoveFilter) {
+			disableFilter(filter)
+			updateLoadingState()
+			return true
+		} else if (query === '') {
+			// Nothing to fetch until a search is started
+			return false
+		} else if (fetchedQueries[filter] === query) {
+			// Results of this query are still there and shown again as is
+			return true
+		} else {
+			return await searchInFilters(query, [filter])
+		}
+	}
+
+	/**
+	 * Abort running requests and cleanup cancel functions
+	 */
+	function abortSearchRequests() {
+		for (const filter of SEARCH_FILTERS) {
+			// Invalidate a pending search, so that its results are not applied
+			searchGenerations[filter]++
+			cancelFilterRequests(filter)
+			// The search is over, its results are not shown again
+			fetchedQueries[filter] = null
+		}
 	}
 
 	return {
+		searchFilters,
 		searchResultsPossibleConversations,
 		searchResultsListedConversations,
 		searchResultsLoading,
 		search,
+		toggleFilter,
 		abortSearchRequests,
 	}
 }

--- a/src/components/LeftSidebar/SearchConversationsResults/useSearchConversationsResults.ts
+++ b/src/components/LeftSidebar/SearchConversationsResults/useSearchConversationsResults.ts
@@ -17,14 +17,15 @@ import { ATTENDEE, CONVERSATION } from '../../../constants.ts'
 import BrowserStorage from '../../../services/BrowserStorage.js'
 import { getTalkConfig } from '../../../services/CapabilitiesManager.ts'
 import { searchListedConversations } from '../../../services/conversationsService.ts'
-import { autocompleteQuery } from '../../../services/coreService.ts'
+import { autocompleteQuery, searchMessages } from '../../../services/coreService.ts'
 import { useActorStore } from '../../../stores/actor.ts'
 import CancelableRequest from '../../../utils/CancelableRequest.ts'
+import { mapMessageResultEntry } from '../../../utils/searchEntries.ts'
 
 const canStartConversations = getTalkConfig('local', 'conversations', 'can-create')
 
 // Scope filters to search in
-export const SEARCH_FILTERS = ['conversations'] as const
+export const SEARCH_FILTERS = ['conversations', 'messages'] as const
 export type SearchFilter = typeof SEARCH_FILTERS[number]
 
 /**
@@ -44,6 +45,7 @@ function restoreSearchFilters(): SearchFilter[] {
  * Composable to control logic for fetching search results:
  * - listed conversations
  * - possible conversations (users, groups, teams)
+ * - messages from all conversations
  *
  * Has only single consumer (LeftSidebar.vue)
  */
@@ -54,15 +56,19 @@ export function useSearchConversationsResults() {
 	const searchFilters = ref<SearchFilter[]>(restoreSearchFilters())
 	const searchResultsListedConversations = ref<Conversation[]>([])
 	const searchResultsPossibleConversations = ref<AutocompleteResult[]>([])
+	const searchResultsMessages = ref<ReturnType<typeof mapMessageResultEntry>[]>([])
 	const searchResultsLoading = ref(true)
 
 	let cancelSearchListedConversations: ReturnType<typeof CancelableRequest>['cancel'] | null = null
 	let cancelSearchPossibleConversations: ReturnType<typeof CancelableRequest>['cancel'] | null = null
-	// Generation counter - increases with every started or aborted search.
+	let cancelSearchMessages: ReturnType<typeof CancelableRequest>['cancel'] | null = null
+
+	// Generation counter - increases with every started, aborted or disabled search.
 	// Individual per filter.
 	// Results of a search are only applied with matching generation
 	const searchGenerations: Record<SearchFilter, number> = {
 		conversations: 0,
+		messages: 0,
 	}
 
 	// Query the stored results of each filter belong to, null if there are none.
@@ -70,6 +76,7 @@ export function useSearchConversationsResults() {
 	// unchanged query shows them again instead of requesting them anew
 	const fetchedQueries: Record<SearchFilter, string | null> = {
 		conversations: null,
+		messages: null,
 	}
 
 	onBeforeUnmount(() => {
@@ -172,20 +179,68 @@ export function useSearchConversationsResults() {
 	}
 
 	/**
+	 * Get list of messages matching the query and write to ref
+	 *
+	 * @param query search text
+	 * @param generation search generation
+	 */
+	async function fetchMessages(query: string, generation: number) {
+		const { request, cancel } = CancelableRequest(searchMessages)
+		try {
+			// Cancel previous search request if pending, and store reference to new one
+			cancelSearchMessages?.()
+			cancelSearchMessages = cancel
+
+			// TODO: implement offset with 'Show more' feature
+			const response = await request({ term: query, limit: 10 })
+
+			if (generation !== searchGenerations.messages) {
+				// Results are outdated
+				return
+			}
+
+			searchResultsMessages.value = response.data.ocs.data.entries.map(mapMessageResultEntry)
+		} catch (exception) {
+			if (isCancel(exception)) {
+				return
+			}
+			console.error('Error searching for messages', exception)
+			if (generation === searchGenerations.messages) {
+				// Drop results of the failed search
+				searchResultsMessages.value = []
+			}
+			throw exception
+		} finally {
+			if (cancelSearchMessages === cancel) {
+				cancelSearchMessages = null
+			}
+		}
+	}
+
+	/**
 	 * Cancel the pending requests of a filter
 	 *
 	 * @param filter filter to cancel the requests of
 	 * @return whether any request was pending
 	 */
 	function cancelFilterRequests(filter: SearchFilter): boolean {
-		const hasPendingRequests = cancelSearchListedConversations !== null
-			|| cancelSearchPossibleConversations !== null
+		if (filter === 'conversations') {
+			const hasPendingRequests = cancelSearchListedConversations !== null
+				|| cancelSearchPossibleConversations !== null
 
-		cancelSearchListedConversations?.()
-		cancelSearchListedConversations = null
+			cancelSearchListedConversations?.()
+			cancelSearchListedConversations = null
 
-		cancelSearchPossibleConversations?.()
-		cancelSearchPossibleConversations = null
+			cancelSearchPossibleConversations?.()
+			cancelSearchPossibleConversations = null
+
+			return hasPendingRequests
+		}
+
+		const hasPendingRequests = cancelSearchMessages !== null
+
+		cancelSearchMessages?.()
+		cancelSearchMessages = null
 
 		return hasPendingRequests
 	}
@@ -214,8 +269,12 @@ export function useSearchConversationsResults() {
 		disableFilter(filter)
 		fetchedQueries[filter] = null
 
-		searchResultsListedConversations.value = []
-		searchResultsPossibleConversations.value = []
+		if (filter === 'conversations') {
+			searchResultsListedConversations.value = []
+			searchResultsPossibleConversations.value = []
+		} else {
+			searchResultsMessages.value = []
+		}
 	}
 
 	/**
@@ -224,6 +283,7 @@ export function useSearchConversationsResults() {
 	function updateLoadingState() {
 		searchResultsLoading.value = cancelSearchListedConversations !== null
 			|| cancelSearchPossibleConversations !== null
+			|| cancelSearchMessages !== null
 	}
 
 	/**
@@ -255,10 +315,9 @@ export function useSearchConversationsResults() {
 
 		const generations = filters.map((filter) => [filter, ++searchGenerations[filter]] as const)
 		const promiseResults = await Promise.all(generations.map(async ([filter, generation]) => {
-			const results = await Promise.allSettled([
-				fetchListedConversations(query, generation),
-				fetchPossibleConversations(query, generation),
-			])
+			const results = await Promise.allSettled(filter === 'conversations'
+				? [fetchListedConversations(query, generation), fetchPossibleConversations(query, generation)]
+				: [fetchMessages(query, generation)])
 
 			if (generation === searchGenerations[filter]) {
 				// Only complete results of the current query can be shown again later
@@ -332,6 +391,7 @@ export function useSearchConversationsResults() {
 		searchFilters,
 		searchResultsPossibleConversations,
 		searchResultsListedConversations,
+		searchResultsMessages,
 		searchResultsLoading,
 		search,
 		toggleFilter,

--- a/src/components/RightSidebar/SearchMessages/SearchMessageItem.vue
+++ b/src/components/RightSidebar/SearchMessages/SearchMessageItem.vue
@@ -17,7 +17,7 @@ import NcListItem from '@nextcloud/vue/components/NcListItem'
 import CloseCircleOutline from 'vue-material-design-icons/CloseCircleOutline.vue'
 import AvatarWrapper from '../../AvatarWrapper/AvatarWrapper.vue'
 import ConversationIcon from '../../ConversationIcon.vue'
-import { CONVERSATION } from '../../../constants.ts'
+import { AVATAR, CONVERSATION } from '../../../constants.ts'
 import { EventBus } from '../../../services/EventBus.ts'
 import { useDashboardStore } from '../../../stores/dashboard.ts'
 import { formatDateTime } from '../../../utils/formattedTime.ts'
@@ -34,6 +34,7 @@ const props = withDefaults(defineProps<{
 	timestamp: number
 	messageParameters?: ChatMessage['messageParameters']
 	isReminder?: boolean
+	compact?: boolean
 }>(), {
 	messageParameters: () => ({}),
 	isReminder: false,
@@ -47,6 +48,10 @@ const dashboardStore = useDashboardStore()
 const conversation = computed<Conversation | undefined>(() => store.getters.conversation(props.token))
 const isOneToOneConversation = computed(() => conversation.value?.type === CONVERSATION.TYPE.ONE_TO_ONE)
 const name = computed(() => {
+	if (props.compact) {
+		// Compact view has a single line, showing the message instead of its author
+		return richSubline.value
+	}
 	if (!props.isReminder || isOneToOneConversation.value) {
 		return props.title
 	}
@@ -88,6 +93,8 @@ function handleResultClick() {
 		:to="to"
 		:active="active"
 		:title="richSubline"
+		:compact
+		class="search-message"
 		forceMenu
 		@click="handleResultClick">
 		<template #icon>
@@ -96,6 +103,7 @@ function handleResultClick() {
 				:id="actorId"
 				:name="title"
 				:source="actorType"
+				:size="compact ? AVATAR.SIZE.COMPACT : AVATAR.SIZE.DEFAULT"
 				disableMenu
 				:token="token" />
 			<ConversationIcon
@@ -103,7 +111,7 @@ function handleResultClick() {
 				:item="conversation"
 				hideUserStatus />
 		</template>
-		<template #subname>
+		<template v-if="!compact" #subname>
 			{{ richSubline }}
 		</template>
 		<template v-if="isReminder" #actions>
@@ -119,7 +127,7 @@ function handleResultClick() {
 		<template #details>
 			<NcDateTime
 				:timestamp="timestamp * 1000"
-				class="search-results__date"
+				class="search-message__date"
 				relativeTime="short"
 				ignoreSeconds />
 		</template>
@@ -127,7 +135,14 @@ function handleResultClick() {
 </template>
 
 <style lang="scss" scoped>
-.search-results__date {
-	font-size: x-small;
+.search-message {
+	&__date {
+		font-size: x-small;
+	}
+
+	/* Overwrite NcListItem styles for compact view */
+	:deep(.list-item--compact .list-item-content__name) {
+		font-weight: 400;
+	}
 }
 </style>

--- a/src/components/RightSidebar/SearchMessages/SearchMessagesTab.vue
+++ b/src/components/RightSidebar/SearchMessages/SearchMessagesTab.vue
@@ -40,6 +40,7 @@ import { ATTENDEE } from '../../../constants.ts'
 import { searchMessagesInCurrentConversation } from '../../../services/coreService.ts'
 import { EventBus } from '../../../services/EventBus.ts'
 import CancelableRequest from '../../../utils/CancelableRequest.ts'
+import { mapMessageResultEntry } from '../../../utils/searchEntries.ts'
 
 const props = defineProps<{
 	isActive: boolean
@@ -213,19 +214,7 @@ async function fetchSearchResults(isNew = true): Promise<void> {
 				}
 			}
 
-			searchResults.value = searchResults.value.concat(entries.map((entry: UnifiedSearchResultEntry) => {
-				const threadId = (entry.attributes.threadId !== entry.attributes.messageId) ? entry.attributes.threadId : undefined
-
-				return {
-					...entry,
-					to: {
-						name: 'conversation',
-						hash: `#message_${entry.attributes.messageId}`,
-						params: { token: entry.attributes.conversation },
-						query: { threadId },
-					},
-				}
-			}))
+			searchResults.value = searchResults.value.concat(entries.map(mapMessageResultEntry))
 			nextTick(() => initializeNavigation())
 		}
 	} catch (exception) {

--- a/src/types/core.ts
+++ b/src/types/core.ts
@@ -124,6 +124,9 @@ export type UnifiedSearchResultEntryWithRouterLink = UnifiedSearchResultEntry & 
 		params: {
 			token: string
 		}
+		query?: {
+			threadId?: string
+		}
 	}
 }
 export type UnifiedSearchResponse = ApiResponse<operationsCore['unified_search-search']['responses'][200]['content']['application/json'] & {

--- a/src/utils/searchEntries.ts
+++ b/src/utils/searchEntries.ts
@@ -1,0 +1,30 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type {
+	UnifiedSearchResultEntry,
+	UnifiedSearchResultEntryWithRouterLink,
+} from '../types/index.ts'
+
+/**
+ * Extend a raw unified search entry with a router link to the message
+ *
+ * @param entry the unified search result entry
+ */
+export function mapMessageResultEntry(entry: UnifiedSearchResultEntry): UnifiedSearchResultEntryWithRouterLink {
+	const threadId = entry.attributes.threadId !== entry.attributes.messageId
+		? entry.attributes.threadId
+		: undefined
+
+	return {
+		...entry,
+		to: {
+			name: 'conversation',
+			hash: `#message_${entry.attributes.messageId}`,
+			params: { token: entry.attributes.conversation },
+			query: { threadId },
+		},
+	}
+}


### PR DESCRIPTION
### ☑️ Resolves

* Ref #16977
* Adds an option to get some messages results in Left SIdebar (avoiding global search)
* Using search provider (as RIghtSidebar)

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

Default | Mesages only | Combined
-- | -- | --
<img width="377" height="628" alt="2026-07-31_13h48_03" src="https://github.com/user-attachments/assets/ea6989f1-fc3b-4773-a0e6-46b8bb6593d6" /> | <img width="372" height="742" alt="2026-07-31_13h51_40" src="https://github.com/user-attachments/assets/9b96f8e9-953e-4eee-af2f-e1e7765bb7fd" /> | <img width="299" height="646" alt="image" src="https://github.com/user-attachments/assets/e1dee833-97cb-48d9-bfe3-3a43a0f1a84d" />

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required