### PR TITLE
[stable31] ci(actions): Update workflow templates from organization template repository

### DIFF
--- a/.github/actions-lock.txt
+++ b/.github/actions-lock.txt
@@ -22,5 +22,5 @@ df57926317dc09c646e15e80aecd4982 phpunit-mariadb.yml
 97e9adce61f278540ea7d65cdb89ef40 psalm.yml
 7db5b820f3750eebe988005a0bb2febd reuse.yml
 800d5b188aa885626cf4169fa2dfea9e update-nextcloud-ocp-approve-merge.yml
-aec14bfbb22a09c894e30f624f2d954a update-nextcloud-ocp.yml
+b1ae206d69f6761b8ccbf05b2c2cd0c0 update-nextcloud-ocp.yml
 48c2c657b87747c9faeb589bcce08923 update-stable-titles.yml

--- a/.github/workflows/update-nextcloud-ocp.yml
+++ b/.github/workflows/update-nextcloud-ocp.yml
@@ -28,7 +28,6 @@ jobs:
           - ${{ github.event.repository.default_branch }}
           - 'stable33'
           - 'stable32'
-          - 'stable31'
 
     name: update-nextcloud-ocp-${{ matrix.branches }}
 


### PR DESCRIPTION
Automated update of all workflow templates from [nextcloud/.github](https://github.com/nextcloud/.github)
- 🆙 Updated [update-nextcloud-ocp.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/update-nextcloud-ocp.yml)