### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -334,12 +334,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "01ad50a61f835a4a7511d305e7e21cddce84e804"
+                "reference": "0992cfc56e143a27b3b8311cf69cad83e7956beb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/01ad50a61f835a4a7511d305e7e21cddce84e804",
-                "reference": "01ad50a61f835a4a7511d305e7e21cddce84e804",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/0992cfc56e143a27b3b8311cf69cad83e7956beb",
+                "reference": "0992cfc56e143a27b3b8311cf69cad83e7956beb",
                 "shasum": ""
             },
             "require": {
@@ -375,7 +375,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2026-01-16T00:57:34+00:00"
+            "time": "2026-01-21T00:58:31+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency