### PR TITLE
[stable33] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -333,12 +333,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "b8e5ee82481ddda93f5a7626f36c4d4c1bec16ea"
+                "reference": "a643b20f9ff1849a297d69ef250414ef16c48f6a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/b8e5ee82481ddda93f5a7626f36c4d4c1bec16ea",
-                "reference": "b8e5ee82481ddda93f5a7626f36c4d4c1bec16ea",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/a643b20f9ff1849a297d69ef250414ef16c48f6a",
+                "reference": "a643b20f9ff1849a297d69ef250414ef16c48f6a",
                 "shasum": ""
             },
             "require": {
@@ -373,7 +373,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable33"
             },
-            "time": "2026-02-06T01:05:40+00:00"
+            "time": "2026-02-12T01:11:10+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency