### PR TITLE
fix(SearchPlugin): check search queries for multibyte characters

### DIFF
--- a/lib/Chat/AutoComplete/SearchPlugin.php
+++ b/lib/Chat/AutoComplete/SearchPlugin.php
@@ -182,7 +182,7 @@ class SearchPlugin implements ISearchPlugin {
 				continue;
 			}
 
-			if (strtolower($cloudId) === $search) {
+			if (mb_strtolower($cloudId) === $search) {
 				$exactMatches[] = $this->createResult('federated_user', $cloudId, $displayName);
 				continue;
 			}
@@ -234,12 +234,12 @@ class SearchPlugin implements ISearchPlugin {
 				continue;
 			}
 
-			if (strtolower($groupId) === $search) {
+			if (mb_strtolower($groupId) === $search) {
 				$exactMatches[] = $this->createGroupResult($groupId, $displayName);
 				continue;
 			}
 
-			if (stripos($groupId, $search) !== false) {
+			if (mb_stripos($groupId, $search) !== false) {
 				$matches[] = $this->createGroupResult($groupId, $displayName);
 				continue;
 			}

--- a/lib/Chat/ChatManager.php
+++ b/lib/Chat/ChatManager.php
@@ -1299,7 +1299,7 @@ class ChatManager {
 	}
 
 	private function searchIsPartOfConversationNameOrAtAll(string $search, string $roomDisplayName): bool {
-		if (stripos($roomDisplayName, $search) !== false) {
+		if (mb_stripos($roomDisplayName, $search) !== false) {
 			return true;
 		}
 		/**

--- a/lib/Collaboration/Collaborators/RoomPlugin.php
+++ b/lib/Collaboration/Collaborators/RoomPlugin.php
@@ -35,6 +35,7 @@ class RoomPlugin implements ISearchPlugin {
 		if (!is_string($search) || $search === '') {
 			return false;
 		}
+		$search = mb_strtolower($search);
 
 		$userId = $this->userSession->getUser()->getUID();
 
@@ -57,10 +58,10 @@ class RoomPlugin implements ISearchPlugin {
 				continue;
 			}
 
-			if (stripos($room->getDisplayName($userId), $search) !== false) {
+			if (mb_stripos($room->getDisplayName($userId), $search) !== false) {
 				$item = $this->roomToSearchResultItem($room, $userId);
 
-				if (strtolower($item['label']) === strtolower($search)) {
+				if (mb_strtolower($item['label']) === mb_strtolower($search)) {
 					$result['exact'][] = $item;
 				} else {
 					$result['wide'][] = $item;

--- a/lib/Search/ConversationSearch.php
+++ b/lib/Search/ConversationSearch.php
@@ -103,12 +103,12 @@ class ConversationSearch implements IProvider {
 					'',
 					$room->getName()
 				);
-				if (stripos($otherUserId, $query->getTerm()) === false
-					&& stripos($displayName, $query->getTerm()) === false) {
+				if (mb_stripos($otherUserId, $query->getTerm()) === false
+					&& mb_stripos($displayName, $query->getTerm()) === false) {
 					// Neither name nor displayname (one-to-one) match, skip
 					continue;
 				}
-			} elseif (stripos($room->getName(), $query->getTerm()) === false) {
+			} elseif (mb_stripos($room->getName(), $query->getTerm()) === false) {
 				continue;
 			}
 
@@ -123,10 +123,10 @@ class ConversationSearch implements IProvider {
 
 			$entry->addAttribute('conversation', $room->getToken());
 
-			$result[strtolower($displayName . '#' . $room->getToken())] = $entry;
+			$result[mb_strtolower($displayName . '#' . $room->getToken())] = $entry;
 
 			if ($query->getCursor() === $room->getToken()) {
-				$cursorKey = strtolower($displayName . '#' . $room->getToken());
+				$cursorKey = mb_strtolower($displayName . '#' . $room->getToken());
 			}
 		}
 

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -3027,11 +3027,11 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 		$results = $data['entries'];
 
 		if ($expectedCursor !== null) {
-			Assert::assertSame($expectedCursor, $data['cursor']);
+			Assert::assertSame($expectedCursor, $data['cursor'], 'Cursor mismatch');
 		}
 
 		if ($formData === null) {
-			Assert::assertEmpty($results);
+			Assert::assertEmpty($results, 'Result count does not match:' . "\n" . print_r($results, true));
 			return;
 		}
 
@@ -3049,7 +3049,7 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 		}, $formData->getHash());
 
 		$count = count($expected);
-		Assert::assertCount($count, $results, 'Result count does not match');
+		Assert::assertCount($count, $results, 'Result count does not match:' . "\n" . print_r($results, true));
 
 		Assert::assertEquals($expected, array_map(static function ($actual) {
 			$compare = [
@@ -3184,8 +3184,8 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 		}, $results));
 	}
 
-	#[Then('/^user "([^"]*)" searches for conversations with "([^"]*)"(?: offset "([^"]*)")? limit (\d+)(?: expected cursor "([^"]*)")?$/')]
-	public function userSearchesRooms(string $user, string $search, string $offset, int $limit, string $expectedCursor, ?TableNode $formData = null): void {
+	#[Then('/^user "([^"]*)" searches for conversations with "([^"]*)"(?: offset "([^"]*)")? limit (\d+) expected cursor "([^"]*)"$/')]
+	public function userSearchesRooms(string $user, string $search, string $offset, int $limit, ?string $expectedCursor, ?TableNode $formData = null): void {
 		$searchUrl = '/search/providers/talk-conversations/search?limit=' . $limit;
 		if ($offset && array_key_exists($offset, self::$identifierToToken)) {
 			$searchUrl .= '&cursor=' . self::$identifierToToken[$offset];
@@ -3197,7 +3197,9 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 		$this->sendRequest('GET', $searchUrl);
 		$this->assertStatusCode($this->response, 200);
 
-		if ($expectedCursor !== null) {
+		if ($expectedCursor === 'NULL') {
+			$expectedCursor = null;
+		} else {
 			$expectedCursor = self::$identifierToToken[$expectedCursor] ?? '';
 		}
 

--- a/tests/integration/features/chat-2/mentions.feature
+++ b/tests/integration/features/chat-2/mentions.feature
@@ -69,16 +69,19 @@ Feature: chat-2/mentions
   Scenario: Cyrillic lower casing test
     When user "participant1" creates room "group room" (v4)
       | roomType | 2 |
-      | roomName | room |
+      | roomName | Кирилл |
     And user "participant1" adds user "participant4" to room "group room" with 200 (v4)
     And set display name of user "participant4" to "Кирилл"
     Then user "participant1" gets the following candidate mentions in room "group room" for "кири" with 200
-      | id           | label  | source | mentionId    | details           |
-      | participant4 | Кирилл | users  | participant4 |                   |
+      | id           | label  | source | mentionId    | details            |
+      | participant4 | Кирилл | users  | participant4 |                    |
+      | all          | Кирилл | calls  | all          | All 2 participants |
     And set display name of user "participant4" to "кирилл"
+    And user "participant1" renames room "group room" to "кирилл" with 200 (v4)
     Then user "participant1" gets the following candidate mentions in room "group room" for "Кири" with 200
-      | id           | label  | source | mentionId    | details           |
-      | participant4 | кирилл | users  | participant4 |                   |
+      | id           | label  | source | mentionId    | details            |
+      | participant4 | кирилл | users  | participant4 |                    |
+      | all          | кирилл | calls  | all          | All 2 participants |
 
   Scenario: get mentions in a group room
     When user "participant1" creates room "group room" (v4)

--- a/tests/integration/features/conversation-5/search.feature
+++ b/tests/integration/features/conversation-5/search.feature
@@ -32,3 +32,25 @@ Feature: conversation-5/search
       | title  | subline | attributes.conversation |
       | Room 5 |         | Room 5                  |
       | Room 6 |         | Room 6                  |
+
+  Scenario: Search for conversations with cyrillic multibyte chars
+    Given user "participant1" creates room "кирилл 1" (v4)
+      | roomType | 2 |
+      | roomName | кирилл 1 |
+    Given user "participant1" creates room "Кирилл 2" (v4)
+      | roomType | 2 |
+      | roomName |Кирилл 2 |
+    And user "participant1" searches for conversations with "ки" limit 3 expected cursor "NULL"
+      | title    | subline | attributes.conversation |
+      | кирилл 1 |         | кирилл 1                |
+      | Кирилл 2 |         | Кирилл 2                |
+    And user "participant1" searches for conversations with "Ки" limit 3 expected cursor "NULL"
+      | title    | subline | attributes.conversation |
+      | кирилл 1 |         | кирилл 1                |
+      | Кирилл 2 |         | Кирилл 2                |
+    And user "participant1" searches for conversations with "Ки" limit 1 expected cursor "кирилл 1"
+      | title    | subline | attributes.conversation |
+      | кирилл 1 |         | кирилл 1                |
+    And user "participant1" searches for conversations with "Ки" offset "кирилл 1" limit 1 expected cursor ""
+      | title    | subline | attributes.conversation |
+      | Кирилл 2 |         | Кирилл 2                |


### PR DESCRIPTION
### ☑️ Resolves

* Fix chat mentions search + non-latin alphabet with case-insensitive examples

`@кирилл` | `@Кирилл`


## 🛠️ API Checklist

Before | After
-- | --
<img width="160" height="54" alt="image" src="https://github.com/user-attachments/assets/76d8b47d-a9db-4913-b9ad-b3eac439aa0c" /> | <img width="195" height="59" alt="image" src="https://github.com/user-attachments/assets/252dc7b7-9cab-4c35-9ecb-b690e4cd6d5a" />


### 🚧 Tasks

- [ ] So far only displayName checks were added in one places. Maybe there's more needed?

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not possible
- [ ] 📘 API documentation in `docs/` has been updated or is not required
- [ ] 🔖 Capability is added or not needed 
