### PR TITLE
perf(sharing): Use new user field from VerifyMountEvent

### DIFF
--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="6.13.1@1e3b7f0a8ab32b23197b91107adc0a7ed8a05b51">
+<files psalm-version="6.15.1@28dc127af1b5aecd52314f6f645bafc10d0e11f9">
   <file src="lib/AppInfo/Application.php">
     <UndefinedClass>
       <code><![CDATA[BeforeTemplateRenderedEvent]]></code>
@@ -154,12 +154,6 @@
   </file>
   <file src="lib/Share/Listener.php">
     <UndefinedClass>
-      <code><![CDATA[$event->getView()]]></code>
-      <code><![CDATA[$event->getView()]]></code>
-      <code><![CDATA[$event->getView()]]></code>
-      <code><![CDATA[$view]]></code>
-      <code><![CDATA[$view]]></code>
-      <code><![CDATA[$view]]></code>
       <code><![CDATA[Filesystem]]></code>
     </UndefinedClass>
   </file>


### PR DESCRIPTION
### ☑️ Resolves

* [x] Performance improvement based on Server change in https://github.com/nextcloud/server/pull/58207
* [x] Obsoletes https://github.com/nextcloud/spreed/pull/16832
* [x] Psalm is fixed by updating OCP once merged in server

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [X] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
