### PR TITLE
fix(SettingsDialog): expose appearance & sounds for guests

### DIFF
--- a/src/components/SettingsDialog/SettingsDialog.vue
+++ b/src/components/SettingsDialog/SettingsDialog.vue
@@ -52,11 +52,11 @@
 		</NcAppSettingsSection>
 
 		<NcAppSettingsSection
-			v-if="!isGuest && supportConversationsListStyle"
 			id="talk_appearance"
 			:name="t('spreed', 'Appearance & Sounds')">
 			<NcFormBox>
 				<NcFormBoxSwitch
+					v-if="!isGuest && supportConversationsListStyle"
 					:model-value="conversationsListStyle"
 					:label="t('spreed', 'Compact conversations list')"
 					:disabled="appearanceLoading"
@@ -78,6 +78,7 @@
 					:disabled="playSoundsLoading"
 					@update:model-value="togglePlaySounds" />
 				<NcFormBoxButton
+					v-if="!isGuest"
 					:label="t('spreed', 'Notification settings')"
 					:description="t('spreed', 'Sounds for chat and call notifications')"
 					:href="settingsUrl"


### PR DESCRIPTION
### ☑️ Resolves

* Fix regression from #16192


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="682" height="357" alt="2025-11-20_15h30_38" src="https://github.com/user-attachments/assets/b3e7ef6c-db23-4714-87f2-fc4ee83ac476" /> | <img width="692" height="485" alt="2025-11-20_15h28_02" src="https://github.com/user-attachments/assets/c1fd2009-d5a4-46ce-9012-bbb87a629e39" />

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required