### PR TITLE
fix: swift clearance of unread marker when scrolling to the bottom

### DIFF
--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -902,15 +902,15 @@ export default {
 
 			const lastReadMessageElement = this.getVisualLastReadMessageElement()
 
-			// first unread message has not been seen yet, so don't move it
-			if (!this.isUnreadMarkerSeen) {
-				return
-			}
-
 			// if we're at bottom of the chat with no more new messages to load, then simply clear the marker
 			if (this.isSticky && this.isChatEndReached) {
 				console.debug('clearLastReadMessage because of isSticky token=' + this.token)
 				this.$store.dispatch('clearLastReadMessage', { token: this.token })
+				return
+			}
+
+			// first unread message has not been seen yet, so don't move it
+			if (!this.isUnreadMarkerSeen) {
 				return
 			}
 
@@ -982,6 +982,11 @@ export default {
 					top: newTop,
 					behavior: options?.smooth ? 'smooth' : 'auto',
 				})
+
+				// If it is a forced scroll to bottom, we need to update the read marker immediately
+				if (options?.force) {
+					this.$store.dispatch('clearLastReadMessage', { token: this.token, updateVisually: true })
+				}
 			})
 		},
 


### PR DESCRIPTION
### ☑️ Resolves

* It may happen that unread marker is not marked as seen when opening the conversation (e.g. there are links that make the list jumps to the middle of the chat). thus when scrolling to the bottom, the unread marker is not resolved
* It makes sense to directly clear unread marker when forcibly scrolling to the bottom, that's what the user expects to happen

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
Screenshot before | Screenshot after

<!-- ☀️ Light theme | 🌑 Dark Theme -->



### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
