### PR TITLE
fix(chat): Don't show email hash as name for email guest

### DIFF
--- a/lib/Chat/Parser/SystemMessage.php
+++ b/lib/Chat/Parser/SystemMessage.php
@@ -1137,7 +1137,7 @@ class SystemMessage implements IEventListener {
 		try {
 			$participant = $this->participantService->getParticipantByActor($room, $actorType, $actorId);
 			$name = $participant->getAttendee()->getDisplayName();
-			if ($name === '' && $actorType === Attendee::ACTOR_EMAILS) {
+			if ($name === '' && $actorType === Attendee::ACTOR_EMAILS && !preg_match('/^[0-9a-f]{64}$/', $actorId)) {
 				$name = $actorId;
 			} elseif ($name === '') {
 				return $this->l->t('Guest');

--- a/tests/php/Chat/Parser/SystemMessageTest.php
+++ b/tests/php/Chat/Parser/SystemMessageTest.php
@@ -1253,6 +1253,10 @@ class SystemMessageTest extends TestCase {
 		return [
 			[Attendee::ACTOR_GUESTS, sha1('name'), 'name', 'name (guest)'],
 			[Attendee::ACTOR_GUESTS, sha1('name'), '', 'Guest'],
+			[Attendee::ACTOR_GUESTS, hash('sha256', 'name'), 'name', 'name (guest)'],
+			[Attendee::ACTOR_GUESTS, hash('sha256', 'name'), '', 'Guest'],
+			[Attendee::ACTOR_EMAILS, hash('sha256', 'test@test.tld'), 'name', 'name (guest)'],
+			[Attendee::ACTOR_EMAILS, hash('sha256', 'test@test.tld'), '', 'Guest'],
 			[Attendee::ACTOR_EMAILS, 'test@test.tld', 'name', 'name (guest)'],
 			[Attendee::ACTOR_EMAILS, 'test@test.tld', '', 'test@test.tld (guest)'],
 		];


### PR DESCRIPTION
🏚️ Before | 🏡 After
-- | --
<img width="1515" height="175" alt="grafik" src="https://github.com/user-attachments/assets/8ad0b686-3f65-461a-abf8-0e1f51910ad3" /> | <img width="1515" height="175" alt="grafik" src="https://github.com/user-attachments/assets/9e6853f3-e577-482b-b0fc-947c184962e0" />

- the actor id used to be the email until we switched to hashes https://github.com/nextcloud/spreed/pull/13499

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
