### PR TITLE
chore: prepare release changelogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 22.0.6 – 2025-12-15
+### Changed
+- Update dependencies
+- Update translations
+
+### Fixed
+- fix(chat): Correctly expire shared items in sidebar
+  [#16569](https://github.com/nextcloud/spreed/pull/16569)
+- fix(call): Show video streams of other attendees for guests
+  [#16544](https://github.com/nextcloud/spreed/pull/16544)
+- fix(call): Prevent call reactions overflow for users
+  [#16581](https://github.com/nextcloud/spreed/pull/16581)
+
+## 21.1.7 – 2025-12-15
+### Changed
+- Update dependencies
+- Update translations
+
+### Fixed
+- fix(chat): Correctly expire shared items in sidebar
+  [#16573](https://github.com/nextcloud/spreed/pull/16573)
+- fix(call): Show video streams of other attendees for guests
+  [#16546](https://github.com/nextcloud/spreed/pull/16546)
+
 ## 22.0.5 – 2025-12-11
 ### Changed
 - Update dependencies


### PR DESCRIPTION
## 22.0.6 – 2025-12-15
### Changed
- Update dependencies
- Update translations

### Fixed
- fix(chat): Correctly expire shared items in sidebar
  [#16569](https://github.com/nextcloud/spreed/pull/16569)
- fix(call): Show video streams of other attendees for guests
  [#16544](https://github.com/nextcloud/spreed/pull/16544)
- fix(call): Prevent call reactions overflow for users
  [#16581](https://github.com/nextcloud/spreed/pull/16581)

## 21.1.7 – 2025-12-15
### Changed
- Update dependencies
- Update translations

### Fixed
- fix(chat): Correctly expire shared items in sidebar
  [#16573](https://github.com/nextcloud/spreed/pull/16573)
- fix(call): Show video streams of other attendees for guests
  [#16546](https://github.com/nextcloud/spreed/pull/16546)