### PR TITLE
fix(conversations): Show full author name on title hover

### DIFF
--- a/src/composables/useConversationInfo.ts
+++ b/src/composables/useConversationInfo.ts
@@ -97,6 +97,14 @@ export function useConversationInfo({
 		return getDisplayNameWithFallback(lastMessage.value.actorDisplayName, lastMessage.value.actorType, true)
 	})
 
+	const fullLastChatMessageAuthor = computed(() => {
+		if (!exposeMessages || !hasLastMessage.value || lastMessage.value.systemMessage.length) {
+			return ''
+		}
+
+		return getDisplayNameWithFallback(lastMessage.value.actorDisplayName, lastMessage.value.actorType)
+	})
+
 	const conversationInformation = computed(() => {
 		// temporary item while joining, only for Conversation component
 		if (isSearchResult.value === false && !item.value.actorId) {
@@ -194,7 +202,7 @@ export function useConversationInfo({
 			icon: getMessageIcon(lastMessage.value),
 			message: simpleLastChatMessage.value,
 			title: t('spreed', '{actor}: {lastMessage}', {
-				actor: shortLastChatMessageAuthor.value,
+				actor: fullLastChatMessageAuthor.value,
 				lastMessage: simpleLastChatMessage.value,
 			}, { escape: false, sanitize: false }).slice(0, TITLE_MAX_LENGTH),
 		}


### PR DESCRIPTION
### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="422" height="140" alt="Bildschirmfoto vom 2026-03-31 15-16-20" src="https://github.com/user-attachments/assets/4e6b61a5-abb6-43f6-b562-1217137162c6" /> | <img width="422" height="140" alt="Bildschirmfoto vom 2026-03-31 15-16-43" src="https://github.com/user-attachments/assets/f13f9c40-b975-4d6c-9b85-92adc1a734b4" />

Coming from a company with 5 Marcels and have 2 on my team, knowing up front if my team or someone else posted a message causes different urgency on my side

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
