### PR TITLE
 perf(sharing): Split getShareWith() and shortcut the happy path with $path

### DIFF
--- a/lib/Manager.php
+++ b/lib/Manager.php
@@ -506,6 +506,22 @@ class Manager {
 		return $roomTokens;
 	}
 
+	public function isUserAttendeeInRoom(string $userId, string $token): bool {
+		$query = $this->db->getQueryBuilder();
+		$query->select('r.token')
+			->from('talk_rooms', 'r')
+			->leftJoin('r', 'talk_attendees', 'a', $query->expr()->eq('a.room_id', 'r.id'))
+			->where($query->expr()->eq('a.actor_id', $query->createNamedParameter($userId)))
+			->andWhere($query->expr()->eq('a.actor_type', $query->createNamedParameter(Attendee::ACTOR_USERS)))
+			->andWhere($query->expr()->eq('r.token', $query->createNamedParameter($token)));
+
+		$result = $query->executeQuery();
+		$row = $result->fetch();
+		$result->closeCursor();
+
+		return $row !== false;
+	}
+
 	/**
 	 * Returns rooms that are listable where the current user is not a participant.
 	 *


### PR DESCRIPTION
### ☑️ Resolves

* Follow up to #17094
* Split "Happy path" when we search for a specific path into a quick path that only checks owner ship of that one conversation

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
