### PR TITLE
fix(pinned): Fix deleting the last pinned message

### DIFF
--- a/tests/integration/features/chat-1/pinned-messages.feature
+++ b/tests/integration/features/chat-1/pinned-messages.feature
@@ -89,3 +89,20 @@ Feature: chat-1/pinned-messages
     Then user "participant2" is participant of the following rooms (v4)
       | id   | type | lastPinnedId | hiddenPinnedId |
       | room | 3    | EMPTY        | EMPTY          |
+
+  Scenario: Deleting last pinned message
+    Given user "participant1" creates room "room" (v4)
+      | roomType | 3 |
+      | roomName | room |
+    And user "participant1" adds user "participant2" to room "room" with 200 (v4)
+    When user "participant1" sends message "Message 1" to room "room" with 201
+    When user "participant1" pins message "Message 1" in room "room" with 200
+    When user "participant1" sends message "Message 2" to room "room" with 201
+    When user "participant1" pins message "Message 2" in room "room" with 200
+    Then user "participant2" is participant of the following rooms (v4)
+      | id   | type | lastPinnedId | hiddenPinnedId |
+      | room | 3    | Message 2    | EMPTY          |
+    When user "participant1" deletes message "Message 2" from room "room" with 200
+    Then user "participant2" is participant of the following rooms (v4)
+      | id   | type | lastPinnedId | hiddenPinnedId |
+      | room | 3    | Message 1    | EMPTY          |


### PR DESCRIPTION
### ☑️ Resolves

🏚️ Before | 🏡 After
-- | --
<img width="1145" height="620" alt="Bildschirmfoto vom 2025-12-10 16-12-07" src="https://github.com/user-attachments/assets/718c0dcd-e942-4f27-88f6-bff36d9b401c" /> | <img width="1145" height="280" alt="Bildschirmfoto vom 2025-12-10 16-11-56" src="https://github.com/user-attachments/assets/46c28828-3523-4baf-a41d-0dedd593e37d" />

> [!WARNING]
> However expired chat messages still have this problem and we can not fix it performant on the API. In case the last pinned message expired, clients/UI should simply not show anything

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
