### PR TITLE
fix(ReactionToaster): fix missing and spamming reactions in call

### DIFF
--- a/src/components/CallView/shared/ReactionToaster.vue
+++ b/src/components/CallView/shared/ReactionToaster.vue
@@ -4,11 +4,7 @@
 -->
 
 <template>
-	<TransitionWrapper
-		class="toaster"
-		name="toast"
-		tag="ul"
-		group>
+	<ul class="toaster">
 		<li
 			v-for="toast in toasts"
 			:key="toast.seed"
@@ -28,7 +24,7 @@
 				{{ toast.name }}
 			</span>
 		</li>
-	</TransitionWrapper>
+	</ul>
 </template>
 
 <script>
@@ -38,7 +34,6 @@ import { imagePath } from '@nextcloud/router'
 import { usernameToColor } from '@nextcloud/vue/functions/usernameToColor'
 import Hex from 'crypto-js/enc-hex.js'
 import SHA1 from 'crypto-js/sha1.js'
-import TransitionWrapper from '../../UIShared/TransitionWrapper.vue'
 import { useActorStore } from '../../../stores/actor.ts'
 import { useGuestNameStore } from '../../../stores/guestName.ts'
 
@@ -64,10 +59,6 @@ let nextProcessedTimestamp = 0
 
 export default {
 	name: 'ReactionToaster',
-
-	components: {
-		TransitionWrapper,
-	},
 
 	props: {
 		/**
@@ -296,6 +287,10 @@ export default {
 @keyframes toast-floating {
 	0% {
 		transform: translateY(0);
+		opacity: 0;
+	}
+	5% {
+		transform: translateY(calc(-0.05 * var(--vertical-offset) * 1vh));
 		opacity: 1;
 	}
 	50% {

--- a/src/components/UIShared/TransitionWrapper.vue
+++ b/src/components/UIShared/TransitionWrapper.vue
@@ -33,7 +33,6 @@ export default {
 					'slide-up',
 					'slide-right',
 					'slide-down',
-					'toast',
 					'zoom',
 				].includes(value)
 			},
@@ -153,23 +152,6 @@ export default {
 	}
 }
 
-@mixin toast-rules {
-	&-enter,
-	&-leave-to {
-		opacity: 0;
-	}
-	&-enter-to,
-	&-leave {
-		opacity: 1;
-	}
-	&-enter-active,
-	&-leave-active {
-		transition: $transition-slow;
-		transition-property: opacity;
-		transition-timing-function: linear;
-	}
-}
-
 @mixin zoom-rules {
 	&-enter,
 	&-leave-to {
@@ -207,10 +189,6 @@ export default {
 	@include slide-down-rules;
 }
 
-.toast {
-	@include toast-rules;
-}
-
 .zoom {
 	@include zoom-rules;
 }
@@ -239,10 +217,6 @@ export default {
 		&.slide-down {
 			@include group-rules;
 			@include slide-down-rules;
-		}
-		&.toast {
-			@include group-rules;
-			@include toast-rules;
 		}
 		&.zoom {
 			@include group-rules;


### PR DESCRIPTION
### ☑️ Resolves

* Fix cases when:
  * User connects to ongoing calls, and some participant models left not subscribed to reactions
  * User brings back tab from suspension, and all processed reactions jump at once
* Additionaly:
  * Allow spamming from single account in debug mode
  * Migrate from TransitionGroup to plain CSS (for performance)

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="529" height="125" alt="2025-12-11_11h50_57" src="https://github.com/user-attachments/assets/274f5358-74dd-4c93-8648-2971d42de4e3" /> | <img width="468" height="202" alt="2025-12-11_11h49_59" src="https://github.com/user-attachments/assets/29ff982f-d78b-4e7c-a913-ddfcf0eb2d0a" />

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client