### PR TITLE
fix(devices): reset stream error after successful getUserMedia

### DIFF
--- a/src/composables/useDevices.js
+++ b/src/composables/useDevices.js
@@ -342,6 +342,7 @@ export const useDevices = createSharedComposable(function() {
 
 		mediaDevicesManager.getUserMedia({ audio: true })
 			.then((stream) => {
+				audioStreamError.value = null
 				if (!initialized) {
 					// The promise was fulfilled once the stream is no
 					// longer needed, so just discard it.
@@ -439,6 +440,7 @@ export const useDevices = createSharedComposable(function() {
 
 		mediaDevicesManager.getUserMedia({ video: true })
 			.then((stream) => {
+				videoStreamError.value = null
 				if (!initialized) {
 					// The promise was fulfilled once the stream is no
 					// longer needed, so just discard it.


### PR DESCRIPTION
### ☑️ Resolves

* Fix case, when correct device is selected after faulty one - error should be reset


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

https://github.com/user-attachments/assets/b97af7a6-6c6c-4887-b565-ea5607f5085f

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required