### PR TITLE
fix(call): ignore unsupported constraints in Safari browser

### DIFF
--- a/src/utils/webrtc/MediaDevicesManager.js
+++ b/src/utils/webrtc/MediaDevicesManager.js
@@ -12,6 +12,7 @@ import {
 	populateMediaDevicesPreferences,
 	promoteMediaDevice,
 } from '../../services/mediaDevicePreferences.ts'
+import { isSafari } from '../browserCheck.ts'
 import EmitterMixin from '../EmitterMixin.js'
 
 /**
@@ -489,9 +490,12 @@ MediaDevicesManager.prototype = {
 				if (this.attributes.audioInputId) {
 					constraints.audio.deviceId = { exact: this.attributes.audioInputId }
 				}
-				constraints.audio.noiseSuppression = BrowserStorage.getItem('noiseSuppression') !== 'false'
+				if (!isSafari) {
+					// Safari does not support noiseSuppression and autoGainControl constraints
+					constraints.audio.noiseSuppression = BrowserStorage.getItem('noiseSuppression') !== 'false'
+					constraints.audio.autoGainControl = BrowserStorage.getItem('autoGainControl') !== 'false'
+				}
 				constraints.audio.echoCancellation = BrowserStorage.getItem('echoCancellation') !== 'false'
-				constraints.audio.autoGainControl = BrowserStorage.getItem('autoGainControl') !== 'false'
 			}
 		}
 
@@ -537,13 +541,17 @@ MediaDevicesManager.prototype = {
 			if (constraints.audio && constraints.audio.deviceId && track.kind === 'audio') {
 				const compatibleConstraints = {
 					deviceId: constraints.audio.deviceId.exact || constraints.audio.deviceId.ideal || constraints.audio.deviceId,
-					noiseSuppression: constraints.audio.noiseSuppression ?? this.attributes.noiseSuppression,
 					echoCancellation: constraints.audio.echoCancellation ?? this.attributes.echoCancellation,
-					autoGainControl: constraints.audio.autoGainControl ?? this.attributes.autoGainControl,
+				}
+				if (!isSafari) {
+					// Safari does not support noiseSuppression and autoGainControl constraints
+					compatibleConstraints.noiseSuppression = constraints.audio.noiseSuppression ?? this.attributes.noiseSuppression
+					compatibleConstraints.autoGainControl = constraints.audio.autoGainControl ?? this.attributes.autoGainControl
 				}
 
 				const settings = track.getSettings()
 				if (settings && Object.keys(compatibleConstraints).some((key) => settings[key] !== compatibleConstraints[key])) {
+					console.debug('[MediaDevicesManager]: Stopping incompatible track: ', { track, compatibleConstraints, settings })
 					track.stop()
 				}
 			}


### PR DESCRIPTION
## ☑️ Resolves

* Fix #17554 
  * MDN states that Safari doesn't support these flags, and getUserMedia silently skips them. Although `_stopIncompatibleTracks` still tries to verify them, which results in blocking audio at the start of the call
  * Not hiding in UI > Advanced settings for now

## 🖌️ UI Checklist

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [x] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required