### PR TITLE
fix(settings): Don't warn about missing optional future feature

### DIFF
--- a/lib/Config.php
+++ b/lib/Config.php
@@ -30,6 +30,10 @@ class Config {
 	public const SIGNALING_EXTERNAL = 'external';
 	public const SIGNALING_CLUSTER_CONVERSATION = 'conversation_cluster';
 
+	public const EXPERIMENTAL_UPDATE_PARTICIPANTS = 1;
+	public const EXPERIMENTAL_RECOVER_SESSION = 2;
+	public const EXPERIMENTAL_CHAT_RELAY = 4;
+
 	public const SIGNALING_TICKET_V1 = 1;
 	public const SIGNALING_TICKET_V2 = 2;
 
@@ -788,6 +792,14 @@ class Config {
 
 	public function enableLobbyOnLockedRooms(): bool {
 		return $this->appConfig->getAppValueBool('inactivity_enable_lobby');
+	}
+
+	/**
+	 * @param self::EXPERIMENTAL_* $experiment
+	 */
+	public function hasExperiment(int $experiment): bool {
+		return $this->appConfig->getAppValueInt('experiments_users') & $experiment
+			|| $this->appConfig->getAppValueInt('experiments_guests') & $experiment;
 	}
 
 	public function isPasswordEnforced(): bool {

--- a/lib/Signaling/Manager.php
+++ b/lib/Signaling/Manager.php
@@ -185,11 +185,16 @@ class Manager {
 		$features = explode(',', $featureHeader);
 		$features = array_map('trim', $features);
 
-		return array_values(array_diff([
+		$optionFeatures = [
 			'dialout',
 			'join-features',
-			'chat-relay',
-		], $features));
+		];
+
+		if ($this->talkConfig->hasExperiment(Config::EXPERIMENTAL_CHAT_RELAY)) {
+			$optionFeatures[] = 'chat-relay';
+		}
+
+		return array_values(array_diff($optionFeatures, $features));
 	}
 
 	public function getSignalingServerLinkForConversation(?Room $room): string {


### PR DESCRIPTION
### ☑️ Resolves

* Fix #16383 

### Before

<img width="1242" height="111" alt="Bildschirmfoto vom 2025-11-20 20-13-24" src="https://github.com/user-attachments/assets/e9b7e520-221c-4c46-92d5-1520d53d74c1" />


### After
<img width="1242" height="111" alt="grafik" src="https://github.com/user-attachments/assets/1bf5835a-455b-4e3c-9517-da4dd2eb7826" />
