### PR TITLE
fix(chat): improve polling paralleled with chat-relay

### DIFF
--- a/src/composables/useGetMessages.ts
+++ b/src/composables/useGetMessages.ts
@@ -58,7 +58,6 @@ let expirationInterval: NodeJS.Timeout | undefined
 let pollingErrorTimeout = 1_000
 let chatRelaySupported: boolean | null = null
 let fallbackPollInterval: NodeJS.Timeout | undefined
-let lastMessageIdGivenByServer: number | null = null
 
 /**
  * Composable to provide control logic for fetching messages list
@@ -150,7 +149,6 @@ export function useGetMessagesProvider() {
 			if (oldToken && oldToken !== newToken) {
 				store.dispatch('cancelPollNewMessages', { requestId: oldToken })
 				chatRelaySupported = null
-				lastMessageIdGivenByServer = null
 				clearInterval(fallbackPollInterval)
 			}
 
@@ -517,21 +515,25 @@ export function useGetMessagesProvider() {
 			return
 		}
 
+		// If chat was previously opened, and messages were received via chat-relay,
+		// start polling from last received by server message id
+		const lastKnownMessageId = chatStore.getLastServerResponseId(token) ?? chatStore.getLastKnownId(token)
+
 		// Make the request
 		try {
 			debugTimer.start(`${token} | long polling`)
 			// TODO: move polling logic to the store and also cancel timers on cancel
 			const response = await store.dispatch('pollNewMessages', {
 				token,
-				lastKnownMessageId: chatStore.getLastKnownId(token),
+				lastKnownMessageId,
 				requestId: token,
 				timeout: chatRelaySupported ? 0 : undefined,
 			})
 
-			lastMessageIdGivenByServer = response.data.ocs.data
+			chatStore.setLastServerResponseId(token, response.data.ocs.data
 				.reduce((acc: number, message: ChatMessage) => {
 					return message.id > acc ? message.id : acc
-				}, lastMessageIdGivenByServer)
+				}, lastKnownMessageId))
 
 			pollingErrorTimeout = 1_000
 			debugTimer.end(`${token} | long polling`, 'status 200')
@@ -545,7 +547,7 @@ export function useGetMessagesProvider() {
 			if (isAxiosErrorResponse(exception) && exception?.response?.status === 304) {
 				debugTimer.end(`${token} | long polling`, 'status 304')
 				// 304 - Not modified
-				lastMessageIdGivenByServer = chatStore.getLastKnownId(token)
+				chatStore.setLastServerResponseId(token, lastKnownMessageId)
 				// This is not an error, so reset error timeout and poll again
 				pollingErrorTimeout = 1_000
 				clearTimeout(pollingTimeout)
@@ -634,23 +636,25 @@ export function useGetMessagesProvider() {
 	 * Get messages history (fallback for chat-relay).
 	 */
 	async function fallbackPollNewMessages() {
-		if (!lastMessageIdGivenByServer || !currentToken.value) {
+		const token = currentToken.value
+		const lastKnownMessageId = chatStore.getLastServerResponseId(token)
+		if (!lastKnownMessageId || !token) {
 			return
 		}
 
 		// Make the request
 		try {
 			const response = await store.dispatch('fetchMessages', {
-				token: currentToken.value,
-				lastKnownMessageId: lastMessageIdGivenByServer,
+				token,
+				lastKnownMessageId,
 				includeLastKnown: false,
 				lookIntoFuture: CHAT.FETCH_NEW,
 				minimumVisible: 0, // handle as many as server gives
 			})
 
-			lastMessageIdGivenByServer = response.data.ocs.data.reduce((acc: number, message: ChatMessage) => {
+			chatStore.setLastServerResponseId(token, response.data.ocs.data.reduce((acc: number, message: ChatMessage) => {
 				return message.id > acc ? message.id : acc
-			}, lastMessageIdGivenByServer)
+			}, lastKnownMessageId))
 		} catch (exception) {
 			if (isCancel(exception)) {
 				console.debug('The request has been canceled', exception)

--- a/src/stores/chat.ts
+++ b/src/stores/chat.ts
@@ -80,6 +80,8 @@ export const useChatStore = defineStore('chat', () => {
 	const chatBlocks = reactive<TokenMap<Set<number>[]>>({})
 	const threadBlocks = reactive<TokenIdMap<Set<number>[]>>({})
 
+	const lastGivenByServerMap = reactive<TokenMap<number>>({})
+
 	/**
 	 * Returns list of messages, belonging to current context
 	 *
@@ -259,6 +261,25 @@ export const useChatStore = defineStore('chat', () => {
 			? chatBlocks[token][0]
 			: chatBlocks[token].find((set) => set.has(messageId)) ?? chatBlocks[token][0]
 		return Math.max(...filterNumericIds(contextBlock))
+	}
+
+	/**
+	 * Returns last message id, returned from server response (fallback paired with chat-relay messages
+	 *
+	 * @param token
+	 */
+	function getLastServerResponseId(token: string): number | undefined {
+		return lastGivenByServerMap[token]
+	}
+
+	/**
+	 * Persists last message id, returned from server response, in the store
+	 *
+	 * @param token
+	 * @param messageId
+	 */
+	function setLastServerResponseId(token: string, messageId: number) {
+		lastGivenByServerMap[token] = messageId
 	}
 
 	/**
@@ -577,16 +598,20 @@ export const useChatStore = defineStore('chat', () => {
 	function purgeChatStore(token: string) {
 		delete chatBlocks[token]
 		delete threadBlocks[token]
+		delete lastGivenByServerMap[token]
 	}
 
 	return {
 		chatBlocks,
 		threadBlocks,
+		lastGivenByServerMap,
 
 		getMessagesList,
 		hasMessage,
 		getFirstKnownId,
 		getLastKnownId,
+		getLastServerResponseId,
+		setLastServerResponseId,
 		getNearestKnownContextId,
 		processChatBlocks,
 		addMessageToChatBlocks,


### PR DESCRIPTION
### ☑️ Resolves

* Fix #17052
* do not block fetching new messages with chat-relay
  - with chatRelaySupported === false, polling is active and condition is valid. otherwise last known will match last given by server, and request will be prevented
 - valid for eased message lists, where more recent messages might be cleared
* persist message id for fallback polling with chat-relay
  - when switching conversations, lastMessageIdGivenByServer got lost, and messages received between last fallback polling and switching have not been confirmed
  - now they will be actualized with next chat opening

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

Need to check network requests

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required