### PR TITLE
Fix(signaling): ignore ECONNABORTED errors to prevent conversation not found

### DIFF
--- a/src/utils/signaling.js
+++ b/src/utils/signaling.js
@@ -543,7 +543,7 @@ Signaling.Internal.prototype._startPullingMessages = function() {
 			if (token !== this.currentRoomToken) {
 				// User navigated away in the meantime. Ignore
 			} else if (isCancel(error) || error.code === 'ECONNABORTED') {
-                console.debug('Pulling messages request was cancelled or aborted')
+				console.debug('Pulling messages request was cancelled or aborted')
 			} else if (error?.response?.status === 409) {
 				// Participant joined a second time and this session was killed
 				console.error('Session was killed but the conversation still exists')


### PR DESCRIPTION
…t found


### ☑️ Resolves

Prevents the "Conversation not found" error page when a temporary network interruption (ECONNABORTED) occurs.

Previously, if a polling request was aborted (e.g., refreshing the page or unstable network), the user was kicked out of the conversation. This patch ignores ECONNABORTED errors just like we ignore isCancel.

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

Screenshot before
<img width="638" height="311" alt="screen_problème" src="https://github.com/user-attachments/assets/a74d421f-bde2-4c13-9e53-8ae0cf221867" />

Screenshot after

No UI changes. The conversation loads normally instead of showing the "Conversation not found" error.

<!-- ☀️ Light theme | 🌑 Dark Theme -->

### 🚧 Tasks

- [x] Add ECONNABORTED to ignored errors in signaling.js

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [x] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required

---
