### PR TITLE
fix(ui): theming neutral "server was updated" messages

### DIFF
--- a/src/components/TopBar/CallButton.vue
+++ b/src/components/TopBar/CallButton.vue
@@ -308,7 +308,7 @@ export default {
 
 		startCallTitle() {
 			if (this.isNextcloudTalkHashDirty) {
-				return t('spreed', 'Nextcloud Talk was updated, you cannot start or join a call.') + ' ' + messagePleaseReload
+				return t('spreed', 'The server was updated, you cannot start or join a call.') + ' ' + messagePleaseReload
 			}
 
 			if (this.callViewStore.callHasJustEnded) {

--- a/src/composables/useHashCheck.js
+++ b/src/composables/useHashCheck.js
@@ -30,7 +30,7 @@ export function useHashCheck() {
 	const showReloadWarning = () => {
 		reloadWarningShown = true
 
-		showError(t('spreed', 'Nextcloud Talk was updated.') + '\n' + messagePleaseReload, {
+		showError(t('spreed', 'The server was updated.') + '\n' + messagePleaseReload, {
 			timeout: TOAST_PERMANENT_TIMEOUT,
 		})
 	}

--- a/src/stores/talkHash.js
+++ b/src/stores/talkHash.js
@@ -100,7 +100,7 @@ export const useTalkHashStore = defineStore('talkHash', {
 		checkMaintenanceMode(response) {
 			if (response?.status === 503 && !this.maintenanceWarningToast) {
 				this.maintenanceWarningToast = showError(
-					t('spreed', 'Nextcloud is in maintenance mode.') + '\n' + messagePleaseReload,
+					t('spreed', 'The server is in maintenance mode.') + '\n' + messagePleaseReload,
 					{ timeout: TOAST_PERMANENT_TIMEOUT },
 				)
 			}
@@ -121,7 +121,7 @@ export const useTalkHashStore = defineStore('talkHash', {
 		 * Show a toast message when Talk Federation requires rejoining
 		 */
 		showTalkProxyHashDirtyToast() {
-			this.proxyHashDirtyToast = showError(t('spreed', 'Nextcloud Talk Federation was updated.') + '\n' + messagePleaseReload, {
+			this.proxyHashDirtyToast = showError(t('spreed', 'Federated server was updated.') + '\n' + messagePleaseReload, {
 				timeout: TOAST_PERMANENT_TIMEOUT,
 			})
 		},


### PR DESCRIPTION
### ☑️ Resolves

* Rename messages like "Nextcloud Talk was updated" to "Server was" to make it theming and branding neutral
* For the end user this is not important, what exactly was updated
* "App" term is not used to not make it sound like a client update
* Alternative: `Service` instead of `Server`

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required