### PR TITLE
fix(chat): rename audio message filename Talk recording -> Voice message

### DIFF
--- a/src/components/NewMessage/NewMessageAudioRecorder.vue
+++ b/src/components/NewMessage/NewMessageAudioRecorder.vue
@@ -292,7 +292,7 @@ export default {
 			const today = new Date()
 			let time = today.getFullYear() + '-' + ('0' + today.getMonth()).slice(-2) + '-' + ('0' + today.getDay()).slice(-2)
 			time += ' ' + ('0' + today.getHours()).slice(-2) + '-' + ('0' + today.getMinutes()).slice(-2) + '-' + ('0' + today.getSeconds()).slice(-2)
-			const name = t('spreed', 'Talk recording from {time} ({conversation})', { time, conversation })
+			const name = t('spreed', 'Voice message {time} ({conversation})', { time, conversation })
 			return name.substring(0, 146) + '.wav'
 		},
 

--- a/src/utils/__tests__/prepareTemporaryMessage.spec.js
+++ b/src/utils/__tests__/prepareTemporaryMessage.spec.js
@@ -88,7 +88,7 @@ describe('prepareTemporaryMessage', () => {
 
 	const audioFile = {
 		type: 'audio/wav',
-		name: 'Talk recording from 2020-01-01 20-00-00.wav',
+		name: 'Voice message 2020-01-01 20-00-00 (Note to self).wav',
 	}
 	const audioFilePayload = {
 		...defaultPayload,
@@ -110,7 +110,7 @@ describe('prepareTemporaryMessage', () => {
 				file: audioFile,
 				mimetype: 'audio/wav',
 				id: expect.stringMatching(/^temp-1577908800000-upload-id-1-0\.[0-9]*$/),
-				name: 'Talk recording from 2020-01-01 20-00-00.wav',
+				name: 'Voice message 2020-01-01 20-00-00 (Note to self).wav',
 				uploadId: 'upload-id-1',
 				localUrl: 'local-url://original-name.txt',
 				index: 'upload-index-1',


### PR DESCRIPTION
### ☑️ Resolves

* Rename audio messages file name:
  * Before: `Talk recording from YYYY-MM-DD HH-MM-SS (Conversation Name).wav`
  * After: `Voice message YYYY-MM-DD HH-MM-SS (Conversation Name).wav`
* Motivation: 
  * Less confusing with call recordings
  * Neutral to application name
  * Simpler grammar without `from`

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required