### PR TITLE
chore: Set E2EE version for talk-ios to 23.0.0

### DIFF
--- a/lib/Middleware/CanUseTalkMiddleware.php
+++ b/lib/Middleware/CanUseTalkMiddleware.php
@@ -46,7 +46,10 @@ class CanUseTalkMiddleware extends Middleware {
 
 	public const TALK_IOS_MIN_VERSION = '15.0.0';
 	public const TALK_IOS_MIN_VERSION_RECORDING_CONSENT = '18.0.0';
-	public const TALK_IOS_MIN_VERSION_E2EE_CALLS = '99.0.0';
+
+	// Talk iOS >= 23 handles the configuration flag for E2EE and shows a appropiate message
+	// Support for E2EE on Talk iOS is still pending
+	public const TALK_IOS_MIN_VERSION_E2EE_CALLS = '23.0.0';
 
 
 	public function __construct(


### PR DESCRIPTION
## 🛠️ API Checklist

* With https://github.com/nextcloud/talk-ios/pull/2369 talk-ios is aware of the end-to-end-encryption flag and can show a message to the user, instead of showing "outdated app".
* Ref https://github.com/nextcloud/spreed/issues/14673

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
