### PR TITLE
fix(ui): simplify signaling server error toast for non-admins

### DIFF
--- a/src/utils/signaling.js
+++ b/src/utils/signaling.js
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import { getCurrentUser } from '@nextcloud/auth'
 import axios, { isCancel } from '@nextcloud/axios'
 import {
 	showError,
@@ -1123,12 +1124,22 @@ Signaling.Standalone.prototype.helloResponseReceived = function(data) {
 			|| (!this.hasFeature('switchto') && hasTalkFeature('local', 'breakout-rooms-v1')) // Talk v16
 			|| (!this.hasFeature('federation') && hasTalkFeature('local', 'federation-v2')) // Talk v20
 		)) {
-		showError(
-			t('spreed', 'The configured signaling server needs to be updated to be compatible with this version of Talk. Please contact your administration.'),
-			{
-				timeout: TOAST_PERMANENT_TIMEOUT,
-			},
-		)
+		if (getCurrentUser()?.isAdmin) {
+			showError(
+				t('spreed', 'The configured signaling server needs to be updated to be compatible with this version of Talk'),
+				{
+					timeout: TOAST_PERMANENT_TIMEOUT,
+				},
+			)
+		} else {
+			showError(
+				t('spreed', 'The server is misconfigured. Please contact your administration.'),
+				{
+					timeout: TOAST_PERMANENT_TIMEOUT,
+				},
+			)
+		}
+
 		console.error('The configured signaling server needs to be updated to be compatible with this version of Talk. Please contact your administration.')
 	}
 

--- a/src/utils/signaling.js
+++ b/src/utils/signaling.js
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import { getCurrentUser } from '@nextcloud/auth'
 import axios, { isCancel } from '@nextcloud/axios'
 import {
 	showError,
@@ -1132,12 +1133,22 @@ Signaling.Standalone.prototype.helloResponseReceived = function(data) {
 			|| (!this.hasFeature('switchto') && hasTalkFeature('local', 'breakout-rooms-v1')) // Talk v16
 			|| (!this.hasFeature('federation') && hasTalkFeature('local', 'federation-v2')) // Talk v20
 		)) {
-		showError(
-			t('spreed', 'The configured signaling server needs to be updated to be compatible with this version of Talk. Please contact your administration.'),
-			{
-				timeout: TOAST_PERMANENT_TIMEOUT,
-			},
-		)
+		if (getCurrentUser()?.isAdmin) {
+			showError(
+				t('spreed', 'High-performance backend needs to be updated.'),
+				{
+					timeout: TOAST_PERMANENT_TIMEOUT,
+				},
+			)
+		} else {
+			showError(
+				t('spreed', 'The server is misconfigured. Please contact your administration.'),
+				{
+					timeout: TOAST_PERMANENT_TIMEOUT,
+				},
+			)
+		}
+
 		console.error('The configured signaling server needs to be updated to be compatible with this version of Talk. Please contact your administration.')
 	}
 


### PR DESCRIPTION
### ☑️ Resolves

* An end-user doesn't know that "signaling server" is
* Keep the current message for admins only and simplify for the end user
* In addition, make it branding-neutral for the end users


### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
