### PR TITLE
fix(NewMessage): allow chat functionality with failed HPB connection

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -335,6 +335,7 @@ export default {
 
 			if (from.name === 'conversation' && from.params.token !== to.params.token) {
 				this.$store.dispatch('leaveConversation', { token: from.params.token })
+				this.tokenStore.setLastJoinConversationFailed(false)
 			}
 
 			/**

--- a/src/components/NewMessage/NewMessage.vue
+++ b/src/components/NewMessage/NewMessage.vue
@@ -544,7 +544,8 @@ export default {
 		},
 
 		disabled() {
-			return this.isReadOnly || this.noChatPermission || !this.currentConversationIsJoined || this.isRecordingAudio
+			return this.isReadOnly || this.noChatPermission || this.isRecordingAudio
+				|| (!this.currentConversationIsJoined && !this.currentConversationIsJoinedWithoutHPB)
 		},
 
 		scheduleMessageTime() {
@@ -571,7 +572,7 @@ export default {
 				return t('spreed', 'This conversation has been locked')
 			} else if (this.noChatPermission) {
 				return t('spreed', 'No permission to post messages in this conversation')
-			} else if (!this.currentConversationIsJoined) {
+			} else if (!this.currentConversationIsJoined && !this.currentConversationIsJoinedWithoutHPB) {
 				return t('spreed', 'Joining conversation …')
 			} else if (this.silentChat) {
 				return t('spreed', 'Write a message without notification')
@@ -636,6 +637,10 @@ export default {
 
 		currentConversationIsJoined() {
 			return this.tokenStore.currentConversationIsJoined
+		},
+
+		currentConversationIsJoinedWithoutHPB() {
+			return this.tokenStore.currentConversationIsJoinedWithoutHPB
 		},
 
 		currentUploadId() {
@@ -776,6 +781,10 @@ export default {
 
 	watch: {
 		currentConversationIsJoined() {
+			this.focusInput()
+		},
+
+		currentConversationIsJoinedWithoutHPB() {
 			this.focusInput()
 		},
 

--- a/src/init.js
+++ b/src/init.js
@@ -59,6 +59,9 @@ window.OCA.Talk.registerParticipantSearchAction = ({ label, callback, show, icon
 EventBus.on('signaling-join-room', ([token]) => {
 	tokenStore.updateLastJoinedConversationToken(token)
 })
+EventBus.on('signaling-join-room-failed', ([token]) => {
+	tokenStore.setLastJoinConversationFailed(true)
+})
 
 EventBus.on('signaling-recording-status-changed', ([token, status]) => {
 	store.dispatch('setConversationProperties', { token, properties: { callRecording: status } })

--- a/src/services/EventBus.ts
+++ b/src/services/EventBus.ts
@@ -45,6 +45,7 @@ export type Events = {
 	'signaling-join-call': [string, number]
 	'signaling-join-call-failed': [string, { meta: components['schemas']['OCSMeta'], data: { error: string } }]
 	'signaling-join-room': [string]
+	'signaling-join-room-failed': [string]
 	'signaling-participant-list-changed': void
 	'signaling-participant-list-updated': void
 	'signaling-recording-status-changed': [string, number]

--- a/src/store/participantsStore.js
+++ b/src/store/participantsStore.js
@@ -1081,6 +1081,9 @@ const actions = {
 				}
 			} else if (error?.response?.status === 403 && error?.response?.data?.ocs?.data?.error === 'ban') {
 				EventBus.emit('forbidden-route', error.response.data.ocs.data)
+			} else if (error === 'cancelled') {
+				 // Ignore
+				console.log(error)
 			} else {
 				console.error(error)
 				showError(t('spreed', 'Failed to join the conversation.') + '\n' + messagePleaseTryToReload)

--- a/src/stores/token.ts
+++ b/src/stores/token.ts
@@ -17,8 +17,15 @@ export const useTokenStore = defineStore('token', () => {
 	 * A in the signaling server.
 	 */
 	const lastJoinedConversationToken = ref<'' | (string & {})>('')
+	/**
+	 * The joining of a room with the signaling server might fail
+	 * for various reasons. We still want to allow basic functionality
+	 * (e.g. chatting and file sharing) which does not depend on it.
+	 */
+	const lastJoinConversationFailed = ref<boolean>(false)
 
 	const currentConversationIsJoined = computed(() => token.value !== '' && lastJoinedConversationToken.value === token.value)
+	const currentConversationIsJoinedWithoutHPB = computed(() => token.value !== '' && lastJoinConversationFailed.value)
 
 	/**
 	 * @param newToken token of active conversation
@@ -43,16 +50,28 @@ export const useTokenStore = defineStore('token', () => {
 	 */
 	function updateLastJoinedConversationToken(newToken: string) {
 		lastJoinedConversationToken.value = newToken
+		// Reset last failed conversation attempt on successful join
+		lastJoinConversationFailed.value = false
+	}
+
+	/**
+	 * @param newValue value of the flag for last joined conversation
+	 */
+	function setLastJoinConversationFailed(newValue: boolean) {
+		lastJoinConversationFailed.value = newValue
 	}
 
 	return {
 		token,
 		fileIdForToken,
 		lastJoinedConversationToken,
+		lastJoinConversationFailed,
 		currentConversationIsJoined,
+		currentConversationIsJoinedWithoutHPB,
 
 		updateToken,
 		updateTokenAndFileIdForToken,
 		updateLastJoinedConversationToken,
+		setLastJoinConversationFailed,
 	}
 })

--- a/src/utils/signaling.js
+++ b/src/utils/signaling.js
@@ -866,6 +866,7 @@ Signaling.Standalone.prototype._handleConnectionError = function(type) {
 		this.signalingConnectionError = showError(t('spreed', 'Failed to connect. The signaling server may be set up incorrectly'), {
 			timeout: TOAST_PERMANENT_TIMEOUT,
 		})
+		this._trigger('joinRoomFailed', [this.settings.token])
 	}
 }
 

--- a/src/utils/signaling.js
+++ b/src/utils/signaling.js
@@ -737,22 +737,7 @@ Signaling.Standalone.prototype.connect = function() {
 			this.signalingConnectionWarning = null
 		}
 
-		this.socketErrorCount++
-		if (this.signalingConnectionError === null && this.socketErrorCount < 5) {
-			this.signalingConnectionError = showError(t('spreed', 'Failed to connect. Retrying …'), {
-				timeout: TOAST_PERMANENT_TIMEOUT,
-			})
-		} else if (this.socketErrorCount === 5) {
-			// Switch to a different message as several errors in a row in hello
-			// responses indicate that the signaling server might be unable to
-			// connect to Nextcloud.
-			if (this.signalingConnectionError) {
-				this.signalingConnectionError.hideToast()
-			}
-			this.signalingConnectionError = showError(t('spreed', 'Failed to connect. The signaling server may be set up incorrectly'), {
-				timeout: TOAST_PERMANENT_TIMEOUT,
-			})
-		}
+		this._handleConnectionError('socket')
 		this.reconnect()
 	}.bind(this)
 	this.socket.onclose = function(event) {
@@ -852,6 +837,36 @@ Signaling.Standalone.prototype.connect = function() {
 		}
 		this._trigger('onAfterReceiveMessage', [data])
 	}.bind(this)
+}
+
+Signaling.Standalone.prototype._handleConnectionError = function(type) {
+	let errorCount
+	if (type === 'socket') {
+		this.socketErrorCount++
+		errorCount = this.socketErrorCount
+	} else if (type === 'hello') {
+		this.helloResponseErrorCount++
+		errorCount = this.helloResponseErrorCount
+	} else {
+		// Type is not provided, do not process the error
+		return
+	}
+
+	if (this.signalingConnectionError === null && errorCount < 5) {
+		this.signalingConnectionError = showError(t('spreed', 'Failed to connect. Retrying …'), {
+			timeout: TOAST_PERMANENT_TIMEOUT,
+		})
+	} else if (errorCount === 5) {
+		// Switch to a different message as several errors in a row in hello
+		// responses indicate that the signaling server might be unable to
+		// connect to Nextcloud.
+		if (this.signalingConnectionError) {
+			this.signalingConnectionError.hideToast()
+		}
+		this.signalingConnectionError = showError(t('spreed', 'Failed to connect. The signaling server may be set up incorrectly'), {
+			timeout: TOAST_PERMANENT_TIMEOUT,
+		})
+	}
 }
 
 Signaling.Standalone.prototype.welcomeReceived = function(data) {
@@ -1084,23 +1099,7 @@ Signaling.Standalone.prototype.helloResponseReceived = function(data) {
 			return
 		}
 
-		this.helloResponseErrorCount++
-
-		if (this.signalingConnectionError === null && this.helloResponseErrorCount < 5) {
-			this.signalingConnectionError = showError(t('spreed', 'Failed to connect. Retrying …'), {
-				timeout: TOAST_PERMANENT_TIMEOUT,
-			})
-		} else if (this.helloResponseErrorCount === 5) {
-			// Switch to a different message as several errors in a row in hello
-			// responses indicate that the signaling server might be unable to
-			// connect to Nextcloud.
-			if (this.signalingConnectionError) {
-				this.signalingConnectionError.hideToast()
-			}
-			this.signalingConnectionError = showError(t('spreed', 'Failed to connect. The signaling server may be set up incorrectly'), {
-				timeout: TOAST_PERMANENT_TIMEOUT,
-			})
-		}
+		this._handleConnectionError('hello')
 
 		// TODO(fancycode): How should this be handled better?
 		const url = this._getBackendUrl()

--- a/src/utils/signaling.js
+++ b/src/utils/signaling.js
@@ -1173,7 +1173,7 @@ Signaling.Standalone.prototype.joinRoom = function(token, sessionId) {
 		}
 
 		if (this._pendingJoinRoomPromise) {
-			this._pendingJoinRoomPromise.reject()
+			this._pendingJoinRoomPromise.reject('cancelled')
 		}
 
 		let pendingJoinRoomPromiseResolve


### PR DESCRIPTION
### ☑️ Resolves

* Fix #16725
* Signaling standalone remains in connecting/reconnecting state until success
* We can emit an event on 5th attempt (roughly 10-15s), that there is no connection to HPB
* Additional flag to track current state of HPB join result

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

<img width="573" height="229" alt="image" src="https://github.com/user-attachments/assets/1beac7b9-6caf-44fb-bfc5-4d7b59f12b1d" />


### 🚧 Tasks

- [ ] Initial error after page reload
- [ ] Switch rooms
- [ ] Resolving afterwards with reconnection
- [ ] Various connection errors (WebSocket, hello response, server requests)
- [ ] ...

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
