### PR TITLE
fix(session): Mark session as inactive when blurring the window

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -139,7 +139,9 @@ Legend:
 
 Features that can be toggled on-off with the `experiments_users` and `experiments_guests` bit flags:
 
-| Bit | Status | Introduced                       | Ended | Description                                                                                                                 |
-|-----|--------|----------------------------------|-------|-----------------------------------------------------------------------------------------------------------------------------|
-| 1   | Active | Web 21.1.0<br>Desktop 1.2.2-beta | -     | Instead of refreshing the participant list repeatingly during calls, the data is generated from received signaling messages |
-| 2   | Active | Web 21.1.0<br>Desktop 1.2.2      | -     | Make automatic attempts to recover suspended / expired signaling session to allow join the call without page reload         |
+| Bit | Status | Introduced                       | Ended                   | Description                                                                                                                 |
+|-----|--------|----------------------------------|-------------------------|-----------------------------------------------------------------------------------------------------------------------------|
+| 1   | Active | Web 21.1.0<br>Desktop 1.2.2-beta | -                       | Instead of refreshing the participant list repeatingly during calls, the data is generated from received signaling messages |
+| 2   | Active | Web 21.1.0<br>Desktop 1.2.2      | -                       | Make automatic attempts to recover suspended / expired signaling session to allow join the call without page reload         |
+| 4   | Ended  | Web 22.0.3<br>Desktop 2.0.4      | Web 23.0<br>Desktop 3.0 | Send chat messages via the High performance-backend / websocket                                                             |
+| 8   | Active | Web 22.0.3<br>Desktop 2.0.4      | -                       | Mark sessions immediately as inactive when switching away from Talk                                                         |

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -27,6 +27,11 @@ export const CONFIG = {
 		 * Send chat messages via the High performance-backend / websocket
 		 */
 		CHAT_RELAY: 4,
+		/**
+		 * Since 22.0.3
+		 * Mark sessions immediately as inactive when switching away from Talk
+		 */
+		SESSION_INACTIVE_ON_BLUR: 8,
 	},
 } as const
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix #…

Workaround in case of complaint:
```js
localStorage.setItem('nextcloud_per_dGFsaw==_pause-notification-on-blur', 'yes')
```

- [ ] Should make sure the readmarker is not set during an inactive session and when returning unless the user:
  - Writes message
  - Uses "Scroll to end" button
  - Reacts
  - Opens … menu on a message
  - Scrolls?

- [ ] It should definitely not mark read when:
  - First user interaction is clicking on another chat
  - First user interaction is clicking on another app
  - First user interaction is navigating away
  - First user interaction is opening notifications or any other top bar menu

