### PR TITLE
Fix emoji picker not kept open after selecting an emoji

### DIFF
--- a/src/components/NewMessage/NewMessage.vue
+++ b/src/components/NewMessage/NewMessage.vue
@@ -55,7 +55,7 @@
 				<div class="new-message-form__emoji-picker">
 					<NcEmojiPicker
 						v-if="!disabled"
-						keepOpen
+						:closeOnSelect="false"
 						:setReturnFocus="getContenteditable"
 						@select="addEmoji">
 						<NcButton


### PR DESCRIPTION
This fixes a regression introduced in https://github.com/nextcloud/spreed/commit/c196f9ce1cad91f54606a3e052d1b050301ecc81#diff-55bf2669cf035804b60f900689ffd183b6c9ce9b15cd5e22dbed16ca3576c653

[`keepOpen`](https://github.com/nextcloud-libraries/nextcloud-vue/blob/6c5a91030350d6063a682b9522e3a4bdaba4acab/src/components/NcSelect/NcSelect.vue#L486-L495) property is used for `NcSelect`, but the equivalent property for `NcEmojiPicker` is (still) [`:closeOnSelect="false"`](https://github.com/nextcloud-libraries/nextcloud-vue/blob/d870e1292ee3cb05515476bcbe92582e5e4e15f9/src/components/NcEmojiPicker/NcEmojiPicker.vue#L309-L315); when the occurrences of `:close-on-select="false"` were replaced with `keep-open` due to [the property name change in `NcSelect`](https://github.com/nextcloud-libraries/nextcloud-vue/blob/2f95da531f9579f286192527e3dfc20d17a4e2b4/CHANGELOG.md?plain=1#L344-L346) it was also modified in `NcEmojiPicker` by mistake.

## How to test

- Create a conversation
- In the new message area, open the emoji picker
- Select an emoji

### Result with this pull request

The emoji picker is kept open and a new emoji can be selected; the picker is closed when clicking outside

### Result without this pull request

The emoji picker is immediately closed and it needs to be open again to select another emoji
