### PR TITLE
[stable32] fix(admin-settings): get JS assets from correct path

### DIFF
--- a/src/mainAdminSettings.js
+++ b/src/mainAdminSettings.js
@@ -3,12 +3,15 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import { generateFilePath } from '@nextcloud/router'
 import { createApp } from 'vue'
 import AdminSettings from './views/AdminSettings.vue'
 import { NextcloudGlobalsVuePlugin } from './utils/NextcloudGlobalsVuePlugin.js'
 
 import '@nextcloud/dialogs/style.css'
 import './assets/admin-settings.css'
+
+__webpack_public_path__ = generateFilePath('spreed', '', 'js/')
 
 export default createApp(AdminSettings)
 	.use(NextcloudGlobalsVuePlugin)


### PR DESCRIPTION
### ☑️ Resolves

* Fix #16380
* Follow-up to #16310

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts
<img width="255" height="69" alt="image" src="https://github.com/user-attachments/assets/b145cef7-6020-410a-815c-9cd4f4eaf4af" />

<!-- ☀️ Light theme | 🌑 Dark Theme -->

### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [x] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required