### PR TITLE
fix(noise-suppresion): allow auto-gain, rework UI

### DIFF
--- a/src/components/MediaSettings/AdvancedAudioDialog.vue
+++ b/src/components/MediaSettings/AdvancedAudioDialog.vue
@@ -69,7 +69,7 @@ function onClosing(result?: unknown) {
 		updateAudioStream(true)
 
 		if (localMediaModel.getWebRtc()) {
-			if (settingsStore.noiseSuppressionWithModel) {
+			if (settingsStore.noiseSuppressionWithModel !== 'none') {
 				localMediaModel.enableNoiseSuppression()
 			} else {
 				localMediaModel.disableNoiseSuppression()

--- a/src/components/MediaSettings/AdvancedAudioDialog.vue
+++ b/src/components/MediaSettings/AdvancedAudioDialog.vue
@@ -110,10 +110,9 @@ function onClosing(result?: unknown) {
 				:description="echoCancellationDescription"
 				@update:modelValue="settingsStore.setEchoCancellation" />
 			<NcFormBoxSwitch
-				:modelValue="!(settingsStore.noiseSuppression && settingsStore.noiseSuppressionWithModel) && settingsStore.autoGainControl"
+				:modelValue="settingsStore.autoGainControl"
 				:label="autoGainControlLabel"
 				:description="autoGainControlDescription"
-				:disabled="settingsStore.noiseSuppression && settingsStore.noiseSuppressionWithModel"
 				@update:modelValue="settingsStore.setAutoGainControl" />
 		</NcFormBox>
 	</NcDialog>

--- a/src/components/MediaSettings/AdvancedAudioDialog.vue
+++ b/src/components/MediaSettings/AdvancedAudioDialog.vue
@@ -5,14 +5,17 @@
 
 <script setup lang="ts">
 import { t } from '@nextcloud/l10n'
+import { computed } from 'vue'
 import NcDialog from '@nextcloud/vue/components/NcDialog'
 import NcFormBox from '@nextcloud/vue/components/NcFormBox'
 import NcFormBoxSwitch from '@nextcloud/vue/components/NcFormBoxSwitch'
+import NcRadioGroup from '@nextcloud/vue/components/NcRadioGroup'
+import NcRadioGroupButton from '@nextcloud/vue/components/NcRadioGroupButton'
 import { useDevices } from '../../composables/useDevices.js'
 import { useSettingsStore } from '../../stores/settings.ts'
 import { localMediaModel } from '../../utils/webrtc/index.js'
 
-const props = defineProps<{
+const { container = undefined } = defineProps<{
 	container?: string
 }>()
 
@@ -20,13 +23,21 @@ const emit = defineEmits<{
 	close: [value?: unknown]
 }>()
 
+const NOISE_LEVEL = {
+	OFF: 'off',
+	BASIC: 'basic',
+	ADVANCED: 'advanced',
+} as const
+
 // TRANSLATORS Microphone setting to reduce background noises for better voice quality
 const noiseSuppressionLabel = t('spreed', 'Enable noise suppression')
 const noiseSuppressionDescription = t('spreed', 'Reduce background noises for better voice quality')
-
-// TRANSLATORS Microphone setting to reduce background noises for better voice quality
-const noiseSuppressionWithModelLabel = t('spreed', 'Enhanced noise suppression')
-const noiseSuppressionWithModelDescription = t('spreed', 'Use "{modelName}" real-time noise suppression algorithm', { modelName: 'RNNoise' })
+// TRANSLATORS Noise suppression disabled
+const noiseSuppressionLevelLabelOff = t('spreed', 'Off')
+// TRANSLATORS Basic noise suppression level
+const noiseSuppressionLevelLabelBasic = t('spreed', 'Basic')
+// TRANSLATORS Advanced noise suppression level
+const noiseSuppressionLevelLabelAdvanced = t('spreed', 'Advanced')
 
 // TRANSLATORS Microphone setting to minimize echo effect from own surrounding
 const echoCancellationLabel = t('spreed', 'Enable echo cancellation')
@@ -39,6 +50,39 @@ const autoGainControlDescription = t('spreed', 'Dynamically adjust microphone vo
 const settingsStore = useSettingsStore()
 
 const { audioPreviewAvailable, updateAudioStream } = useDevices()
+
+const noiseSuppressionLevel = computed(() => {
+	if (settingsStore.noiseSuppressionWithModel === 'none') {
+		return settingsStore.noiseSuppression ? NOISE_LEVEL.BASIC : NOISE_LEVEL.OFF
+	}
+	return NOISE_LEVEL.ADVANCED
+})
+
+/**
+ * Change noise suppression level in the store
+ *
+ * @param value desired noise suppression level
+ */
+function setNoiseSuppressionLevel(value: string) {
+	switch (value) {
+		case NOISE_LEVEL.ADVANCED: {
+			settingsStore.setNoiseSuppression(false)
+			settingsStore.setNoiseSuppressionWithModel('rnnoise')
+			break
+		}
+		case NOISE_LEVEL.BASIC: {
+			settingsStore.setNoiseSuppression(true)
+			settingsStore.setNoiseSuppressionWithModel('none')
+			break
+		}
+		case NOISE_LEVEL.OFF:
+		default: {
+			settingsStore.setNoiseSuppression(false)
+			settingsStore.setNoiseSuppressionWithModel('none')
+			break
+		}
+	}
+}
 
 const originalState = {
 	noiseSuppression: settingsStore.noiseSuppression,
@@ -84,7 +128,7 @@ function onClosing(result?: unknown) {
 <template>
 	<NcDialog
 		:name="t('spreed', 'Microphone settings')"
-		:container="container"
+		:container
 		size="normal"
 		:buttons="[
 			{ label: t('spreed', 'Cancel'), variant: 'tertiary', callback: () => undefined },
@@ -92,18 +136,18 @@ function onClosing(result?: unknown) {
 		]"
 		closeOnClickOutside
 		@closing="onClosing">
+		<NcRadioGroup
+			class="audio-dialog__radiogroup"
+			:label="noiseSuppressionLabel"
+			:description="noiseSuppressionDescription"
+			:modelValue="noiseSuppressionLevel"
+			@update:modelValue="setNoiseSuppressionLevel">
+			<NcRadioGroupButton :label="noiseSuppressionLevelLabelOff" :value="NOISE_LEVEL.OFF" />
+			<NcRadioGroupButton :label="noiseSuppressionLevelLabelBasic" :value="NOISE_LEVEL.BASIC" />
+			<NcRadioGroupButton :label="noiseSuppressionLevelLabelAdvanced" :value="NOISE_LEVEL.ADVANCED" />
+		</NcRadioGroup>
+
 		<NcFormBox>
-			<NcFormBoxSwitch
-				:modelValue="settingsStore.noiseSuppression"
-				:label="noiseSuppressionLabel"
-				:description="noiseSuppressionDescription"
-				@update:modelValue="settingsStore.setNoiseSuppression" />
-			<NcFormBoxSwitch
-				:modelValue="settingsStore.noiseSuppression && settingsStore.noiseSuppressionWithModel"
-				:label="noiseSuppressionWithModelLabel"
-				:description="noiseSuppressionWithModelDescription"
-				:disabled="!settingsStore.noiseSuppression"
-				@update:modelValue="settingsStore.setNoiseSuppressionWithModel" />
 			<NcFormBoxSwitch
 				:modelValue="settingsStore.echoCancellation"
 				:label="echoCancellationLabel"
@@ -117,3 +161,11 @@ function onClosing(result?: unknown) {
 		</NcFormBox>
 	</NcDialog>
 </template>
+
+<style scoped lang="scss">
+.audio-dialog {
+	&__radiogroup {
+		margin-block-end: calc(3 * var(--default-grid-baseline));
+	}
+}
+</style>

--- a/src/components/MediaSettings/AdvancedAudioDialog.vue
+++ b/src/components/MediaSettings/AdvancedAudioDialog.vue
@@ -13,6 +13,7 @@ import NcRadioGroup from '@nextcloud/vue/components/NcRadioGroup'
 import NcRadioGroupButton from '@nextcloud/vue/components/NcRadioGroupButton'
 import { useDevices } from '../../composables/useDevices.js'
 import { useSettingsStore } from '../../stores/settings.ts'
+import { isSafari } from '../../utils/browserCheck.ts'
 import { localMediaModel } from '../../utils/webrtc/index.js'
 
 const { container = undefined } = defineProps<{
@@ -34,7 +35,7 @@ const noiseSuppressionLabel = t('spreed', 'Enable noise suppression')
 const noiseSuppressionDescription = t('spreed', 'Reduce background noises for better voice quality')
 // TRANSLATORS Noise suppression disabled
 const noiseSuppressionLevelLabelOff = t('spreed', 'Off')
-// TRANSLATORS Basic noise suppression level
+// TRANSLATORS Basic noise suppression level (disabled for Safari, native browser suppression for rest)
 const noiseSuppressionLevelLabelBasic = t('spreed', 'Basic')
 // TRANSLATORS Advanced noise suppression level
 const noiseSuppressionLevelLabelAdvanced = t('spreed', 'Advanced')
@@ -142,8 +143,8 @@ function onClosing(result?: unknown) {
 			:description="noiseSuppressionDescription"
 			:modelValue="noiseSuppressionLevel"
 			@update:modelValue="setNoiseSuppressionLevel">
-			<NcRadioGroupButton :label="noiseSuppressionLevelLabelOff" :value="NOISE_LEVEL.OFF" />
-			<NcRadioGroupButton :label="noiseSuppressionLevelLabelBasic" :value="NOISE_LEVEL.BASIC" />
+			<NcRadioGroupButton :label="isSafari ? noiseSuppressionLevelLabelBasic : noiseSuppressionLevelLabelOff" :value="NOISE_LEVEL.OFF" />
+			<NcRadioGroupButton v-if="!isSafari" :label="noiseSuppressionLevelLabelBasic" :value="NOISE_LEVEL.BASIC" />
 			<NcRadioGroupButton :label="noiseSuppressionLevelLabelAdvanced" :value="NOISE_LEVEL.ADVANCED" />
 		</NcRadioGroup>
 
@@ -154,6 +155,7 @@ function onClosing(result?: unknown) {
 				:description="echoCancellationDescription"
 				@update:modelValue="settingsStore.setEchoCancellation" />
 			<NcFormBoxSwitch
+				v-if="!isSafari"
 				:modelValue="settingsStore.autoGainControl"
 				:label="autoGainControlLabel"
 				:description="autoGainControlDescription"

--- a/src/components/MediaSettings/AdvancedAudioDialog.vue
+++ b/src/components/MediaSettings/AdvancedAudioDialog.vue
@@ -13,6 +13,7 @@ import NcRadioGroup from '@nextcloud/vue/components/NcRadioGroup'
 import NcRadioGroupButton from '@nextcloud/vue/components/NcRadioGroupButton'
 import { useDevices } from '../../composables/useDevices.js'
 import { useSettingsStore } from '../../stores/settings.ts'
+import { isSafari } from '../../utils/browserCheck.ts'
 import { localMediaModel } from '../../utils/webrtc/index.js'
 
 const { container = undefined } = defineProps<{
@@ -143,7 +144,7 @@ function onClosing(result?: unknown) {
 			:modelValue="noiseSuppressionLevel"
 			@update:modelValue="setNoiseSuppressionLevel">
 			<NcRadioGroupButton :label="noiseSuppressionLevelLabelOff" :value="NOISE_LEVEL.OFF" />
-			<NcRadioGroupButton :label="noiseSuppressionLevelLabelBasic" :value="NOISE_LEVEL.BASIC" />
+			<NcRadioGroupButton v-if="!isSafari" :label="noiseSuppressionLevelLabelBasic" :value="NOISE_LEVEL.BASIC" />
 			<NcRadioGroupButton :label="noiseSuppressionLevelLabelAdvanced" :value="NOISE_LEVEL.ADVANCED" />
 		</NcRadioGroup>
 
@@ -154,6 +155,7 @@ function onClosing(result?: unknown) {
 				:description="echoCancellationDescription"
 				@update:modelValue="settingsStore.setEchoCancellation" />
 			<NcFormBoxSwitch
+				v-if="!isSafari"
 				:modelValue="settingsStore.autoGainControl"
 				:label="autoGainControlLabel"
 				:description="autoGainControlDescription"

--- a/src/components/NewMessage/NewMessageAudioRecorder.vue
+++ b/src/components/NewMessage/NewMessageAudioRecorder.vue
@@ -188,7 +188,7 @@ export default {
 					audio: {
 						noiseSuppression: this.settingsStore.noiseSuppression && !this.settingsStore.noiseSuppressionWithModel,
 						echoCancellation: this.settingsStore.echoCancellation,
-						autoGainControl: this.settingsStore.autoGainControl && !this.settingsStore.noiseSuppressionWithModel,
+						autoGainControl: this.settingsStore.autoGainControl,
 					},
 					video: false,
 				})

--- a/src/components/NewMessage/NewMessageAudioRecorder.vue
+++ b/src/components/NewMessage/NewMessageAudioRecorder.vue
@@ -186,7 +186,7 @@ export default {
 			try {
 				this.audioStream = await mediaDevicesManager.getUserMedia({
 					audio: {
-						noiseSuppression: this.settingsStore.noiseSuppression && !this.settingsStore.noiseSuppressionWithModel,
+						noiseSuppression: this.settingsStore.noiseSuppression && this.settingsStore.noiseSuppressionWithModel === 'none',
 						echoCancellation: this.settingsStore.echoCancellation,
 						autoGainControl: this.settingsStore.autoGainControl,
 					},
@@ -205,7 +205,7 @@ export default {
 
 			// Create a media recorder to capture the stream
 			try {
-				if (this.settingsStore.noiseSuppressionWithModel) {
+				if (this.settingsStore.noiseSuppressionWithModel !== 'none') {
 					this.noiseSuppressionConsumer = await registerNoiseSuppressionWorklet()
 				}
 				const audioStreamProcessed = processNoiseSuppression(this.audioStream, this.noiseSuppressionConsumer, this.settingsStore.noiseSuppressionWithModel)

--- a/src/init.js
+++ b/src/init.js
@@ -9,7 +9,7 @@
 import { showError } from '@nextcloud/dialogs'
 import { t } from '@nextcloud/l10n'
 import { reactive } from 'vue'
-import { CALL, PARTICIPANT, VIRTUAL_BACKGROUND } from './constants.ts'
+import { CALL, PARTICIPANT } from './constants.ts'
 import BrowserStorage from './services/BrowserStorage.js'
 import { EventBus } from './services/EventBus.ts'
 import { setTalkSessionUniqueTabIdHeader } from './services/talkSessionUniqueTabId.ts'
@@ -17,6 +17,7 @@ import store from './store/index.js'
 import { useIntegrationsStore } from './stores/integrations.js'
 import pinia from './stores/pinia.ts'
 import { useTokenStore } from './stores/token.ts'
+import { isSafari } from './utils/browserCheck.ts'
 
 import '@nextcloud/dialogs/style.css'
 
@@ -111,6 +112,11 @@ function cleanOutdatedBrowserStorageKeys() {
 			localStorage.removeItem(key)
 		}
 	})
+
+	if (isSafari) {
+		BrowserStorage.removeItem('noiseSuppression') // Not supported by Safari browsers
+		BrowserStorage.removeItem('autoGainControl') // Not supported by Safari browsers
+	}
 }
 
 setTalkSessionUniqueTabIdHeader()

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -45,7 +45,7 @@ export const useSettingsStore = defineStore('settings', () => {
 	const typingStatusPrivacy = ref<PRIVACY_KEYS>(getTalkConfig('local', 'chat', 'typing-privacy') as TALK_CONFIG_PRIVACY ?? PRIVACY.PRIVATE)
 	const showMediaSettings = ref<boolean>(BrowserStorage.getItem('showMediaSettings') !== 'false')
 	const noiseSuppression = ref<boolean>(BrowserStorage.getItem('noiseSuppression') !== 'false')
-	const noiseSuppressionWithModel = ref<boolean>(BrowserStorage.getItem('noiseSuppressionWithModel') === 'true')
+	const noiseSuppressionWithModel = ref<'none' | 'rnnoise' | (string & {})>(BrowserStorage.getItem('noiseSuppressionWithModel') ?? 'none')
 	const echoCancellation = ref<boolean>(BrowserStorage.getItem('echoCancellation') !== 'false')
 	const autoGainControl = ref<boolean>(BrowserStorage.getItem('autoGainControl') !== 'false')
 	const startWithoutMedia = ref<boolean | undefined>(getTalkConfig('local', 'call', 'start-without-media'))
@@ -108,8 +108,12 @@ export const useSettingsStore = defineStore('settings', () => {
 	 *
 	 * @param value - new selected state
 	 */
-	function setNoiseSuppressionWithModel(value: boolean) {
-		BrowserStorage.setItem('noiseSuppressionWithModel', value.toString())
+	function setNoiseSuppressionWithModel(value: 'none' | 'rnnoise' | (string & {})) {
+		if (value !== 'none') {
+			BrowserStorage.setItem('noiseSuppressionWithModel', value)
+		} else {
+			BrowserStorage.removeItem('noiseSuppressionWithModel')
+		}
 		noiseSuppressionWithModel.value = value
 	}
 

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -45,7 +45,7 @@ export const useSettingsStore = defineStore('settings', () => {
 	const typingStatusPrivacy = ref<PRIVACY_KEYS>(getTalkConfig('local', 'chat', 'typing-privacy') as TALK_CONFIG_PRIVACY ?? PRIVACY.PRIVATE)
 	const showMediaSettings = ref<boolean>(BrowserStorage.getItem('showMediaSettings') !== 'false')
 	const noiseSuppression = ref<boolean>(BrowserStorage.getItem('noiseSuppression') !== 'false')
-	const noiseSuppressionWithModel = ref<boolean>(BrowserStorage.getItem('noiseSuppressionWithModel') === 'true')
+	const noiseSuppressionWithModel = ref<'none' | 'rnnoise' | (string & {})>(BrowserStorage.getItem('noiseSuppressionWithModel') ?? 'none')
 	const echoCancellation = ref<boolean>(BrowserStorage.getItem('echoCancellation') !== 'false')
 	const autoGainControl = ref<boolean>(BrowserStorage.getItem('autoGainControl') !== 'false')
 	const startWithoutMedia = ref<boolean | undefined>(getTalkConfig('local', 'call', 'start-without-media'))
@@ -105,11 +105,16 @@ export const useSettingsStore = defineStore('settings', () => {
 
 	/**
 	 * Update the noise suppression (with model) settings for the user
+	 * BrowserStorage simply removes an entry instead of storing a string `'none'`, so it's `null` on read from local storage
 	 *
 	 * @param value - new selected state
 	 */
-	function setNoiseSuppressionWithModel(value: boolean) {
-		BrowserStorage.setItem('noiseSuppressionWithModel', value.toString())
+	function setNoiseSuppressionWithModel(value: 'none' | 'rnnoise' | (string & {})) {
+		if (value !== 'none') {
+			BrowserStorage.setItem('noiseSuppressionWithModel', value)
+		} else {
+			BrowserStorage.removeItem('noiseSuppressionWithModel')
+		}
 		noiseSuppressionWithModel.value = value
 	}
 

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -24,6 +24,7 @@ import {
 	setStartWithoutMedia,
 	setTypingStatusPrivacy,
 } from '../services/settingsService.ts'
+import { isSafari } from '../utils/browserCheck.ts'
 
 type PRIVACY_KEYS = typeof PRIVACY[keyof typeof PRIVACY]
 type TALK_CONFIG_PRIVACY = PRIVACY_KEYS | undefined
@@ -44,10 +45,10 @@ export const useSettingsStore = defineStore('settings', () => {
 	const readStatusPrivacy = ref<PRIVACY_KEYS>(getTalkConfig('local', 'chat', 'read-privacy') as TALK_CONFIG_PRIVACY ?? PRIVACY.PRIVATE)
 	const typingStatusPrivacy = ref<PRIVACY_KEYS>(getTalkConfig('local', 'chat', 'typing-privacy') as TALK_CONFIG_PRIVACY ?? PRIVACY.PRIVATE)
 	const showMediaSettings = ref<boolean>(BrowserStorage.getItem('showMediaSettings') !== 'false')
-	const noiseSuppression = ref<boolean>(BrowserStorage.getItem('noiseSuppression') !== 'false')
+	const noiseSuppression = ref<boolean>(BrowserStorage.getItem('noiseSuppression') !== 'false' && !isSafari)
 	const noiseSuppressionWithModel = ref<'none' | 'rnnoise' | (string & {})>(BrowserStorage.getItem('noiseSuppressionWithModel') ?? 'none')
 	const echoCancellation = ref<boolean>(BrowserStorage.getItem('echoCancellation') !== 'false')
-	const autoGainControl = ref<boolean>(BrowserStorage.getItem('autoGainControl') !== 'false')
+	const autoGainControl = ref<boolean>(BrowserStorage.getItem('autoGainControl') !== 'false' && !isSafari)
 	const startWithoutMedia = ref<boolean | undefined>(getTalkConfig('local', 'call', 'start-without-media'))
 	const blurVirtualBackgroundEnabled = ref<boolean | undefined>(getTalkConfig('local', 'call', 'blur-virtual-background'))
 	const conversationsListStyle = ref<LIST_STYLE_OPTIONS | undefined>(getTalkConfig('local', 'conversations', 'list-style'))

--- a/src/utils/media/pipeline/NoiseSuppressor.js
+++ b/src/utils/media/pipeline/NoiseSuppressor.js
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import BrowserStorage from '../../../services/BrowserStorage.js'
 import {
 	processNoiseSuppression,
 	registerNoiseSuppressionWorklet,
@@ -115,7 +116,8 @@ export default class NoiseSuppressor extends TrackSinkSource {
 		}
 
 		this._inputStream = new MediaStream([track])
-		this._outputStream = processNoiseSuppression(this._inputStream, this._noiseSuppressionConsumer, true)
+		const model = BrowserStorage.getItem('noiseSuppressionWithModel')
+		this._outputStream = processNoiseSuppression(this._inputStream, this._noiseSuppressionConsumer, model)
 		const processedTrack = this._outputStream.getAudioTracks()[0]
 		processedTrack.enabled = this._audioEnabled
 

--- a/src/utils/suppressNoise.ts
+++ b/src/utils/suppressNoise.ts
@@ -114,10 +114,10 @@ export async function destroyNoiseSuppressionWorklet() {
  *
  * @param stream - MediaStream to process
  * @param consumer - Unique consumer id returned by `registerNoiseSuppressionWorklet`
- * @param enabled - Whether noise suppression is enabled
+ * @param model - Noise suppression model name to be used (null for disabling)
  */
-export function processNoiseSuppression(stream: MediaStream, consumer: symbol | null, enabled = false): MediaStream {
-	if (!enabled) {
+export function processNoiseSuppression(stream: MediaStream, consumer: symbol | null, model: string | null = null): MediaStream {
+	if (!model || model === 'none') {
 		// No noise suppression requested; return the original stream
 		return stream
 	}
@@ -132,7 +132,13 @@ export function processNoiseSuppression(stream: MediaStream, consumer: symbol | 
 	}
 
 	cleanupNoiseSuppressionWorklet(consumer)
-	return processRnnoise(stream, consumer)
+
+	if (model === 'rnnoise') {
+		return processRnnoise(stream, consumer)
+	} else {
+		// TODO for another model implementation
+		return stream
+	}
 }
 
 /**

--- a/src/utils/suppressNoise.ts
+++ b/src/utils/suppressNoise.ts
@@ -114,10 +114,10 @@ export async function destroyNoiseSuppressionWorklet() {
  *
  * @param stream - MediaStream to process
  * @param consumer - Unique consumer id returned by `registerNoiseSuppressionWorklet`
- * @param enabled - Whether noise suppression is enabled
+ * @param model - Noise suppression model name to be used (null for disabling)
  */
-export function processNoiseSuppression(stream: MediaStream, consumer: symbol | null, enabled = false): MediaStream {
-	if (!enabled) {
+export function processNoiseSuppression(stream: MediaStream, consumer: symbol | null, model: 'rnnoise' | 'none' | null = null): MediaStream {
+	if (!model || model === 'none') {
 		// No noise suppression requested; return the original stream
 		return stream
 	}
@@ -132,7 +132,13 @@ export function processNoiseSuppression(stream: MediaStream, consumer: symbol | 
 	}
 
 	cleanupNoiseSuppressionWorklet(consumer)
-	return processRnnoise(stream, consumer)
+
+	if (model === 'rnnoise') {
+		return processRnnoise(stream, consumer)
+	} else {
+		// TODO for another model implementation
+		return stream
+	}
 }
 
 /**

--- a/src/utils/suppressNoise.ts
+++ b/src/utils/suppressNoise.ts
@@ -144,15 +144,10 @@ export function processNoiseSuppression(stream: MediaStream, consumer: symbol | 
 export function processRnnoise(stream: MediaStream, consumer: symbol): MediaStream {
 	try {
 		const mediaStreamAudioSource = audioContext!.createMediaStreamSource(stream)
-		const outputGainNode = audioContext!.createGain()
 		const mediaStreamAudioDestinationNode = audioContext!.createMediaStreamDestination()
 
-		// Gain node configuration (to increase the output of processed track)
-		outputGainNode.gain.value = 2
-
 		mediaStreamAudioSource.connect(rnnoiseWorklet!)
-		rnnoiseWorklet!.connect(outputGainNode)
-		outputGainNode.connect(mediaStreamAudioDestinationNode)
+		rnnoiseWorklet!.connect(mediaStreamAudioDestinationNode)
 
 		const processedAudioTrack = mediaStreamAudioDestinationNode.stream.getAudioTracks()[0]
 		if (!processedAudioTrack) {
@@ -168,8 +163,7 @@ export function processRnnoise(stream: MediaStream, consumer: symbol): MediaStre
 		workletCleanupCallbackMap.set(consumer, () => {
 			try {
 				mediaStreamAudioSource.disconnect(rnnoiseWorklet!)
-				rnnoiseWorklet!.disconnect(outputGainNode)
-				outputGainNode.disconnect(mediaStreamAudioDestinationNode)
+				rnnoiseWorklet!.disconnect(mediaStreamAudioDestinationNode)
 				mediaStreamAudioDestinationNode.disconnect()
 			} catch (error) {
 				console.error(error)

--- a/src/utils/webrtc/MediaDevicesManager.js
+++ b/src/utils/webrtc/MediaDevicesManager.js
@@ -499,9 +499,8 @@ MediaDevicesManager.prototype = {
 					constraints.audio.autoGainControl = BrowserStorage.getItem('autoGainControl') !== 'false'
 
 					if (BrowserStorage.getItem('noiseSuppressionWithModel') === 'true') {
-						// Disable browser native noise suppression and auto gain, as they're replaced with processing node
+						// Disable browser native noise suppression, as it's replaced with processing node
 						constraints.audio.noiseSuppression = false
-						constraints.audio.autoGainControl = false
 					}
 				}
 				constraints.audio.echoCancellation = BrowserStorage.getItem('echoCancellation') !== 'false'

--- a/src/utils/webrtc/MediaDevicesManager.js
+++ b/src/utils/webrtc/MediaDevicesManager.js
@@ -81,7 +81,7 @@ export default function MediaDevicesManager() {
 		videoInputId: undefined,
 
 		noiseSuppression: BrowserStorage.getItem('noiseSuppression') !== 'false',
-		noiseSuppressionWithModel: BrowserStorage.getItem('noiseSuppressionWithModel') === 'true',
+		noiseSuppressionWithModel: BrowserStorage.getItem('noiseSuppressionWithModel'),
 		echoCancellation: BrowserStorage.getItem('echoCancellation') !== 'false',
 		autoGainControl: BrowserStorage.getItem('autoGainControl') !== 'false',
 	})
@@ -498,7 +498,7 @@ MediaDevicesManager.prototype = {
 					constraints.audio.noiseSuppression = BrowserStorage.getItem('noiseSuppression') !== 'false'
 					constraints.audio.autoGainControl = BrowserStorage.getItem('autoGainControl') !== 'false'
 
-					if (BrowserStorage.getItem('noiseSuppressionWithModel') === 'true') {
+					if (BrowserStorage.getItem('noiseSuppressionWithModel')) {
 						// Disable browser native noise suppression, as it's replaced with processing node
 						constraints.audio.noiseSuppression = false
 					}

--- a/src/utils/webrtc/index.js
+++ b/src/utils/webrtc/index.js
@@ -265,7 +265,7 @@ async function signalingJoinCall(token, flags, silent, recordingConsent, silentF
 
 			// The previous state might be wiped after the media is started, so
 			// it should be saved now.
-			const noiseSuppressionWithModel = BrowserStorage.getItem('noiseSuppressionWithModel') === 'true'
+			const noiseSuppressionWithModel = !!BrowserStorage.getItem('noiseSuppressionWithModel')
 			const enableAudio = options?.audioOn ?? !BrowserStorage.getItem('audioDisabled_' + token)
 			const enableVideo = options?.videoOn ?? !BrowserStorage.getItem('videoDisabled_' + token)
 			const enableVirtualBackground = !!BrowserStorage.getItem('virtualBackgroundEnabled')

--- a/src/utils/webrtc/index.js
+++ b/src/utils/webrtc/index.js
@@ -262,7 +262,7 @@ async function signalingJoinCall(token, flags, silent, recordingConsent, silentF
 
 			// The previous state might be wiped after the media is started, so
 			// it should be saved now.
-			const noiseSuppressionWithModel = BrowserStorage.getItem('noiseSuppressionWithModel') === 'true'
+			const noiseSuppressionWithModel = BrowserStorage.getItem('noiseSuppressionWithModel')
 			const enableAudio = !BrowserStorage.getItem('audioDisabled_' + token)
 			const enableVideo = !BrowserStorage.getItem('videoDisabled_' + token)
 			const enableVirtualBackground = !!BrowserStorage.getItem('virtualBackgroundEnabled')


### PR DESCRIPTION
## ☑️ Resolves

* Follow-up to #17335
* Extend logic for possible support of another model
* Replace UI toggle with radio group for better readability
* Rework controls for noise suppression / auto-gain in Safari
  *  'autoGainControl' - 'On' not supported and hidden
  * 'noiseSuppression' - 'Basic' not supported and hidden, 'Off' renamed to 'Basic'

### AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
Screenshot before | Screenshot after
<img width="457" height="284" alt="2026-04-09_17h24_10" src="https://github.com/user-attachments/assets/c42698f0-5dd6-493e-9e61-7ea3524a9b52" /> | <img width="413" height="234" alt="image" src="https://github.com/user-attachments/assets/e5f2c271-984e-474b-8685-4240de593b06" />
Safari | <img width="371" height="169" alt="image" src="https://github.com/user-attachments/assets/6c8bbc08-8b5e-4b6e-bcb4-7a28f516861b" />

<!-- ☀️ Light theme | 🌑 Dark Theme -->

### 🚧 Tasks

- [x] 'High' is not implemented and will be hidden until better times
- [x] Better wording for these labels?
- [x] Better Safari support (no 'Low', no auto gain constraint)

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari ⚠️
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required