### PR TITLE
chore: Bump E2EE supported versions for mobile clients to 99

### DIFF
--- a/lib/Middleware/CanUseTalkMiddleware.php
+++ b/lib/Middleware/CanUseTalkMiddleware.php
@@ -42,11 +42,11 @@ class CanUseTalkMiddleware extends Middleware {
 
 	public const TALK_ANDROID_MIN_VERSION = '15.0.0';
 	public const TALK_ANDROID_MIN_VERSION_RECORDING_CONSENT = '18.0.0';
-	public const TALK_ANDROID_MIN_VERSION_E2EE_CALLS = '22.0.0';
+	public const TALK_ANDROID_MIN_VERSION_E2EE_CALLS = '99.0.0';
 
 	public const TALK_IOS_MIN_VERSION = '15.0.0';
 	public const TALK_IOS_MIN_VERSION_RECORDING_CONSENT = '18.0.0';
-	public const TALK_IOS_MIN_VERSION_E2EE_CALLS = '22.0.0';
+	public const TALK_IOS_MIN_VERSION_E2EE_CALLS = '99.0.0';
 
 
 	public function __construct(


### PR DESCRIPTION
## 🛠️ API Checklist

E2EE was not done in mobile clients for 22, but we now have 22 versions released, which are accepted by accident.

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not possible
- [ ] 📘 API documentation in `docs/` has been updated or is not required
- [ ] 🔖 Capability is added or not needed 
