### PR TITLE
ci(lint): Use multi file argument in lint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,12 @@
 	"scripts": {
 		"cs:check": "php-cs-fixer fix --dry-run --diff",
 		"cs:fix": "php-cs-fixer fix",
-		"lint": "find . -name \\*.php -not -path './vendor/*' -not -path './vendor-bin/*' -not -path './lib/Vendor/*' -not -path './build/*' -not -path './tests/integration/vendor/*' -print0 | xargs -0 -n1 php -l",
+		"lint": [
+			"@lint-8.2-or-earlier",
+			"@lint-8.3-or-later"
+		],
+		"lint-8.2-or-earlier": "[ $(php -r \"echo PHP_VERSION_ID;\") -ge 80300 ] || find . -type f -name '*.php' -not -path './vendor/*' -not -path './vendor-bin/*' -not -path './lib/Vendor/*' -not -path './build/*' -not -path './tests/integration/vendor/*' -not -path 'tests/stubs/*' -print0 | xargs -0 -n1 -P$(nproc) php -l",
+		"lint-8.3-or-later": "[ $(php -r \"echo PHP_VERSION_ID;\") -lt 80300 ] || find . -type f -name '*.php' -not -path './vendor/*' -not -path './vendor-bin/*' -not -path './lib/Vendor/*' -not -path './build/*' -not -path './tests/integration/vendor/*' -not -path 'tests/stubs/*' -print0 | xargs -0 -n200 -P$(nproc) php -l",
 		"openapi": "generate-spec && (npm run typescript:generate || echo 'Please manually regenerate the typescript OpenAPI models')",
 		"rector:check": "rector --dry-run",
 		"rector:fix": "rector",


### PR DESCRIPTION
> Since PHP 8.3 the linting command "php -l" can consume multiple files at once. This drastically speeds up the time necessary for the linting from ~3 minutes to few seconds.
By also running the linting on multiple cores, the time can be dropped to < 1s

- Same as https://github.com/nextcloud/server/pull/57566 in server
- Saved time drops from ~20s to <0.5s