### PR TITLE
fix(conversation): always expand the right sidebar information

### DIFF
--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -486,9 +486,21 @@ export default {
 
 				// Discard notification if the conversation changes or closed
 				this.notifyUnreadMessages(null)
+
+				if (this.isOneToOne || this.conversation.messageExpiration) {
+					this.contentModeIndex = 1
+				} else {
+					this.contentModeIndex = 0
+				}
 			},
 
 			immediate: true,
+		},
+
+		'conversation.messageExpiration': function(value) {
+			if (value) {
+				this.contentModeIndex = 1
+			}
 		},
 
 		isGuestModerator(newValue) {


### PR DESCRIPTION
### ☑️ Resolves

* Fix minor regression from message expiration PR
  * Info should always expand for 1-1 chats and chat with message expirations, not keep the user value (0 by default and hides the feature)


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="250" height="122" alt="image" src="https://github.com/user-attachments/assets/c2565822-8cd0-4d8c-9846-159c4d0b6b94" /> | <img width="255" height="162" alt="image" src="https://github.com/user-attachments/assets/f94fe904-cca4-4e01-81f2-20c655b1512f" />

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client