### PR TITLE
fix(NewMessage): do not reset cursor on currently edited message

### DIFF
--- a/src/components/NewMessage/NewMessage.vue
+++ b/src/components/NewMessage/NewMessage.vue
@@ -746,8 +746,12 @@ export default {
 			this.errorTitle = ''
 		},
 
-		messageToEdit(newValue) {
-			if (newValue) {
+		messageToEdit(newValue, oldValue) {
+			if (newValue?.id === oldValue?.id) {
+				// Currently edited message was updated, keep cursor position
+				return
+			} else if (newValue) {
+				// Enter editing mode or editing another message
 				this.text = this.chatExtrasStore.getChatEditInput(this.token)
 
 				// Clear thread title when editing a message (unless it's a scheduled thread)
@@ -764,6 +768,7 @@ export default {
 					this.chatExtrasStore.removeParentIdToReply(this.token)
 				}
 			} else {
+				// Leaving editing mode
 				this.text = this.chatInput
 			}
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix #16587
* Currently any change of message object resets the input. This shouldn't happen, when it's the same message (compare by id)

## 🖌️ UI Checklist

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client