### PR TITLE
fix(chat): make failed message more prominent

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/MessageBody.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/MessageBody.vue
@@ -125,7 +125,7 @@
 						<IconReload :size="iconMessageDeliverySize" />
 					</template>
 				</NcButton>
-				<IconAlertCircleOutline v-else :size="iconMessageDeliverySize" />
+				<IconAlertCircleOutline v-else fillColor="var(--color-element-error)" :size="iconMessageDeliverySize" />
 			</div>
 			<div
 				v-else-if="showLoadingIcon"


### PR DESCRIPTION
### ☑️ Resolves

* Bring more attention to failed message, so it's not missed



## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="114" height="36" alt="2026-02-10_16h42_23" src="https://github.com/user-attachments/assets/e0aa4c07-6862-488c-a2b5-32d854965cc2" /> | <img width="110" height="36" alt="2026-02-10_16h47_48" src="https://github.com/user-attachments/assets/c8fe8496-7521-4224-b50f-db46ce02b398" />
<img width="114" height="36" alt="2026-02-10_16h42_50" src="https://github.com/user-attachments/assets/20f6d058-6eaa-49eb-aa34-bee6334794a2" /> | <img width="113" height="34" alt="2026-02-10_16h47_38" src="https://github.com/user-attachments/assets/f3e2d6e9-4215-4979-b5f9-8b27e31810ce" />
<img width="228" height="43" alt="2026-02-10_16h43_17" src="https://github.com/user-attachments/assets/28579071-01ee-4d38-966c-6a6bc3522b17" /> | <img width="232" height="43" alt="2026-02-10_16h47_13" src="https://github.com/user-attachments/assets/747b4d8f-193a-4616-ae21-802f2c127af8" />
<img width="231" height="47" alt="2026-02-10_16h43_08" src="https://github.com/user-attachments/assets/8e6a5ad6-e0cc-41d4-a3d3-889b16f36c0a" /> | <img width="228" height="42" alt="2026-02-10_16h47_29" src="https://github.com/user-attachments/assets/d007997c-af4b-44ac-a568-15b8f2431914" />

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required