### PR TITLE
fix(chat-relay): poll messages when receive a file share

### DIFF
--- a/src/composables/useGetMessages.ts
+++ b/src/composables/useGetMessages.ts
@@ -698,6 +698,12 @@ export function useGetMessagesProvider() {
 			}
 		}
 
+		// FIXME Patch for file uploads: messageParameters['file']['path'] and messageParameters['file']['link'] do not match server request
+		if (Object.keys(message.messageParameters ?? {}).some((key) => key.startsWith('file'))) {
+			tryPollNewMessages()
+			return
+		}
+
 		// Patch for federated conversations: disable unsupported file shares
 		if (conversation.value?.remoteServer && Object.keys(message.messageParameters ?? {}).some((key) => key.startsWith('file'))
 			&& [MESSAGE.TYPE.COMMENT, MESSAGE.TYPE.VOICE_MESSAGE, MESSAGE.TYPE.RECORD_VIDEO, MESSAGE.TYPE.RECORD_AUDIO].includes(message.messageType)) {


### PR DESCRIPTION
### ☑️ Resolves

* Might be caused by current failures from Files side

Example from server:
```json
"path": "Talk\/picture2.png",
"link": "https:\/\/nextcloud.local\/index.php\/f\/316",
```


Example from chat-relay:
```json
"path": "picture2.png",
"link": "https://nextcloud.local/index.php/s/k2A68sakfs3fgWa",
```


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before

https://github.com/user-attachments/assets/a85696e9-034a-4615-b0b2-17fe189378d2


🏡 After

https://github.com/user-attachments/assets/9d57e616-71ba-4a1c-b6a8-444572ea278a


### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client