### PR TITLE
fix(federation): Handle permission mismatches for reaction permissions

### DIFF
--- a/lib/Middleware/InjectionMiddleware.php
+++ b/lib/Middleware/InjectionMiddleware.php
@@ -343,6 +343,22 @@ class InjectionMiddleware extends Middleware {
 			throw new PermissionsException();
 		}
 
+		$room = $controller->getRoom();
+
+		/**
+		 * This handles version mismatches where the local instance may have different
+		 * permission bits than the host (e.g., after a migration that adds new permission types like REACT).
+		 *
+		 * - REACT to CHAT fallback introduced with Nextcloud 34, can be dropped once Nextcloud 33 can not be federated with
+		 */
+		if ($permission === RequirePermission::REACT
+			&& !($participant->getPermissions() & Attendee::PERMISSIONS_REACT)
+			&& ($participant->getPermissions() & Attendee::PERMISSIONS_CHAT)
+			&& $room?->isFederatedConversation()) {
+			// Allow reacting with chat permission for now, in case the host server does not have split permissions yet.
+			return;
+		}
+
 		if ($permission === RequirePermission::CHAT && !($participant->getPermissions() & Attendee::PERMISSIONS_CHAT)) {
 			throw new PermissionsException();
 		}


### PR DESCRIPTION
## Summary

This PR fixes issues when federated instances are at different versions and have different permission bits (e.g., one instance has the new `REACT` permission from the migration, while the other doesn't yet).

### Problem

When the reaction permission feature is deployed across federated Nextcloud instances at different version levels:

1. **Your instance (v34) updates before host (v33)**: Local permissions include `PERMISSIONS_REACT` due to migration, but host doesn't understand it. The middleware permission check fails locally even though the host would accept the request.

2. **Host updates after you**: The host's migration adds REACT permission to federated attendees, but the remote participant's local copy doesn't get updated (migrations don't trigger federation notifications).

3. **Host updates before you**: Your migration might accidentally grant REACT permission that a moderator had intentionally restricted.

### Solution

- **Skip local permission checks for federated conversations**: Since requests are proxied to the host server anyway, the host validates permissions authoritatively. This prevents false negatives from version mismatches.

- **Add permission healing on federated room join**: When a user joins a federated room, sync local permissions with the host's authoritative permissions. This ensures permissions stay in sync across version differences.

## Test plan

- [ ] User on v34 instance can react in federated conversation hosted on v33 instance
- [ ] User on v33 instance can react in federated conversation hosted on v34 instance  
- [ ] Permissions are synced when joining a federated room after either instance upgrades
- [ ] Moderator permission restrictions are respected after both instances upgrade

Fixes: #16902