### PR TITLE
fix(command): exclude only 1-1 conversations from executing

### DIFF
--- a/lib/Command/Room/Add.php
+++ b/lib/Command/Room/Add.php
@@ -60,8 +60,8 @@ class Add extends Base {
 			return 1;
 		}
 
-		if (!in_array($room->getType(), [Room::TYPE_GROUP, Room::TYPE_PUBLIC], true)) {
-			$output->writeln('<error>Room is no group call.</error>');
+		if (in_array($room->getType(), [Room::TYPE_ONE_TO_ONE, Room::TYPE_ONE_TO_ONE_FORMER], true)) {
+			$output->writeln('<error>Room is a private (1 to 1) conversation.</error>');
 			return 1;
 		}
 

--- a/lib/Command/Room/Delete.php
+++ b/lib/Command/Room/Delete.php
@@ -46,8 +46,8 @@ class Delete extends Base {
 			return 1;
 		}
 
-		if (!in_array($room->getType(), [Room::TYPE_GROUP, Room::TYPE_PUBLIC], true)) {
-			$output->writeln('<error>Room is no group call.</error>');
+		if (in_array($room->getType(), [Room::TYPE_ONE_TO_ONE], true)) {
+			$output->writeln('<error>Room is a private (1 to 1) conversation.</error>');
 			return 1;
 		}
 

--- a/lib/Command/Room/Demote.php
+++ b/lib/Command/Room/Demote.php
@@ -52,8 +52,8 @@ class Demote extends Base {
 			return 1;
 		}
 
-		if (!in_array($room->getType(), [Room::TYPE_GROUP, Room::TYPE_PUBLIC], true)) {
-			$output->writeln('<error>Room is no group call.</error>');
+		if (in_array($room->getType(), [Room::TYPE_ONE_TO_ONE, Room::TYPE_ONE_TO_ONE_FORMER], true)) {
+			$output->writeln('<error>Room is a private (1 to 1) conversation.</error>');
 			return 1;
 		}
 

--- a/lib/Command/Room/Promote.php
+++ b/lib/Command/Room/Promote.php
@@ -52,8 +52,8 @@ class Promote extends Base {
 			return 1;
 		}
 
-		if (!in_array($room->getType(), [Room::TYPE_GROUP, Room::TYPE_PUBLIC], true)) {
-			$output->writeln('<error>Room is no group call.</error>');
+		if (in_array($room->getType(), [Room::TYPE_ONE_TO_ONE, Room::TYPE_ONE_TO_ONE_FORMER], true)) {
+			$output->writeln('<error>Room is a private (1 to 1) conversation.</error>');
 			return 1;
 		}
 

--- a/lib/Command/Room/Remove.php
+++ b/lib/Command/Room/Remove.php
@@ -52,8 +52,8 @@ class Remove extends Base {
 			return 1;
 		}
 
-		if (!in_array($room->getType(), [Room::TYPE_GROUP, Room::TYPE_PUBLIC], true)) {
-			$output->writeln('<error>Room is no group call.</error>');
+		if (in_array($room->getType(), [Room::TYPE_ONE_TO_ONE, Room::TYPE_ONE_TO_ONE_FORMER], true)) {
+			$output->writeln('<error>Room is a private (1 to 1) conversation.</error>');
 			return 1;
 		}
 

--- a/lib/Command/Room/Update.php
+++ b/lib/Command/Room/Update.php
@@ -116,8 +116,8 @@ class Update extends Base {
 			return 1;
 		}
 
-		if (!in_array($room->getType(), [Room::TYPE_GROUP, Room::TYPE_PUBLIC], true)) {
-			$output->writeln('<error>Room is no group call.</error>');
+		if (in_array($room->getType(), [Room::TYPE_ONE_TO_ONE, Room::TYPE_ONE_TO_ONE_FORMER], true)) {
+			$output->writeln('<error>Room is a private (1 to 1) conversation.</error>');
 			return 1;
 		}
 


### PR DESCRIPTION
## ☑️ Resolves

* Fix command execution for newly added room types since 2020:
  * changelog
  * note to self
  * former 1-1 (blocked)

### AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI



## 🛠️ API Checklist

### 🚧 Tasks

- [ ] Should we block former 1-1 ?

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
