### PR TITLE
fix(call): improve virtual background performance

### DIFF
--- a/src/utils/media/effects/virtual-background/VideoStreamBackgroundEffect.js
+++ b/src/utils/media/effects/virtual-background/VideoStreamBackgroundEffect.js
@@ -457,8 +457,12 @@ export default class VideoStreamBackgroundEffect {
 			return
 		}
 
-		this._outputCanvasElement.width = width
-		this._outputCanvasElement.height = height
+		// Assigning canvas dimensions clears the canvas and reallocates its
+		// buffer even if values are unchanged, so only set them on change.
+		if (this._outputCanvasElement.width !== width || this._outputCanvasElement.height !== height) {
+			this._outputCanvasElement.width = width
+			this._outputCanvasElement.height = height
+		}
 
 		if (this._useWebGL) {
 			if (!this._glFx) {

--- a/src/utils/media/effects/virtual-background/VideoStreamBackgroundEffect.js
+++ b/src/utils/media/effects/virtual-background/VideoStreamBackgroundEffect.js
@@ -18,6 +18,12 @@ import WebGLCompositor from './WebGLCompositor.js'
 let _WasmFileset = null
 
 /**
+ * Throttle coefficient for _runInference method.
+ * Every Nth frame will be inferenced (mask calculation)
+ */
+const INFERENCE_THROTTLE_RATE = 1
+
+/**
  * Represents a modified MediaStream that applies virtual background effects
  * (blur, image, video, or video stream) using MediaPipe segmentation.
  *
@@ -62,6 +68,8 @@ export default class VideoStreamBackgroundEffect {
 		this._useWebGL = this._options.webGL
 
 		this._segmentationPixelCount = this._options.width * this._options.height
+
+		this._inferenceRunning = false
 
 		this._initMediaPipe().catch((e) => console.error(e))
 
@@ -148,13 +156,36 @@ export default class VideoStreamBackgroundEffect {
 	}
 
 	/**
+	 * Start inference if not already running.
+	 * Deferred to next microtask to not block rendering.
+	 *
+	 * @private
+	 * @return {void}
+	 */
+	_queueInference() {
+		if (this._inferenceRunning) {
+			return
+		}
+
+		this._inferenceRunning = true
+		Promise.resolve()
+			.then(() => this._runInference())
+			.catch((error) => {
+				console.error('MediaPipe inference failed:', error)
+				this._inferenceRunning = false
+			})
+	}
+
+	/**
 	 * Run segmentation inference on the current video frame.
+	 * Update cached mask when done.
 	 *
 	 * @private
 	 * @return {Promise<void>}
 	 */
 	async _runInference() {
-		if (!this._imageSegmenter || !this._loaded) {
+		if (!this._running || !this._imageSegmenter || !this._loaded) {
+			this._inferenceRunning = false
 			return
 		}
 
@@ -165,22 +196,26 @@ export default class VideoStreamBackgroundEffect {
 				performance.now(),
 			)
 
-			if (segmentationResult.confidenceMasks && segmentationResult.confidenceMasks.length > 0) {
+			// Effect might have been stopped while inferencing
+			if (this._running && segmentationResult.confidenceMasks && segmentationResult.confidenceMasks.length > 0) {
 				this._processSegmentationResult(segmentationResult)
 			}
-
-			this.runPostProcessing()
-			this._lastFrameId = this._frameId
-		} catch (error) {
-			console.error('MediaPipe inference failed:', error)
 		} finally {
 			if (segmentationResult?.categoryMask) {
 				segmentationResult.categoryMask.close()
 			}
 
 			if (segmentationResult?.confidenceMasks?.length) {
-				segmentationResult.confidenceMasks.forEach((mask) => mask.close())
+				segmentationResult.confidenceMasks.forEach((mask) => {
+					// The mask cached in _lastMask is kept for the next postProcessing
+					if (mask === this._lastMask) {
+						return
+					}
+					mask.close()
+				})
 			}
+
+			this._inferenceRunning = false
 		}
 	}
 
@@ -258,6 +293,9 @@ export default class VideoStreamBackgroundEffect {
 			// Update segmentation mask canvas
 			this._segmentationMaskCtx.putImageData(this._segmentationMask, 0, 0)
 		} else {
+			if (this._lastMask) {
+				this._lastMask.close()
+			}
 			this._lastMask = maskData
 		}
 	}
@@ -269,18 +307,15 @@ export default class VideoStreamBackgroundEffect {
 	 * @return {void}
 	 */
 	_renderMask() {
-		if (this._frameId < this._lastFrameId) {
-			console.debug('Fixing frame id, this should not happen', this._frameId, this._lastFrameId)
-			this._frameId = this._lastFrameId
+		// Run inference if ready
+		if (this._loaded) {
+			this._frameId++
+			if (this._frameId % INFERENCE_THROTTLE_RATE === 0) {
+				this._queueInference()
+			}
 		}
 
-		// Run inference if ready
-		if (this._loaded && this._frameId === this._lastFrameId) {
-			this._frameId++
-			this._runInference().catch((e) => console.error(e))
-		} else if (this._useWebGL) {
-			this.runPostProcessing()
-		}
+		this.runPostProcessing()
 
 		// Schedule next frame
 		this._maskFrameTimerWorker.postMessage({
@@ -643,7 +678,6 @@ export default class VideoStreamBackgroundEffect {
 		}
 
 		this._frameId = -1
-		this._lastFrameId = -1
 
 		this._bgChanged = true
 
@@ -669,7 +703,6 @@ export default class VideoStreamBackgroundEffect {
 		})
 
 		this._frameId = -1
-		this._lastFrameId = -1
 	}
 
 	/**
@@ -695,6 +728,11 @@ export default class VideoStreamBackgroundEffect {
 		if (this._glFx) {
 			this._glFx.dispose()
 			this._glFx = null
+		}
+
+		if (this._lastMask) {
+			this._lastMask.close()
+			this._lastMask = null
 		}
 
 		this._segmentationMask = null

--- a/src/utils/media/effects/virtual-background/VideoStreamBackgroundEffect.js
+++ b/src/utils/media/effects/virtual-background/VideoStreamBackgroundEffect.js
@@ -136,6 +136,9 @@ export default class VideoStreamBackgroundEffect {
 						'./vendor/models/selfie_segmenter.tflite',
 						import.meta.url,
 					).pathname,
+					// delegate: 'CPU' was tried as a GPU-load reduction; it
+					// made things worse (no GPU win, added main-thread
+					// stalls). Keeping GPU.
 					delegate: 'GPU',
 				},
 				runningMode: 'VIDEO',
@@ -486,8 +489,13 @@ export default class VideoStreamBackgroundEffect {
 			return
 		}
 
-		this._outputCanvasElement.width = width
-		this._outputCanvasElement.height = height
+		// Assigning canvas dimensions clears and reallocates its backing
+		// buffer even when the values are unchanged, so only set them on
+		// an actual resize.
+		if (this._outputCanvasElement.width !== width || this._outputCanvasElement.height !== height) {
+			this._outputCanvasElement.width = width
+			this._outputCanvasElement.height = height
+		}
 
 		if (this._useWebGL) {
 			if (!this._glFx) {

--- a/src/utils/media/effects/virtual-background/VideoStreamBackgroundEffect.js
+++ b/src/utils/media/effects/virtual-background/VideoStreamBackgroundEffect.js
@@ -188,7 +188,13 @@ export default class VideoStreamBackgroundEffect {
 			}
 
 			if (segmentationResult?.confidenceMasks?.length) {
-				segmentationResult.confidenceMasks.forEach((mask) => mask.close())
+				// The mask kept as _lastMask (WebGL path) must stay open for
+				// reuse on stale redraws; see _processSegmentationResult().
+				segmentationResult.confidenceMasks.forEach((mask) => {
+					if (mask !== this._lastMask) {
+						mask.close()
+					}
+				})
 			}
 		}
 	}
@@ -267,6 +273,11 @@ export default class VideoStreamBackgroundEffect {
 			// Update segmentation mask canvas
 			this._segmentationMaskCtx.putImageData(this._segmentationMask, 0, 0)
 		} else {
+			// Close the previous mask only once replaced; it stays open
+			// until then for reuse on stale redraws (see _runInference()).
+			if (this._lastMask && this._lastMask !== maskData) {
+				this._lastMask.close()
+			}
 			this._lastMask = maskData
 		}
 	}
@@ -734,6 +745,11 @@ export default class VideoStreamBackgroundEffect {
 		if (this._rvfcHandle !== undefined) {
 			this._inputVideoElement.cancelVideoFrameCallback(this._rvfcHandle)
 			this._rvfcHandle = undefined
+		}
+
+		if (this._lastMask) {
+			this._lastMask.close()
+			this._lastMask = null
 		}
 
 		if (this._maskFrameTimerWorker) {

--- a/src/utils/media/effects/virtual-background/VideoStreamBackgroundEffect.js
+++ b/src/utils/media/effects/virtual-background/VideoStreamBackgroundEffect.js
@@ -37,6 +37,9 @@ export default class VideoStreamBackgroundEffect {
 	// _renderMask: Function;
 	// _virtualImage: HTMLImageElement;
 	// _virtualVideo: HTMLVideoElement;
+	// _useRVFC: boolean;
+	// _rvfcHandle: number;
+	// _lastInferenceTimestamp: number;
 
 	/**
 	 * Create a new background effect processor.
@@ -81,6 +84,9 @@ export default class VideoStreamBackgroundEffect {
 		this._inputVideoElement = document.createElement('video')
 		this._bgChanged = false
 		this._prevBgMode = null
+		this._useRVFC = undefined
+		this._rvfcHandle = undefined
+		this._lastInferenceTimestamp = -1
 	}
 
 	/**
@@ -157,11 +163,15 @@ export default class VideoStreamBackgroundEffect {
 			return
 		}
 
+		// MediaPipe VIDEO mode requires strictly increasing timestamps.
+		const now = performance.now()
+		this._lastInferenceTimestamp = now > this._lastInferenceTimestamp ? now : this._lastInferenceTimestamp + 1
+
 		let segmentationResult
 		try {
 			segmentationResult = await this._imageSegmenter.segmentForVideo(
 				this._inputVideoElement,
-				performance.now(),
+				this._lastInferenceTimestamp,
 			)
 
 			if (segmentationResult.confidenceMasks && segmentationResult.confidenceMasks.length > 0) {
@@ -281,12 +291,56 @@ export default class VideoStreamBackgroundEffect {
 			this.runPostProcessing()
 		}
 
-		// Schedule next frame
+		// rVFC reschedules itself in _startFrameLoop(); only the fallback needs this.
+		if (!this._useRVFC) {
+			this._scheduleFallbackTick()
+		}
+	}
+
+	/**
+	 * Schedules the next _renderMask() tick via the fixed-interval Worker
+	 * timer (fallback for browsers without requestVideoFrameCallback).
+	 *
+	 * @private
+	 * @return {void}
+	 */
+	_scheduleFallbackTick() {
 		this._maskFrameTimerWorker.postMessage({
 			id: SET_TIMEOUT,
 			timeMs: 1000 / this._frameRate,
 			message: 'this._maskFrameTimerWorker',
 		})
+	}
+
+	/**
+	 * Starts the loop that triggers _renderMask() once per input video frame.
+	 *
+	 * Uses requestVideoFrameCallback where available (fires exactly on new
+	 * frames, keeps working in background tabs); falls back to the
+	 * Worker-based timer otherwise.
+	 *
+	 * @private
+	 * @return {void}
+	 */
+	_startFrameLoop() {
+		if ('requestVideoFrameCallback' in this._inputVideoElement) {
+			this._useRVFC = true
+
+			const onVideoFrame = () => {
+				this._renderMask()
+
+				if (this._running) {
+					this._rvfcHandle = this._inputVideoElement.requestVideoFrameCallback(onVideoFrame)
+				}
+			}
+
+			this._rvfcHandle = this._inputVideoElement.requestVideoFrameCallback(onVideoFrame)
+
+			return
+		}
+
+		this._useRVFC = false
+		this._scheduleFallbackTick()
 	}
 
 	/**
@@ -629,11 +683,7 @@ export default class VideoStreamBackgroundEffect {
 		this._inputVideoElement.autoplay = true
 		this._inputVideoElement.srcObject = this._stream
 		this._inputVideoElement.onloadeddata = () => {
-			this._maskFrameTimerWorker.postMessage({
-				id: SET_TIMEOUT,
-				timeMs: 1000 / this._frameRate,
-				message: 'this._maskFrameTimerWorker',
-			})
+			this._startFrameLoop()
 			this._inputVideoElement.onloadeddata = null
 		}
 
@@ -678,6 +728,13 @@ export default class VideoStreamBackgroundEffect {
 	 */
 	stopEffect() {
 		this._running = false
+
+		// The "_running" check in onVideoFrame only stops future callbacks;
+		// one may already be pending, so cancel it explicitly.
+		if (this._rvfcHandle !== undefined) {
+			this._inputVideoElement.cancelVideoFrameCallback(this._rvfcHandle)
+			this._rvfcHandle = undefined
+		}
 
 		if (this._maskFrameTimerWorker) {
 			this._maskFrameTimerWorker.postMessage({

--- a/src/utils/media/effects/virtual-background/WebGLCompositor.js
+++ b/src/utils/media/effects/virtual-background/WebGLCompositor.js
@@ -291,6 +291,14 @@ export default class WebGLCompositor {
 		this.bgScale = [1.0, 1.0]
 		this.lastOutW = 0
 		this.lastOutH = 0
+
+		// Tracks the size texMaskFiltered/texBlurred{1,2} are currently
+		// allocated at, so their storage is only reallocated on resize
+		// instead of on every render() call.
+		this._maskFilteredW = 0
+		this._maskFilteredH = 0
+		this._blurW = 0
+		this._blurH = 0
 	}
 
 	/**
@@ -527,11 +535,17 @@ export default class WebGLCompositor {
 		const texelWidth = 1 / blurWidth
 		const texelHeight = 1 / blurHeight
 
-		// Allocate blur textures
-		gl.bindTexture(gl.TEXTURE_2D, this.texBlurred1)
-		gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, blurWidth, blurHeight, 0, gl.RGBA, gl.UNSIGNED_BYTE, null)
-		gl.bindTexture(gl.TEXTURE_2D, this.texBlurred2)
-		gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, blurWidth, blurHeight, 0, gl.RGBA, gl.UNSIGNED_BYTE, null)
+		// Allocate blur textures, only reallocating storage when the blur
+		// size actually changes (see the matching comment on texMaskFiltered
+		// in render() for why this check matters).
+		if (this._blurW !== blurWidth || this._blurH !== blurHeight) {
+			gl.bindTexture(gl.TEXTURE_2D, this.texBlurred1)
+			gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, blurWidth, blurHeight, 0, gl.RGBA, gl.UNSIGNED_BYTE, null)
+			gl.bindTexture(gl.TEXTURE_2D, this.texBlurred2)
+			gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, blurWidth, blurHeight, 0, gl.RGBA, gl.UNSIGNED_BYTE, null)
+			this._blurW = blurWidth
+			this._blurH = blurHeight
+		}
 
 		// Setup FBOs
 		gl.bindFramebuffer(gl.FRAMEBUFFER, this.fboBlur1)
@@ -718,9 +732,16 @@ export default class WebGLCompositor {
 			return
 		}
 
-		// Allocate mask filtered texture
-		gl.bindTexture(gl.TEXTURE_2D, this.texMaskFiltered)
-		gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, outW, outH, 0, gl.RGBA, gl.UNSIGNED_BYTE, null)
+		// Allocate mask filtered texture, only reallocating storage when the
+		// output size actually changes (texImage2D(null) forces the GPU to
+		// allocate new backing storage every call, which is wasted work when
+		// called every frame at an unchanged size).
+		if (this._maskFilteredW !== outW || this._maskFilteredH !== outH) {
+			gl.bindTexture(gl.TEXTURE_2D, this.texMaskFiltered)
+			gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, outW, outH, 0, gl.RGBA, gl.UNSIGNED_BYTE, null)
+			this._maskFilteredW = outW
+			this._maskFilteredH = outH
+		}
 
 		// Upload and process mask
 		if (mask) {


### PR DESCRIPTION
## ☑️ Resolves

Goal is to reduce GPU load while maintaining similar blur/mask quality and responsiveness

fix(virtual-bg): use requestVideoFrameCallback when available
- render loop was scheduled via TimerWorker that fired with 1000/frameRate interval
- this allowed delay for up to 1-2 frames
- requestVideoFrameCallback fires exactly when a new video frame is available
- cancel on stopping the effect
- add _lastInferenceTimestamp guard for MediaPipe's VIDEO mode (strictly requires incrementing values)
- should reduce delay, but negligible

fix(virtual-bg): keep _lastMask open while being reused
- when inference hasn't finished yet, previous _lastMask is reused for frame output
- _lastMask references should be kept open until replaced ot not needed anymore
- most noticeable, if inference is throttled (manually or due to perf issues)

fix(virtual-bg): avoid GPU/canvas reallocation every frame
- texMaskFiltered, texBlurred1, texBlurred2 were reallocated on every single render() call
- reallocating GPU texture every frame is a confirmed overhead on some GPUs/drivers
- needs to be only reallocated when the actual size changes
- similar with output canvas element
- impact is negligible, so more a hardening

### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

Tested on Windows with Intel(R) UHD Graphincs

🏚️ Before | 🏡 After
-- | -- | 
A | B


### 🚧 Tasks

- [ ] Check for possible mask freezing in _runInference with active video frame and _postProcessing
- [ ] Uncaught (in promise) RuntimeError: divide by zero
- [ ] Other errors

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required