### PR TITLE
fix(thread): process thread starter message from system message

### DIFF
--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -486,6 +486,17 @@ const actions = {
 				return
 			}
 
+			if (message.systemMessage === MESSAGE.SYSTEM_TYPE.THREAD_CREATED) {
+				// Fetch thread data in case it doesn't exist in the store yet
+				if (!chatExtrasStore.getThread(token, message.threadId)) {
+					chatExtrasStore.fetchSingleThread(token, message.threadId)
+				}
+			}
+
+			if (message.systemMessage === MESSAGE.SYSTEM_TYPE.THREAD_RENAMED) {
+				chatExtrasStore.updateThreadTitle(token, message.threadId, message.threadTitle)
+			}
+
 			if (!message.parent) {
 				context.commit('addMessage', { token, message })
 				return
@@ -547,17 +558,6 @@ const actions = {
 					.forEach((storedMessage) => {
 						context.commit('addMessage', { token, message: { ...storedMessage, parent: message.parent } })
 					})
-			}
-
-			if (message.systemMessage === MESSAGE.SYSTEM_TYPE.THREAD_CREATED) {
-				// Fetch thread data in case it doesn't exist in the store yet
-				if (!chatExtrasStore.getThread(token, message.threadId)) {
-					chatExtrasStore.fetchSingleThread(token, message.threadId)
-				}
-			}
-
-			if (message.systemMessage === MESSAGE.SYSTEM_TYPE.THREAD_RENAMED) {
-				chatExtrasStore.updateThreadTitle(token, message.threadId, message.threadTitle)
 			}
 
 			// Auto unpin system message (for time-limited pins)

--- a/src/stores/chatExtras.ts
+++ b/src/stores/chatExtras.ts
@@ -254,6 +254,10 @@ export const useChatExtrasStore = defineStore('chatExtras', () => {
 			pendingFetchSingleThreadRequests.add(threadId)
 			const response = await getSingleThreadForConversation(token, threadId)
 			addThread(token, response.data.ocs.data)
+			// FIXME: to be removed when chat relay provides thread data in original message
+			if (response.data.ocs.data.first) {
+				vuexStore.commit('addMessage', { token, message: response.data.ocs.data.first })
+			}
 		} catch (error) {
 			console.error('Error fetching thread:', error)
 		} finally {


### PR DESCRIPTION
### ☑️ Resolves

* system message `thread_created` has no parent 🤡 


### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
