### PR TITLE
fix(CallFailedDialog): expose reload function

### DIFF
--- a/src/components/CallView/CallFailedDialog.vue
+++ b/src/components/CallView/CallFailedDialog.vue
@@ -7,9 +7,11 @@
 import { t } from '@nextcloud/l10n'
 import { computed } from 'vue'
 import { useStore } from 'vuex'
+import NcButton from '@nextcloud/vue/components/NcButton'
 import NcEmptyContent from '@nextcloud/vue/components/NcEmptyContent'
 import NcModal from '@nextcloud/vue/components/NcModal'
 import IconAlertOctagonOutline from 'vue-material-design-icons/AlertOctagonOutline.vue'
+import IconRefresh from 'vue-material-design-icons/Refresh.vue'
 import { messagePleaseTryToReload } from '../../utils/talkDesktopUtils.ts'
 
 const props = defineProps({
@@ -46,10 +48,17 @@ const message = computed(() => {
 })
 
 /**
- *
+ * Reset error status in the store
  */
 function clearConnectionFailedError() {
 	store.dispatch('clearConnectionFailed', props.token)
+}
+
+/**
+ * Reload the page to get a valid room object and HPB settings
+ */
+function reloadApp() {
+	window.location.reload()
 }
 
 </script>
@@ -63,6 +72,16 @@ function clearConnectionFailedError() {
 			:description="message">
 			<template #icon>
 				<IconAlertOctagonOutline />
+			</template>
+			<template #action>
+				<NcButton
+					variant="primary"
+					@click="reloadApp">
+					<template #icon>
+						<IconRefresh />
+					</template>
+					{{ t('spreed', 'Reload') }}
+				</NcButton>
 			</template>
 		</NcEmptyContent>
 	</NcModal>


### PR DESCRIPTION
### ☑️ Resolves

* Fix non-intuitive UI when connection failed and user likely needs to reload the page to apply new settings
* This adds a direct button in the dialog user sees


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="419" height="212" alt="2025-12-22_11h49_28" src="https://github.com/user-attachments/assets/6102d4b0-1a8e-4b9b-bd2f-0c8d874e50f4" /> | <img width="413" height="215" alt="2025-12-22_11h49_07" src="https://github.com/user-attachments/assets/3d76d725-3805-4923-aaeb-09f16750ce45" />

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [x] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team