### PR TITLE
feat(message-expiry): Add message expiry msg on the right side bar

### DIFF
--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -484,9 +484,6 @@ export default {
 
 				// Discard notification if the conversation changes or closed
 				this.notifyUnreadMessages(null)
-
-				// FIXME collapse for group conversations until we show anything useful there
-				this.contentModeIndex = this.isOneToOne ? 1 : 0
 			},
 
 			immediate: true,


### PR DESCRIPTION
### ☑️ Resolves

* Fix #7953
* Add message expiration message on the right side bar for individual and group chats

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts
| 🏚️ Before | 🏡 After |
|-----------|----------|
| **Personal** | |
| | <img width="1919" height="882" alt="image" src="https://github.com/user-attachments/assets/6f83cc1c-44e3-4972-9dd2-f3469d3dcde2" /> |
| **Group** | |
| | 
<img width="1919" height="891" alt="image" src="https://github.com/user-attachments/assets/4927f080-6fd8-44d6-a083-a82a06eec9fa" />
 |


### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [x] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
