### PR TITLE
fix(chat): capture token mismatch when receiving chat messages

### DIFF
--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -459,6 +459,12 @@ const actions = {
 	 * @param {boolean} [payload.fromRealtime] whether the message comes from realtime (polling or signaling)
 	 */
 	processMessage(context, { token, message, fromRealtime = false }) {
+		if (message.token !== token) {
+			// FIXME Unresolved issue: https://github.com/nextcloud/spreed/issues/15668#issuecomment-3743283784
+			console.error('processMessage: message token "%s" mismatch called token "%s" \n If you see this, please report issue to developers on Github', message.token, token)
+			return
+		}
+
 		const sharedItemsStore = useSharedItemsStore()
 		const actorStore = useActorStore()
 		const chatExtrasStore = useChatExtrasStore()

--- a/src/stores/__tests__/chat.spec.js
+++ b/src/stores/__tests__/chat.spec.js
@@ -59,16 +59,16 @@ describe('chatStore', () => {
 	 */
 
 	const mockMessages = {
-		101: { id: 101, threadId: 101, isThread: true, message: 'Hello' },
-		102: { id: 102, threadId: 102, isThread: false, message: 'World' },
-		103: { id: 103, threadId: 101, isThread: true, message: '!' },
-		104: { id: 104, threadId: 104, isThread: true, message: 'Lorem ipsum' },
-		105: { id: 105, threadId: 105, isThread: false, message: 'dolor sit amet' },
-		106: { id: 106, threadId: 101, isThread: true, message: 'consectetur adipiscing elit' },
-		107: { id: 107, threadId: 104, isThread: true, message: 'Vestibulum quis' },
-		108: { id: 108, threadId: 108, isThread: false, message: 'sed diam nonumy' },
-		109: { id: 109, threadId: 104, isThread: true, message: 'eirmod tempor invidunt' },
-		110: { id: 110, threadId: 110, isThread: false, message: 'ut labore et dolore' },
+		101: { token: TOKEN, id: 101, threadId: 101, isThread: true, message: 'Hello' },
+		102: { token: TOKEN, id: 102, threadId: 102, isThread: false, message: 'World' },
+		103: { token: TOKEN, id: 103, threadId: 101, isThread: true, message: '!' },
+		104: { token: TOKEN, id: 104, threadId: 104, isThread: true, message: 'Lorem ipsum' },
+		105: { token: TOKEN, id: 105, threadId: 105, isThread: false, message: 'dolor sit amet' },
+		106: { token: TOKEN, id: 106, threadId: 101, isThread: true, message: 'consectetur adipiscing elit' },
+		107: { token: TOKEN, id: 107, threadId: 104, isThread: true, message: 'Vestibulum quis' },
+		108: { token: TOKEN, id: 108, threadId: 108, isThread: false, message: 'sed diam nonumy' },
+		109: { token: TOKEN, id: 109, threadId: 104, isThread: true, message: 'eirmod tempor invidunt' },
+		110: { token: TOKEN, id: 110, threadId: 110, isThread: false, message: 'ut labore et dolore' },
 	}
 
 	const chatBlockA = [mockMessages[109], mockMessages[108]]
@@ -150,8 +150,8 @@ describe('chatStore', () => {
 
 		it('returns an empty array if no messages or blocks present', () => {
 			// Arrange
-			vuexStore.dispatch('processMessage', { token: 'token1', message: mockMessages[109] })
-			chatStore.processChatBlocks('token2', [mockMessages[110]])
+			vuexStore.dispatch('processMessage', { token: 'token1', message: { token: 'token1', id: 109, threadId: 104, isThread: true, message: 'eirmod tempor invidunt' } })
+			chatStore.processChatBlocks('token2', [{ token: 'token2', id: 110, threadId: 110, isThread: false, message: 'ut labore et dolore' }])
 
 			// Assert
 			expect(chatStore.getMessagesList('token1')).toEqual([]) // No chat blocks

--- a/src/stores/chat.ts
+++ b/src/stores/chat.ts
@@ -298,6 +298,12 @@ export const useChatStore = defineStore('chat', () => {
 	function processChatBlocks(token: string, messages: ChatMessage[], options?: ProcessChatBlocksOptions): void {
 		const threadIdSetsToUpdate: IdMap<Set<number>> = {}
 		const newMessageIdsSet = messages.reduce((acc, message) => {
+			if (message.token !== token) {
+				// FIXME Unresolved issue: https://github.com/nextcloud/spreed/issues/15668#issuecomment-3743283784
+				console.error('processChatBlocks: message token "%s" mismatch called token "%s" \n If you see this, please report issue to developers on Github', message.token, token)
+				return acc
+			}
+
 			acc.add(message.id)
 			if (message.isThread && message.threadId) {
 				if (!threadIdSetsToUpdate[message.threadId]) {


### PR DESCRIPTION
### ☑️ Resolves

* Ref #15668
* Attempt to identify the cause of the issue
* See comment in the original issue:
  * `chatStore->getMessagesList`, `chatStore->processChatBlocks`, `messagesStore->processMessage` are storing and showing correctly to the arguments - given `token` and `messages[]`
  * That means some of functions is passing a new token with old messages to `process*()`
  * And open chat (with new token) might show 'old messages'
* WIth this PR:
  * Mismatching messages will be ignored and not saved. Page reload or another conversation switch should bring them back with the new request (if this one isn't failing too)

> [!TIP]
> As it's tricky to reproduce with client only, easy way to mock it is to modify `ChatController.php#prepareCommentsAsDataResponse()`:
> Use `<some_token>` from a known conversation as an indicator - this conversation will work as expected
```diff
+		foreach ($messages as $idx => $message) {
+			$messages[$idx]['token'] = '<some_token>';
+		}
 		return new DataResponse($messages, Http::STATUS_OK, $headers);
 	}
 ```


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

<img width="754" height="212" alt="image" src="https://github.com/user-attachments/assets/de762544-4123-49f8-98c7-bc7cad4af49d" />

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
  - [x] Not risky to federations, as tokens are translated
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
