### PR TITLE
fix: sync session storage with signaling connection

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -287,6 +287,7 @@ export default {
 		window.addEventListener('unload', () => {
 			console.info('Navigating away, leaving conversation')
 			if (this.token) {
+				SessionStorage.removeItem('joined_conversation')
 				// We have to do this synchronously, because in unload and beforeunload
 				// Promises, async and await are prohibited.
 				signalingKill()

--- a/src/FilesSidebarTabApp.vue
+++ b/src/FilesSidebarTabApp.vue
@@ -46,6 +46,7 @@ import { getFileConversation } from './services/filesIntegrationServices.ts'
 import {
 	leaveConversationSync,
 } from './services/participantsService.js'
+import SessionStorage from './services/SessionStorage.js'
 import { useActorStore } from './stores/actor.ts'
 import { useTokenStore } from './stores/token.ts'
 import { checkBrowser } from './utils/browserCheck.ts'
@@ -182,6 +183,7 @@ export default {
 		window.addEventListener('unload', () => {
 			console.info('Navigating away, leaving conversation')
 			if (this.token) {
+				SessionStorage.removeItem('joined_conversation')
 				// We have to do this synchronously, because in unload and beforeunload
 				// Promises, async and await are prohibited.
 				signalingKill()

--- a/src/PublicShareAuthSidebar.vue
+++ b/src/PublicShareAuthSidebar.vue
@@ -43,6 +43,7 @@ import {
 	leaveConversationSync,
 	setGuestUserName,
 } from './services/participantsService.js'
+import SessionStorage from './services/SessionStorage.js'
 import { useActorStore } from './stores/actor.ts'
 import { useTokenStore } from './stores/token.ts'
 import { signalingKill } from './utils/webrtc/index.js'
@@ -115,6 +116,7 @@ export default {
 		window.addEventListener('unload', () => {
 			console.info('Navigating away, leaving conversation')
 			if (this.token) {
+				SessionStorage.removeItem('joined_conversation')
 				// We have to do this synchronously, because in unload and beforeunload
 				// Promises, async and await are prohibited.
 				signalingKill()

--- a/src/PublicShareSidebar.vue
+++ b/src/PublicShareSidebar.vue
@@ -59,6 +59,7 @@ import { getPublicShareConversationData } from './services/filesIntegrationServi
 import {
 	leaveConversationSync,
 } from './services/participantsService.js'
+import SessionStorage from './services/SessionStorage.js'
 import { useActorStore } from './stores/actor.ts'
 import { useTokenStore } from './stores/token.ts'
 import { checkBrowser } from './utils/browserCheck.ts'
@@ -142,6 +143,7 @@ export default {
 	beforeMount() {
 		window.addEventListener('unload', () => {
 			if (this.token) {
+				SessionStorage.removeItem('joined_conversation')
 				// We have to do this synchronously, because in unload and beforeunload
 				// Promises, async and await are prohibited.
 				signalingKill()

--- a/src/RecordingApp.vue
+++ b/src/RecordingApp.vue
@@ -8,6 +8,7 @@ import { onBeforeMount } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import CallView from './components/CallView/CallView.vue'
 import { useGetToken } from './composables/useGetToken.ts'
+import SessionStorage from './services/SessionStorage.js'
 import { useSoundsStore } from './stores/sounds.js'
 import { useTokenStore } from './stores/token.ts'
 import { signalingKill } from './utils/webrtc/index.js'
@@ -31,6 +32,7 @@ onBeforeMount(async () => {
 	window.addEventListener('unload', () => {
 		console.info('Navigating away, leaving conversation')
 		if (token.value) {
+			SessionStorage.removeItem('joined_conversation')
 			// We have to do this synchronously, because in unload and
 			// beforeunload Promises, async and await are prohibited.
 			signalingKill()

--- a/src/store/participantsStore.js
+++ b/src/store/participantsStore.js
@@ -1101,6 +1101,10 @@ const actions = {
 	 * @param {string} data.token - conversation token.
 	 */
 	async leaveConversation(context, { token }) {
+		if (SessionStorage.getItem('joined_conversation') === token) {
+			// Drop token from SessionStorage to not consider a room joined anymore
+			SessionStorage.removeItem('joined_conversation')
+		}
 		const actorStore = useActorStore()
 		if (context.getters.isInCall(token)) {
 			await context.dispatch('leaveCall', {


### PR DESCRIPTION
## ☑️ Resolves

* Follow-up to #17332
* But should also be the case before, so need a backport
* Test scenario 1:
  * Join voice room
  * Leave to dashboard
  * Join the same room again
  * See error
* Test scenario 2:
  * Join voice room
  * Reload the page
  * See error

### AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI


## 🖌️ UI Checklist

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
