### PR TITLE
feat(conversation_settings): Allow changing password for convo without disabling

### DIFF
--- a/src/components/ConversationSettings/LinkShareSettings.vue
+++ b/src/components/ConversationSettings/LinkShareSettings.vue
@@ -46,7 +46,7 @@
 					</NcNoteCard>
 				</template>
 
-				<form v-if="showPasswordField" class="password-form" @submit.prevent="handleSetNewPassword">
+				<form v-if="isPasswordProtectionChecked" class="password-form" @submit.prevent="handleSetNewPassword">
 					<NcPasswordField
 						ref="passwordField"
 						v-model="password"
@@ -55,11 +55,11 @@
 						:disabled="isSaving"
 						class="password-form__input-field"
 						labelVisible
-						:label="t('spreed', 'Enter new password')"
+						:label="conversation.hasPassword ? t('spreed', 'Change password') : t('spreed', 'Enter new password')"
 						@valid="isValid = true"
 						@invalid="isValid = false" />
 					<NcButton
-						:disabled="isSaving || !isValid"
+						:disabled="isSaving || !isValid || !password.length"
 						variant="primary"
 						type="submit"
 						class="password-form__button">
@@ -162,8 +162,6 @@ export default {
 		return {
 			// The conversation's password
 			password: '',
-			// Switch for the password-editing operation
-			showPasswordField: false,
 			isSaving: false,
 			isSendingInvitations: false,
 			isValid: true,
@@ -184,7 +182,7 @@ export default {
 		},
 
 		isPasswordProtectionChecked() {
-			return this.conversation.hasPassword || this.showPasswordField
+			return this.conversation.hasPassword || this.password.length > 0
 		},
 
 		forcePasswordProtection() {
@@ -226,14 +224,12 @@ export default {
 			if (checked) {
 				// Generate a random password
 				this.password = await generatePassword()
-				this.showPasswordField = true
 			} else {
 				// disable the password protection for the current conversation
 				if (this.conversation.hasPassword) {
 					await this.setConversationPassword('')
 				}
 				this.password = ''
-				this.showPasswordField = false
 				this.isValid = true
 			}
 		},
@@ -242,7 +238,6 @@ export default {
 			if (this.isValid) {
 				await this.setConversationPassword(this.password)
 				this.password = ''
-				this.showPasswordField = false
 			}
 		},
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix #17000 …

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

| Scenario | Screenshots |
|----------|------------|
| **Password change – Before** | 
<img width="913" height="818" alt="image" src="https://github.com/user-attachments/assets/2ee31d4e-a5af-4679-b7bd-d004c6dd9e39" /><br/>
<img width="955" height="841" alt="before-disable-enable" src="https://github.com/user-attachments/assets/4210b4e8-3f83-4860-b3b1-96124132237c" /> |
| **Password change – After** | 
<img width="906" height="811" alt="image" src="https://github.com/user-attachments/assets/b237d6f4-178e-4154-b76f-0fb50c1a7334" /> |


### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
