### PR TITLE
fix(build): define vue compile time flags

### DIFF
--- a/rspack.config.js
+++ b/rspack.config.js
@@ -197,6 +197,17 @@ module.exports = defineConfig((env) => {
 				__IS_DESKTOP__: false,
 				appName: JSON.stringify(appName),
 				appVersion: JSON.stringify(appVersion),
+				// Vue compile time flags
+				// See: https://vuejs.org/api/compile-time-flags.html#compile-time-flags
+				// See: https://github.com/vuejs/core/blob/v3.5.24/packages/vue/README.md#bundler-build-feature-flags
+				// > The build will work without configuring these flags,
+				// > however it is strongly recommended to properly configure them in order to get proper tree-shaking in the final bundle
+				// Unlike Vite plugin, vue-loader does not do this automatically for Webpack
+				// Although documentation says, it is optional, sometimes it breaks with:
+				// ReferenceError: __VUE_PROD_DEVTOOLS__ is not defined
+				__VUE_OPTIONS_API__: true,
+				__VUE_PROD_DEVTOOLS__: false,
+				__VUE_PROD_HYDRATION_MISMATCH_DETAILS__: false,
 			}),
 
 			new CssExtractRspackPlugin({


### PR DESCRIPTION
### ☑️ Resolves

* Same as https://github.com/nextcloud-libraries/webpack-vue-config/pull/698

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
