### PR TITLE
chore(release): Add changelog for 23.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 23.0.0 – 2026-02-18
+### Added
+- Live translations in call
+- Allow moderators to pin messages in a chat
+  [#3390](https://github.com/nextcloud/spreed/issues/3390)
+- Chat is now shown in split view by default
+  [#14944](https://github.com/nextcloud/spreed/issues/14944)
+- Allow users to schedule messages to send at a later time
+  [#3954](https://github.com/nextcloud/spreed/issues/3954)
+- Use hardware acceleration for background blurring when available
+  [#16072](https://github.com/nextcloud/spreed/issues/16072)
+- Allow participants to control noise suppression, echo cancellation and auto gain for their microphone
+  [#3252](https://github.com/nextcloud/spreed/issues/3252)
+- Relay chat messages via the High-performance backend to improve performance and scaling
+  [#624](https://github.com/nextcloud/spreed/issues/624)
+- Add number of calls and participants to openmetrics
+  [#16874](https://github.com/nextcloud/spreed/pull/16874)
+
+### Changed
+- Update dependencies
+- Update translations
+- Require Nextcloud 33 / Hub 26 Winter
+- Enable notifications in group conversations by default for new instances
+  [#16319](https://github.com/nextcloud/spreed/issues/16319)
+- Bots: The `object.name` was set to an empty string for messages with attachments. This was fixed to be `'message'` as for normal messages without any attachments.
+- Improve performance for shares
+
 ## 23.0.0-rc.4 – 2026-02-12
 ### Changed
 - Update dependencies


### PR DESCRIPTION
## Added
- Live translations in call
- Allow moderators to pin messages in a chat [#3390](https://github.com/nextcloud/spreed/issues/3390)
- Chat is now shown in split view by default [#14944](https://github.com/nextcloud/spreed/issues/14944)
- Allow users to schedule messages to send at a later time [#3954](https://github.com/nextcloud/spreed/issues/3954)
- Use hardware acceleration for background blurring when available [#16072](https://github.com/nextcloud/spreed/issues/16072)
- Allow participants to control noise suppression, echo cancellation and auto gain for their microphone [#3252](https://github.com/nextcloud/spreed/issues/3252)
- Relay chat messages via the High-performance backend to improve performance and scaling [#624](https://github.com/nextcloud/spreed/issues/624)
- feat(openmetrics): Add number of calls and participants to openmetrics [#16874](https://github.com/nextcloud/spreed/pull/16874)

## Changed
- Update dependencies
- Update translations
- Require Nextcloud 33 / Hub 26 Winter
- Enable notifications in group conversations by default for new instances [#16319](https://github.com/nextcloud/spreed/issues/16319)
- Bots: The `object.name` was set to an empty string for messages with attachments. This was fixed to be `'message'` as for normal messages without any attachments.
- perf(shares): Improve performance for shares
