### PR TITLE
fix(settings): keep classic chat style for older server versions

### DIFF
--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -23,6 +23,8 @@ type PRIVACY_KEYS = typeof PRIVACY[keyof typeof PRIVACY]
 type LIST_STYLE_OPTIONS = 'two-lines' | 'compact'
 type CHAT_STYLE_OPTIONS = 'split' | 'unified'
 
+const supportChatStyle = getTalkConfig('local', 'chat', 'style') !== undefined
+
 /**
  * Store for shared items shown in RightSidebar
  */
@@ -33,7 +35,7 @@ export const useSettingsStore = defineStore('settings', () => {
 	const startWithoutMedia = ref<boolean | undefined>(getTalkConfig('local', 'call', 'start-without-media'))
 	const blurVirtualBackgroundEnabled = ref<boolean | undefined>(getTalkConfig('local', 'call', 'blur-virtual-background'))
 	const conversationsListStyle = ref<LIST_STYLE_OPTIONS | undefined>(getTalkConfig('local', 'conversations', 'list-style'))
-	const chatStyle = ref<CHAT_STYLE_OPTIONS | undefined>(getTalkConfig('local', 'chat', 'style') ?? 'split')
+	const chatStyle = ref<CHAT_STYLE_OPTIONS | undefined>(supportChatStyle ? (getTalkConfig('local', 'chat', 'style') ?? 'split') : 'unified')
 
 	const attachmentFolder = ref<string>(loadState('spreed', 'attachment_folder', ''))
 	const attachmentFolderFreeSpace = ref<number>(loadState('spreed', 'attachment_folder_free_space', 0))


### PR DESCRIPTION
### ☑️ Resolves

* Ref #16590
  * Talk Desktop against Nextcloud 32 and below do not have `chatStyle` config from server and stuck with split view
  * Alternative: keep temporary key in BrowserStorage. But default should still not be changed for old versions

## 🖌️ UI Checklist

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [x] Talk Desktop (against main and stable32)
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required