### PR TITLE
fix(videoverification): Fix missing "can start call" permission in vi…

### DIFF
--- a/lib/Service/RoomFormatter.php
+++ b/lib/Service/RoomFormatter.php
@@ -382,7 +382,9 @@ class RoomFormatter {
 			return $roomData;
 		}
 
-		$roomData['canStartCall'] = $currentParticipant->canStartCall($this->serverConfig);
+		$roomData['canStartCall'] = $currentParticipant->canStartCall($this->serverConfig)
+			|| ($room->getType() === Room::TYPE_PUBLIC
+				&& $room->getObjectType() === Room::OBJECT_TYPE_VIDEO_VERIFICATION);
 
 		// FIXME This should not be done, but currently all the clients use it to get the avatar of the user …
 		if ($room->getType() === Room::TYPE_ONE_TO_ONE) {


### PR DESCRIPTION
…deo verification

### Steps

- Set "Limit starting a call" to "Users and moderators"
- Create a folder
- Share with link, set a password and enable video verification
- As guest try to open the link

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
