### PR TITLE
fix(ui): remove Talk name from message sample in settings

### DIFF
--- a/src/__mocks__/messages.ts
+++ b/src/__mocks__/messages.ts
@@ -17,7 +17,7 @@ export const mockedChatMessages: Record<string, ChatMessage> = {
 		actorDisplayName: t('spreed', 'Another user'),
 		timestamp: 1768826595,
 		// TRANSLATORS fake message to show chat appearance in settings
-		message: t('spreed', 'Hey! Are you using Talk in list style or with message bubbles?'),
+		message: t('spreed', 'Hey! Are you using the list style or message bubbles?'),
 		messageParameters: {},
 		systemMessage: '',
 		messageType: 'comment',
@@ -35,7 +35,7 @@ export const mockedChatMessages: Record<string, ChatMessage> = {
 		actorId: 'deleted_users',
 		actorDisplayName: t('spreed', 'Another user'),
 		timestamp: 1768826627,
-		message: t('spreed', 'I picked list style'),
+		message: t('spreed', 'I picked the list style'),
 		messageParameters: {},
 		systemMessage: '',
 		messageType: 'comment',

--- a/src/components/SettingsDialog/AppearanceSettings.vue
+++ b/src/components/SettingsDialog/AppearanceSettings.vue
@@ -50,7 +50,7 @@ const mockMessageOutgoing = computed(() => ({
 		// TRANSLATORS fake message to show chat appearance in settings
 		? t('spreed', 'I picked message bubbles')
 		// TRANSLATORS fake message to show chat appearance in settings
-		: t('spreed', 'I picked list style'),
+		: t('spreed', 'I picked the list style'),
 }))
 provide('messagesList:isSplitViewEnabled', chatSplitViewEnabled)
 


### PR DESCRIPTION
### ☑️ Resolves

* Remove the application name to simplify branding support

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="610" height="249" alt="image" src="https://github.com/user-attachments/assets/29395268-8844-472a-9b34-637d89f87c8e" /> | <img width="611" height="247" alt="image" src="https://github.com/user-attachments/assets/66018f6d-f037-48e0-a426-1c0367ed047d" />

<!-- ☀️ Light theme | 🌑 Dark Theme -->

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required