### PR TITLE
fix(MediaSettings): track actual guest username

### DIFF
--- a/src/components/MediaSettings/MediaSettings.vue
+++ b/src/components/MediaSettings/MediaSettings.vue
@@ -189,10 +189,7 @@
 					</MediaSettingsTabs>
 
 					<!-- Guest display name setting-->
-					<SetGuestUsername
-						v-if="isGuest"
-						compact
-						@update="guestUserName = $event" />
+					<SetGuestUsername v-if="isGuest" compact />
 
 					<!-- Moderator options before starting a call-->
 					<NcCheckboxRadioSwitch
@@ -407,20 +404,12 @@ export default {
 			skipBlurVirtualBackground: false,
 			mediaLoading: false,
 			isDeviceCheck: false,
-			guestUserName: '',
 		}
 	},
 
 	computed: {
 		displayName() {
 			return this.actorStore.displayName
-		},
-
-		guestName() {
-			return this.guestNameStore.getGuestName(
-				this.token,
-				this.actorStore.actorId,
-			)
 		},
 
 		isGuest() {
@@ -583,7 +572,7 @@ export default {
 
 		disabledCallButton() {
 			return (this.isRecordingConsentRequired && !this.recordingConsentGiven)
-				|| (this.isGuest && !this.guestUserName.length)
+				|| (this.isGuest && !this.guestNameStore.guestUserName.length)
 		},
 
 		forceShowMediaSettings() {

--- a/src/components/SetGuestUsername.vue
+++ b/src/components/SetGuestUsername.vue
@@ -48,7 +48,6 @@
 <script setup lang="ts">
 import type { NextcloudUser } from '@nextcloud/auth'
 
-import { getGuestNickname } from '@nextcloud/auth'
 import { subscribe, unsubscribe } from '@nextcloud/event-bus'
 import { t } from '@nextcloud/l10n'
 import { generateUrl } from '@nextcloud/router'
@@ -68,9 +67,6 @@ const { compact = false } = defineProps<{
 	compact?: boolean
 }>()
 
-const emit = defineEmits<{
-	(event: 'update', value: string): void
-}>()
 const loginUrl = `${generateUrl('/login')}?redirect_url=${encodeURIComponent(window.location.pathname)}`
 
 const actorStore = useActorStore()
@@ -84,7 +80,6 @@ const guestUserName = computed({
 	set: (newValue: string) => {
 		guestNameStore.guestUserName = newValue
 		debounceUpdateDisplayName()
-		emit('update', newValue)
 	},
 })
 const isEditingUsername = ref(false)


### PR DESCRIPTION
### ☑️ Resolves

* Follow-up to #16361 
* MediaSettings should rely on the same value as in the store


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="579" height="237" alt="2025-11-20_19h36_03" src="https://github.com/user-attachments/assets/a67c624c-30b5-4cd4-aa23-ec004dd597df" /> | <img width="583" height="240" alt="2025-11-20_19h29_21" src="https://github.com/user-attachments/assets/0a5d53c9-e0f9-4f73-ba69-4047144741ec" />


### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
