### PR TITLE
fix(chat): restore position of tribute popup

### DIFF
--- a/src/components/NewMessage/NewMessageUploadEditor.vue
+++ b/src/components/NewMessage/NewMessageUploadEditor.vue
@@ -184,6 +184,9 @@ export default {
 				} else {
 					this.$refs.submitButton.$el.focus()
 				}
+			} else {
+				// Reset internal state on modal unmounting to correctly attach tribute
+				this.modalContainerId = null
 			}
 		},
 	},


### PR DESCRIPTION
- internal state should be reset with unmounting the modal

## ☑️ Resolves

* Follow-up fix to #16980
  * after first mounting, container id is kept internally. But it's update is a trigger for NewMessage to remount input field with tributes, so should be done on each modal mounting

### AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="319" height="143" alt="image" src="https://github.com/user-attachments/assets/7c41f519-40a8-42db-8201-ae48085cba73" /> |  <img width="169" height="75" alt="image" src="https://github.com/user-attachments/assets/20b4d2d4-67d2-4987-910b-41ac56e9435d" />


### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required