### PR TITLE
fix(chat): improve rendering of markdown elements in message bubbles

### DIFF
--- a/src/assets/markdown.scss
+++ b/src/assets/markdown.scss
@@ -43,6 +43,7 @@
 
 	code {
 		display: inline-block;
+		max-width: 100%;
 		padding: 2px 4px;
 		margin: 2px 0;
 		border-radius: var(--border-radius);
@@ -55,6 +56,10 @@
 		padding-inline-start: 13px;
 		/* stylelint-disable-next-line csstools/use-logical */
 		border-left: none;
-		border-inline-start: 4px solid var(--color-border);
+		border-inline-start: 4px solid var(--color-border-dark);
+	}
+
+	img {
+		max-width: min(100%, 600px);
 	}
 }


### PR DESCRIPTION
### ☑️ Resolves

* Fix some styling issues with split-view

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="178" height="43" alt="image" src="https://github.com/user-attachments/assets/a13659e1-5080-44a8-8ce9-323aa2f08d37" /> | <img width="177" height="45" alt="image" src="https://github.com/user-attachments/assets/b222d38d-6773-4983-ac69-c13cb92acf2f" />
<img width="175" height="50" alt="image" src="https://github.com/user-attachments/assets/7ccef73d-0988-4029-b35a-eed92528b881" /> | <img width="177" height="39" alt="image" src="https://github.com/user-attachments/assets/148c7f7d-eeef-4bf2-9e73-88af27a7385a" />
<img width="402" height="115" alt="image" src="https://github.com/user-attachments/assets/f78057fc-72d9-4ae9-ba0b-df9012c4a4ed" /> | <img width="389" height="144" alt="image" src="https://github.com/user-attachments/assets/f76b5148-52c1-48aa-a988-a04ab3212edf" />
<img width="405" height="88" alt="image" src="https://github.com/user-attachments/assets/d3800f42-7754-44a3-9336-43de0f048ca0" /> | <img width="403" height="87" alt="image" src="https://github.com/user-attachments/assets/7dd124f3-ccab-4660-a21d-906b8ddf312c" />


### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [x] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required