### PR TITLE
fix(reactions): correctly handle unsorted reaction details

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/ReactionsWrapper.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/ReactionsWrapper.vue
@@ -197,26 +197,32 @@ export default {
 			}
 			return undefined
 		},
-
-		/**
-		 * Compare the plain reactions with the simplified detailed reactions.
-		 */
-		hasOutdatedDetails() {
-			const detailedReactionsSimplified = Object.fromEntries(Object.entries(this.detailedReactions)
-				.sort() // Plain reactions come sorted
-				.map(([key, value]) => [key, value.length]))
-			return this.hasReactionsLoaded
-				&& JSON.stringify(this.plainReactions) !== JSON.stringify(detailedReactionsSimplified)
-		},
 	},
 
 	methods: {
 		t,
 		n,
+
 		fetchReactions() {
-			if (!this.hasReactionsLoaded || this.hasOutdatedDetails) {
+			if (this.hasOutdatedDetails()) {
 				this.reactionsStore.fetchReactions(this.token, this.id)
 			}
+		},
+
+		/**
+		 * Compare the plain reactions with the simplified detailed reactions.
+		 */
+		hasOutdatedDetails() {
+			if (!this.hasReactionsLoaded) {
+				// No details available yet
+				return true
+			}
+
+			const allPlainReactions = Object.keys(this.plainReactions)
+
+			// If the keys differ, we have outdated details
+			return allPlainReactions.length !== Object.keys(this.detailedReactions).length
+				|| allPlainReactions.some((reaction) => this.plainReactions[reaction] !== this.detailedReactions[reaction]?.length)
 		},
 
 		userHasReacted(reaction) {


### PR DESCRIPTION
### ☑️ Resolves

* Fix excessive calls to GET reaction details endpoint
  * Reaction details are filled from 'processMessage' via polling or HPB relay to save requests on update
  * JSON stringify is not reliable in object comparison, when it becomes to different order
  * We don't need to hold computed value in memory, if it can be only checked on hover

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before

https://github.com/user-attachments/assets/78658f51-9417-4302-be1c-e174b04228ca

🏡 After

https://github.com/user-attachments/assets/4a35fab6-1152-42db-ade1-d8ec51a28ddc

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client