### PR TITLE
fix(chat): copy message link with threadId

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
@@ -817,7 +817,11 @@ export default {
 		},
 
 		handleCopyMessageLink() {
-			copyConversationLinkToClipboard(this.message.token, this.message.id)
+			if (this.message.isThread && this.message.id !== this.message.threadId) {
+				copyConversationLinkToClipboard(this.message.token, this.message.id, this.message.threadId)
+			} else {
+				copyConversationLinkToClipboard(this.message.token, this.message.id)
+			}
 		},
 
 		async handleMarkAsUnread() {

--- a/src/utils/handleUrl.ts
+++ b/src/utils/handleUrl.ts
@@ -29,8 +29,13 @@ export function generateAbsoluteUrl(url: string, params?: object, options: UrlOp
  *
  * @param token - Conversation token
  * @param [messageId] - messageId for message in conversation link
+ * @param [threadId] - threadId for message in conversation link
  */
-export function generateFullConversationLink(token: string, messageId?: string): string {
+export function generateFullConversationLink(token: string, messageId?: string, threadId?: string): string {
+	if (threadId && messageId) {
+		return generateAbsoluteUrl('/call/{token}?threadId={threadId}#message_{messageId}', { token, messageId, threadId })
+	}
+
 	return messageId !== undefined
 		? generateAbsoluteUrl('/call/{token}#message_{messageId}', { token, messageId })
 		: generateAbsoluteUrl('/call/{token}', { token })
@@ -41,11 +46,16 @@ export function generateFullConversationLink(token: string, messageId?: string):
  *
  * @param token - conversation token
  * @param [messageId] - messageId for message in conversation link
+ * @param [threadId] - threadId for message in conversation link
  */
-export async function copyConversationLinkToClipboard(token: string, messageId?: string) {
+export async function copyConversationLinkToClipboard(token: string, messageId?: string, threadId?: string) {
 	try {
-		await navigator.clipboard.writeText(generateFullConversationLink(token, messageId))
-		showSuccess(t('spreed', 'Conversation link copied to clipboard'))
+		await navigator.clipboard.writeText(generateFullConversationLink(token, messageId, threadId))
+		if (messageId) {
+			showSuccess(t('spreed', 'Message link copied to clipboard'))
+		} else {
+			showSuccess(t('spreed', 'Conversation link copied to clipboard'))
+		}
 	} catch (error) {
 		showError(t('spreed', 'The link could not be copied'))
 	}


### PR DESCRIPTION

## ☑️ Resolves

- 'Copy message link' now works correctly with thread messages
- adjust toast message (lost in #9051)

### AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

<img width="235" height="91" alt="2026-03-24_10h39_04" src="https://github.com/user-attachments/assets/a9ab59b3-c2c6-467f-84b6-d9199ae8fdc9" />

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required