### PR TITLE
Fix guest window separator bar color

### DIFF
--- a/src/components/GuestWelcomeWindow.vue
+++ b/src/components/GuestWelcomeWindow.vue
@@ -166,6 +166,6 @@ export default {
 
 .separator {
     margin: calc(var(--default-grid-baseline) * 3) 0 var(--default-grid-baseline);
-    border-top: 1px solid;
+    border-top: 1px solid var(--color-border-dark);
 }
 </style>


### PR DESCRIPTION
## ☑️ Resolves

Fixes the separator bar in the guest window being way too contrasting. Now it uses a standard border color variable instead of the text color.


<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="662" height="510" alt="Screenshot From 2026-04-15 17-17-13" src="https://github.com/user-attachments/assets/c33a0fd0-99d3-4953-8db8-32e40e82605e" />|<img width="662" height="510" alt="Screenshot From 2026-04-15 17-16-53" src="https://github.com/user-attachments/assets/633786ff-62ad-44fb-b21a-deb33a57899c" />
<img width="662" height="510" alt="Screenshot From 2026-04-15 17-17-08" src="https://github.com/user-attachments/assets/0b61412d-26e3-4304-8061-bf200972a86f" />|<img width="662" height="510" alt="Screenshot From 2026-04-15 17-17-00" src="https://github.com/user-attachments/assets/db87f916-4e09-4d9e-9abd-3313e3fe2c8e" />

<!-- ☀️ Light theme | 🌑 Dark Theme -->

### 🚧 Tasks

None

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [x] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
