### PR TITLE
Fix translation button enabled state

### DIFF
--- a/src/components/CallView/BottomBar.vue
+++ b/src/components/CallView/BottomBar.vue
@@ -674,7 +674,7 @@ useHotKey('r', toggleHandRaised)
 					:title="liveTranslationButtonLabel"
 					:aria-label="liveTranslationButtonLabel"
 					:variant="(callViewStore.isLiveTranscriptionEnabled && languageType === LanguageType.Target) ? 'secondary' : 'tertiary'"
-					:disabled="isLiveTranscriptionLoading"
+					:disabled="isLiveTranscriptionLoading || !targetLanguageAvailable"
 					@click="toggleLiveTranslation">
 					<template #icon>
 						<NcLoadingIcon


### PR DESCRIPTION
### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="318" height="206" alt="Bildschirmfoto vom 2026-02-12 10-11-15" src="https://github.com/user-attachments/assets/f76c9c26-d93a-4487-a788-d1d9f0ebf893" /> | <img width="318" height="206" alt="Bildschirmfoto vom 2026-02-12 11-34-40" src="https://github.com/user-attachments/assets/e7357970-c848-457d-a0ab-a27b988f8879" />
<img width="326" height="206" alt="Bildschirmfoto vom 2026-02-12 12-00-58" src="https://github.com/user-attachments/assets/17264122-6d0d-49e9-93b0-c09fa437a8ad" /> | <img width="326" height="206" alt="Bildschirmfoto vom 2026-02-12 12-01-35" src="https://github.com/user-attachments/assets/be5b2ddd-f4c2-4dfd-9a2b-b1a90648d8f0" />

The buttons in the menu should probably include the language name, but if needed that should be done in another pull request to ease backporting due to the string freeze for 33.

## How to reproduce

- Setup live transcriptions and translations
- Set default translation language to English in Talk app settings
- Create a new conversation (which will use English as the default transcription language)
- Start a call
- Try to enable translations

### Result with this pull request

The button is disabled

### Result without this pull request

The button is enabled, and trying to enable translations fail because the original and target languages are the same