### PR TITLE
fix(SettingsDialog): Remove Settings save toasts

### DIFF
--- a/src/components/SettingsDialog/SettingsDialog.vue
+++ b/src/components/SettingsDialog/SettingsDialog.vue
@@ -152,7 +152,7 @@
 </template>
 
 <script>
-import { showError, showSuccess } from '@nextcloud/dialogs'
+import { showError } from '@nextcloud/dialogs'
 import { getFilePickerBuilder } from '@nextcloud/dialogs'
 import { emit, subscribe, unsubscribe } from '@nextcloud/event-bus'
 import { t } from '@nextcloud/l10n'
@@ -326,7 +326,6 @@ export default {
 			this.privacyLoading = true
 			try {
 				await this.settingsStore.updateReadStatusPrivacy(this.readStatusPrivacyIsPublic ? PRIVACY.PRIVATE : PRIVACY.PUBLIC)
-				showSuccess(t('spreed', 'Your privacy setting has been saved'))
 			} catch (exception) {
 				showError(t('spreed', 'Error while setting read status privacy'))
 			}
@@ -337,7 +336,6 @@ export default {
 			this.privacyLoading = true
 			try {
 				await this.settingsStore.updateTypingStatusPrivacy(this.typingStatusPrivacyIsPublic ? PRIVACY.PRIVATE : PRIVACY.PUBLIC)
-				showSuccess(t('spreed', 'Your privacy setting has been saved'))
 			} catch (exception) {
 				showError(t('spreed', 'Error while setting typing status privacy'))
 			}
@@ -348,7 +346,6 @@ export default {
 			this.appearanceLoading = true
 			try {
 				await this.settingsStore.updateConversationsListStyle(value ? CONVERSATION.LIST_STYLE.COMPACT : CONVERSATION.LIST_STYLE.TWO_LINES)
-				showSuccess(t('spreed', 'Your personal setting has been saved'))
 			} catch (exception) {
 				showError(t('spreed', 'Error while setting personal setting'))
 			}
@@ -359,7 +356,6 @@ export default {
 			this.chatAppearanceLoading = true
 			try {
 				await this.settingsStore.updateChatStyle(value ? CHAT_STYLE.SPLIT : CHAT_STYLE.UNIFIED)
-				showSuccess(t('spreed', 'Your personal setting has been saved'))
 			} catch (exception) {
 				showError(t('spreed', 'Error while setting personal setting'))
 			}
@@ -374,7 +370,6 @@ export default {
 				} catch (e) {
 					showError(t('spreed', 'Failed to save sounds setting'))
 				}
-				showSuccess(t('spreed', 'Sounds setting saved'))
 			} catch (exception) {
 				showError(t('spreed', 'Error while saving sounds setting'))
 			}
@@ -385,7 +380,6 @@ export default {
 			this.mediaLoading = true
 			try {
 				await this.settingsStore.updateStartWithoutMedia(value)
-				showSuccess(t('spreed', 'Your default media state has been saved'))
 			} catch (exception) {
 				showError(t('spreed', 'Error while setting default media state'))
 			} finally {


### PR DESCRIPTION
### ☑️ Resolves

* Fix #16659 

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
- Toasts for the settings save will be removed.


### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required