### PR TITLE
fix(meetings): reword meetigns related messages on Home page and in title

### DIFF
--- a/lib/Listener/CalDavEventListener.php
+++ b/lib/Listener/CalDavEventListener.php
@@ -178,7 +178,7 @@ class CalDavEventListener implements IEventListener {
 
 
 		// So we can unset names & descriptions in case the user deleted them
-		$this->roomService->setName($room, $name ?? $this->l10n->t('Talk conversation for event'));
+		$this->roomService->setName($room, $name ?? $this->l10n->t('Meeting'));
 		$this->roomService->setDescription($room, $description ?? '');
 
 		/** @var DateTime $start */

--- a/src/components/Dashboard/TalkDashboard.vue
+++ b/src/components/Dashboard/TalkDashboard.vue
@@ -317,7 +317,7 @@ function scrollEventCards({ direction }: { direction: 'backward' | 'forward' }) 
 					wide
 					:title="t('spreed', 'Schedule meetings')"
 					:subtitle="t('spreed', 'You don\'t have any upcoming meetings')"
-					:description="t('spreed', 'Schedule a meeting from your calendar. A Talk conversation needs to be set as location to show up here')">
+					:description="t('spreed', 'Calendar events with a conversation link as the location are shown here')">
 					<template #image>
 						<img :src="imagePath('spreed', 'dashboard/meetings.png')">
 					</template>


### PR DESCRIPTION
### ☑️ Resolves

* Remove app name from the strings
* Fallback meeting conversation title:
  * `Talk conversation for event` -> `Meeting conversation`
* Reword the placeholder on the Home page

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
Talk conversation for event | Meeting conversation
![Uploading image.png…]() | <img width="1088" height="238" alt="image" src="https://github.com/user-attachments/assets/2428e913-8faa-4f1c-a77a-625d77ec29e9" />


### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required