### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -333,12 +333,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "b0e4d6e517a192db3360319b25d4f3439c1f1094"
+                "reference": "26aac678bd92adaa91e4e5715ba11cb3f627361d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/b0e4d6e517a192db3360319b25d4f3439c1f1094",
-                "reference": "b0e4d6e517a192db3360319b25d4f3439c1f1094",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/26aac678bd92adaa91e4e5715ba11cb3f627361d",
+                "reference": "26aac678bd92adaa91e4e5715ba11cb3f627361d",
                 "shasum": ""
             },
             "require": {
@@ -374,7 +374,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2026-03-11T09:02:54+00:00"
+            "time": "2026-03-14T01:06:50+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency