### PR TITLE
fix(useGetParticipants): ensure user is in the room before checking permissions

### DIFF
--- a/src/composables/useGetParticipants.ts
+++ b/src/composables/useGetParticipants.ts
@@ -84,6 +84,13 @@ function useGetParticipantsComposable(activeTab = ref('participants')) {
 	 * @param payload."0" - users list
 	 */
 	async function checkCurrentUserPermissions([users]: [StandaloneSignalingUpdateSession[]]) {
+		if (!token.value || !conversation.value) {
+			// No token / conversation to associate message with (user left the room)
+			// TODO: should instead compare if signaling message came for the right room (need event payload change):
+			// data.event.update.roomid === token.value
+			return
+		}
+
 		// TODO: move logic to sessionStore
 		const currentUser = users.find((user) => {
 			return user.userId ? user.userId === actorStore.userId : user.actorId === actorStore.actorId
@@ -92,7 +99,7 @@ function useGetParticipantsComposable(activeTab = ref('participants')) {
 			return
 		}
 		// refresh conversation, if current user permissions have been changed
-		if (currentUser.participantPermissions !== conversation.value?.permissions) {
+		if (currentUser.participantPermissions !== conversation.value.permissions) {
 			await store.dispatch('fetchConversation', { token: token.value })
 		}
 


### PR DESCRIPTION
## ☑️ Resolves

* Patches a race condition UI <> signaling:
  * User leaves the call and conversation -> UI token already updated to new value (or '')
  * HPB sends the message with `update.roomid = oldToken` and `update.users = [{ ...currentUser, callFlags: 0 }]`
  * checkCurrentUserPermissions() -> `conversation?... = undefined` -> tries to fetch conversation with wrong token / no token

To test:
 * Join and leave voice room

### AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI



## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
See console | ---

### 🚧 Tasks

- [ ] FIXME - convert to issue? all `_trigger()` events currently passing only limited payload without token (although it's known)

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required