### PR TITLE
fix(caldav): handle non-vevents in CalDavEventListener

### DIFF
--- a/lib/Listener/CalDavEventListener.php
+++ b/lib/Listener/CalDavEventListener.php
@@ -70,7 +70,7 @@ class CalDavEventListener implements IEventListener {
 		}
 
 		if (!str_contains($calData, 'LOCATION:')) {
-			$this->logger->debug('No location for the even, skipping for calendar event integration');
+			$this->logger->debug('No location for the event, skipping for calendar event integration');
 			return;
 		}
 
@@ -82,6 +82,13 @@ class CalDavEventListener implements IEventListener {
 		}
 
 		$vevent = $vobject->VEVENT;
+
+		// Calendar objects can also be VTODO or VJOURNAL for instance
+		if ($vevent === null) {
+			$this->logger->debug('Calendar object is not an event, skipping for calendar event integration');
+			return;
+		}
+
 		// Check if the location is set and if the location string contains a call url
 		$location = $vevent->LOCATION?->getValue();
 		if ($location === null || !str_contains($location, '/call/')) {

--- a/tests/php/Listener/CalDavEventListenerTest.php
+++ b/tests/php/Listener/CalDavEventListenerTest.php
@@ -162,6 +162,37 @@ EOD;
 		$this->listener->handle($event);
 	}
 
+	public function testIsCalendarEventNoEventInVObject(): void {
+		$calData = <<<EOD
+BEGIN:VCALENDAR
+PRODID:-//IDN nextcloud.com//Something fancy//EN
+CALSCALE:GREGORIAN
+VERSION:2.0
+BEGIN:VTIMEZONE
+TZID:Europe/Paris
+X-LIC-LOCATION:Europe/Paris
+END:VTIMEZONE
+BEGIN:VTODO
+CREATED:20250310T171800Z
+DTSTAMP:20250310T171819Z
+LAST-MODIFIED:20250310T171819Z
+UID:4d336aa1-a29e-4015-b1dd-98e1dae802db
+DTSTART;TZID=Europe/Vienna:20250314T100000
+DUE;TZID=Europe/Vienna:20250314T110000
+STATUS:CONFIRMED
+SUMMARY:Test
+END:VTODO
+END:VCALENDAR
+EOD;
+		$event = new CalendarObjectCreatedEvent(1, ['principaluri' => $this->userUri], [], ['calendardata' => $calData]);
+
+		$this->logger->expects(self::once())
+			->method('debug')
+			->with('Calendar object is not an event, skipping for calendar event integration');
+
+		$this->listener->handle($event);
+	}
+
 	public function testIsCalendarEventNoData(): void {
 		$event = new CalendarObjectCreatedEvent(1, ['principaluri' => $this->userUri], [], []);
 


### PR DESCRIPTION
For instance if vobject contains vtodos or vjournals.

Fixes :
```
[PHP] Attempt to read property "LOCATION" on null at spreed/lib/Listener/CalDavEventListener.php#86
```

## 🛠️ API Checklist

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
