### PR TITLE
fix(performance): simplify MentionChip component

### DIFF
--- a/src/icons.css
+++ b/src/icons.css
@@ -190,24 +190,28 @@ body[dir="rtl"] .bidirectional-icon {
 }
 
 .user-bubble__avatar .icon-user-forced-white,
+.mention-chip .icon-user-forced-white,
 .autocomplete-result .icon-user-forced-white.autocomplete-result__icon--,
 .mention-bubble .icon-user-forced-white.mention-bubble__icon-- {
 	background-image: url(../img/icon-user-white.svg);
 }
 
 .user-bubble__avatar .icon-mail-forced-white,
+.mention-chip .icon-mail-forced-white,
 .autocomplete-result .icon-mail-forced-white.autocomplete-result__icon--,
 .mention-bubble .icon-mail-forced-white.mention-bubble__icon-- {
 	background-image: url(../img/icon-mail-white.svg);
 }
 
 .user-bubble__avatar .icon-group-forced-white,
+.mention-chip .icon-group-forced-white,
 .autocomplete-result .icon-group-forced-white.autocomplete-result__icon--,
 .mention-bubble .icon-group-forced-white.mention-bubble__icon-- {
 	background-image: url(../img/icon-contacts-white.svg);
 }
 
 .user-bubble__avatar .icon-team-forced-white,
+.mention-chip .icon-team-forced-white,
 .autocomplete-result .icon-team-forced-white.autocomplete-result__icon--,
 .mention-bubble .icon-team-forced-white.mention-bubble__icon-- {
 	background-image: url(../img/icon-team-white.svg);


### PR DESCRIPTION
### ☑️ Resolves

- switch from NcUserBubble to NcChip
  - NcUserBubble has an overhead of NcAvatar and internal computed props on top of MentionChip logic
  - NcChip is a simple wrapper
- drop style recalculation and re-render in mounted hook
  - get rid of call to window.getComputedStyle


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="756" height="302" alt="image" src="https://github.com/user-attachments/assets/090478a4-ca3a-458e-8bf1-ae13808dc3d9" /> | <img width="710" height="289" alt="image" src="https://github.com/user-attachments/assets/9a22a9ae-6c36-42b9-8432-5f9f6d87bd5b" />
<img width="605" height="316" alt="image" src="https://github.com/user-attachments/assets/1f35bdcd-7164-4081-a821-087087b377e7" /> | <img width="599" height="300" alt="image" src="https://github.com/user-attachments/assets/a3547e7f-7e47-4ae8-a3b1-74a2df701a75" />
<img width="542" height="321" alt="image" src="https://github.com/user-attachments/assets/664c4ec1-fdd6-4d67-ab9a-dcdcce49cc82" /> | <img width="544" height="305" alt="image" src="https://github.com/user-attachments/assets/fe3a9a7c-43c9-4971-a51e-2075c37539fa" />
<img width="542" height="319" alt="image" src="https://github.com/user-attachments/assets/64b3099b-20e3-4453-99d7-e00e2d82836e" /> | <img width="545" height="308" alt="image" src="https://github.com/user-attachments/assets/34ca6321-e3dc-49e6-961e-7f2186601f8c" />

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team