### PR TITLE
fix(filesintegration): Correctly handle optional values for file inte…

### DIFF
--- a/lib/Files/Util.php
+++ b/lib/Files/Util.php
@@ -45,6 +45,7 @@ class Util {
 
 			$node = array_shift($nodes);
 			$accessList = $this->shareManager->getAccessList($node);
+			$accessList['users'] ??= [];
 			if (!$node->getStorage()->instanceOfStorage(SharedStorage::class)) {
 				// The file is not a shared file,
 				// let's check the accesslist for mount points of groupfolders and external storages
@@ -76,7 +77,7 @@ class Util {
 
 			$node = array_shift($nodes);
 			$accessList = $this->shareManager->getAccessList($node, false);
-			$this->publicAccessLists[$fileId] = $accessList['public'];
+			$this->publicAccessLists[$fileId] = $accessList['public'] ?? false;
 		}
 		return $this->publicAccessLists[$fileId] === true;
 	}


### PR DESCRIPTION
…gration


### ☑️ Resolves

* Fix #16477 

## 🛠️ API Checklist

- Only explanation I have is the file has no owner, which means groupfolders or something
- It's a bit weird that static analysis did not complain

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
