### PR TITLE
fix(ci): adjust run conditions for approve-merge steps

### DIFF
--- a/.github/workflows/dependabot-approve-merge.yml
+++ b/.github/workflows/dependabot-approve-merge.yml
@@ -65,10 +65,12 @@ jobs:
           fi
 
       # GitHub actions bot approve
-      - uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363 # v4.0.0
+      - name: Auto approve
+        id: auto_approve
+        uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363 # v4.0.0
         if: ${{ github.event.pull_request.user.login == 'dependabot[bot]'
             && steps.validate.outputs.ignore != 'true'
-            && ((env.ALLOW_MINOR && steps.metadata.outputs.update-type == 'version-update:semver-minor')
+            && ((fromJSON(env.ALLOW_MINOR) && steps.metadata.outputs.update-type == 'version-update:semver-minor')
                 || steps.metadata.outputs.update-type == 'version-update:semver-patch')
           }}
         with:
@@ -77,6 +79,6 @@ jobs:
       # Enable GitHub auto merge
       - name: Auto merge
         uses: alexwilson/enable-github-automerge-action@56e3117d1ae1540309dc8f7a9f2825bc3c5f06ff # v2.0.0
-        if: github.event.pull_request.user.login == 'dependabot[bot]'
+        if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' && steps.auto_approve.conclusion == 'success' }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## ☑️ Resolves

* Fix #17401 
* `env.ALLOW_MINOR` in if condition is a string, should be converted to boolean with `fromJSON(env.ALLOW_MINOR)`
  * docs: https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#example-returning-a-json-data-type
* auto-merge is running regardless of auto-approve step, listen for `steps.auto_approve.conclusion == 'success'` to execute or skip
  * docs: https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#steps-context

### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI