### PR TITLE
fix: join call immediately with `#direct-call` param

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -68,6 +68,9 @@ import { signalingKill } from './utils/webrtc/index.js'
 /** Internal handlers for 'joined-conversation' watcher (voice-, breakout- rooms) */
 let unwatchJoinedConversation = undefined
 let watchedJoinedConversationToken = undefined
+/**
+ * Release the listener for joined conversation
+ */
 function stopWatchingJoinedConversation() {
 	unwatchJoinedConversation?.()
 	unwatchJoinedConversation = undefined

--- a/src/components/LeftSidebar/CallPhoneDialog/CallPhoneDialog.vue
+++ b/src/components/LeftSidebar/CallPhoneDialog/CallPhoneDialog.vue
@@ -179,6 +179,7 @@ export default {
 					flags,
 					silent: false,
 					recordingConsent: true,
+					options: { videoOn: false },
 				})
 
 				// request above could be cancelled, if there is parallel request, and return null

--- a/src/components/RightSidebar/Participants/ParticipantItem.vue
+++ b/src/components/RightSidebar/Participants/ParticipantItem.vue
@@ -947,6 +947,7 @@ export default {
 						flags,
 						silent: false,
 						recordingConsent: true,
+						options: { videoOn: false },
 					})
 				}
 				await callSIPDialOut(this.token, this.participant.attendeeId)

--- a/src/components/SettingsDialog/SettingsDialog.vue
+++ b/src/components/SettingsDialog/SettingsDialog.vue
@@ -36,7 +36,7 @@
 					v-if="!isGuest"
 					:modelValue="hideMediaSettings"
 					:label="t('spreed', 'Skip device preview before joining a call')"
-					:description="t('spreed', 'Always shown if recording consent is required')"
+					:description="t('spreed', 'Camera will be turned off when joining. Always shown if recording consent is required.')"
 					@update:modelValue="setHideMediaSettings" />
 				<NcFormBoxButton
 					:label="t('spreed', 'Microphone settings')"

--- a/src/components/TopBar/CallButton.vue
+++ b/src/components/TopBar/CallButton.vue
@@ -115,6 +115,7 @@ import IconPhoneOffOutline from 'vue-material-design-icons/PhoneOffOutline.vue'
 import IconPhoneOutline from 'vue-material-design-icons/PhoneOutline.vue'
 import { useGetToken } from '../../composables/useGetToken.ts'
 import { useIsInCall } from '../../composables/useIsInCall.js'
+import { useJoinCall } from '../../composables/useJoinCall.ts'
 import { ATTENDEE, CALL, CONVERSATION, PARTICIPANT } from '../../constants.ts'
 import { callSIPDialOut } from '../../services/callsService.ts'
 import { getTalkConfig, hasTalkFeature } from '../../services/CapabilitiesManager.ts'
@@ -204,6 +205,7 @@ export default {
 	},
 
 	setup() {
+		const { joinCall } = useJoinCall()
 		return {
 			actorStore: useActorStore(),
 			tokenStore: useTokenStore(),
@@ -215,6 +217,7 @@ export default {
 			settingsStore: useSettingsStore(),
 			soundsStore: useSoundsStore(),
 			isMobile: useIsMobile(),
+			joinCall,
 		}
 	},
 
@@ -379,52 +382,15 @@ export default {
 
 	methods: {
 		t,
-		isParticipantTypeModerator(participantType) {
-			return [PARTICIPANT.TYPE.OWNER, PARTICIPANT.TYPE.MODERATOR, PARTICIPANT.TYPE.GUEST_MODERATOR].includes(participantType)
-		},
 
-		/**
-		 * Starts or joins a call
-		 */
-		async joinCall() {
-			let flags = PARTICIPANT.CALL_FLAG.IN_CALL
-			if (this.conversation.permissions & PARTICIPANT.PERMISSIONS.PUBLISH_AUDIO) {
-				flags |= PARTICIPANT.CALL_FLAG.WITH_AUDIO
-			}
-			if (this.conversation.permissions & PARTICIPANT.PERMISSIONS.PUBLISH_VIDEO && !this.isPhoneRoom) {
-				flags |= PARTICIPANT.CALL_FLAG.WITH_VIDEO
-			}
-
-			console.info('Joining call')
+		async handleJoinCall() {
 			this.loading = true
-			// Close navigation
-			emit('toggle-navigation', {
-				open: false,
-			})
-			await this.$store.dispatch('joinCall', {
-				token: this.token,
-				participantIdentifier: this.actorStore.participantIdentifier,
-				flags,
+			await this.joinCall(this.token, {
 				silent: this.hasCall ? true : this.silentCall,
 				recordingConsent: this.recordingConsentGiven,
+				shouldStartRecording: this.isRecordingFromStart,
 			})
 			this.loading = false
-
-			if (this.isRecordingFromStart) {
-				this.$store.dispatch('startCallRecording', {
-					token: this.token,
-					callRecording: CALL.RECORDING.VIDEO,
-				})
-			}
-
-			if (this.isPhoneRoom) {
-				const attendeeId = this.$store.getters.participantsList(this.token)
-					.find((participant) => participant.actorType === ATTENDEE.ACTOR_TYPE.PHONES)
-					?.attendeeId
-				if (attendeeId) {
-					this.dialOutPhoneNumber(attendeeId)
-				}
-			}
 		},
 
 		async leaveCall(endMeetingForAll = false) {
@@ -463,16 +429,14 @@ export default {
 			this.soundsStore.initAudioObjects()
 
 			if (this.isMediaSettings || this.isPhoneRoom) {
-				emit('talk:media-settings:hide')
-				this.joinCall()
+				this.handleJoinCall()
 				return
 			}
 
 			if (this.showRecordingWarning || this.showMediaSettings) {
 				emit('talk:media-settings:show')
 			} else {
-				emit('talk:media-settings:hide')
-				this.joinCall()
+				this.handleJoinCall()
 			}
 		},
 
@@ -480,21 +444,6 @@ export default {
 			EventBus.emit('switch-to-conversation', {
 				token: this.breakoutRoomsStore.getParentRoomToken(this.token),
 			})
-		},
-
-		async dialOutPhoneNumber(attendeeId) {
-			try {
-				await callSIPDialOut(this.token, attendeeId)
-			} catch (error) {
-				if (error?.response?.data?.ocs?.data?.message) {
-					showError(t('spreed', 'Phone number could not be called: {error}', {
-						error: error?.response?.data?.ocs?.data?.message,
-					}))
-				} else {
-					console.error(error)
-					showError(t('spreed', 'Phone number could not be called'))
-				}
-			}
 		},
 	},
 }

--- a/src/composables/useJoinCall.ts
+++ b/src/composables/useJoinCall.ts
@@ -13,6 +13,7 @@ import { ATTENDEE, CALL, CONVERSATION, PARTICIPANT } from '../constants.ts'
 import { callSIPDialOut } from '../services/callsService.ts'
 import { getTalkConfig } from '../services/CapabilitiesManager.ts'
 import { useActorStore } from '../stores/actor.ts'
+import { useSettingsStore } from '../stores/settings.ts'
 import { isAxiosErrorResponse } from '../types/guards.ts'
 
 /**
@@ -20,6 +21,7 @@ import { isAxiosErrorResponse } from '../types/guards.ts'
  */
 export function useJoinCall() {
 	const actorStore = useActorStore()
+	const settingsStore = useSettingsStore()
 	const vuexStore = useStore()
 
 	/**
@@ -67,11 +69,13 @@ export function useJoinCall() {
 	 * @param options.silent - whether to join the call silently (no notifications)
 	 * @param options.recordingConsent - whether to join the call with recording consent
 	 * @param options.shouldStartRecording - whether to start the recording together with the call (requires recording backend)
+	 * @param options.directCall - whether to join call with video off
 	 */
 	async function joinCall(token: string, {
 		silent = false,
 		recordingConsent = false,
 		shouldStartRecording = false,
+		directCall = false,
 	} = {}) {
 		const conversation = vuexStore.getters.conversation(token)
 		if (!actorStore.participantIdentifier.sessionId || conversation.attendeeId !== actorStore.participantIdentifier.attendeeId) {
@@ -95,6 +99,19 @@ export function useJoinCall() {
 		// Close navigation when joining the call
 		emit('toggle-navigation', { open: false })
 
+		const options: Partial<Record<'audioOn' | 'videoOn', boolean>> = {}
+		if (settingsStore.startWithoutMedia) {
+			// Option: 'Turn camera and microphone off by default'
+			options.audioOn = false
+			options.videoOn = false
+		} else if (!settingsStore.showMediaSettings) {
+			// Join calls with video off if device preview skipped
+			options.videoOn = false
+		} else if (directCall) {
+			// Join direct calls with video off
+			options.videoOn = false
+		}
+
 		console.debug('Joining call')
 		await vuexStore.dispatch('joinCall', {
 			token,
@@ -102,6 +119,7 @@ export function useJoinCall() {
 			flags,
 			silent,
 			recordingConsent,
+			options,
 		})
 
 		if (shouldStartRecording && getTalkConfig(token, 'call', 'recording')) {

--- a/src/composables/useJoinCall.ts
+++ b/src/composables/useJoinCall.ts
@@ -1,0 +1,124 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { Conversation, Participant } from '../types/index.ts'
+
+import { showError } from '@nextcloud/dialogs'
+import { emit } from '@nextcloud/event-bus'
+import { t } from '@nextcloud/l10n'
+import { useStore } from 'vuex'
+import { ATTENDEE, CALL, CONVERSATION, PARTICIPANT } from '../constants.ts'
+import { callSIPDialOut } from '../services/callsService.ts'
+import { getTalkConfig } from '../services/CapabilitiesManager.ts'
+import { useActorStore } from '../stores/actor.ts'
+import { isAxiosErrorResponse } from '../types/guards.ts'
+
+/**
+ * Handler function to join a call and manage side effects
+ */
+export function useJoinCall() {
+	const actorStore = useActorStore()
+	const vuexStore = useStore()
+
+	/**
+	 * Returns whether the conversation is a phone room (with a single SIP phone participant)
+	 *
+	 * @param conversation - conversation object
+	 * @param conversation.objectId - conversation objectId
+	 * @param conversation.objectType - conversation objectType
+	 */
+	function isConversationPhoneRoom({ objectId, objectType }: Conversation) {
+		return objectId === CONVERSATION.OBJECT_ID.PHONE_OUTGOING
+			&& [
+				CONVERSATION.OBJECT_TYPE.PHONE_LEGACY,
+				CONVERSATION.OBJECT_TYPE.PHONE_PERSISTENT,
+				CONVERSATION.OBJECT_TYPE.PHONE_TEMPORARY,
+			].includes(objectType)
+	}
+
+	/**
+	 * Tries to call the given SIP phone participant
+	 *
+	 * @param token - conversation token of where to join
+	 * @param attendeeId - id of the phone participant
+	 */
+	async function dialOutPhoneNumber(token: string, attendeeId: number) {
+		try {
+			await callSIPDialOut(token, attendeeId)
+		} catch (exception) {
+			if (isAxiosErrorResponse<{ message: string }>(exception) && exception.response?.data?.ocs?.data?.message) {
+				showError(t('spreed', 'Phone number could not be called: {error}', {
+					error: exception.response.data.ocs.data.message,
+				}))
+			} else {
+				console.error(exception)
+				showError(t('spreed', 'Phone number could not be called'))
+			}
+		}
+	}
+
+	/**
+	 * Starts or joins a call
+	 *
+	 * @param token - conversation token of where to join
+	 * @param options - joining options
+	 * @param options.silent - whether to join the call silently (no notifications)
+	 * @param options.recordingConsent - whether to join the call with recording consent
+	 * @param options.shouldStartRecording - whether to start the recording together with the call (requires recording backend)
+	 */
+	async function joinCall(token: string, {
+		silent = false,
+		recordingConsent = false,
+		shouldStartRecording = false,
+	} = {}) {
+		const conversation = vuexStore.getters.conversation(token)
+		const isPhoneRoom = isConversationPhoneRoom(conversation)
+
+		// Define flags to join with (just call / with audio / with video)
+		let flags = PARTICIPANT.CALL_FLAG.IN_CALL
+		if (conversation.permissions & PARTICIPANT.PERMISSIONS.PUBLISH_AUDIO) {
+			flags |= PARTICIPANT.CALL_FLAG.WITH_AUDIO
+		}
+		if (conversation.permissions & PARTICIPANT.PERMISSIONS.PUBLISH_VIDEO && !isPhoneRoom) {
+			flags |= PARTICIPANT.CALL_FLAG.WITH_VIDEO
+		}
+
+		// Close MediaSettings
+		emit('talk:media-settings:hide')
+		// Close navigation when joining the call
+		emit('toggle-navigation', { open: false })
+
+		console.debug('Joining call')
+		await vuexStore.dispatch('joinCall', {
+			token,
+			participantIdentifier: actorStore.participantIdentifier,
+			flags,
+			silent,
+			recordingConsent,
+		})
+
+		if (shouldStartRecording && getTalkConfig(token, 'call', 'recording')) {
+			// Do not wait for async operation
+			vuexStore.dispatch('startCallRecording', {
+				token,
+				callRecording: CALL.RECORDING.VIDEO,
+			})
+		}
+
+		if (isPhoneRoom) {
+			const attendeeId = vuexStore.getters.participantsList(token)
+				.find((participant: Participant) => participant.actorType === ATTENDEE.ACTOR_TYPE.PHONES)
+				?.attendeeId
+			if (attendeeId) {
+				// Do not wait for async operation
+				dialOutPhoneNumber(token, attendeeId)
+			}
+		}
+	}
+
+	return {
+		joinCall,
+	}
+}

--- a/src/composables/useJoinCall.ts
+++ b/src/composables/useJoinCall.ts
@@ -74,6 +74,11 @@ export function useJoinCall() {
 		shouldStartRecording = false,
 	} = {}) {
 		const conversation = vuexStore.getters.conversation(token)
+		if (!actorStore.participantIdentifier.sessionId || conversation.attendeeId !== actorStore.participantIdentifier.attendeeId) {
+			console.error('Trying to join call without having joined the conversation')
+			return
+		}
+
 		const isPhoneRoom = isConversationPhoneRoom(conversation)
 
 		// Define flags to join with (just call / with audio / with video)

--- a/src/services/callsService.ts
+++ b/src/services/callsService.ts
@@ -35,10 +35,11 @@ import {
  * sound for other participants or not
  * @param recordingConsent Whether the participant gave their consent to be recorded
  * @param silentFor List of participants that should not receive a notification about the call
+ * @param options Additional options (for media)
  * @return The actual flags based on the available media
  */
-async function joinCall(token: string, flags: number, silent: boolean, recordingConsent: boolean, silentFor: string[]): Promise<void> {
-	return signalingJoinCall(token, flags, silent, recordingConsent, silentFor)
+async function joinCall(token: string, flags: number, silent: boolean, recordingConsent: boolean, silentFor: string[], options = {}): Promise<void> {
+	return signalingJoinCall(token, flags, silent, recordingConsent, silentFor, options)
 }
 
 /**

--- a/src/store/participantsStore.js
+++ b/src/store/participantsStore.js
@@ -849,7 +849,7 @@ const actions = {
 		return false
 	},
 
-	async joinCall({ commit, getters, state }, { token, participantIdentifier, flags, silent, recordingConsent, silentFor }) {
+	async joinCall({ commit, getters, state }, { token, participantIdentifier, flags, silent, recordingConsent, silentFor, options }) {
 		// SUMMARY: join call process
 		// There are 2 main steps to join a call:
 		// 1. Join the call (signaling-join-call)
@@ -945,7 +945,7 @@ const actions = {
 		EventBus.on('signaling-users-changed', handleUsersChanged)
 
 		try {
-			const actualFlags = await joinCall(token, flags, silent, recordingConsent, silentFor)
+			const actualFlags = await joinCall(token, flags, silent, recordingConsent, silentFor, options)
 			const updatedData = {
 				inCall: actualFlags,
 			}

--- a/src/store/participantsStore.spec.js
+++ b/src/store/participantsStore.spec.js
@@ -601,7 +601,7 @@ describe('participantsStore', () => {
 		})
 
 		const assertInitialCallState = () => {
-			expect(joinCall).toHaveBeenCalledWith(TOKEN, flags, false, false, undefined)
+			expect(joinCall).toHaveBeenCalledWith(TOKEN, flags, false, false, undefined, undefined)
 			EventBus.emit('signaling-join-call', [TOKEN, actualFlags])
 			expect(store.getters.isInCall(TOKEN)).toBe(true)
 			expect(store.getters.isConnecting(TOKEN)).toBe(true)

--- a/src/types/vendor/@nextcloud/event-bus.d.ts
+++ b/src/types/vendor/@nextcloud/event-bus.d.ts
@@ -10,6 +10,14 @@ declare module '@nextcloud/event-bus' {
 		'user:info:changed': NextcloudUser
 		'notifications:action:execute': NotificationEvent
 		'notifications:notification:received': NotificationEvent
+		// LeftSidebar > NcAppNavigation
+		'toggle-navigation': { open: boolean }
+		// MediaSettings
+		'talk:media-settings:hide': void
+		'talk:media-settings:show': void | 'video-verification' | 'device-check' | 'backgrounds'
+		// ConversationSettingsDialog
+		'show-conversation-settings': { token: string }
+		'hide-conversation-settings': void
 	}
 }
 export {}

--- a/src/utils/webrtc/index.js
+++ b/src/utils/webrtc/index.js
@@ -233,10 +233,13 @@ async function signalingJoinConversation(token, sessionId) {
  * sound for other participants or not
  * @param {boolean} recordingConsent Whether the participant gave their consent to be recorded
  * @param {Array<string>} silentFor List of participants that should not receive a notification about the call
+ * @param {object} options Additional options (for media)
+ * @param {boolean} [options.audioOn] Whether to enable audio on join
+ * @param {boolean} [options.videoOn] Whether to enable audio on join
  * @return {Promise<void>} Resolved with the actual flags based on the
  *          available media
  */
-async function signalingJoinCall(token, flags, silent, recordingConsent, silentFor) {
+async function signalingJoinCall(token, flags, silent, recordingConsent, silentFor, options = {}) {
 	if (tokensInSignaling[token]) {
 		pendingJoinCallToken = token
 
@@ -263,8 +266,8 @@ async function signalingJoinCall(token, flags, silent, recordingConsent, silentF
 			// The previous state might be wiped after the media is started, so
 			// it should be saved now.
 			const noiseSuppressionWithModel = BrowserStorage.getItem('noiseSuppressionWithModel') === 'true'
-			const enableAudio = !BrowserStorage.getItem('audioDisabled_' + token)
-			const enableVideo = !BrowserStorage.getItem('videoDisabled_' + token)
+			const enableAudio = options?.audioOn ?? !BrowserStorage.getItem('audioDisabled_' + token)
+			const enableVideo = options?.videoOn ?? !BrowserStorage.getItem('videoDisabled_' + token)
 			const enableVirtualBackground = !!BrowserStorage.getItem('virtualBackgroundEnabled')
 			const virtualBackgroundType = BrowserStorage.getItem('virtualBackgroundType')
 			const virtualBackgroundBlurStrength = BrowserStorage.getItem('virtualBackgroundBlurStrength')

--- a/src/views/MainView.vue
+++ b/src/views/MainView.vue
@@ -4,7 +4,7 @@
 -->
 <script lang="ts" setup>
 import { emit } from '@nextcloud/event-bus'
-import { computed, onMounted, watch, watchEffect } from 'vue'
+import { computed, onMounted, onUnmounted, watch, watchEffect } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useStore } from 'vuex'
 import CallFailedDialog from '../components/CallView/CallFailedDialog.vue'
@@ -14,7 +14,12 @@ import LobbyScreen from '../components/LobbyScreen.vue'
 import PollViewer from '../components/PollViewer/PollViewer.vue'
 import TopBar from '../components/TopBar/TopBar.vue'
 import { useIsInCall } from '../composables/useIsInCall.js'
+import { useJoinCall } from '../composables/useJoinCall.ts'
+import { CALL, CONVERSATION } from '../constants.ts'
+import { EventBus } from '../services/EventBus.ts'
+import SessionStorage from '../services/SessionStorage.js'
 import { useActorStore } from '../stores/actor.ts'
+import { useSettingsStore } from '../stores/settings.ts'
 
 const props = defineProps<{
 	token: string
@@ -22,9 +27,11 @@ const props = defineProps<{
 
 const store = useStore()
 const isInCall = useIsInCall()
+const { joinCall } = useJoinCall()
 const router = useRouter()
 const route = useRoute()
 const actorStore = useActorStore()
+const settingsStore = useSettingsStore()
 
 const isInLobby = computed(() => store.getters.isInLobby)
 const connectionFailed = computed(() => store.getters.connectionFailed(props.token))
@@ -42,7 +49,7 @@ watch(isInLobby, (isInLobby) => {
 onMounted(() => {
 	watchEffect(() => {
 		if (route.hash === '#direct-call') {
-			emit('talk:media-settings:show', '')
+			handleDirectCall(route.params.token as string)
 			router.replace({ hash: '' })
 		} else if (route.hash === '#settings') {
 			emit('show-conversation-settings', { token: props.token })
@@ -50,6 +57,51 @@ onMounted(() => {
 		}
 	})
 })
+
+onUnmounted(() => {
+	EventBus.off('joined-conversation')
+})
+
+/**
+ * Check if the user should join the call directly or show MediaSettings
+ *
+ * @param routeToken token of conversation to join
+ */
+function handleDirectCall(routeToken: string) {
+	const conversation = store.getters.conversation(routeToken)
+	const showRecordingWarning = [
+		CALL.RECORDING.VIDEO_STARTING,
+		CALL.RECORDING.AUDIO_STARTING,
+		CALL.RECORDING.VIDEO,
+		CALL.RECORDING.AUDIO,
+	].includes(conversation.callRecording)
+	|| conversation.recordingConsent === CALL.RECORDING_CONSENT.ENABLED
+	const isConversationPhoneRoom = [
+		CONVERSATION.OBJECT_TYPE.PHONE_LEGACY,
+		CONVERSATION.OBJECT_TYPE.PHONE_PERSISTENT,
+		CONVERSATION.OBJECT_TYPE.PHONE_TEMPORARY,
+	].includes(conversation.objectType)
+	&& conversation.objectId === CONVERSATION.OBJECT_ID.PHONE_OUTGOING
+
+	// Verify conditions for showing MediaSettings (required or user opted out)
+	if (showRecordingWarning || settingsStore.showMediaSettings || isConversationPhoneRoom) {
+		emit('talk:media-settings:show')
+		return
+	}
+
+	// Verify that conversation is joined before trying to join the call
+	const currentJoinedToken = SessionStorage.getItem('joined_conversation')
+	if (currentJoinedToken === routeToken) {
+		joinCall(routeToken)
+	} else {
+		EventBus.once('joined-conversation', async ({ token }) => {
+			if (token === routeToken) {
+				// If the correct conversation joined, proceed
+				joinCall(routeToken)
+			}
+		})
+	}
+}
 </script>
 
 <template>

--- a/src/views/MainView.vue
+++ b/src/views/MainView.vue
@@ -3,6 +3,8 @@
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <script lang="ts" setup>
+import type { WatchStopHandle } from 'vue'
+
 import { emit } from '@nextcloud/event-bus'
 import { computed, onMounted, onUnmounted, watch, watchEffect } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
@@ -15,9 +17,8 @@ import PollViewer from '../components/PollViewer/PollViewer.vue'
 import TopBar from '../components/TopBar/TopBar.vue'
 import { useIsInCall } from '../composables/useIsInCall.js'
 import { useJoinCall } from '../composables/useJoinCall.ts'
+import { watchJoinedConversation } from '../composables/useJoinedConversation.ts'
 import { CALL, CONVERSATION } from '../constants.ts'
-import { EventBus } from '../services/EventBus.ts'
-import SessionStorage from '../services/SessionStorage.js'
 import { useActorStore } from '../stores/actor.ts'
 import { useSettingsStore } from '../stores/settings.ts'
 
@@ -33,6 +34,18 @@ const route = useRoute()
 const actorStore = useActorStore()
 const settingsStore = useSettingsStore()
 
+/** Internal handlers for 'joined-conversation' watcher (direct-call) */
+let unwatchJoinedConversation: WatchStopHandle | undefined
+let watchedJoinedConversationToken: string | undefined
+/**
+ * Release the listener for joined conversation
+ */
+function stopWatchingJoinedConversation() {
+	unwatchJoinedConversation?.()
+	unwatchJoinedConversation = undefined
+	watchedJoinedConversationToken = undefined
+}
+
 const isInLobby = computed(() => store.getters.isInLobby)
 const connectionFailed = computed(() => store.getters.connectionFailed(props.token))
 
@@ -43,6 +56,12 @@ watch(isInLobby, (isInLobby) => {
 			token: props.token,
 			participantIdentifier: actorStore.participantIdentifier,
 		})
+	}
+})
+
+watch(() => props.token, (newToken) => {
+	if (watchedJoinedConversationToken && watchedJoinedConversationToken !== newToken) {
+		stopWatchingJoinedConversation()
 	}
 })
 
@@ -59,7 +78,7 @@ onMounted(() => {
 })
 
 onUnmounted(() => {
-	EventBus.off('joined-conversation')
+	stopWatchingJoinedConversation()
 })
 
 /**
@@ -68,6 +87,8 @@ onUnmounted(() => {
  * @param routeToken token of conversation to join
  */
 function handleDirectCall(routeToken: string) {
+	stopWatchingJoinedConversation()
+
 	const conversation = store.getters.conversation(routeToken)
 	const showRecordingWarning = [
 		CALL.RECORDING.VIDEO_STARTING,
@@ -89,18 +110,11 @@ function handleDirectCall(routeToken: string) {
 		return
 	}
 
-	// Verify that conversation is joined before trying to join the call
-	const currentJoinedToken = SessionStorage.getItem('joined_conversation')
-	if (currentJoinedToken === routeToken) {
-		joinCall(routeToken, { directCall: true })
-	} else {
-		EventBus.once('joined-conversation', async ({ token }) => {
-			if (token === routeToken) {
-				// If the correct conversation joined, proceed
-				joinCall(routeToken, { directCall: true })
-			}
-		})
-	}
+	watchedJoinedConversationToken = routeToken
+	unwatchJoinedConversation = watchJoinedConversation(routeToken, () => {
+		stopWatchingJoinedConversation()
+		void joinCall(routeToken, { directCall: true })
+	}, { immediate: true })
 }
 </script>
 

--- a/src/views/MainView.vue
+++ b/src/views/MainView.vue
@@ -90,6 +90,11 @@ function handleDirectCall(routeToken: string) {
 	stopWatchingJoinedConversation()
 
 	const conversation = store.getters.conversation(routeToken)
+	if ([CONVERSATION.TYPE.CHANGELOG, CONVERSATION.TYPE.NOTE_TO_SELF].includes(conversation.type)) {
+		// Do not allow calls in these conversations
+		return
+	}
+
 	const showRecordingWarning = [
 		CALL.RECORDING.VIDEO_STARTING,
 		CALL.RECORDING.AUDIO_STARTING,

--- a/src/views/MainView.vue
+++ b/src/views/MainView.vue
@@ -92,12 +92,12 @@ function handleDirectCall(routeToken: string) {
 	// Verify that conversation is joined before trying to join the call
 	const currentJoinedToken = SessionStorage.getItem('joined_conversation')
 	if (currentJoinedToken === routeToken) {
-		joinCall(routeToken)
+		joinCall(routeToken, { directCall: true })
 	} else {
 		EventBus.once('joined-conversation', async ({ token }) => {
 			if (token === routeToken) {
 				// If the correct conversation joined, proceed
-				joinCall(routeToken)
+				joinCall(routeToken, { directCall: true })
 			}
 		})
 	}


### PR DESCRIPTION
## ☑️ Resolves

* Fix #17471
  * Extract logic from CallButton to composable
  * Reuse same logic in MainView
* Fix #17574
  * join direct calls rooms with video off
  * join when 'Skip device preview' with video off

### AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
Screenshot before | <img width="413" height="183" alt="image" src="https://github.com/user-attachments/assets/3ac8f3a3-604b-40dc-80e3-1e763458d6d3" />

<!-- ☀️ Light theme | 🌑 Dark Theme -->

### 🚧 Tasks

- [x] FIXME need to wait for join conversation

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [x] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required