### PR TITLE
fix(csp): replace non-existent addAllowedChildSrcDomain with addAllow…

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -262,8 +262,8 @@ class PageController extends Controller {
 		$csp->addAllowedMediaDomain('blob:');
 		$csp->addAllowedWorkerSrcDomain('blob:');
 		$csp->addAllowedWorkerSrcDomain("'self'");
-		$csp->addAllowedChildSrcDomain('blob:');
-		$csp->addAllowedChildSrcDomain("'self'");
+		$csp->addAllowedFrameDomain('blob:');
+		$csp->addAllowedFrameDomain("'self'");
 		$csp->addAllowedScriptDomain('blob:');
 		$csp->addAllowedScriptDomain("'self'");
 		$csp->addAllowedScriptDomain("'wasm-unsafe-eval'");
@@ -329,8 +329,8 @@ class PageController extends Controller {
 		$csp->addAllowedMediaDomain('blob:');
 		$csp->addAllowedWorkerSrcDomain('blob:');
 		$csp->addAllowedWorkerSrcDomain("'self'");
-		$csp->addAllowedChildSrcDomain('blob:');
-		$csp->addAllowedChildSrcDomain("'self'");
+		$csp->addAllowedFrameDomain('blob:');
+		$csp->addAllowedFrameDomain("'self'");
 		$csp->addAllowedScriptDomain('blob:');
 		$csp->addAllowedScriptDomain("'self'");
 		$csp->addAllowedScriptDomain("'wasm-unsafe-eval'");
@@ -417,8 +417,8 @@ class PageController extends Controller {
 		$csp->addAllowedMediaDomain('blob:');
 		$csp->addAllowedWorkerSrcDomain('blob:');
 		$csp->addAllowedWorkerSrcDomain("'self'");
-		$csp->addAllowedChildSrcDomain('blob:');
-		$csp->addAllowedChildSrcDomain("'self'");
+		$csp->addAllowedFrameDomain('blob:');
+		$csp->addAllowedFrameDomain("'self'");
 		$csp->addAllowedScriptDomain('blob:');
 		$csp->addAllowedScriptDomain("'self'");
 		$csp->addAllowedScriptDomain("'wasm-unsafe-eval'");
@@ -476,8 +476,8 @@ class PageController extends Controller {
 		$csp->addAllowedMediaDomain('blob:');
 		$csp->addAllowedWorkerSrcDomain('blob:');
 		$csp->addAllowedWorkerSrcDomain("'self'");
-		$csp->addAllowedChildSrcDomain('blob:');
-		$csp->addAllowedChildSrcDomain("'self'");
+		$csp->addAllowedFrameDomain('blob:');
+		$csp->addAllowedFrameDomain("'self'");
 		$csp->addAllowedScriptDomain('blob:');
 		$csp->addAllowedScriptDomain("'self'");
 		$csp->addAllowedScriptDomain("'wasm-unsafe-eval'");

--- a/lib/Listener/CSPListener.php
+++ b/lib/Listener/CSPListener.php
@@ -35,8 +35,8 @@ class CSPListener implements IEventListener {
 		$csp->addAllowedMediaDomain('blob:');
 		$csp->addAllowedWorkerSrcDomain('blob:');
 		$csp->addAllowedWorkerSrcDomain("'self'");
-		$csp->addAllowedChildSrcDomain('blob:');
-		$csp->addAllowedChildSrcDomain("'self'");
+		$csp->addAllowedFrameDomain('blob:');
+		$csp->addAllowedFrameDomain("'self'");
 		$csp->addAllowedScriptDomain('blob:');
 		$csp->addAllowedScriptDomain("'self'");
 		$csp->addAllowedScriptDomain("'wasm-unsafe-eval'");


### PR DESCRIPTION
…edFrameDomain

addAllowedChildSrcDomain was never part of the server's public CSP API. Replace with addAllowedFrameDomain, which together with the existing addAllowedWorkerSrcDomain covers the same scope as child-src.

<!--
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
░░░███████░░░█████████░░█████░
░░███░░░███░░░███░░░███░░███░░
░░█████████░░░████████░░░███░░
░░███░░░███░░░███░░░░░░░░███░░
░█████░█████░█████░░░░░░█████░
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching frontend/UI code
-->

## 🛠️ API Checklist

### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
