### PR TITLE
fix: Use strict comparaison with in_array

### DIFF
--- a/lib/BackgroundJob/CheckHostedSignalingServer.php
+++ b/lib/BackgroundJob/CheckHostedSignalingServer.php
@@ -44,11 +44,11 @@ class CheckHostedSignalingServer extends TimedJob {
 	}
 
 	private function formatTurnSchemes(array $schemes): string {
-		if (in_array('turn', $schemes) && in_array('turns', $schemes)) {
+		if (in_array('turn', $schemes, true) && in_array('turns', $schemes, true)) {
 			return 'turn,turns';
-		} elseif (in_array('turn', $schemes)) {
+		} elseif (in_array('turn', $schemes, true)) {
 			return 'turn';
-		} elseif (in_array('turns', $schemes)) {
+		} elseif (in_array('turns', $schemes, true)) {
 			return 'turns';
 		} else {
 			return 'turn';
@@ -56,11 +56,11 @@ class CheckHostedSignalingServer extends TimedJob {
 	}
 
 	private function formatTurnProtocols(array $protocols): string {
-		if (in_array('udp', $protocols) && in_array('tcp', $protocols)) {
+		if (in_array('udp', $protocols, true) && in_array('tcp', $protocols, true)) {
 			return 'udp,tcp';
-		} elseif (in_array('udp', $protocols)) {
+		} elseif (in_array('udp', $protocols, true)) {
 			return 'udp';
-		} elseif (in_array('tcp', $protocols)) {
+		} elseif (in_array('tcp', $protocols, true)) {
 			return 'tcp';
 		} else {
 			return 'udp';

--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -1031,7 +1031,7 @@ class ParticipantService {
 		$users = json_decode($room->getName(), true);
 		$participants = $this->getParticipantUserIds($room);
 		if ($enforceUserId !== null) {
-			$missingUsers = !in_array($enforceUserId, $participants) ? [$enforceUserId] : [];
+			$missingUsers = !in_array($enforceUserId, $participants, true) ? [$enforceUserId] : [];
 		} else {
 			$missingUsers = array_diff($users, $participants);
 		}

--- a/lib/Service/RecordingService.php
+++ b/lib/Service/RecordingService.php
@@ -408,7 +408,7 @@ class RecordingService {
 		}
 
 		$extension = strtolower(pathinfo($fileName, PATHINFO_EXTENSION));
-		if (!$extension || !in_array($extension, $allowed[$mimeType])) {
+		if (!$extension || !in_array($extension, $allowed[$mimeType], true)) {
 			$this->logger->warning("Uploaded file extensions ($extension) is not allowed for the detected mime type ($mimeType)");
 			throw new InvalidArgumentException('file_extension');
 		}


### PR DESCRIPTION
## 🛠️ API Checklist

### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not possible
- [ ] 📘 API documentation in `docs/` has been updated or is not required
- [ ] 🔖 Capability is added or not needed 
