### PR TITLE
fix: manage existing breakout rooms from conversation settings

### DIFF
--- a/src/components/BreakoutRoomsEditor/BreakoutRoomsEditor.vue
+++ b/src/components/BreakoutRoomsEditor/BreakoutRoomsEditor.vue
@@ -6,6 +6,7 @@
 <template>
 	<NcModal
 		:class="{ 'modal-mask__participants-step': isEditingParticipants }"
+		:container="container"
 		:labelId="dialogHeaderId"
 		@close="$emit('close')">
 		<div
@@ -108,6 +109,11 @@ export default {
 		token: {
 			type: String,
 			required: true,
+		},
+
+		container: {
+			type: String,
+			default: 'body',
 		},
 	},
 

--- a/src/components/BreakoutRoomsEditor/BreakoutRoomsParticipantsEditor.vue
+++ b/src/components/BreakoutRoomsEditor/BreakoutRoomsParticipantsEditor.vue
@@ -62,6 +62,7 @@
 				v-if="hasSelected"
 				variant="primary"
 				container=".participants-editor__buttons"
+				placement="top"
 				:menuName="t('spreed', 'Assign')">
 				<NcActionButton
 					v-for="(item, index) in assignments"

--- a/src/components/ConversationSettings/BreakoutRoomsSettings.vue
+++ b/src/components/ConversationSettings/BreakoutRoomsSettings.vue
@@ -30,6 +30,7 @@
 	<!-- Breakout rooms editor -->
 	<BreakoutRoomsEditor
 		v-if="showBreakoutRoomsEditor"
+		container=".breakout-rooms-settings"
 		:token="token"
 		@close="showBreakoutRoomsEditor = false" />
 

--- a/src/components/RightSidebar/BreakoutRooms/BreakoutRoomsActions.vue
+++ b/src/components/RightSidebar/BreakoutRooms/BreakoutRoomsActions.vue
@@ -103,7 +103,6 @@
 				<BreakoutRoomsParticipantsEditor
 					:token="mainToken"
 					:breakoutRooms="breakoutRooms"
-					:isCreatingRooms="false"
 					@close="closeParticipantsEditor" />
 			</div>
 		</NcModal>


### PR DESCRIPTION
### ☑️ Resolves

* Fix #16726
  * Already configured rooms should show the participants editor / manager to move them across rooms, or delete all rooms
  * Logic, styles and strings copied from Right sidebar > Breakout rooms action
  * Modals are now mounted inside the conversation settings dialog - so should not be behind

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="758" height="156" alt="image" src="https://github.com/user-attachments/assets/0f9895bb-f69d-49bb-9c89-71e729ddcb10" /> | <img width="624" height="161" alt="image" src="https://github.com/user-attachments/assets/ed8662a1-b6c5-4b57-8648-008c198591a5" />
<img width="943" height="482" alt="image" src="https://github.com/user-attachments/assets/fbbdd9d7-494e-4a9e-8d0e-2c6939b2aa31" /> | <img width="965" height="741" alt="image" src="https://github.com/user-attachments/assets/2a2135b5-d8e5-486b-a962-762fbc3148bd" />

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required