### PR TITLE
fix: fix loading shares in folder when share is moved

### DIFF
--- a/lib/Share/RoomShareProvider.php
+++ b/lib/Share/RoomShareProvider.php
@@ -958,10 +958,12 @@ class RoomShareProvider implements IShareProvider, IPartialShareProvider, IShare
 				->selectAlias('sc.permissions', 'sc_permissions');
 
 			$qb->andWhere(
-				$qb->expr()->like('s.file_target', $qb->createNamedParameter($childPathTemplatePlaceholder, IQueryBuilder::PARAM_STR)),
 				$qb->expr()->orX(
+					$qb->expr()->andX(
+						$qb->expr()->like('s.file_target', $qb->createNamedParameter($childPathTemplatePlaceholder, IQueryBuilder::PARAM_STR)),
+						$qb->expr()->isNull('sc.file_target'),
+					),
 					$qb->expr()->like('sc.file_target', $qb->createNamedParameter($childPathTemplate, IQueryBuilder::PARAM_STR)),
-					$qb->expr()->isNull('sc.file_target'),
 				),
 			);
 

--- a/tests/integration/features/sharing-1/move.feature
+++ b/tests/integration/features/sharing-1/move.feature
@@ -269,3 +269,24 @@ Feature: sharing-1/move
     And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
     When user "participant3" moves file "/Talk/welcome.txt" to "/test/renamed.txt"
     Then the HTTP status code should be "403"
+
+  Scenario: move received share to a subfolder
+    Given user "participant1" creates room "group room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    And user "participant1" adds user "participant2" to room "group room" with 200 (v4)
+    And user "participant1" adds user "participant3" to room "group room" with 200 (v4)
+    And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
+    When user "participant3" gets the DAV properties for "/Talk"
+    Then the list of returned files for "participant3" is
+      | /Talk/ |
+      | /Talk/welcome.txt |
+    When user "participant3" creates folder "/Talk/test"
+    And user "participant3" moves file "/Talk/welcome.txt" to "/Talk/test/renamed.txt"
+    Then the HTTP status code should be "201"
+    # Trigger a full fs setup to ensure the mounts are refreshed
+    And user "participant3" gets the DAV properties for "/"
+    When user "participant3" gets the DAV properties for "/Talk/test"
+    Then the list of returned files for "participant3" is
+      | /Talk/test/ |
+      | /Talk/test/renamed.txt |


### PR DESCRIPTION
Trying to construct the target of the parent share doesn't work if the share is moved, but also isn't necessary if we already match the path of the moved share.

Server master doesn't currently trigger the bug in the integration tests because cache gc is triggering a full fs setup (https://github.com/nextcloud/server/pull/52000)