### PR TITLE
fix(conversation): Fix string for automatic deletion

### DIFF
--- a/src/components/UIShared/ConversationActionsShortcut.vue
+++ b/src/components/UIShared/ConversationActionsShortcut.vue
@@ -5,7 +5,7 @@
 
 <script setup lang="ts">
 import { showError } from '@nextcloud/dialogs'
-import { getLanguage, t } from '@nextcloud/l10n'
+import { n, t } from '@nextcloud/l10n'
 import { spawnDialog } from '@nextcloud/vue/functions/dialog'
 import { computed } from 'vue'
 import { isNavigationFailure, NavigationFailureType } from 'vue-router'
@@ -52,8 +52,12 @@ const descriptionLabel = computed(() => {
 	if (expirationDuration.value === 0) {
 		return t('spreed', 'Would you like to delete this conversation?')
 	}
-	const expirationDurationFormatted = new Intl.RelativeTimeFormat(getLanguage(), { numeric: 'always' }).format(expirationDuration.value!, 'days')
-	return t('spreed', 'This conversation will be automatically deleted for everyone {expirationDurationFormatted} of no activity.', { expirationDurationFormatted })
+	return n(
+		'spreed',
+		'This conversation will be automatically deleted for everyone after %n day of inactivity.',
+		'This conversation will be automatically deleted for everyone after %n days of inactivity.',
+		expirationDuration.value!,
+	)
 })
 
 /**


### PR DESCRIPTION
## ☑️ Resolves

* Fix #17381 

## 🖌️ UI Checklist

### Before
This conversation will be automatically deleted for everyone in 28 days of no activity.


### After
This conversation will be automatically deleted for everyone, after 28 days of inactivity.

In German (and potentially other languages) the string made even less sense