### PR TITLE
fix(chat): improve updating of unread marker from chat-relay

### DIFF
--- a/src/store/messagesStore.spec.js
+++ b/src/store/messagesStore.spec.js
@@ -809,6 +809,7 @@ describe('messagesStore', () => {
 		let updateLastCommonReadMessageAction
 		let addGuestNameAction
 		let cancelFunctionMock
+		let conversationMock
 
 		const oldMessagesList = [{
 			id: 98,
@@ -842,6 +843,8 @@ describe('messagesStore', () => {
 			addGuestNameAction = vi.fn()
 			testStoreConfig.actions.updateLastCommonReadMessage = updateLastCommonReadMessageAction
 			guestNameStore.addGuestName = addGuestNameAction
+			conversationMock = vi.fn()
+			testStoreConfig.getters.conversation = vi.fn().mockReturnValue(conversationMock)
 
 			cancelFunctionMock = vi.fn()
 			CancelableRequest.mockImplementation((request) => {
@@ -945,6 +948,7 @@ describe('messagesStore', () => {
 		let updateLastCommonReadMessageAction
 		let addGuestNameAction
 		let cancelFunctionMock
+		let conversationMock
 
 		beforeEach(() => {
 			testStoreConfig = cloneDeep(messagesStore)
@@ -954,6 +958,8 @@ describe('messagesStore', () => {
 			addGuestNameAction = vi.fn()
 			testStoreConfig.actions.updateLastCommonReadMessage = updateLastCommonReadMessageAction
 			guestNameStore.addGuestName = addGuestNameAction
+			conversationMock = vi.fn()
+			testStoreConfig.getters.conversation = vi.fn().mockReturnValue(conversationMock)
 
 			cancelFunctionMock = vi.fn()
 			CancelableRequest.mockImplementation((request) => {


### PR DESCRIPTION
### ☑️ Resolves

* Fix inconsistency of unread-marker and conversations list update (difference between polling/chat-relay)

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before

https://github.com/user-attachments/assets/1da6b802-e5b7-40ae-8e59-d044af8dc881

🏡 After (synced with LeftSidebar)


https://github.com/user-attachments/assets/41dabc72-db61-4ab4-9973-37ccc54b5c9f


### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required