### PR TITLE
fix: Cast value to string in validation check

### DIFF
--- a/lib/MatterbridgeManager.php
+++ b/lib/MatterbridgeManager.php
@@ -502,7 +502,7 @@ class MatterbridgeManager {
 				throw new \InvalidArgumentException('Invalid matterbridge parameters');
 			}
 			foreach ($part as $key => $value) {
-				if (preg_match('/["\n]/', $key) || preg_match('/["\n]/', $value)) {
+				if (preg_match('/["\n]/', $key) || preg_match('/["\n]/', (string)$value)) {
 					$this->logger->error('User tried to configure a malicious matterbridge setup');
 					throw new \InvalidArgumentException('Invalid matterbridge parameters');
 				}


### PR DESCRIPTION
Fixes exception:
Exception preg_match(): Argument #2 ($subject) must be of type string, false given in file '/var/www/html/nextcloud/apps/spreed/lib/MatterbridgeManager.php' line 505

validateParts() iterates over all keys/values of each bridge part and calls
preg_match() on them directly. Boolean fields like `skiptls` (which is false
by default) are not cast to string first, causing a fatal exception that
prevents any bridge config from being saved.


### ☑️ Resolves

* Fix #17140

<!--
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
░░░███████░░░█████████░░█████░
░░███░░░███░░░███░░░███░░███░░
░░█████████░░░████████░░░███░░
░░███░░░███░░░███░░░░░░░░███░░
░█████░█████░█████░░░░░░█████░
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching frontend/UI code
-->

## 🛠️ API Checklist

### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not possible
- [ ] 📘 API documentation in `docs/` has been updated or is not required
- [ ] 🔖 Capability is added or not needed 
