### PR TITLE
perf(sharing): Don't hit the "parent" path when we load all shares an…

### DIFF
--- a/lib/Share/RoomShareProvider.php
+++ b/lib/Share/RoomShareProvider.php
@@ -719,7 +719,7 @@ class RoomShareProvider implements IShareProvider, IPartialShareProvider, IShare
 	 * @param bool $allRoomShares indicates that the passed in shares are all room shares for the user
 	 * @return list<IShare>
 	 */
-	private function resolveSharesForRecipient(array $shareMap, string $userId, ?string $path = null, bool $forChildren = false): array {
+	private function resolveSharesForRecipient(array $shareMap, string $userId, ?string $path = null, bool $forChildren = false, bool $allRoomShares = false): array {
 		$qb = $this->dbConnection->getQueryBuilder();
 
 		$query = $qb->select('parent', 'permissions', 'file_target')
@@ -732,15 +732,17 @@ class RoomShareProvider implements IShareProvider, IPartialShareProvider, IShare
 				$qb->expr()->eq('item_type', $qb->createNamedParameter('folder'))
 			));
 
-		if ($path !== null) {
-			$path = str_replace('/' . $userId . '/files', '', $path);
-			$path = rtrim($path, '/');
+		if ($path !== null || $allRoomShares) {
+			if ($path !== null) {
+				$path = str_replace('/' . $userId . '/files', '', $path);
+				$path = rtrim($path, '/');
 
-			if ($forChildren) {
-				$qb->andWhere($qb->expr()->like('file_target', $qb->createNamedParameter($this->dbConnection->escapeLikeParameter($path) . '/_%')));
-			} else {
-				$nonChildPath = $path === '' ? '/' : $path;
-				$qb->andWhere($qb->expr()->eq('file_target', $qb->createNamedParameter($nonChildPath)));
+				if ($forChildren) {
+					$qb->andWhere($qb->expr()->like('file_target', $qb->createNamedParameter($this->dbConnection->escapeLikeParameter($path) . '/_%')));
+				} else {
+					$nonChildPath = $path === '' ? '/' : $path;
+					$qb->andWhere($qb->expr()->eq('file_target', $qb->createNamedParameter($nonChildPath)));
+				}
 			}
 
 			$stmt = $query->executeQuery();
@@ -938,7 +940,7 @@ class RoomShareProvider implements IShareProvider, IPartialShareProvider, IShare
 			$cursor->closeCursor();
 		}
 
-		$shares = $this->resolveSharesForRecipient($shares, $userId, $path, $forChildren);
+		$shares = $this->resolveSharesForRecipient($shares, $userId, $path, $forChildren, true);
 
 		return $shares;
 	}


### PR DESCRIPTION
…yway

- Since https://github.com/nextcloud/spreed/pull/16988 the query did not use an index anymore when entering from `getSharedWith()` which does not have a path. It used to have `$allRoomShares = true` set, but now is using the else branch which chunks and does a query on parent in blocks of 1k

### Before
```sql
MariaDB [oc]> EXPLAIN SELECT `parent`, `permissions`, `file_target` FROM `oc_share` WHERE (`share_type` = '11') AND (`share_with` = 'joas');
+------+-------------+----------+-------------+---------------------------------------------------------------+----------------------------------+-----------+------+-------+----------------------------------------------------------------+
| id   | select_type | table    | type        | possible_keys                                                 | key                              | key_len   | ref  | rows  | Extra                                                          |
+------+-------------+----------+-------------+---------------------------------------------------------------+----------------------------------+-----------+------+-------+----------------------------------------------------------------+
|    1 | SIMPLE      | oc_share | index_merge | share_with_index,share_type_with,share_with_file_target_index | share_with_index,share_type_with | 1023,1025 | NULL | 17445 | Using intersect(share_with_index,share_type_with); Using where |
+------+-------------+----------+-------------+---------------------------------------------------------------+----------------------------------+-----------+------+-------+----------------------------------------------------------------+
1 row in set (0.000 sec)
```

### After
```sql
+------+--------------+-------------+------+--------------------------------------------------------------------------------------------------+--------------+---------+--------------+------+------------------------------------+
| id   | select_type  | table       | type | possible_keys                                                                                    | key          | key_len | ref          | rows | Extra                              |
+------+--------------+-------------+------+--------------------------------------------------------------------------------------------------+--------------+---------+--------------+------+------------------------------------+
|    1 | PRIMARY      | <subquery2> | ALL  | distinct_key                                                                                     | NULL         | NULL    | NULL         | 1000 |                                    |
|    1 | PRIMARY      | oc_share    | ref  | item_share_type_index,share_with_index,parent_index,share_type_with,share_with_file_target_index | parent_index | 9       | tvc_0._col_1 | 10   | Using index condition; Using where |
|    2 | MATERIALIZED | <derived3>  | ALL  | NULL                                                                                             | NULL         | NULL    | NULL         | 1000 |                                    |
|    3 | DERIVED      | NULL        | NULL | NULL                                                                                             | NULL         | NULL    | NULL         | NULL | No tables used                     |
+------+--------------+-------------+------+--------------------------------------------------------------------------------------------------+--------------+---------+--------------+------+------------------------------------+
4 rows in set (0.001 sec)
```
