### PR TITLE
fix(filesintegration): Use UserFolder to check for access

### DIFF
--- a/lib/Chat/AutoComplete/SearchPlugin.php
+++ b/lib/Chat/AutoComplete/SearchPlugin.php
@@ -52,7 +52,7 @@ class SearchPlugin implements ISearchPlugin {
 	#[\Override]
 	public function search($search, $limit, $offset, ISearchResult $searchResult): bool {
 		if ($this->room->getObjectType() === 'file') {
-			$usersWithFileAccess = $this->util->getUsersWithAccessFile($this->room->getObjectId());
+			$usersWithFileAccess = $this->util->getUsersWithAccessFile($this->room->getObjectId(), $this->userId);
 			if (!empty($usersWithFileAccess)) {
 				$users = [];
 				foreach ($usersWithFileAccess as $userId) {

--- a/lib/Controller/FilesIntegrationController.php
+++ b/lib/Controller/FilesIntegrationController.php
@@ -104,7 +104,7 @@ class FilesIntegrationController extends OCSController {
 			throw new OCSNotFoundException($this->l->t('File is not shared, or shared but not with the user'));
 		}
 
-		$users = $this->util->getUsersWithAccessFile($fileId);
+		$users = $this->util->getUsersWithAccessFile($fileId, $currentUser->getUID());
 		if (count($users) <= 1 && !$this->util->canGuestsAccessFile($fileId)) {
 			throw new OCSNotFoundException($this->l->t('File is not shared, or shared but not with the user'));
 		}

--- a/lib/Files/Util.php
+++ b/lib/Files/Util.php
@@ -35,9 +35,10 @@ class Util {
 	/**
 	 * @return string[]
 	 */
-	public function getUsersWithAccessFile(string $fileId): array {
+	public function getUsersWithAccessFile(string $fileId, string $userId): array {
 		if (!isset($this->accessLists[$fileId])) {
-			$nodes = $this->rootFolder->getById((int)$fileId);
+			$userFolder = $this->rootFolder->getUserFolder($userId);
+			$nodes = $userFolder->getById((int)$fileId);
 
 			if (empty($nodes)) {
 				return [];
@@ -64,7 +65,7 @@ class Util {
 	}
 
 	public function canUserAccessFile(string $fileId, string $userId): bool {
-		return \in_array($userId, $this->getUsersWithAccessFile($fileId), true);
+		return \in_array($userId, $this->getUsersWithAccessFile($fileId, $userId), true);
 	}
 
 	public function canGuestsAccessFile(string $fileId): bool {


### PR DESCRIPTION
### ☑️ Resolves

* Fix CI from https://github.com/nextcloud/server/pull/57834
* Not fully sure this should be needed, it basically means that also other code places that rely on RootFolder to get "any trace to a file" no longer work