### PR TITLE
fix(call): bring fallback device labels to call controls

### DIFF
--- a/src/components/CallView/shared/LocalAudioControlButton.vue
+++ b/src/components/CallView/shared/LocalAudioControlButton.vue
@@ -281,11 +281,22 @@ export default {
 		},
 
 		audioInputDevices() {
-			return [...this.devices.filter((device) => device.kind === 'audioinput'), { deviceId: null, label: t('spreed', 'None') }]
+			return [
+				...this.devices.filter((device) => device.kind === 'audioinput')
+					.map((device) => ({
+						deviceId: device.deviceId,
+						label: device.label || device.fallbackLabel,
+					})),
+				{ deviceId: null, label: t('spreed', 'None') },
+			]
 		},
 
 		audioOutputDevices() {
 			return this.devices.filter((device) => device.kind === 'audiooutput')
+				.map((device) => ({
+					deviceId: device.deviceId,
+					label: device.label || device.fallbackLabel,
+				}))
 		},
 	},
 

--- a/src/components/CallView/shared/LocalVideoControlButton.vue
+++ b/src/components/CallView/shared/LocalVideoControlButton.vue
@@ -198,7 +198,14 @@ export default {
 		},
 
 		videoDevices() {
-			return [...this.devices.filter((device) => device.kind === 'videoinput'), { deviceId: null, label: t('spreed', 'None') }]
+			return [
+				...this.devices.filter((device) => device.kind === 'videoinput')
+					.map((device) => ({
+						deviceId: device.deviceId,
+						label: device.label || device.fallbackLabel,
+					})),
+				{ deviceId: null, label: t('spreed', 'None') },
+			]
 		},
 	},
 

--- a/src/components/MediaSettings/MediaDevicesSelector.vue
+++ b/src/components/MediaSettings/MediaDevicesSelector.vue
@@ -36,7 +36,7 @@ const deviceOptions = computed<NcSelectOption[]>(() => {
 	const kindDevices = props.devices.filter((device) => device.kind === props.kind)
 		.map((device) => ({
 			id: device.deviceId,
-			label: device.label ? device.label : device.fallbackLabel,
+			label: device.label || device.fallbackLabel,
 		}))
 	if (props.kind === 'audiooutput') {
 		return kindDevices


### PR DESCRIPTION
### ☑️ Resolves

* Fix 'default' labels for audio devices in Firefox (at least)
* fallbackLabel set by Talk and will be present in any browser


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="238" height="296" alt="image" src="https://github.com/user-attachments/assets/1aa1bd97-a277-46b0-aabc-3415411283de" /> | <img width="236" height="295" alt="image" src="https://github.com/user-attachments/assets/7583a34c-d4b4-4fbd-84b3-4d8d885c09d2" />

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [x] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required