### PR TITLE
fix: remove deprecated method `$room->getAttendee()`

### DIFF
--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -269,8 +269,8 @@ class RoomController extends AEnvironmentAwareOCSController {
 
 				// Include rooms where only attendee level things changed,
 				// e.g. favorite, read-marker update, notification setting
-				$attendee = $room->getParticipant($this->userId)->getAttendee();
-				return $attendee->getLastAttendeeActivity() >= $modifiedSince;
+				$participant = $this->participantService->getParticipant($room, $this->userId);
+				return $participant->getAttendee()->getLastAttendeeActivity() >= $modifiedSince;
 			});
 		}
 


### PR DESCRIPTION
### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
