### PR TITLE
fix(chat): extract useFileTemplates to separate composable

### DIFF
--- a/src/components/NewMessage/NewMessage.vue
+++ b/src/components/NewMessage/NewMessage.vue
@@ -895,10 +895,6 @@ export default {
 		EventBus.on('upload-discard', this.handleUploadSideEffects)
 		EventBus.on('retry-message', this.handleRetryMessage)
 		EventBus.on('smart-picker-open', this.handleOpenTributeMenu)
-
-		if (!this.$store.getters.areFileTemplatesInitialised) {
-			this.$store.dispatch('getFileTemplates')
-		}
 	},
 
 	beforeUnmount() {

--- a/src/components/NewMessage/NewMessageAttachments.vue
+++ b/src/components/NewMessage/NewMessageAttachments.vue
@@ -89,6 +89,7 @@ import IconPlus from 'vue-material-design-icons/Plus.vue'
 import IconPoll from 'vue-material-design-icons/Poll.vue'
 import IconFileUpload from '../../../img/material-icons/file-upload.svg?raw'
 import IconSmartPicker from '../../../img/material-icons/smart-picker.svg?raw'
+import { useFileTemplates } from '../../composables/useFileTemplates.ts'
 import { EventBus } from '../../services/EventBus.ts'
 
 export default {
@@ -140,17 +141,16 @@ export default {
 	emits: ['updateNewFileDialog', 'openFileUpload', 'handleFileShare', 'createThread'],
 
 	setup() {
+		const fileTemplateOptions = useFileTemplates()
+
 		return {
+			fileTemplateOptions,
 			IconFileUpload,
 			IconSmartPicker,
 		}
 	},
 
 	computed: {
-		fileTemplateOptions() {
-			return this.$store.getters.fileTemplates
-		},
-
 		shareFromNextcloudLabel() {
 			return IS_DESKTOP
 				? t('spreed', 'Share from {nextcloud}', { nextcloud: OC.theme.productName })

--- a/src/components/NewMessage/NewMessageNewFileDialog.vue
+++ b/src/components/NewMessage/NewMessageNewFileDialog.vue
@@ -62,6 +62,7 @@ import NcDialog from '@nextcloud/vue/components/NcDialog'
 import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
 import NcTextField from '@nextcloud/vue/components/NcTextField'
 import NewMessageTemplatePreview from './NewMessageTemplatePreview.vue'
+import { useFileTemplates } from '../../composables/useFileTemplates.ts'
 import { useViewer } from '../../composables/useViewer.js'
 import { createNewFile } from '../../services/filesSharingServices.ts'
 import { useSettingsStore } from '../../stores/settings.ts'
@@ -93,9 +94,12 @@ export default {
 
 	setup() {
 		const { openViewer } = useViewer('files')
+		const fileTemplateOptions = useFileTemplates()
+
 		return {
 			openViewer,
 			settingsStore: useSettingsStore(),
+			fileTemplateOptions,
 		}
 	},
 
@@ -109,10 +113,6 @@ export default {
 	},
 
 	computed: {
-		fileTemplateOptions() {
-			return this.$store.getters.fileTemplates
-		},
-
 		fileTemplate() {
 			return this.fileTemplateOptions[this.showNewFileDialog]
 		},

--- a/src/composables/useFileTemplates.ts
+++ b/src/composables/useFileTemplates.ts
@@ -1,0 +1,55 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { FileTemplate } from '../types/index.ts'
+
+import { getCurrentUser } from '@nextcloud/auth'
+import { ref } from 'vue'
+import { getFileTemplates } from '../services/filesSharingServices.ts'
+
+/**
+ * Shared state for file templates
+ */
+let areFileTemplatesInitialised = false
+let areFileTemplatesLoading = false
+const fileTemplateOptions = ref<FileTemplate[]>([])
+
+/**
+ * Composable to get file templates
+ */
+export function useFileTemplates() {
+	/**
+	 * Fetch file templates from server and store them in the shared state
+	 */
+	async function fetchFileTemplates() {
+		if (areFileTemplatesLoading) {
+			// Already loading in parallel or loaded file templates, skipping
+			return
+		}
+
+		if (!getCurrentUser()) {
+			console.debug('Skip file templates setup for participants that are not logged in')
+			areFileTemplatesInitialised = true
+			return
+		}
+
+		try {
+			areFileTemplatesLoading = true
+			const response = await getFileTemplates()
+			fileTemplateOptions.value = response.data.ocs.data
+			areFileTemplatesInitialised = true
+		} catch (error) {
+			console.error('An error happened when trying to load the templates', error)
+		} finally {
+			areFileTemplatesLoading = false
+		}
+	}
+
+	if (!areFileTemplatesInitialised) {
+		fetchFileTemplates()
+	}
+
+	return fileTemplateOptions
+}

--- a/src/store/fileUploadStore.js
+++ b/src/store/fileUploadStore.js
@@ -4,7 +4,6 @@
  */
 
 import { showError } from '@nextcloud/dialogs'
-import { loadState } from '@nextcloud/initial-state'
 import { t } from '@nextcloud/l10n'
 import { getUploader } from '@nextcloud/upload'
 import { useTemporaryMessage } from '../composables/useTemporaryMessage.ts'
@@ -12,7 +11,6 @@ import { MESSAGE, SHARED_ITEM } from '../constants.ts'
 import { getDavClient } from '../services/DavClient.ts'
 import { EventBus } from '../services/EventBus.ts'
 import {
-	getFileTemplates,
 	shareFile,
 } from '../services/filesSharingServices.ts'
 import { useActorStore } from '../stores/actor.ts'
@@ -35,8 +33,6 @@ function state() {
 		uploads: {},
 		currentUploadId: undefined,
 		localUrls: {},
-		fileTemplatesInitialised: false,
-		fileTemplates: [],
 	}
 }
 
@@ -88,14 +84,6 @@ const getters = {
 
 	currentUploadId: (state) => {
 		return state.currentUploadId
-	},
-
-	areFileTemplatesInitialised: (state) => {
-		return state.fileTemplatesInitialised
-	},
-
-	fileTemplates: (state) => {
-		return state.fileTemplates
 	},
 }
 
@@ -181,15 +169,6 @@ const mutations = {
 
 	discardUpload(state, { uploadId }) {
 		delete state.uploads[uploadId]
-	},
-
-	storeFilesTemplates(state, templates) {
-		state.fileTemplates = templates
-		state.fileTemplatesInitialised = true
-	},
-
-	markFileTemplatesInitialised(state) {
-		state.fileTemplatesInitialised = true
 	},
 }
 
@@ -556,28 +535,6 @@ const actions = {
 	 */
 	removeFileFromSelection({ commit }, temporaryMessageId) {
 		commit('removeFileFromSelection', temporaryMessageId)
-	},
-
-	async getFileTemplates({ commit, getters }) {
-		if (getters.fileTemplates.length) {
-			console.debug('Skip file templates setup as already done')
-			commit('markFileTemplatesInitialised')
-			return
-		}
-
-		const actorStore = useActorStore()
-		if (actorStore.userId === null) {
-			console.debug('Skip file templates setup for participants that are not logged in')
-			commit('markFileTemplatesInitialised')
-			return
-		}
-
-		try {
-			const response = await getFileTemplates()
-			commit('storeFilesTemplates', response.data.ocs.data)
-		} catch (error) {
-			console.error('An error happened when trying to load the templates', error)
-		}
 	},
 }
 

--- a/src/types/core.ts
+++ b/src/types/core.ts
@@ -122,6 +122,7 @@ export type UnifiedSearchResponse = ApiResponse<operationsCore['unified_search-s
 }>
 
 // Files API
+export type FileTemplate = componentsFiles['schemas']['TemplateFileCreatorWithTemplates']
 export type getFileTemplatesListResponse = ApiResponse<operationsFiles['template-list']['responses'][200]['content']['application/json']>
 export type createFileFromTemplateParams = Required<operationsFiles['template-create']>['requestBody']['content']['application/json']
 export type createFileFromTemplateResponse = ApiResponse<operationsFiles['template-create']['responses'][200]['content']['application/json']>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -513,6 +513,7 @@ export type {
 export type {
 	createFileFromTemplateParams,
 	createFileFromTemplateResponse,
+	FileTemplate,
 	getFileTemplatesListResponse,
 } from './core.ts'
 


### PR DESCRIPTION
### ☑️ Resolves

* Ease fileUploadStore by extracting unrelated fileTemplates
  * Prerequisite to migrating fileUploadStore to TS + Pinia

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

<img width="213" height="305" alt="image" src="https://github.com/user-attachments/assets/86ffb56e-69f4-452b-86d4-8914437c6a17" />

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [x] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client