### PR TITLE
fix: provide media controls access for participants with no permissions

### DIFF
--- a/src/components/CallView/shared/LocalAudioControlButton.vue
+++ b/src/components/CallView/shared/LocalAudioControlButton.vue
@@ -16,7 +16,7 @@
 			<template #trigger>
 				<NcButton
 					:title="audioButtonTitle"
-					:variant="variant"
+					:variant="audioStreamError ? 'error' : variant"
 					:aria-label="audioButtonAriaLabel"
 					:class="{
 						'no-audio-available': !isAudioAvailable,
@@ -41,7 +41,7 @@
 
 		<NcActions
 			v-if="showDevices"
-			:disabled="!isAudioAllowed && !audioOutputSupported"
+			:disabled="!isAudioAllowed && !audioOutputSupported || !!audioStreamError"
 			class="audio-selector-button"
 			:class="{
 				'no-audio-available': !isAudioAvailable,
@@ -176,6 +176,7 @@ export default {
 			devices,
 			audioInputId,
 			audioOutputId,
+			audioStreamError,
 			updateDevices,
 			audioOutputSupported,
 			updatePreferences,
@@ -207,6 +208,7 @@ export default {
 			devices,
 			audioInputId,
 			audioOutputId,
+			audioStreamError,
 			updateDevices,
 			audioOutputSupported,
 			updatePreferences,

--- a/src/components/CallView/shared/LocalAudioControlButton.vue
+++ b/src/components/CallView/shared/LocalAudioControlButton.vue
@@ -22,7 +22,7 @@
 						'no-audio-available': !isAudioAvailable,
 						'audio-control-button': showDevices,
 					}"
-					:disabled="!isAudioAllowed || resumeAudioAfterChange"
+					:disabled="resumeAudioAfterChange"
 					@click.stop="toggleAudio">
 					<template #icon>
 						<VolumeIndicator
@@ -41,26 +41,31 @@
 
 		<NcActions
 			v-if="showDevices"
-			:disabled="!isAudioAvailable || !isAudioAllowed"
+			:disabled="!isAudioAllowed && !audioOutputSupported"
 			class="audio-selector-button"
+			:class="{
+				'no-audio-available': !isAudioAvailable,
+			}"
 			@open="updateDevices">
 			<template #icon>
 				<IconChevronUp :size="16" />
 			</template>
-			<NcActionCaption :name="t('spreed', 'Select a microphone')" />
-			<NcActionButton
-				v-for="device in audioInputDevices"
-				:key="device.deviceId ?? 'none'"
-				class="audio-selector__action"
-				type="radio"
-				:model-value="audioInputId"
-				:value="device.deviceId"
-				:title="device.label"
-				@click="handleAudioInputIdChange(device.deviceId)">
-				{{ device.label }}
-			</NcActionButton>
+			<template v-if="isAudioAllowed">
+				<NcActionCaption :name="t('spreed', 'Select a microphone')" />
+				<NcActionButton
+					v-for="device in audioInputDevices"
+					:key="device.deviceId ?? 'none'"
+					class="audio-selector__action"
+					type="radio"
+					:model-value="audioInputId"
+					:value="device.deviceId"
+					:title="device.label"
+					@click="handleAudioInputIdChange(device.deviceId)">
+					{{ device.label }}
+				</NcActionButton>
+			</template>
+			<NcActionSeparator v-if="isAudioAllowed && audioOutputSupported" />
 			<template v-if="audioOutputSupported">
-				<NcActionSeparator />
 				<NcActionCaption :name="t('spreed', 'Select a speaker')" />
 				<NcActionButton
 					v-for="device in audioOutputDevices"
@@ -295,7 +300,7 @@ export default {
 	methods: {
 		t,
 		toggleAudio() {
-			if (!this.isAudioAvailable) {
+			if (!this.isAudioAllowed || !this.isAudioAvailable) {
 				emit('talk:media-settings:show')
 				return
 			}

--- a/src/components/CallView/shared/LocalVideoControlButton.vue
+++ b/src/components/CallView/shared/LocalVideoControlButton.vue
@@ -13,7 +13,7 @@
 				'no-video-available': !isVideoAvailable,
 				'video-control-button': showDevices,
 			}"
-			:disabled="!isVideoAllowed || resumeVideoAfterChange"
+			:disabled="resumeVideoAfterChange"
 			@click.stop="toggleVideo">
 			<template #icon>
 				<IconVideo v-if="showVideoOn || resumeVideoAfterChange" :size="20" />
@@ -220,7 +220,7 @@ export default {
 	methods: {
 		t,
 		toggleVideo() {
-			if (!this.isVideoAvailable) {
+			if (!this.isVideoAllowed || !this.isVideoAvailable) {
 				emit('talk:media-settings:show')
 				return
 			}

--- a/src/components/CallView/shared/LocalVideoControlButton.vue
+++ b/src/components/CallView/shared/LocalVideoControlButton.vue
@@ -7,7 +7,7 @@
 	<div class="local-video-control-wrapper">
 		<NcButton
 			:title="videoButtonTitle"
-			:variant="variant"
+			:variant="videoStreamError ? 'error' : variant"
 			:aria-label="videoButtonAriaLabel"
 			:class="{
 				'no-video-available': !isVideoAvailable,
@@ -23,7 +23,7 @@
 
 		<NcActions
 			v-if="showDevices"
-			:disabled="!isVideoAvailable || !isVideoAllowed"
+			:disabled="!isVideoAvailable || !isVideoAllowed || !!videoStreamError"
 			class="video-selector-button"
 			@open="updateDevices">
 			<template #icon>
@@ -109,6 +109,7 @@ export default {
 		const {
 			devices,
 			videoInputId,
+			videoStreamError,
 			updateDevices,
 			updatePreferences,
 			subscribeToDevices,
@@ -121,6 +122,7 @@ export default {
 		return {
 			devices,
 			videoInputId,
+			videoStreamError,
 			updateDevices,
 			updatePreferences,
 			subscribeToDevices,

--- a/src/components/MediaSettings/MediaSettings.vue
+++ b/src/components/MediaSettings/MediaSettings.vue
@@ -174,7 +174,7 @@
 								@refresh="updateDevices"
 								@update:device-id="handleAudioOutputIdChange">
 								<template #extra-action>
-									<MediaDevicesSpeakerTest :disabled="audioStreamError" />
+									<MediaDevicesSpeakerTest :disabled="!!audioStreamError" />
 								</template>
 							</MediaDevicesSelector>
 						</template>


### PR DESCRIPTION
### ☑️ Resolves

* Fix #16631
  * Disabled state for toggle button should bring the device check dialog (as it was originally)
  * Imitate disabled appearance with no event prevention
  * In popover, hide input actions, if not allowed to enable in call, show only output


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="216" height="64" alt="image" src="https://github.com/user-attachments/assets/f9e1e667-89eb-4fe0-a2b2-2f54518c4bc5" /> | <img width="214" height="65" alt="image" src="https://github.com/user-attachments/assets/b2be632b-1949-43af-bd2d-1f2d2ed7ee4a" />
<img width="212" height="62" alt="image" src="https://github.com/user-attachments/assets/76c362d6-e8be-49fa-b2a6-c9ac28318f85" /> | <img width="213" height="65" alt="image" src="https://github.com/user-attachments/assets/6376ec38-66d2-4fa6-b96b-be9779c6a7ce" />
<img width="368" height="72" alt="image" src="https://github.com/user-attachments/assets/72d32396-4d4e-4125-9a74-46c14da820e7" /> | <img width="373" height="69" alt="image" src="https://github.com/user-attachments/assets/98aaab86-c1a6-4148-adbc-5e4542cbc677" />
<img width="216" height="65" alt="image" src="https://github.com/user-attachments/assets/3c941021-18c8-4338-a0bd-54efc7045901" /> | <img width="215" height="69" alt="image" src="https://github.com/user-attachments/assets/d681dd19-c212-4021-99e2-aec1b29dd601" />

<img width="595" height="300" alt="image" src="https://github.com/user-attachments/assets/68559d49-3565-4aee-905f-32a150ef567a" />

### 🚧 Tasks

- [x] Cases, when it's allowed, but not available? - navigator.mediaDevices.getUserMedia Promise is rejected, no output devices to show anyway

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required