### PR TITLE
fix: change action colors in 'Leave call' confirmation

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -448,10 +448,11 @@ export default {
 					buttons: [
 						{
 							label: t('spreed', 'Stay in call'),
+							variant: 'primary',
 						},
 						{
 							label: t('spreed', 'Leave call'),
-							variant: 'primary',
+							variant: 'error',
 							callback: () => {
 								beforeRouteChangeListener(to, from, next)
 							},


### PR DESCRIPTION
### ☑️ Resolves

* Fix accents in confirmation dialog
  * Leave call - desctructive
  * Stay in call - expected

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="330" height="131" alt="2025-12-04_12h04_38" src="https://github.com/user-attachments/assets/a57a05f2-7d51-41c0-b3cb-0b2bed7b0ee9" /> | <img width="333" height="138" alt="2025-12-04_12h05_14" src="https://github.com/user-attachments/assets/4fb7570f-c833-4efa-96ae-b464f3866667" />

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required