### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -334,12 +334,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "921b790da9b3a7f7b8e9fe41f9343cd832349c50"
+                "reference": "5849237f12acbe79ff80bfc77629a5c5d4b89b65"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/921b790da9b3a7f7b8e9fe41f9343cd832349c50",
-                "reference": "921b790da9b3a7f7b8e9fe41f9343cd832349c50",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/5849237f12acbe79ff80bfc77629a5c5d4b89b65",
+                "reference": "5849237f12acbe79ff80bfc77629a5c5d4b89b65",
                 "shasum": ""
             },
             "require": {
@@ -375,7 +375,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2025-11-13T00:52:15+00:00"
+            "time": "2025-11-22T00:49:45+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency