### PR TITLE
fix(bots): Add reactions from bots before relaying the message

### DIFF
--- a/lib/Service/BotService.php
+++ b/lib/Service/BotService.php
@@ -257,6 +257,20 @@ class BotService {
 									(int)$comment->getId(),
 									$reaction
 								);
+
+								/**
+								 * Add the reactions to the original message for now,
+								 * so that when it's relayed, it shows the reaction already.
+								 *
+								 * TODO:
+								 * However, if we fix the sending order and the "reaction"
+								 * message is relayed after the message, a client would add
+								 * the reaction again showing 2 reactions while there is only one.
+								 * So in case we change that, we need to rever this here.
+								 */
+								$reactions = $comment->getReactions();
+								$reactions[$reaction] = ($reactions[$reaction] ?? 0) + 1;
+								$comment->setReactions($reactions);
 							} catch (\Exception $e) {
 								$this->logger->error('Error while trying to react as a bot: ' . $e->getMessage(), ['exception' => $e]);
 							}


### PR DESCRIPTION
Add the reactions to the original message for now, so that when it's relayed, it shows the reaction already. However, if we fix the sending order and the "reaction" message is relayed after the message, a client would add the reaction again showing 2 reactions while there is only one. So in case we change that, we need to rever this here.

### Steps
- Enable call_summary_bot
- Post `- agenda: test`
- Check if the message has a reaction

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
