### PR TITLE
fix(federation): Fix federation invites when using email or wrong casing

### DIFF
--- a/lib/Federation/CloudFederationProviderTalk.php
+++ b/lib/Federation/CloudFederationProviderTalk.php
@@ -165,7 +165,11 @@ class CloudFederationProviderTalk implements ICloudFederationProvider, ISignedCl
 			} elseif (!str_starts_with($localCloudId, $shareWithUser->getUID() . '@')) {
 				// Fix the user ID as we also return it via the cloud federation api response in Nextcloud 30+
 				$cloudId = $this->cloudIdManager->resolveCloudId($localCloudId);
-				$localCloudId = $shareWithUser->getUID() . '@' . $cloudId->getRemote();
+				$localRemote = $cloudId->getRemote();
+				if (str_starts_with($localRemote, 'https://')) {
+					$localRemote = substr($localRemote, 8);
+				}
+				$localCloudId = $shareWithUser->getUID() . '@' . $localRemote;
 			}
 
 			if ($this->config->isDisabledForUser($shareWithUser)) {


### PR DESCRIPTION
### ☑️ Resolves

* Fix #17089

## 🛠️ API Checklist

### Steps
- Invite a federated user using their email address (or a different casing of their user id)

### 🚧 Tasks

- Sadly not testable with integration test as our tests can't user HTTPS
- Unit test makes no sense as we'd most likely have to mock the server function

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
