### PR TITLE
refactor(QueryBuilder): Avoid using createFunction where possible

### DIFF
--- a/lib/Migration/Version2001Date20170707115443.php
+++ b/lib/Migration/Version2001Date20170707115443.php
@@ -64,12 +64,12 @@ class Version2001Date20170707115443 extends SimpleMigrationStep {
 
 		$query = $this->db->getQueryBuilder();
 
-		$query->selectAlias($query->createFunction('COUNT(*)'), 'num_rooms')
+		$query->selectAlias($query->func()->count('*'), 'num_rooms')
 			->from('spreedme_rooms');
 		$result = $query->executeQuery();
-		$return = (int)$result->fetch();
+		$row = $result->fetch();
 		$result->closeCursor();
-		$numRooms = (int)$return['num_rooms'];
+		$numRooms = (int)$row['num_rooms'];
 
 		if ($numRooms === 0) {
 			return;

--- a/lib/Migration/Version3003Date20180718112436.php
+++ b/lib/Migration/Version3003Date20180718112436.php
@@ -60,7 +60,7 @@ class Version3003Date20180718112436 extends SimpleMigrationStep {
 
 		$query = $this->connection->getQueryBuilder();
 		$query->select('object_id')
-			->selectAlias($query->createFunction('MAX(' . $query->getColumnName('creation_timestamp') . ')'), 'last_activity')
+			->selectAlias($query->func()->max('creation_timestamp'), 'last_activity')
 			->from('comments')
 			->where($query->expr()->eq('object_type', $query->createNamedParameter('chat')))
 			->groupBy('object_id');

--- a/lib/Migration/Version3003Date20180718133519.php
+++ b/lib/Migration/Version3003Date20180718133519.php
@@ -58,7 +58,7 @@ class Version3003Date20180718133519 extends SimpleMigrationStep {
 			->where($update->expr()->eq('id', $update->createParameter('room')));
 
 		$query = $this->connection->getQueryBuilder();
-		$query->selectAlias($query->createFunction('MAX(' . $query->getColumnName('id') . ')'), 'message')
+		$query->selectAlias($query->func()->max('id'), 'message')
 			->addSelect('object_id')
 			->from('comments')
 			->where($query->expr()->eq('object_type', $query->createNamedParameter('chat')))

--- a/lib/Migration/Version7000Date20190724121136.php
+++ b/lib/Migration/Version7000Date20190724121136.php
@@ -63,7 +63,7 @@ class Version7000Date20190724121136 extends SimpleMigrationStep {
 	public function postSchemaChange(IOutput $output, \Closure $schemaClosure, array $options) {
 		$query = $this->connection->getQueryBuilder();
 		$query->select('m.user_id', 'm.object_id')
-			->selectAlias($query->createFunction('MAX(' . $query->getColumnName('c.id') . ')'), 'last_comment')
+			->selectAlias($query->func()->max('c.id'), 'last_comment')
 			->from('comments_read_markers', 'm')
 			->leftJoin('m', 'comments', 'c', $query->expr()->andX(
 				$query->expr()->eq('c.object_id', 'm.object_id'),

--- a/lib/Migration/Version7000Date20190724121137.php
+++ b/lib/Migration/Version7000Date20190724121137.php
@@ -33,7 +33,7 @@ class Version7000Date20190724121137 extends SimpleMigrationStep {
 	public function preSchemaChange(IOutput $output, \Closure $schemaClosure, array $options): void {
 		$query = $this->connection->getQueryBuilder();
 		$query->select('p.user_id', 'p.room_id')
-			->selectAlias($query->createFunction('MAX(' . $query->getColumnName('c.id') . ')'), 'last_mention_message')
+			->selectAlias($query->func()->max('c.id'), 'last_mention_message')
 			->from('talk_participants', 'p')
 			->leftJoin('p', 'comments', 'c', $query->expr()->andX(
 				$query->expr()->eq('c.object_id', $query->expr()->castColumn('p.room_id', IQueryBuilder::PARAM_STR)),

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -97,11 +97,6 @@
       <code><![CDATA[private]]></code>
     </UndefinedClass>
   </file>
-  <file src="lib/Migration/Version2001Date20170707115443.php">
-    <InvalidArrayAccess>
-      <code><![CDATA[$return['num_rooms']]]></code>
-    </InvalidArrayAccess>
-  </file>
   <file src="lib/Model/Poll.php">
     <LessSpecificReturnStatement>
       <code><![CDATA[[


### PR DESCRIPTION
createFunction can be misused, so replace calls to it with IFunctionBuilder instead where possible which is cleaner.

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
