### PR TITLE
fix(call): define target param for 'switch-to-conversation'

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -204,7 +204,7 @@ export default {
 				}
 
 				if (newIsVoiceRoom && newToken) {
-					this.joinCallAutomatically()
+					this.joinCallAutomatically(newToken, oldToken)
 				}
 			},
 		},
@@ -298,7 +298,7 @@ export default {
 		})
 
 		EventBus.on('switch-to-conversation', async (params) => {
-			this.joinCallAutomatically()
+			await this.joinCallAutomatically(params.token)
 
 			this.skipLeaveWarning = true
 			this.$router.push({ name: 'conversation', params: { token: params.token } })
@@ -520,26 +520,26 @@ export default {
 			}
 		},
 
-		async joinCallAutomatically() {
+		async joinCallAutomatically(targetToken, prevToken = this.token) {
 			if (this.isInCall || this.isVoiceRoom) {
 				this.callViewStore.setForceCallView(true)
 
-				const enableAudio = !BrowserStorage.getItem('audioDisabled_' + this.token)
-				const enableVideo = !BrowserStorage.getItem('videoDisabled_' + this.token)
+				const enableAudio = !BrowserStorage.getItem('audioDisabled_' + prevToken)
+				const enableVideo = !BrowserStorage.getItem('videoDisabled_' + prevToken)
 				const enableVirtualBackground = !!BrowserStorage.getItem('virtualBackgroundEnabled')
 				const virtualBackgroundType = BrowserStorage.getItem('virtualBackgroundType')
 				const virtualBackgroundBlurStrength = BrowserStorage.getItem('virtualBackgroundBlurStrength')
 				const virtualBackgroundUrl = BrowserStorage.getItem('virtualBackgroundUrl')
 
 				// Fetch conversation object, if it's not known yet to the client
-				if (!this.$store.getters.conversation(this.token)) {
-					await this.fetchSingleConversation(this.token)
+				if (!this.$store.getters.conversation(targetToken)) {
+					await this.fetchSingleConversation(targetToken)
 				}
 
-				const conversation = this.$store.getters.conversation(this.token)
+				const previousConversation = this.$store.getters.conversation(prevToken)
 				const previousParticipants = []
-				if (conversation.type === CONVERSATION.TYPE.ONE_TO_ONE) {
-					previousParticipants.push(conversation.name)
+				if (previousConversation.type === CONVERSATION.TYPE.ONE_TO_ONE) {
+					previousParticipants.push(previousConversation.name)
 				}
 
 				// Remove previous listener to prevent stacking on rapid token changes
@@ -548,7 +548,7 @@ export default {
 				}
 
 				this._joinCallHandler = async ({ token }) => {
-					if (this.token !== token) {
+					if (targetToken !== token) {
 						return
 					}
 					if (enableAudio) {
@@ -593,7 +593,7 @@ export default {
 					}
 
 					const payload = {
-						token: this.token,
+						token,
 						participantIdentifier: this.actorStore.participantIdentifier,
 						flags,
 						silent: true,
@@ -613,8 +613,8 @@ export default {
 				}
 
 				const currentJoinedToken = SessionStorage.getItem('joined_conversation')
-				if (currentJoinedToken === this.token) {
-					this._joinCallHandler({ token: this.token })
+				if (currentJoinedToken === targetToken) {
+					this._joinCallHandler({ token: currentJoinedToken })
 				} else {
 					EventBus.once('joined-conversation', this._joinCallHandler)
 				}


### PR DESCRIPTION
## ☑️ Resolves

* Fix regression from #17332
  * When do breakout-room switch / extend-room switch, `this.token` still belongs to an old conversation
  * Solution: pass a param

> [!TIP]
> Branch [fix/noid/reverted-17675-17332-17335](https://github.com/nextcloud/spreed/tree/fix/noid/reverted-17675-17332-17335) has three reverted PRs to isolate and test separately
> I'm afraid they're all bringing issues 👀 

### AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="294" height="132" alt="image" src="https://github.com/user-attachments/assets/36d1c5c4-df63-4a17-ab9c-0d8b596495e9" /> <img width="291" height="114" alt="image" src="https://github.com/user-attachments/assets/f5965811-2b37-41a7-9134-f166766db4be" />  | All clean


### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required