### PR TITLE
fix(chat): correctly update last message and unread counter from polling

### DIFF
--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -1153,7 +1153,7 @@ const actions = {
 				guestNameStore.addGuestName(message, { noUpdate: false })
 			}
 			context.dispatch('processMessage', { token, message, fromRealtime })
-			if (!lastMessage || message.id > lastMessage.id) {
+			if ((!lastMessage || message.id > lastMessage.id) && !isHiddenSystemMessage(message)) {
 				if (!message.systemMessage) {
 					if (actorId !== message.actorId || actorType !== message.actorType) {
 						countNewMessages++


### PR DESCRIPTION
### ☑️ Resolves

* Fix incorrect updates in LeftSidebar
  - lastMessage is used later to updated LeftSidebar with subline and unread counter
  - lastMessage should only be of a list of rendered messages for that list
  - this doesn't include hidden system messages like reactions

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before


https://github.com/user-attachments/assets/b8979623-07a0-454b-91b7-35416011f1e7


🏡 After

https://github.com/user-attachments/assets/c835b4bf-a320-40a4-a390-4aac7d921b07


### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client