### PR TITLE
fix(NewMessage): respect threadId and replyTo when sharing a file

### DIFF
--- a/src/components/NewMessage/NewMessage.vue
+++ b/src/components/NewMessage/NewMessage.vue
@@ -1163,7 +1163,14 @@ export default {
 					throw new Error(t('files', 'Invalid path selected'))
 				}
 				this.focusInput()
-				this.$store.dispatch('shareFile', { token: this.token, path })
+
+				const talkMetaData = JSON.stringify(Object.assign(
+					this.threadId ? { threadId: this.threadId } : {},
+					this.parentMessage?.id ? { replyTo: this.parentMessage?.id } : {},
+				))
+				this.chatExtrasStore.removeParentIdToReply(this.token)
+
+				this.$store.dispatch('shareFile', { token: this.token, path, talkMetaData })
 			})
 		},
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix #16785
* We have talkMetadata fr a while now to be able to do it 🙈 
* Solution copied from fileUploadStore.js#shareFiles


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

<img width="504" height="320" alt="image" src="https://github.com/user-attachments/assets/04f68ffc-245e-4087-86a4-8dca663663c1" />
<img width="999" height="321" alt="image" src="https://github.com/user-attachments/assets/b0be34d9-6593-4126-a0d8-9e8ae80948d7" />

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
