### PR TITLE
fix(calendarintegration): trim calendar summary whitespace

### DIFF
--- a/lib/Listener/CalDavEventListener.php
+++ b/lib/Listener/CalDavEventListener.php
@@ -127,7 +127,7 @@ class CalDavEventListener implements IEventListener {
 
 		$name = $vevent->SUMMARY?->getValue();
 		if ($name !== null) {
-			$name = strlen($name) > 254 ? substr($name, 0, 254) . "\u{2026}" : $name;
+			$name = strlen($name) > 254 ? substr($name, 0, 254) . "\u{2026}" : trim($name);
 		}
 
 		$description = $vevent->DESCRIPTION?->getValue();


### PR DESCRIPTION
### ☑️ Resolves

Fixes https://github.com/nextcloud/spreed/issues/17218

<!--
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
░░░███████░░░█████████░░█████░
░░███░░░███░░░███░░░███░░███░░
░░█████████░░░████████░░░███░░
░░███░░░███░░░███░░░░░░░░███░░
░█████░█████░█████░░░░░░█████░
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching frontend/UI code
-->

## 🛠️ API Checklist

### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not possible
- [ ] 📘 API documentation in `docs/` has been updated or is not required
- [ ] 🔖 Capability is added or not needed 
