### PR TITLE
perf(share): select only the required data

### DIFF
--- a/lib/Share/RoomShareProvider.php
+++ b/lib/Share/RoomShareProvider.php
@@ -715,7 +715,7 @@ class RoomShareProvider implements IShareProvider, IPartialShareProvider {
 	private function resolveSharesForRecipient(array $shareMap, string $userId, bool $allRoomShares = false): array {
 		$qb = $this->dbConnection->getQueryBuilder();
 
-		$query = $qb->select('*')
+		$query = $qb->select('parent', 'permissions', 'file_target')
 			->from('share')
 
 			->where($qb->expr()->eq('share_type', $qb->createNamedParameter(self::SHARE_TYPE_USERROOM)))
@@ -728,7 +728,7 @@ class RoomShareProvider implements IShareProvider, IPartialShareProvider {
 		if ($allRoomShares) {
 			$stmt = $query->executeQuery();
 
-			while ($data = $stmt->fetch()) {
+			while ($data = $stmt->fetchAssociative()) {
 				if (isset($shareMap[$data['parent']])) {
 					$shareMap[$data['parent']]->setPermissions((int)$data['permissions']);
 					$shareMap[$data['parent']]->setTarget($data['file_target']);
@@ -744,7 +744,7 @@ class RoomShareProvider implements IShareProvider, IPartialShareProvider {
 				$query->setParameter('share_ids', $ids, IQueryBuilder::PARAM_INT_ARRAY);
 				$stmt = $query->executeQuery();
 
-				while ($data = $stmt->fetch()) {
+				while ($data = $stmt->fetchAssociative()) {
 					$shareMap[$data['parent']]->setPermissions((int)$data['permissions']);
 					$shareMap[$data['parent']]->setTarget($data['file_target']);
 				}


### PR DESCRIPTION
With multiple thousands shares, this represent a significant reduction of IO wait, CPU and memory usage.

Blackfire comparaison

<img width="536" height="59" alt="image" src="https://github.com/user-attachments/assets/46b811c0-9bb1-4e61-a6c6-09cefec44bff" />

<img width="622" height="846" alt="image" src="https://github.com/user-attachments/assets/e5c58156-e1b3-4c10-97f0-fc61f1c0a7b2" />


### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
