### PR TITLE
feat: Add new `CallButton` component for comprehensive call managemet UI and introduce `MainView`.

### DIFF
--- a/src/components/TopBar/CallButton.vue
+++ b/src/components/TopBar/CallButton.vue
@@ -373,6 +373,17 @@ export default {
 		},
 	},
 
+	mounted() {
+		if (this.$route && this.$route.hash === '#direct-call' && !this.isMediaSettings) {
+			this.$router.replace({ hash: '' })
+			if (this.startCallButtonDisabled) {
+				emit('talk:media-settings:show')
+			} else {
+				this.handleClick()
+			}
+		}
+	},
+
 	methods: {
 		t,
 		isParticipantTypeModerator(participantType) {

--- a/src/views/MainView.vue
+++ b/src/views/MainView.vue
@@ -41,10 +41,7 @@ watch(isInLobby, (isInLobby) => {
 
 onMounted(() => {
 	watchEffect(() => {
-		if (route.hash === '#direct-call') {
-			emit('talk:media-settings:show', '')
-			router.replace({ hash: '' })
-		} else if (route.hash === '#settings') {
+		if (route.hash === '#settings') {
 			emit('show-conversation-settings', { token: props.token })
 			router.replace({ hash: '' })
 		}


### PR DESCRIPTION
## ☑️ Resolves

* Fix : #17471

# Direct Call Fix Changes

Here are the complete changes made to defer `#direct-call` joining dynamically to [CallButton.vue](file:///c:/Users/Abhiraj/Desktop/New%20folder/open%20source/spreed/src/components/TopBar/CallButton.vue) instead of unconditionally opening [MediaSettings](file:///c:/Users/Abhiraj/Desktop/New%20folder/open%20source/spreed/src/components/TopBar/CallButton.vue#251-254) in [MainView.vue](file:///c:/Users/Abhiraj/Desktop/New%20folder/open%20source/spreed/src/views/MainView.vue).

## 1. [src/views/MainView.vue](file:///c:/Users/Abhiraj/Desktop/New%20folder/open%20source/spreed/src/views/MainView.vue)

Removed the `#direct-call` check from [MainView.vue](file:///c:/Users/Abhiraj/Desktop/New%20folder/open%20source/spreed/src/views/MainView.vue)'s `watchEffect` block to avoid inadvertently rendering the media settings unconditionally.

```diff
--- a/src/views/MainView.vue
+++ b/src/views/MainView.vue
@@ -41,10 +41,7 @@
 
 onMounted(() => {
 	watchEffect(() => {
-		if (route.hash === '#direct-call') {
-			emit('talk:media-settings:show', '')
-			router.replace({ hash: '' })
-		} else if (route.hash === '#settings') {
+		if (route.hash === '#settings') {
 			emit('show-conversation-settings', { token: props.token })
 			router.replace({ hash: '' })
 		}
```

## 2. [src/components/TopBar/CallButton.vue](file:///c:/Users/Abhiraj/Desktop/New%20folder/open%20source/spreed/src/components/TopBar/CallButton.vue)

Added a [mounted()](file:///c:/Users/Abhiraj/Desktop/New%20folder/open%20source/spreed/src/components/CallView/CallView.vue#530-539) lifecycle hook that catches `#direct-call` dynamically and executes `this.handleClick()` directly (the UI component's function handling permissions, previews, device fetching, and backend). By executing this from a conditional component block, lobby users handle UI flow uniformly until `TopBar` is formally inserted safely inside [MainView.vue](file:///c:/Users/Abhiraj/Desktop/New%20folder/open%20source/spreed/src/views/MainView.vue)!

```diff
--- a/src/components/TopBar/CallButton.vue
+++ b/src/components/TopBar/CallButton.vue
@@ -370,6 +370,17 @@
 		},
 	},
 
+	mounted() {
+		if (this.$route && this.$route.hash === '#direct-call' && !this.isMediaSettings) {
+			this.$router.replace({ hash: '' })
+			if (this.startCallButtonDisabled) {
+				emit('talk:media-settings:show')
+			} else {
+				this.handleClick()
+			}
+		}
+	},
+
 	methods: {
 		t,
 		isParticipantTypeModerator(participantType) {
```
