### PR TITLE
fix(BottomBar): show all available buttons initially

### DIFF
--- a/src/components/CallView/BottomBar.vue
+++ b/src/components/CallView/BottomBar.vue
@@ -12,7 +12,7 @@ import { useHotKey } from '@nextcloud/vue/composables/useHotKey'
 import { useIsMobile } from '@nextcloud/vue/composables/useIsMobile'
 import { useResizeObserver } from '@vueuse/core'
 import debounce from 'debounce'
-import { computed, onUnmounted, ref, toValue, useTemplateRef, watch } from 'vue'
+import { computed, onMounted, onUnmounted, ref, toValue, useTemplateRef, watch } from 'vue'
 import { useStore } from 'vuex'
 import NcActionButton from '@nextcloud/vue/components/NcActionButton'
 import NcActions from '@nextcloud/vue/components/NcActions'
@@ -154,6 +154,10 @@ const debounceAdjustLayout = debounce(adjustLayout, 200)
 
 useResizeObserver(bottomBar, () => {
 	debounceAdjustLayout()
+})
+
+onMounted(() => {
+	adjustLayout()
 })
 
 onUnmounted(() => {


### PR DESCRIPTION
### ☑️ Resolves

- first calculation from observer is delayed for 200ms, which is enough to see UI flickering

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before 

![2025-12-11_15h38_21](https://github.com/user-attachments/assets/77c1081d-9456-45e1-b592-117747ac395c)

🏡 After

![2025-12-11_15h39_45](https://github.com/user-attachments/assets/4e111e44-491e-4514-b510-e376b91550d5)

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client