### PR TITLE
[stable32] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -311,12 +311,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "aa9d5a01d17cb9c19ca32532e08e999d693679fc"
+                "reference": "5d6430816fd4afb6b87251b06e7eabcefba47610"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/aa9d5a01d17cb9c19ca32532e08e999d693679fc",
-                "reference": "aa9d5a01d17cb9c19ca32532e08e999d693679fc",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/5d6430816fd4afb6b87251b06e7eabcefba47610",
+                "reference": "5d6430816fd4afb6b87251b06e7eabcefba47610",
                 "shasum": ""
             },
             "require": {
@@ -351,7 +351,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable32"
             },
-            "time": "2026-02-24T01:08:25+00:00"
+            "time": "2026-03-21T01:05:00+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency