### PR TITLE
fix: search conversations/participants has no focus indication

### DIFF
--- a/src/components/UIShared/SearchBox.vue
+++ b/src/components/UIShared/SearchBox.vue
@@ -191,14 +191,3 @@ export default {
 	},
 }
 </script>
-
-<style lang="scss" scoped>
-.search-box {
-	:deep(.input-field__input) {
-		&:focus:not([disabled]),&:active:not([disabled]) {
-			box-shadow: unset !important; // Remove the outer white border which is unnecessary here
-		}
-	}
-}
-
-</style>


### PR DESCRIPTION
### ☑️ Resolves

* Form element must have a visual focus indication
* Current style overrides breaks new `NcTextField` styles
* Also, removing box shadow should not be necessary

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="294" height="125" alt="image" src="https://github.com/user-attachments/assets/2d82f86d-2ad9-4bf6-8cda-9752cf92f36e" /> | <img width="295" height="124" alt="image" src="https://github.com/user-attachments/assets/8043ea42-dcc3-4a0e-8679-230df8861d75" />
<img width="372" height="111" alt="image" src="https://github.com/user-attachments/assets/35944f9a-0dc3-4a23-b470-b4ae573cdc1e" /> | <img width="374" height="110" alt="image" src="https://github.com/user-attachments/assets/4f1481dd-3023-4b8d-a75c-46fc620299d9" />

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team (not actual)
- [x] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required