### PR TITLE
fix(chat): block non-supported actions for guests

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
@@ -83,7 +83,7 @@
 					<NcActionSeparator />
 
 					<NcActionButton
-						v-if="supportReminders"
+						v-if="supportReminders && !isCurrentGuest"
 						key="set-reminder-menu"
 						is-menu
 						@click.stop="submenu = 'reminder'">

--- a/src/components/NewMessage/NewMessage.vue
+++ b/src/components/NewMessage/NewMessage.vue
@@ -516,6 +516,8 @@ export default {
 
 		canEditMessage() {
 			return hasTalkFeature(this.token, 'edit-messages')
+				&& !this.isReadOnly && !this.noChatPermission
+				&& !this.actorStore.isActorGuest
 		},
 
 		supportThreads() {

--- a/src/components/SettingsDialog/SettingsDialog.vue
+++ b/src/components/SettingsDialog/SettingsDialog.vue
@@ -126,15 +126,15 @@
 			v-if="!disableKeyboardShortcuts">
 			<NcHotkeyList>
 				<NcHotkey :label="t('spreed', 'Toggle full screen')" hotkey="F" />
-				<NcHotkey :label="t('spreed', 'Return to Home screen')" hotkey="Escape" />
+				<NcHotkey v-if="!isGuest" :label="t('spreed', 'Return to Home screen')" hotkey="Escape" />
 				<!-- FIXME Overriden by Unified Search -->
-				<NcHotkey :label="t('spreed', 'Search')" hotkey="Control F" />
+				<NcHotkey v-if="!isGuest" :label="t('spreed', 'Search')" hotkey="Control F" />
 			</NcHotkeyList>
 
 			<NcHotkeyList :label="t('spreed', 'Shortcuts while in a chat')">
 				<NcHotkey :label="t('spreed', 'Focus the chat input')" hotkey="C" />
 				<NcHotkey :label="t('spreed', 'Unfocus the chat input to use shortcuts')" hotkey="Escape" />
-				<NcHotkey :label="t('spreed', 'Edit your last message')" hotkey="Control ArrowUp" />
+				<NcHotkey v-if="!isGuest" :label="t('spreed', 'Edit your last message')" hotkey="Control ArrowUp" />
 			</NcHotkeyList>
 
 			<NcHotkeyList :label="t('spreed', 'Shortcuts while in a call')">


### PR DESCRIPTION
### ☑️ Resolves

* Fix noticed actions that aren't allowed for guests
- set reminder
- edit message with shortcut
- some shortcuts

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="339" height="382" alt="2025-11-24_17h01_10" src="https://github.com/user-attachments/assets/6fc8464c-7a9c-4db1-a675-8836960427c8" /> | <img width="314" height="332" alt="2025-11-24_17h02_18" src="https://github.com/user-attachments/assets/ef861a79-261b-417b-90af-106f9191bbae" />
<img width="535" height="615" alt="image" src="https://github.com/user-attachments/assets/3d21169a-a974-4734-a9f3-5e9aae68069a" /> | <img width="597" height="597" alt="2025-11-24_17h29_32" src="https://github.com/user-attachments/assets/302659b6-701f-437d-87ac-81d89495aab3" />
<img width="842" height="95" alt="2025-11-24_17h39_06" src="https://github.com/user-attachments/assets/1139d34c-8950-4820-bbf9-bed821879745" /> | --

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required