### PR TITLE
fix(signaling): clear 'joined_conversation' after successful leave

### DIFF
--- a/src/services/participantsService.js
+++ b/src/services/participantsService.js
@@ -66,16 +66,11 @@ async function rejoinConversation(token) {
  * @param {string} token The conversation token;
  */
 async function leaveConversation(token) {
-	try {
-		// FIXME Signaling should not be synchronous
-		await signalingLeaveConversation(token)
+	// FIXME Signaling should not be synchronous
+	await signalingLeaveConversation(token)
 
-		const response = await axios.delete(generateOcsUrl('apps/spreed/api/v4/room/{token}/participants/active', { token }))
-		return response
-	} catch (error) {
-		console.debug(error)
-		// FIXME: should throw
-	}
+	const response = await axios.delete(generateOcsUrl('apps/spreed/api/v4/room/{token}/participants/active', { token }))
+	return response
 }
 
 /**

--- a/src/store/participantsStore.js
+++ b/src/store/participantsStore.js
@@ -1101,10 +1101,6 @@ const actions = {
 	 * @param {string} data.token - conversation token.
 	 */
 	async leaveConversation(context, { token }) {
-		if (SessionStorage.getItem('joined_conversation') === token) {
-			// Drop token from SessionStorage to not consider a room joined anymore
-			SessionStorage.removeItem('joined_conversation')
-		}
 		const actorStore = useActorStore()
 		if (context.getters.isInCall(token)) {
 			await context.dispatch('leaveCall', {
@@ -1113,7 +1109,15 @@ const actions = {
 			})
 		}
 
-		await leaveConversation(token)
+		try {
+			await leaveConversation(token)
+			if (SessionStorage.getItem('joined_conversation') === token) {
+				// Drop token from SessionStorage to not consider a room joined anymore
+				SessionStorage.removeItem('joined_conversation')
+			}
+		} catch (error) {
+			console.error('Error while leaving conversation:', error)
+		}
 	},
 
 	/**


### PR DESCRIPTION
## ☑️ Resolves

* Follow-up to #17675
  * Rushed a bit to merge it; although should be no regressions introduced
  * Session should be considered joined, until left on both server/HPB
  * Better handle error

### AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI

## 🖌️ UI Checklist

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [x] ⛑️ Tests are included or not possible