### PR TITLE
build(deps): fix dependencies' types in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,6 @@
         "vue-draggable-resizable": "^3.0.0",
         "vue-material-design-icons": "^5.3.1",
         "vue-router": "^5.0.4",
-        "vue-tsc": "^3.2.6",
         "vuex": "^4.1.0",
         "wasm-check": "^2.1.2",
         "webdav": "^5.8.0",
@@ -86,7 +85,8 @@
         "sass-loader": "^16.0.7",
         "typescript": "^5.9.3",
         "vitest": "^4.0.9",
-        "vue-loader": "^17.4.2"
+        "vue-loader": "^17.4.2",
+        "vue-tsc": "^3.2.6"
       },
       "engines": {
         "node": "^24.0.0",
@@ -3813,6 +3813,7 @@
       "version": "2.4.28",
       "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.28.tgz",
       "integrity": "sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@volar/source-map": "2.4.28"
@@ -3822,12 +3823,14 @@
       "version": "2.4.28",
       "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.28.tgz",
       "integrity": "sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@volar/typescript": {
       "version": "2.4.28",
       "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.28.tgz",
       "integrity": "sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@volar/language-core": "2.4.28",
@@ -3976,6 +3979,7 @@
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.2.6.tgz",
       "integrity": "sha512-xYYYX3/aVup576tP/23sEUpgiEnujrENaoNRbaozC1/MA9I6EGFQRJb4xrt/MmUCAGlxTKL2RmT8JLTPqagCkg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@volar/language-core": "2.4.28",
@@ -3991,6 +3995,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -4529,6 +4534,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-3.1.2.tgz",
       "integrity": "sha512-d9dYqZTS90WLiU0I5c6DHj/HcKkF8ZyGN3G5x8wSbslulz70KOxaqCT0hQCo9KOyhVqzqGojvNdJXoTumZOtcw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/amator": {
@@ -12477,7 +12483,8 @@
     "node_modules/path-browserify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
-      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -15426,6 +15433,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16096,6 +16104,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
       "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/vue": {
@@ -16368,6 +16377,7 @@
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.2.6.tgz",
       "integrity": "sha512-gYW/kWI0XrwGzd0PKc7tVB/qpdeAkIZLNZb10/InizkQjHjnT8weZ/vBarZoj4kHKbUTZT/bAVgoOr8x4NsQ/Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@volar/typescript": "2.4.28",
@@ -19554,6 +19564,7 @@
       "version": "2.4.28",
       "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.28.tgz",
       "integrity": "sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==",
+      "dev": true,
       "requires": {
         "@volar/source-map": "2.4.28"
       }
@@ -19561,12 +19572,14 @@
     "@volar/source-map": {
       "version": "2.4.28",
       "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.28.tgz",
-      "integrity": "sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ=="
+      "integrity": "sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==",
+      "dev": true
     },
     "@volar/typescript": {
       "version": "2.4.28",
       "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.28.tgz",
       "integrity": "sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==",
+      "dev": true,
       "requires": {
         "@volar/language-core": "2.4.28",
         "path-browserify": "^1.0.1",
@@ -19677,6 +19690,7 @@
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.2.6.tgz",
       "integrity": "sha512-xYYYX3/aVup576tP/23sEUpgiEnujrENaoNRbaozC1/MA9I6EGFQRJb4xrt/MmUCAGlxTKL2RmT8JLTPqagCkg==",
+      "dev": true,
       "requires": {
         "@volar/language-core": "2.4.28",
         "@vue/compiler-dom": "^3.5.0",
@@ -19690,7 +19704,8 @@
         "picomatch": {
           "version": "4.0.4",
           "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-          "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="
+          "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+          "dev": true
         }
       }
     },
@@ -20095,7 +20110,8 @@
     "alien-signals": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-3.1.2.tgz",
-      "integrity": "sha512-d9dYqZTS90WLiU0I5c6DHj/HcKkF8ZyGN3G5x8wSbslulz70KOxaqCT0hQCo9KOyhVqzqGojvNdJXoTumZOtcw=="
+      "integrity": "sha512-d9dYqZTS90WLiU0I5c6DHj/HcKkF8ZyGN3G5x8wSbslulz70KOxaqCT0hQCo9KOyhVqzqGojvNdJXoTumZOtcw==",
+      "dev": true
     },
     "amator": {
       "version": "1.1.0",
@@ -25397,7 +25413,8 @@
     "path-browserify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
-      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true
     },
     "path-exists": {
       "version": "4.0.0",
@@ -27373,7 +27390,8 @@
     "typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "devOptional": true
     },
     "typescript-eslint": {
       "version": "8.58.1",
@@ -27729,7 +27747,8 @@
     "vscode-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
-      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ=="
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "dev": true
     },
     "vue": {
       "version": "3.5.28",
@@ -27905,6 +27924,7 @@
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.2.6.tgz",
       "integrity": "sha512-gYW/kWI0XrwGzd0PKc7tVB/qpdeAkIZLNZb10/InizkQjHjnT8weZ/vBarZoj4kHKbUTZT/bAVgoOr8x4NsQ/Q==",
+      "dev": true,
       "requires": {
         "@volar/typescript": "2.4.28",
         "@vue/language-core": "3.2.6"

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,7 @@
         "vue-router": "^5.0.4",
         "vue-tsc": "^3.2.6",
         "vuex": "^4.1.0",
+        "wasm-check": "^2.1.2",
         "webdav": "^5.8.0",
         "webrtc-adapter": "^9.0.4",
         "webrtcsupport": "^2.2.0",
@@ -85,8 +86,7 @@
         "sass-loader": "^16.0.7",
         "typescript": "^5.9.3",
         "vitest": "^4.0.9",
-        "vue-loader": "^17.4.2",
-        "wasm-check": "^2.1.2"
+        "vue-loader": "^17.4.2"
       },
       "engines": {
         "node": "^24.0.0",
@@ -16419,7 +16419,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/wasm-check/-/wasm-check-2.1.2.tgz",
       "integrity": "sha512-Eu162RfercUY9BZ4QN4PbOkuKkXwyuD+V5+iZ+VJ85W6ubDqZcNQMBAbBcqyrHs0Qb0D0IWVhPlfYFVhMoKhYw==",
-      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 8"
       }
@@ -27938,8 +27938,7 @@
     "wasm-check": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/wasm-check/-/wasm-check-2.1.2.tgz",
-      "integrity": "sha512-Eu162RfercUY9BZ4QN4PbOkuKkXwyuD+V5+iZ+VJ85W6ubDqZcNQMBAbBcqyrHs0Qb0D0IWVhPlfYFVhMoKhYw==",
-      "dev": true
+      "integrity": "sha512-Eu162RfercUY9BZ4QN4PbOkuKkXwyuD+V5+iZ+VJ85W6ubDqZcNQMBAbBcqyrHs0Qb0D0IWVhPlfYFVhMoKhYw=="
     },
     "watchpack": {
       "version": "2.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "@vueuse/router": "^14.2.1",
         "base64-js": "^1.5.1",
         "blurhash": "^2.0.5",
+        "cropperjs": "^1.6.2",
         "crypto-js": "^4.2.0",
         "debounce": "^3.0.0",
         "emoji-regex": "^10.6.0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "vue-draggable-resizable": "^3.0.0",
     "vue-material-design-icons": "^5.3.1",
     "vue-router": "^5.0.4",
-    "vue-tsc": "^3.2.6",
     "vuex": "^4.1.0",
     "wasm-check": "^2.1.2",
     "webdav": "^5.8.0",
@@ -106,7 +105,8 @@
     "sass-loader": "^16.0.7",
     "typescript": "^5.9.3",
     "vitest": "^4.0.9",
-    "vue-loader": "^17.4.2"
+    "vue-loader": "^17.4.2",
+    "vue-tsc": "^3.2.6"
   },
   "engines": {
     "node": "^24.0.0",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "vue-router": "^5.0.4",
     "vue-tsc": "^3.2.6",
     "vuex": "^4.1.0",
+    "wasm-check": "^2.1.2",
     "webdav": "^5.8.0",
     "webrtc-adapter": "^9.0.4",
     "webrtcsupport": "^2.2.0",
@@ -105,8 +106,7 @@
     "sass-loader": "^16.0.7",
     "typescript": "^5.9.3",
     "vitest": "^4.0.9",
-    "vue-loader": "^17.4.2",
-    "wasm-check": "^2.1.2"
+    "vue-loader": "^17.4.2"
   },
   "engines": {
     "node": "^24.0.0",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@vueuse/router": "^14.2.1",
     "base64-js": "^1.5.1",
     "blurhash": "^2.0.5",
+    "cropperjs": "^1.6.2",
     "crypto-js": "^4.2.0",
     "debounce": "^3.0.0",
     "emoji-regex": "^10.6.0",


### PR DESCRIPTION
## ☑️ Resolves

* List dependencies in the right place to support `npm ci --omit=dev`
  * `vue-tsc` is a development dependency like TS and must be in `devDependencies`, not `dependencies`
  * `wasm-check` is used in runtime and must be in `dependencies`, not `devDependencies`
  * `cropperjs` is extraneous — it is used directly, but was installed only as `vue-cropperjs` cransitive dependency

### AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [x] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required