### PR TITLE
[stable33] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -334,12 +334,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "b92d626c25f78bf12a20d187c274e17a75fa598f"
+                "reference": "338330faa9ce0c50117257614ede27034d527a31"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/b92d626c25f78bf12a20d187c274e17a75fa598f",
-                "reference": "b92d626c25f78bf12a20d187c274e17a75fa598f",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/338330faa9ce0c50117257614ede27034d527a31",
+                "reference": "338330faa9ce0c50117257614ede27034d527a31",
                 "shasum": ""
             },
             "require": {
@@ -374,7 +374,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable33"
             },
-            "time": "2026-04-14T01:25:24+00:00"
+            "time": "2026-04-17T01:25:07+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency