### PR TITLE
fix(l10n): handle special characters in conversation name

### DIFF
--- a/src/components/ConversationSettings/ConversationPermissionsSettings.vue
+++ b/src/components/ConversationSettings/ConversationPermissionsSettings.vue
@@ -184,14 +184,14 @@ export default {
 					token: this.token,
 					permissions,
 				})
-				showSuccess(t('spreed', 'Default permissions modified for {conversationName}', { conversationName: this.conversationName }))
+				showSuccess(t('spreed', 'Default permissions modified for {conversationName}', { conversationName: this.conversationName }, { escape: false, sanitize: false }))
 
 				// Modify the radio buttons value
 				this.radioValue = this.getPermissionRadioValue(permissions)
 				this.showPermissionsEditor = false
 			} catch (error) {
 				console.debug(error)
-				showError(t('spreed', 'Could not modify default permissions for {conversationName}', { conversationName: this.conversationName }))
+				showError(t('spreed', 'Could not modify default permissions for {conversationName}', { conversationName: this.conversationName }, { escape: false, sanitize: false }))
 
 				// Go back to the previous radio value
 				this.radioValue = this.getPermissionRadioValue(this.conversationPermissions)

--- a/src/components/NewConversationDialog/NewConversationDialog.vue
+++ b/src/components/NewConversationDialog/NewConversationDialog.vue
@@ -230,7 +230,7 @@ export default {
 				}
 				return t('spreed', 'Error while creating the conversation')
 			} else if (this.success && this.isPublic) {
-				return t('spreed', 'All set, the conversation "{conversationName}" was created.', { conversationName: this.conversationName })
+				return t('spreed', 'All set, the conversation "{conversationName}" was created.', { conversationName: this.conversationName }, { escape: false, sanitize: false })
 			}
 			return ''
 		},

--- a/src/search.js
+++ b/src/search.js
@@ -34,7 +34,7 @@ function init() {
 				emit('nextcloud:unified-search:add-filter', {
 					id: 'talk-message',
 					payload: conversation,
-					filterUpdateText: t('spreed', 'Search in conversation: {conversation}', { conversation: conversation.displayName }),
+					filterUpdateText: t('spreed', 'Search in conversation: {conversation}', { conversation: conversation.displayName }, { escape: false, sanitize: false }),
 					filterParams: { conversation: conversation.token },
 				})
 			}


### PR DESCRIPTION
### ☑️ Resolves

* Fix displaying of conversation name (coming from server) containing < and >


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="308" height="134" alt="image" src="https://github.com/user-attachments/assets/c3b834c9-fc88-4175-aca0-2962534273cc" /> | <img width="301" height="137" alt="image" src="https://github.com/user-attachments/assets/f144d8ba-684b-453f-8f5f-db860c1e4fc4" />
<img width="299" height="136" alt="image" src="https://github.com/user-attachments/assets/40f9c13c-233a-4378-a5ae-a292dbe7c81a" /> | <img width="296" height="134" alt="image" src="https://github.com/user-attachments/assets/a5181da8-94b9-4f95-aac7-48a94421f78e" />

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client