### PR TITLE
fix: fullscreen mode with non-default theme

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -591,7 +591,8 @@ export default {
 }
 
 // Styles for the app content at fullscreen mode
-:root:has(body.talk-in-fullscreen) {
+:root:has(body.talk-in-fullscreen) /* Default theme values override */,
+body.talk-in-fullscreen /* Theme values override */ {
 	--body-container-margin: 0px !important;
 	--body-container-radius: 0px !important;
 	--header-height: 0px !important;


### PR DESCRIPTION
### ☑️ Resolves

* Variables are defined on 2 levels:
  1. `:root` for the default theme
  2. `body` (via `data-theme-x`) in a specific theme (light/dark)
* Level 2 is missing

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/2135e19b-7a5d-435c-a17f-555af68010ae" /> | <img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/45d77446-ffb4-4604-895d-58838e399ecd" />

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [x] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required