### PR TITLE
fix: extract useJoinedConversation from useIsInCall

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -51,6 +51,7 @@ import { useGetToken } from './composables/useGetToken.ts'
 import { useHashCheck } from './composables/useHashCheck.js'
 import { useInterceptNotifications } from './composables/useInterceptNotifications.ts'
 import { useIsInCall } from './composables/useIsInCall.js'
+import { watchJoinedConversation } from './composables/useJoinedConversation.ts'
 import { useSessionIssueHandler } from './composables/useSessionIssueHandler.ts'
 import { CONVERSATION, PARTICIPANT } from './constants.ts'
 import BrowserStorage from './services/BrowserStorage.js'
@@ -63,6 +64,15 @@ import { useSidebarStore } from './stores/sidebar.ts'
 import { useTokenStore } from './stores/token.ts'
 import { checkBrowser } from './utils/browserCheck.ts'
 import { signalingKill } from './utils/webrtc/index.js'
+
+/** Internal handlers for 'joined-conversation' watcher (voice-, breakout- rooms) */
+let unwatchJoinedConversation = undefined
+let watchedJoinedConversationToken = undefined
+function stopWatchingJoinedConversation() {
+	unwatchJoinedConversation?.()
+	unwatchJoinedConversation = undefined
+	watchedJoinedConversationToken = undefined
+}
 
 export default {
 	name: 'App',
@@ -183,6 +193,10 @@ export default {
 			if (!this.isBreakoutRoomsNavigation(oldValue, newValue)) {
 				this.recordingConsentGiven = false
 			}
+
+			if (watchedJoinedConversationToken && watchedJoinedConversationToken !== newValue) {
+				stopWatchingJoinedConversation()
+			}
 		},
 
 		voiceRoomIdentifier: {
@@ -262,6 +276,7 @@ export default {
 		}
 
 		window.removeEventListener('beforeunload', this.preventUnload)
+		stopWatchingJoinedConversation()
 
 		EventBus.off('joined-conversation')
 		EventBus.off('switch-to-conversation')
@@ -542,10 +557,7 @@ export default {
 					previousParticipants.push(previousConversation.name)
 				}
 
-				// Remove previous listener to prevent stacking on rapid token changes
-				if (this._joinCallHandler) {
-					EventBus.off('joined-conversation', this._joinCallHandler)
-				}
+				stopWatchingJoinedConversation()
 
 				this._joinCallHandler = async ({ token }) => {
 					if (targetToken !== token) {
@@ -612,12 +624,11 @@ export default {
 					this.callViewStore.setForceCallView(false)
 				}
 
-				const currentJoinedToken = SessionStorage.getItem('joined_conversation')
-				if (currentJoinedToken === targetToken) {
-					this._joinCallHandler({ token: currentJoinedToken })
-				} else {
-					EventBus.once('joined-conversation', this._joinCallHandler)
-				}
+				watchedJoinedConversationToken = targetToken
+				unwatchJoinedConversation = watchJoinedConversation(targetToken, () => {
+					stopWatchingJoinedConversation()
+					this._joinCallHandler({ token: targetToken })
+				}, { immediate: true })
 			}
 		},
 	},

--- a/src/composables/useIsInCall.js
+++ b/src/composables/useIsInCall.js
@@ -5,12 +5,11 @@
  */
 
 import { createSharedComposable } from '@vueuse/core'
-import { computed, onBeforeMount, onBeforeUnmount, ref } from 'vue'
+import { computed } from 'vue'
 import { useStore } from 'vuex'
-import { EventBus } from '../services/EventBus.ts'
-import SessionStorage from '../services/SessionStorage.js'
 import { useCallViewStore } from '../stores/callView.ts'
 import { useGetToken } from './useGetToken.ts'
+import { useJoinedConversation } from './useJoinedConversation.ts'
 
 /**
  * Check whether the user joined the call of the current token in this PHP session or not
@@ -21,27 +20,13 @@ function useIsInCallComposable() {
 	const store = useStore()
 	const callViewStore = useCallViewStore()
 	const token = useGetToken()
-
-	const sessionStorageJoinedConversation = ref(null)
-
-	const readSessionStorageJoinedConversation = () => {
-		sessionStorageJoinedConversation.value = SessionStorage.getItem('joined_conversation')
-	}
-
-	onBeforeMount(() => {
-		EventBus.on('joined-conversation', readSessionStorageJoinedConversation)
-		readSessionStorageJoinedConversation()
-	})
-
-	onBeforeUnmount(() => {
-		EventBus.off('joined-conversation', readSessionStorageJoinedConversation)
-	})
+	const joinedConversationToken = useJoinedConversation()
 
 	return computed(() => {
 		if (callViewStore.forceCallView) {
 			return true
 		}
-		return sessionStorageJoinedConversation.value === token.value && store.getters.isInCall(token.value)
+		return joinedConversationToken.value === token.value && store.getters.isInCall(token.value)
 	})
 }
 

--- a/src/composables/useJoinedConversation.ts
+++ b/src/composables/useJoinedConversation.ts
@@ -3,8 +3,10 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import type { MaybeRefOrGetter, WatchCallback, WatchOptions, WatchStopHandle } from 'vue'
+
 import { createSharedComposable } from '@vueuse/core'
-import { onBeforeMount, onBeforeUnmount, readonly, ref } from 'vue'
+import { onBeforeMount, onBeforeUnmount, readonly, ref, toValue, watch } from 'vue'
 import { EventBus } from '../services/EventBus.ts'
 import SessionStorage from '../services/SessionStorage.js'
 
@@ -34,3 +36,27 @@ function useJoinedConversationComposable() {
 }
 
 export const useJoinedConversation = createSharedComposable(useJoinedConversationComposable)
+
+/**
+ * Watch for the current joined conversation matching the provided token.
+ *
+ * @param token token to match against the joined conversation
+ * @param callback callback triggered when the joined conversation matches the token
+ * @param options watch options
+ */
+export function watchJoinedConversation(
+	token: MaybeRefOrGetter<string | null>,
+	callback: WatchCallback<string, string | null | undefined>,
+	options?: WatchOptions,
+): WatchStopHandle {
+	const currentJoinedConversation = useJoinedConversation()
+
+	return watch(currentJoinedConversation, (newToken, oldToken, onCleanup) => {
+		const targetToken = toValue(token)
+		if (!targetToken || newToken !== targetToken) {
+			return
+		}
+
+		callback(newToken, oldToken, onCleanup)
+	}, options)
+}

--- a/src/composables/useJoinedConversation.ts
+++ b/src/composables/useJoinedConversation.ts
@@ -1,0 +1,36 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { createSharedComposable } from '@vueuse/core'
+import { onBeforeMount, onBeforeUnmount, readonly, ref } from 'vue'
+import { EventBus } from '../services/EventBus.ts'
+import SessionStorage from '../services/SessionStorage.js'
+
+const joinedConversationToken = ref<string | null>(null)
+
+/**
+ * Update ref from SessionStorage
+ */
+function readJoinedConversation() {
+	joinedConversationToken.value = SessionStorage.getItem('joined_conversation')
+}
+
+/**
+ * Shared composable exposing the currently joined conversation token.
+ */
+function useJoinedConversationComposable() {
+	onBeforeMount(() => {
+		EventBus.on('joined-conversation', readJoinedConversation)
+		readJoinedConversation()
+	})
+
+	onBeforeUnmount(() => {
+		EventBus.off('joined-conversation', readJoinedConversation)
+	})
+
+	return readonly(joinedConversationToken)
+}
+
+export const useJoinedConversation = createSharedComposable(useJoinedConversationComposable)


### PR DESCRIPTION
## ☑️ Resolves

* Follow-up to #17332 
* Pre-requisite to #17498
  * Extract reused logic for reading SessionStorage
  * Correctly handle wrong events of 'joined-convresation', wait for requested token
    * Previous implementation doesn't handle when:
      * call should be joined in `token1`
      * ... (no tested case where it can be triggered, but should be possible with race condition) ...
      * currently joined in-storage is `token2`
      * first received event is `token3`, followed by event with `token1`
      * => call in `token1` is never joined


### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI


## 🖌️ UI Checklist

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required