### PR TITLE
fix: extract `getCustomDateOptions` to utils

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
@@ -260,7 +260,7 @@
 					<NcActionSeparator />
 
 					<NcActionButton
-						v-for="option in reminderOptions"
+						v-for="option in getCustomDateOptions()"
 						:key="option.key"
 						:aria-label="option.ariaLabel"
 						close-after-click
@@ -385,6 +385,7 @@ import { useIntegrationsStore } from '../../../../../stores/integrations.js'
 import { useReactionsStore } from '../../../../../stores/reactions.js'
 import { generatePublicShareDownloadUrl, generateUserFileUrl } from '../../../../../utils/davUtils.ts'
 import { convertToUnix, formatDateTime } from '../../../../../utils/formattedTime.ts'
+import { getCustomDateOptions } from '../../../../../utils/getCustomDateOptions.ts'
 import { copyConversationLinkToClipboard } from '../../../../../utils/handleUrl.ts'
 import { parseMentions } from '../../../../../utils/textParse.ts'
 
@@ -521,6 +522,7 @@ export default {
 			actorStore,
 			chatExtrasStore,
 			threadId,
+			getCustomDateOptions,
 		}
 	},
 
@@ -604,66 +606,6 @@ export default {
 					this.customReminderTimestamp = value.valueOf()
 				}
 			},
-		},
-
-		reminderOptions() {
-			const currentDate = new Date()
-			const currentDayOfWeek = currentDate.getDay()
-
-			const nextDay = new Date()
-			nextDay.setDate(currentDate.getDate() + 1)
-
-			const nextSaturday = new Date()
-			nextSaturday.setDate(currentDate.getDate() + ((6 + 7 - currentDayOfWeek) % 7 || 7))
-
-			const nextMonday = new Date()
-			nextMonday.setDate(currentDate.getDate() + ((1 + 7 - currentDayOfWeek) % 7 || 7))
-
-			// Same day 18:00 PM (hidden if after 17:00 PM now)
-			const laterTodayTime = (currentDate.getHours() < 17)
-				? new Date().setHours(18, 0, 0, 0)
-				: null
-
-			// Tomorrow 08:00 AM
-			const tomorrowTime = nextDay.setHours(8, 0, 0, 0)
-
-			// Saturday 08:00 AM (hidden if Friday, Saturday or Sunday now)
-			const thisWeekendTime = (![0, 5, 6].includes(currentDayOfWeek))
-				? nextSaturday.setHours(8, 0, 0, 0)
-				: null
-
-			// Next Monday 08:00 AM (hidden if Sunday now)
-			// TODO: use getFirstDay from nextcloud/l10n
-			const nextWeekTime = (currentDayOfWeek !== 0)
-				? nextMonday.setHours(8, 0, 0, 0)
-				: null
-
-			return [
-				{
-					key: 'laterToday',
-					timestamp: laterTodayTime,
-					label: t('spreed', 'Later today – {timeLocale}', { timeLocale: formatDateTime(laterTodayTime, 'shortTime') }),
-					ariaLabel: t('spreed', 'Set reminder for later today'),
-				},
-				{
-					key: 'tomorrow',
-					timestamp: tomorrowTime,
-					label: t('spreed', 'Tomorrow – {timeLocale}', { timeLocale: formatDateTime(tomorrowTime, 'shortWeekdayWithTime') }),
-					ariaLabel: t('spreed', 'Set reminder for tomorrow'),
-				},
-				{
-					key: 'thisWeekend',
-					timestamp: thisWeekendTime,
-					label: t('spreed', 'This weekend – {timeLocale}', { timeLocale: formatDateTime(thisWeekendTime, 'shortWeekdayWithTime') }),
-					ariaLabel: t('spreed', 'Set reminder for this weekend'),
-				},
-				{
-					key: 'nextWeek',
-					timestamp: nextWeekTime,
-					label: t('spreed', 'Next week – {timeLocale}', { timeLocale: formatDateTime(nextWeekTime, 'shortWeekdayWithTime') }),
-					ariaLabel: t('spreed', 'Set reminder for next week'),
-				},
-			].filter((option) => option.timestamp !== null)
 		},
 
 		clearReminderLabel() {

--- a/src/utils/getCustomDateOptions.ts
+++ b/src/utils/getCustomDateOptions.ts
@@ -1,0 +1,79 @@
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { t } from '@nextcloud/l10n'
+import { formatDateTime } from './formattedTime.ts'
+
+type CustomDateOption = {
+	key: string
+	timestamp: number
+	label: string
+	ariaLabel: string
+}
+
+/**
+ * Returns array of custom date options for reminders / schedulers
+ */
+export function getCustomDateOptions() {
+	const currentDate = new Date()
+	const currentDayOfWeek = currentDate.getDay()
+
+	const options: CustomDateOption[] = []
+
+	// Same day 18:00 PM (hidden if after 17:00 PM now)
+	if (currentDate.getHours() < 17) {
+		const laterTodayTime = new Date().setHours(18, 0, 0, 0)
+
+		options.push({
+			key: 'laterToday',
+			timestamp: laterTodayTime,
+			label: t('spreed', 'Later today – {timeLocale}', { timeLocale: formatDateTime(laterTodayTime, 'shortTime') }),
+			ariaLabel: t('spreed', 'Set time for later today'),
+		})
+	}
+
+	// Tomorrow 08:00 AM
+	const nextDay = new Date()
+	nextDay.setDate(currentDate.getDate() + 1)
+	const tomorrowTime = nextDay.setHours(8, 0, 0, 0)
+
+	options.push({
+		key: 'tomorrow',
+		timestamp: tomorrowTime,
+		label: t('spreed', 'Tomorrow – {timeLocale}', { timeLocale: formatDateTime(tomorrowTime, 'shortWeekdayWithTime') }),
+		ariaLabel: t('spreed', 'Set time for tomorrow'),
+	})
+
+	// Saturday 08:00 AM (hidden if Friday, Saturday or Sunday now)
+	if (![0, 5, 6].includes(currentDayOfWeek)) {
+		const nextSaturday = new Date()
+		nextSaturday.setDate(currentDate.getDate() + ((6 + 7 - currentDayOfWeek) % 7 || 7))
+		const thisWeekendTime = nextSaturday.setHours(8, 0, 0, 0)
+
+		options.push({
+			key: 'thisWeekend',
+			timestamp: thisWeekendTime,
+			label: t('spreed', 'This weekend – {timeLocale}', { timeLocale: formatDateTime(thisWeekendTime, 'shortWeekdayWithTime') }),
+			ariaLabel: t('spreed', 'Set time for this weekend'),
+		})
+	}
+
+	// Next Monday 08:00 AM (hidden if Sunday now)
+	// TODO: use getFirstDay from nextcloud/l10n
+	if (currentDayOfWeek !== 0) {
+		const nextMonday = new Date()
+		nextMonday.setDate(currentDate.getDate() + ((1 + 7 - currentDayOfWeek) % 7 || 7))
+		const nextWeekTime = nextMonday.setHours(8, 0, 0, 0)
+
+		options.push({
+			key: 'nextWeek',
+			timestamp: nextWeekTime,
+			label: t('spreed', 'Next week – {timeLocale}', { timeLocale: formatDateTime(nextWeekTime, 'shortWeekdayWithTime') }),
+			ariaLabel: t('spreed', 'Set time for next week'),
+		})
+	}
+
+	return options
+}


### PR DESCRIPTION
### ☑️ Resolves

* Prerequisite to scheduled messages
  * Options are to be reused in another UI components
  * adjust logic to satisfy TS

⚠️ Computed is dropped, as it has no reactive dependencies and calculated one when component is mounted - no difference
⚠️ Change translation strings for aria-labels to be feature-independent (`set reminder` -> `set time`)

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

No visual changes

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team