### PR TITLE
feat(call): adjust thumbnails color to be more coherent

### DIFF
--- a/src/components/CallView/shared/LocalVideo.vue
+++ b/src/components/CallView/shared/LocalVideo.vue
@@ -41,10 +41,7 @@
 				class="video-loading" />
 		</div>
 		<div v-if="!screenshotModeUrl && !localMediaModel.attributes.videoEnabled && !isSidebar" class="avatar-container">
-			<VideoBackground
-				v-if="isGrid || isStripe"
-				:displayName="displayName"
-				:user="userId" />
+			<VideoBackground v-if="isGrid || isStripe" />
 			<AvatarWrapper
 				:id="userId"
 				:token="token"

--- a/src/components/CallView/shared/VideoBackground.vue
+++ b/src/components/CallView/shared/VideoBackground.vue
@@ -3,54 +3,35 @@
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
-<template>
-	<div class="video-background" :style="{ 'background-color': backgroundColor }" />
-</template>
+<script setup lang="ts">
+import { useIsDarkTheme } from '@nextcloud/vue/composables/useIsDarkTheme'
 
-<script>
-import { usernameToColor } from '@nextcloud/vue/functions/usernameToColor'
-
-export default {
-	name: 'VideoBackground',
-
-	props: {
-		displayName: {
-			type: String,
-			default: null,
-		},
-
-		user: {
-			type: String,
-			default: '',
-		},
-	},
-
-	computed: {
-		backgroundColor() {
-			// If the prop is empty. We're not checking for the default value
-			// because the user's displayName might be '?'
-			if (!this.displayName) {
-				return 'var(--color-text-maxcontrast)'
-			} else {
-				const color = usernameToColor(this.displayName)
-				return `rgb(${color.r}, ${color.g}, ${color.b})`
-			}
-		},
-	},
-}
+const isDarkTheme = useIsDarkTheme()
 </script>
 
+<template>
+	<div class="video-background" :class="{ 'dark-theme': isDarkTheme }" />
+</template>
+
 <style lang="scss" scoped>
+
 .video-background {
 	position: absolute;
 	inset-inline-start: 0;
 	top: 0;
 	height: 100%;
 	width: 100%;
+	background-color: rgba(var(--overlay-color), 0.2);
+	background-image: none;
+
+	--overlay-color: 0, 0, 0;
+	&.dark-theme {
+		--overlay-color: 255, 255, 255;
+	}
 
 	&::after {
 		content: ' ';
-		background-color: rgba(0, 0, 0, 0.12);
+		background-color: rgba(var(--overlay-color), 0.12);
 		position: absolute;
 		width: 100%;
 		height: 100%;

--- a/src/components/CallView/shared/VideoVue.vue
+++ b/src/components/CallView/shared/VideoVue.vue
@@ -51,7 +51,7 @@
 		<div
 			v-if="showBackgroundAndAvatar"
 			class="avatar-container">
-			<VideoBackground :displayName="displayName" :user="participantUserId" />
+			<VideoBackground />
 			<AvatarWrapper
 				:id="participantUserId"
 				:token="token"

--- a/src/components/MediaSettings/MediaSettings.vue
+++ b/src/components/MediaSettings/MediaSettings.vue
@@ -64,9 +64,7 @@
 					<div
 						v-show="!showVideo"
 						class="preview__novideo">
-						<VideoBackground
-							:displayName="displayName"
-							:user="userId" />
+						<VideoBackground class="background-preview" />
 						<AvatarWrapper
 							:id="userId"
 							:token="token"
@@ -1032,6 +1030,10 @@ export default {
 
 .media-settings__recording-warning--mobile {
 	max-width: 450px;
+}
+
+.background-preview {
+	background: linear-gradient(rgba(var(--overlay-color), 0.2), rgba(var(--overlay-color), 0.2)), center / cover no-repeat var(--image-background);
 }
 
 // Override NcModal styles for large horizontal layout


### PR DESCRIPTION
### ☑️ Resolves

* Fix #16079

hmm maybe it needs to be lighter than background and has a blur effect?

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

Dark| Light
-- | --
<img width="1056" height="646" alt="image" src="https://github.com/user-attachments/assets/63a8ebfc-c9f2-49da-a6ce-35d291c726a4" /> | <img width="1060" height="647" alt="image" src="https://github.com/user-attachments/assets/374a877b-3176-440e-a7f3-e0d25fd2a8c4" />

<!-- ☀️ Light theme | 🌑 Dark Theme -->


### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
