### PR TITLE
fix(chat): Don't mention in markdown code

### DIFF
--- a/lib/Chat/Parser/UserMention.php
+++ b/lib/Chat/Parser/UserMention.php
@@ -138,7 +138,7 @@ class UserMention implements IEventListener {
 			// index of the mentions of that type.
 			$mentionParameterId = 'mention-' . str_replace('_', '-', $mention['type']) . $mentionTypeCount[$mention['type']];
 
-			$message = str_replace('@"' . $search . '"', '{' . $mentionParameterId . '}', $message);
+			$message = $this->replaceOutsideCode($message, '@"' . $search . '"', '{' . $mentionParameterId . '}');
 			if (!str_contains($search, ' ')
 				&& !str_starts_with($search, 'guest/')
 				&& !str_starts_with($search, 'email/')
@@ -147,7 +147,7 @@ class UserMention implements IEventListener {
 				 && !str_starts_with($search, 'team/')
 				// && !str_starts_with($search, 'federated_team/')
 				&& !str_starts_with($search, 'federated_user/')) {
-				$message = str_replace('@' . $search, '{' . $mentionParameterId . '}', $message);
+				$message = $this->replaceOutsideCode($message, '@' . $search, '{' . $mentionParameterId . '}');
 			}
 
 			if ($mention['type'] === 'call') {
@@ -252,6 +252,16 @@ class UserMention implements IEventListener {
 		}
 
 		$chatMessage->setMessage($message, $messageParameters);
+	}
+
+	/**
+	 * Replace mentions only outside of markdown code blocks and inline code.
+	 */
+	protected function replaceOutsideCode(string $message, string $search, string $replacement): string {
+		$pattern = '/^```.*?^```|^~~~.*?^~~~|`[^`\n]*`|' . preg_quote($search, '/') . '/sm';
+		return preg_replace_callback($pattern, static function (array $match) use ($search, $replacement): string {
+			return ($match[0] === $search) ? $replacement : $match[0];
+		}, $message) ?? $message;
 	}
 
 	/**

--- a/tests/php/Chat/Parser/UserMentionTest.php
+++ b/tests/php/Chat/Parser/UserMentionTest.php
@@ -615,4 +615,136 @@ class UserMentionTest extends TestCase {
 		$this->assertEquals('Mention to {mention-guest1}, and again {mention-guest1}', $chatMessage->getMessage());
 		$this->assertEquals($expectedMessageParameters, $chatMessage->getMessageParameters());
 	}
+
+	public static function dataCodeBlockMention(): array {
+		return [
+			['@testUser'],
+			['Hello @testUser'],
+			['Hello @testUser bye'],
+			['@testUser bye'],
+		];
+	}
+
+	#[DataProvider(methodName: 'dataCodeBlockMention')]
+	public function testGetRichMessageWithMentionInInlineCode(string $codeBlock): void {
+		$mentions = [
+			['type' => 'user', 'id' => 'testUser'],
+		];
+		$comment = $this->newComment($mentions);
+
+		$this->commentsManager->expects($this->once())
+			->method('resolveDisplayName')
+			->with('user', 'testUser')
+			->willReturn('testUser display name');
+
+		$this->userManager->expects($this->once())
+			->method('getDisplayName')
+			->with('testUser')
+			->willReturn('testUser display name');
+
+		/** @var Room&MockObject $room */
+		$room = $this->createMock(Room::class);
+		/** @var Participant&MockObject $participant */
+		$participant = $this->createMock(Participant::class);
+		/** @var IL10N&MockObject $l */
+		$l = $this->createMock(IL10N::class);
+		$chatMessage = new Message($room, $participant, $comment, $l);
+		$chatMessage->setMessage('Mention @testUser but not `' . $codeBlock . '` in inline code', []);
+
+		self::invokePrivate($this->parser, 'parseMessage', [$chatMessage]);
+
+		$expectedMessageParameters = [
+			'mention-user1' => [
+				'type' => 'user',
+				'id' => 'testUser',
+				'name' => 'testUser display name',
+				'mention-id' => 'testUser',
+			]
+		];
+
+		$this->assertEquals('Mention {mention-user1} but not `' . $codeBlock . '` in inline code', $chatMessage->getMessage());
+		$this->assertEquals($expectedMessageParameters, $chatMessage->getMessageParameters());
+	}
+
+	#[DataProvider(methodName: 'dataCodeBlockMention')]
+	public function testGetRichMessageWithMentionInFencedCodeBlock(string $codeBlock): void {
+		$mentions = [
+			['type' => 'user', 'id' => 'testUser'],
+		];
+		$comment = $this->newComment($mentions);
+
+		$this->commentsManager->expects($this->once())
+			->method('resolveDisplayName')
+			->with('user', 'testUser')
+			->willReturn('testUser display name');
+
+		$this->userManager->expects($this->once())
+			->method('getDisplayName')
+			->with('testUser')
+			->willReturn('testUser display name');
+
+		/** @var Room&MockObject $room */
+		$room = $this->createMock(Room::class);
+		/** @var Participant&MockObject $participant */
+		$participant = $this->createMock(Participant::class);
+		/** @var IL10N&MockObject $l */
+		$l = $this->createMock(IL10N::class);
+		$chatMessage = new Message($room, $participant, $comment, $l);
+		$chatMessage->setMessage("Mention @testUser but not\n```\n" . $codeBlock . "\n```\nin code block", []);
+
+		self::invokePrivate($this->parser, 'parseMessage', [$chatMessage]);
+
+		$expectedMessageParameters = [
+			'mention-user1' => [
+				'type' => 'user',
+				'id' => 'testUser',
+				'name' => 'testUser display name',
+				'mention-id' => 'testUser',
+			]
+		];
+
+		$this->assertEquals("Mention {mention-user1} but not\n```\n" . $codeBlock . "\n```\nin code block", $chatMessage->getMessage());
+		$this->assertEquals($expectedMessageParameters, $chatMessage->getMessageParameters());
+	}
+
+	#[DataProvider(methodName: 'dataCodeBlockMention')]
+	public function testGetRichMessageWithMentionOnlyInCodeBlock(string $codeBlock): void {
+		$mentions = [
+			['type' => 'user', 'id' => 'testUser'],
+		];
+		$comment = $this->newComment($mentions);
+
+		$this->commentsManager->expects($this->once())
+			->method('resolveDisplayName')
+			->with('user', 'testUser')
+			->willReturn('testUser display name');
+
+		$this->userManager->expects($this->once())
+			->method('getDisplayName')
+			->with('testUser')
+			->willReturn('testUser display name');
+
+		/** @var Room&MockObject $room */
+		$room = $this->createMock(Room::class);
+		/** @var Participant&MockObject $participant */
+		$participant = $this->createMock(Participant::class);
+		/** @var IL10N&MockObject $l */
+		$l = $this->createMock(IL10N::class);
+		$chatMessage = new Message($room, $participant, $comment, $l);
+		$chatMessage->setMessage('Only in code `' . $codeBlock . '`', []);
+
+		self::invokePrivate($this->parser, 'parseMessage', [$chatMessage]);
+
+		$expectedMessageParameters = [
+			'mention-user1' => [
+				'type' => 'user',
+				'id' => 'testUser',
+				'name' => 'testUser display name',
+				'mention-id' => 'testUser',
+			]
+		];
+
+		$this->assertEquals('Only in code `' . $codeBlock . '`', $chatMessage->getMessage());
+		$this->assertEquals($expectedMessageParameters, $chatMessage->getMessageParameters());
+	}
 }


### PR DESCRIPTION
### ☑️ Resolves

* Fix #10252 
* Currently it still triggers notifications if a user is only mentioned in code, but that will be fixed in server

<img width="691" height="472" alt="grafik" src="https://github.com/user-attachments/assets/54dc4ea1-2f4c-466d-a29a-f8e096422807" />


### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
