### PR TITLE
fix: enhance preview coherence in media settings

### DIFF
--- a/src/components/CallView/shared/VideoBackground.vue
+++ b/src/components/CallView/shared/VideoBackground.vue
@@ -21,22 +21,12 @@ const isDarkTheme = useIsDarkTheme()
 	top: 0;
 	height: 100%;
 	width: 100%;
-	background-color: rgba(var(--overlay-color), 0.2);
+	background-color: rgba(var(--overlay-color), 0.3);
 	background-image: none;
 
 	--overlay-color: 0, 0, 0;
 	&.dark-theme {
 		--overlay-color: 255, 255, 255;
-	}
-
-	&::after {
-		content: ' ';
-		background-color: rgba(var(--overlay-color), 0.12);
-		position: absolute;
-		width: 100%;
-		height: 100%;
-		top: 0;
-		inset-inline-start: 0;
 	}
 }
 </style>

--- a/src/components/MediaSettings/MediaSettings.vue
+++ b/src/components/MediaSettings/MediaSettings.vue
@@ -1033,7 +1033,16 @@ export default {
 }
 
 .background-preview {
-	background: linear-gradient(rgba(var(--overlay-color), 0.2), rgba(var(--overlay-color), 0.2)), center / cover no-repeat var(--image-background);
+	overflow: hidden;
+
+	&::before {
+		content: '';
+		position: absolute;
+		inset: 0;
+		background: linear-gradient(rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0.2)), center / cover no-repeat var(--image-background);
+		filter: blur(10px);
+		transform: scale(1.1);
+	}
 }
 
 // Override NcModal styles for large horizontal layout


### PR DESCRIPTION
### ☑️ Resolves

I understand that the preview is not on the same darkness/lightness as in call view but the preview is rendered in different theme, so it has to be close to it (e,g if it is light them, it should not be too dark)
<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="1097" height="550" alt="image" src="https://github.com/user-attachments/assets/ae0147c7-dfb4-4fc5-bb41-7462527663fa" />| <img width="1112" height="549" alt="image" src="https://github.com/user-attachments/assets/ae3dcba2-172a-494d-9d24-5ac1186c70be" />
<img width="1458" height="614" alt="image" src="https://github.com/user-attachments/assets/a919c2fb-364a-4570-8553-56adc6f41c28" /> |  <img width="1463" height="701" alt="image" src="https://github.com/user-attachments/assets/1d6de862-4f7d-4cea-833c-b32e69e843c9" />



<!-- ☀️ Light theme | 🌑 Dark Theme -->


### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
