### PR TITLE
fix(chat): reset actions state after reacting to message

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
@@ -920,6 +920,7 @@ export default {
 
 		closeReactionsMenu() {
 			this.$emit('update:isReactionsMenuOpen', false)
+			this.$emit('update:isEmojiPickerOpen', false)
 		},
 
 		updateFrequentlyUsedEmojis() {


### PR DESCRIPTION
### ☑️ Resolves

* Fix hanging menu after selecting a reaction from EmojiPicker
* Additionally: check upstream for component closing events

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before

https://github.com/user-attachments/assets/3b8b9a9b-6d7f-48ea-9511-890f5601c7c9

🏡 After


https://github.com/user-attachments/assets/b77e71f3-fffa-4636-b4ef-5f71be59ca0a



### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required