### PR TITLE
[stable32] ci(actions): Update workflow templates from organization template repository

### DIFF
--- a/.github/actions-lock.txt
+++ b/.github/actions-lock.txt
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
 # SPDX-License-Identifier: MIT
-ed304b04f68e51ee768cedf2be1c7df4 appstore-build-publish.yml
+8b8f9d3706c7ed5640263806b87e153a appstore-build-publish.yml
 30c9fe81a0a80bcf36cc7d441fcb8f9d block-unconventional-commits.yml
 d2e622168cdfb5036e36a3ab03e77cf5 command-openapi.yml
 d1898b1290d50f874d8092ebda6ee5e1 dependabot-approve-merge.yml
@@ -8,7 +8,7 @@ d1898b1290d50f874d8092ebda6ee5e1 dependabot-approve-merge.yml
 d27927b05654f34212637d9817c601ba lint-eslint.yml
 80a58e5584612def0e751fcfb7669814 lint-info-xml.yml
 995d1c0e3885a4024f7dca0bf290d805 lint-php-cs.yml
-5981160d66dceee84a5299018af530f6 lint-php.yml
+d07679d68c67685448c5006302fcaf55 lint-php.yml
 a907411975eec39544c50a1d1b1de7e7 lint-stylelint.yml
 c8770d61f6f9339176e7c123fa528111 lint-typescript.yml
 c8c74639ba12730c90464d1e870e9dc4 node-test.yml

--- a/.github/workflows/appstore-build-publish.yml
+++ b/.github/workflows/appstore-build-publish.yml
@@ -181,7 +181,7 @@ jobs:
           tar -zcvf ${{ env.APP_NAME }}.tar.gz ${{ env.APP_NAME }}
 
       - name: Attach tarball to github release
-        uses: svenstaro/upload-release-action@6b7fa9f267e90b50a19fef07b3596790bb941741 # v2.11.3
+        uses: svenstaro/upload-release-action@b98a3b12e86552593f3e4e577ca8a62aa2f3f22b # v2.11.4
         id: attach_to_release
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -21,7 +21,8 @@ jobs:
   matrix:
     runs-on: ubuntu-latest-low
     outputs:
-      php-versions: ${{ steps.versions.outputs.php-versions }}
+      php-min: ${{ steps.versions.outputs.php-min }}
+      php-max: ${{ steps.versions.outputs.php-max }}
     steps:
       - name: Checkout app
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -37,7 +38,7 @@ jobs:
     needs: matrix
     strategy:
       matrix:
-        php-versions: ${{fromJson(needs.matrix.outputs.php-versions)}}
+        php-versions: ['${{ needs.matrix.outputs.php-min }}', '${{ needs.matrix.outputs.php-max }}']
 
     name: php-lint
 


### PR DESCRIPTION
Automated update of all workflow templates from [nextcloud/.github](https://github.com/nextcloud/.github)
- 🆙 Updated [appstore-build-publish.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/appstore-build-publish.yml)
- 🆙 Updated [lint-php.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/lint-php.yml)