### PR TITLE
test: Run tests against nextcloud/server#57760 share-update-check-single

### DIFF
--- a/tests/integration/features/sharing-1/create.feature
+++ b/tests/integration/features/sharing-1/create.feature
@@ -350,7 +350,7 @@ Feature: sharing-1/create
       | item_type              | file |
       | mimetype               | text/plain |
       | storage_id             | home::participant2 |
-      | file_target            | /{TALK_PLACEHOLDER}/welcome (2).txt |
+      | file_target            | /Talk/welcome (2).txt |
       | share_with             | group room |
       | share_with_displayname | Group room |
     And user "participant3" gets last share

--- a/tests/integration/features/sharing-4/transfer-ownership.feature
+++ b/tests/integration/features/sharing-4/transfer-ownership.feature
@@ -95,7 +95,7 @@ Feature: sharing-4/transfer-ownership
       | item_type              | file |
       | mimetype               | text/plain |
       | storage_id             | home::participant3 |
-      | file_target            | /{TALK_PLACEHOLDER}/welcome (2).txt |
+      | file_target            | /Talk/welcome (2).txt |
       | share_with             | group room |
       | share_with_displayname | Group room |
 


### PR DESCRIPTION
- [x] Testing nextcloud/server#57760
- [ ] Drop first commit before merging

> - Root cause seems to be that for a share created in a new conversation, the other participants aren't registered as being in the room yet by the time the ShareCreatedEvent is emitted. So fetching the shares for the user doesn't return the share in the new room.
> - https://github.com/nextcloud/server/pull/57760 seems to fix it for the basic 1-1 room at least. Not sure if there are other edge cases