### PR TITLE
[main] ci(actions): Update workflow templates from organization template repository

### DIFF
--- a/.github/actions-lock.txt
+++ b/.github/actions-lock.txt
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
 # SPDX-License-Identifier: MIT
 33b8f6ada9dc4e4b5c68de74282135e4 appstore-build-publish.yml
-47c32497a8381ffe8930af4cdc101a9c block-unconventional-commits.yml
+30c9fe81a0a80bcf36cc7d441fcb8f9d block-unconventional-commits.yml
 d2e622168cdfb5036e36a3ab03e77cf5 command-openapi.yml
 d1898b1290d50f874d8092ebda6ee5e1 dependabot-approve-merge.yml
 2581a67c5bcdcd570427e6d51db767d7 fixup.yml
@@ -22,5 +22,5 @@ df57926317dc09c646e15e80aecd4982 phpunit-mariadb.yml
 97e9adce61f278540ea7d65cdb89ef40 psalm.yml
 7db5b820f3750eebe988005a0bb2febd reuse.yml
 800d5b188aa885626cf4169fa2dfea9e update-nextcloud-ocp-approve-merge.yml
-b957be292ffeb59c0a7c41811148b3f0 update-nextcloud-ocp.yml
+aec14bfbb22a09c894e30f624f2d954a update-nextcloud-ocp.yml
 48c2c657b87747c9faeb589bcce08923 update-stable-titles.yml


### PR DESCRIPTION
Automated update of all workflow templates from [nextcloud/.github](https://github.com/nextcloud/.github)
- 🆙 Updated [block-unconventional-commits.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/block-unconventional-commits.yml)
- 🆙 Updated [update-nextcloud-ocp.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/update-nextcloud-ocp.yml)