### PR TITLE
fix(ui): clarify duplicate session error message

### DIFF
--- a/src/views/SessionConflictView.vue
+++ b/src/views/SessionConflictView.vue
@@ -11,7 +11,7 @@ import EmptyView from '../components/EmptyView.vue'
 <template>
 	<EmptyView
 		:name="t('spreed', 'Duplicate session')"
-		:description="t('spreed', 'You joined the conversation in another window or device. This is currently not supported by Nextcloud Talk so this session was closed.')">
+		:description="t('spreed', 'This conversation was opened in another tab. The current server version does not support opening a conversation in multiple tabs.')">
 		<template #icon>
 			<!-- TODO: use information-slab-symbol after update to MDI 7 -->
 			<IconInformationOutline />


### PR DESCRIPTION
### ☑️ Resolves

* `or device` is not relevant for a long time
* This is not about **windows**, but about web-browser **tabs**
* Even tabs are now supported, so this is only a limitation for the user server version
* **Sessions** is a technical term, not relevant for the end-user
* **Joined** is also more technical (joined a session) that the user action (a user just opened a conversation)
* Theming/branding neutral
* Follow-up: add a button to close this tab and focus another one

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
