### PR TITLE
fix(chat): restore position of tribute popup

### DIFF
--- a/src/components/NewMessage/NewMessageUploadEditor.vue
+++ b/src/components/NewMessage/NewMessageUploadEditor.vue
@@ -7,6 +7,7 @@
 	<NcModal
 		v-if="showModal"
 		ref="modal"
+		:id="dialogMaskId"
 		:size="isVoiceMessage ? 'small' : 'normal'"
 		:labelId="dialogHeaderId"
 		@close="handleDismiss">
@@ -112,11 +113,13 @@ export default {
 	setup() {
 		const modalContainerId = ref(null)
 		const isDraggingOver = ref(false)
-		const dialogHeaderId = `new-message-upload-${useId()}`
+		const dialogMaskId = `new-message-upload-${useId()}`
+		const dialogHeaderId = `new-message-upload-header-${useId()}`
 
 		return {
 			modalContainerId,
 			isDraggingOver,
+			dialogMaskId,
 			dialogHeaderId,
 			token: useGetToken(),
 			threadId: useGetThreadId(),
@@ -173,7 +176,7 @@ export default {
 			if (show) {
 				// Wait for modal content to be rendered
 				await this.$nextTick()
-				this.modalContainerId = `#modal-description-${this.$refs.modal.randId}`
+				this.modalContainerId = `#${this.dialogMaskId}`
 				if (this.supportMediaCaption) {
 					this.$refs.newMessage.focusInput()
 				} else {


### PR DESCRIPTION
### ☑️ Resolves

* Fix #16975
- fix emoji, mentions, links in message field showing behind the dialog
- breaking change in vue-library@9 (non-public API)


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="368" height="283" alt="2026-02-05_10h40_59" src="https://github.com/user-attachments/assets/d5c20d2d-85f1-47bb-9eeb-d07396cd1d0a" /> | <img width="380" height="283" alt="2026-02-05_10h38_36" src="https://github.com/user-attachments/assets/f50b1ea7-7e6c-4503-9ffb-926dc2ba19da" />

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required