### PR TITLE
fix(federations): reword invitations dialog title

### DIFF
--- a/src/components/LeftSidebar/InvitationHandler.vue
+++ b/src/components/LeftSidebar/InvitationHandler.vue
@@ -11,7 +11,7 @@
 		closeOnClickOutside>
 		<div class="inbox">
 			<p class="inbox__disclaimer">
-				{{ t('spreed', 'Join conversations from remote Nextcloud servers') }}
+				{{ t('spreed', 'Join conversations from other servers') }}
 			</p>
 			<ul v-if="invitationsLoadedCount" class="inbox__list">
 				<li


### PR DESCRIPTION
### ☑️ Resolves

* Reword federation invitations dialog title to make it branding-neutral

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
