### PR TITLE
fix: move expensive capabilities check from URL generation service

### DIFF
--- a/src/services/conversationsService.ts
+++ b/src/services/conversationsService.ts
@@ -57,7 +57,6 @@ import type {
 
 import axios from '@nextcloud/axios'
 import { generateOcsUrl } from '@nextcloud/router'
-import { hasTalkFeature } from './CapabilitiesManager.ts'
 
 /**
  * Fetches all conversations from the server.
@@ -289,10 +288,19 @@ async function setNotificationCalls(token: string, level: setConversationNotifyC
  * @param password The password to set for the conversation (optional, only if force password is enabled)
  */
 async function makeConversationPublic(token: string, password: makeConversationPublicParams['password']): makeConversationPublicResponse {
-	const data = (hasTalkFeature(token, 'conversation-creation-password') && password)
-		? { password }
-		: undefined
-	return axios.post(generateOcsUrl('apps/spreed/api/v4/room/{token}/public', { token }), data as makeConversationPublicParams)
+	return axios.post(generateOcsUrl('apps/spreed/api/v4/room/{token}/public', { token }), {
+		password,
+	} as makeConversationPublicParams)
+}
+
+/**
+ * Make the conversation public (legacy method, doesn't support password payload)
+ * Capability check for 'conversation-creation-password'
+ *
+ * @param token The token of the conversation to be removed from favorites
+ */
+async function makeLegacyConversationPublic(token: string): makeConversationPublicResponse {
+	return axios.post(generateOcsUrl('apps/spreed/api/v4/room/{token}/public', { token }))
 }
 
 /**
@@ -433,6 +441,7 @@ export {
 	fetchNoteToSelfConversation,
 	makeConversationPrivate,
 	makeConversationPublic,
+	makeLegacyConversationPublic,
 	markAsImportant,
 	markAsInsensitive,
 	markAsSensitive,

--- a/src/store/conversationsStore.js
+++ b/src/store/conversationsStore.js
@@ -34,6 +34,7 @@ import {
 	fetchConversations,
 	makeConversationPrivate,
 	makeConversationPublic,
+	makeLegacyConversationPublic,
 	markAsImportant,
 	markAsInsensitive,
 	markAsSensitive,
@@ -553,7 +554,11 @@ const actions = {
 		try {
 			const conversation = { ...getters.conversation(token) }
 			if (allowGuests) {
-				await makeConversationPublic(token, password)
+				if (hasTalkFeature(token, 'conversation-creation-password')) {
+					await makeConversationPublic(token, password)
+				} else {
+					await makeLegacyConversationPublic(token)
+				}
 				conversation.type = CONVERSATION.TYPE.PUBLIC
 				showSuccess(t('spreed', 'You allowed guests'))
 			} else {


### PR DESCRIPTION
### ☑️ Resolves

* Fix ~~problem that doesn't exist yet~~ Talk plugins compiled size
* `conversationsService` is pulling `CapabilitiesManager` <- `useTalkHashStore` <- `pinia` library and some other utils
* caused by `makeConversationPublic()`, which is used in a single store and can be checked there


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

`talk-floating-call` is WIP, but it reveals an issue
Not noticed in another plugins, since they already including pinia from other sources

🏚️ Before | 🏡 After
-- | --
<img width="744" height="131" alt="image" src="https://github.com/user-attachments/assets/58f10b3d-336a-4270-8650-335cd3c18cfc" /> | <img width="742" height="135" alt="image" src="https://github.com/user-attachments/assets/c278172d-33b6-4205-b095-857602c24e0d" />

### 🚧 Tasks

- [x] checked files sidebars and deck integration, no effect on size for any existing plugin

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client