### PR TITLE
refactor(room): Move getPropertiesForSignaling() to RoomPropertiesHelper

### DIFF
--- a/lib/Controller/SignalingController.php
+++ b/lib/Controller/SignalingController.php
@@ -27,6 +27,7 @@ use OCA\Talk\Service\ParticipantService;
 use OCA\Talk\Service\RoomService;
 use OCA\Talk\Service\SessionService;
 use OCA\Talk\Signaling\Messages;
+use OCA\Talk\Signaling\RoomPropertiesHelper;
 use OCA\Talk\TalkSession;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\ApiRoute;
@@ -75,6 +76,7 @@ class SignalingController extends OCSController {
 		private BanService $banService,
 		private LoggerInterface $logger,
 		protected Authenticator $federationAuthenticator,
+		private RoomPropertiesHelper $roomPropertiesHelper,
 		private ?string $userId,
 	) {
 		parent::__construct($appName, $request);
@@ -931,7 +933,7 @@ class SignalingController extends OCSController {
 			'room' => [
 				'version' => '1.0',
 				'roomid' => $room->getToken(),
-				'properties' => $room->getPropertiesForSignaling((string)$userId),
+				'properties' => $this->roomPropertiesHelper->getPropertiesForSignaling($room, (string)$userId),
 				'permissions' => $permissions,
 			],
 		];

--- a/lib/Manager.php
+++ b/lib/Manager.php
@@ -160,7 +160,6 @@ class Manager {
 
 		return new Room(
 			$this,
-			$this->dispatcher,
 			$this->timeFactory,
 			(int)$row['r_id'],
 			(int)$row['type'],

--- a/lib/Room.php
+++ b/lib/Room.php
@@ -8,13 +8,11 @@ declare(strict_types=1);
 
 namespace OCA\Talk;
 
-use OCA\Talk\Events\BeforeSignalingRoomPropertiesSentEvent;
 use OCA\Talk\Service\ParticipantService;
 use OCA\Talk\Service\RecordingService;
 use OCA\Talk\Service\RoomService;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Comments\IComment;
-use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Server;
 
 class Room {
@@ -103,7 +101,6 @@ class Room {
 	 */
 	public function __construct(
 		private Manager $manager,
-		private IEventDispatcher $dispatcher,
 		private ITimeFactory $timeFactory,
 		private int $id,
 		private int $type,
@@ -411,37 +408,6 @@ class Room {
 		$this->currentUser = $userId;
 		$this->participant = $participant;
 	}
-
-	/**
-	 * Return the room properties to send to the signaling server.
-	 *
-	 * @param string $userId
-	 * @param bool $roomModified
-	 * @return array
-	 */
-	public function getPropertiesForSignaling(string $userId, bool $roomModified = true): array {
-		$properties = [
-			'name' => $this->getDisplayName($userId),
-			'type' => $this->getType(),
-			'lobby-state' => $this->getLobbyState(),
-			'lobby-timer' => $this->getLobbyTimer(),
-			'read-only' => $this->getReadOnly(),
-			'listable' => $this->getListable(),
-			'active-since' => $this->getActiveSince(),
-			'sip-enabled' => $this->getSIPEnabled(),
-		];
-
-		if ($roomModified) {
-			$properties['description'] = $this->getDescription();
-		} else {
-			$properties['participant-list'] = 'refresh';
-		}
-
-		$event = new BeforeSignalingRoomPropertiesSentEvent($this, $userId, $properties);
-		$this->dispatcher->dispatchTyped($event);
-		return $event->getProperties();
-	}
-
 
 	public function setActiveSince(\DateTime $since, int $callFlag): void {
 		if (!$this->activeSince) {

--- a/lib/Signaling/BackendNotifier.php
+++ b/lib/Signaling/BackendNotifier.php
@@ -35,6 +35,7 @@ class BackendNotifier {
 		private Manager $signalingManager,
 		private ParticipantService $participantService,
 		private IURLGenerator $urlGenerator,
+		private RoomPropertiesHelper $roomPropertiesHelper,
 	) {
 	}
 
@@ -160,7 +161,7 @@ class BackendNotifier {
 				// TODO(fancycode): We should try to get rid of 'alluserids' and
 				// find a better way to notify existing users to update the room.
 				'alluserids' => $this->participantService->getParticipantUserIdsAndFederatedUserCloudIds($room),
-				'properties' => $room->getPropertiesForSignaling('', false),
+				'properties' => $this->roomPropertiesHelper->getPropertiesForSignaling($room, '', false),
 			],
 		]);
 		$duration = microtime(true) - $start;
@@ -196,7 +197,7 @@ class BackendNotifier {
 				// TODO(fancycode): We should try to get rid of 'alluserids' and
 				// find a better way to notify existing users to update the room.
 				'alluserids' => $allUserIds,
-				'properties' => $room->getPropertiesForSignaling('', false),
+				'properties' => $this->roomPropertiesHelper->getPropertiesForSignaling($room, '', false),
 			],
 		]);
 		$duration = microtime(true) - $start;
@@ -226,7 +227,7 @@ class BackendNotifier {
 				// TODO(fancycode): We should try to get rid of 'alluserids' and
 				// find a better way to notify existing users to update the room.
 				'alluserids' => $allUserIds,
-				'properties' => $room->getPropertiesForSignaling('', false),
+				'properties' => $this->roomPropertiesHelper->getPropertiesForSignaling($room, '', false),
 			],
 		]);
 		$duration = microtime(true) - $start;
@@ -253,7 +254,7 @@ class BackendNotifier {
 				// the message from their federated Nextcloud server once the
 				// property change is propagated.
 				'userids' => $this->participantService->getParticipantUserIds($room),
-				'properties' => $room->getPropertiesForSignaling(''),
+				'properties' => $this->roomPropertiesHelper->getPropertiesForSignaling($room, ''),
 			],
 		]);
 		$duration = microtime(true) - $start;

--- a/lib/Signaling/RoomPropertiesHelper.php
+++ b/lib/Signaling/RoomPropertiesHelper.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Talk\Signaling;
+
+use OCA\Talk\Events\BeforeSignalingRoomPropertiesSentEvent;
+use OCA\Talk\Room;
+use OCP\EventDispatcher\IEventDispatcher;
+
+class RoomPropertiesHelper {
+
+	public function __construct(
+		private IEventDispatcher $dispatcher,
+	) {
+	}
+
+	public function getPropertiesForSignaling(Room $room, string $userId, bool $roomModified = true): array {
+		$properties = [
+			'name' => $room->getDisplayName($userId),
+			'type' => $room->getType(),
+			'lobby-state' => $room->getLobbyState(),
+			'lobby-timer' => $room->getLobbyTimer(),
+			'read-only' => $room->getReadOnly(),
+			'listable' => $room->getListable(),
+			'active-since' => $room->getActiveSince(),
+			'sip-enabled' => $room->getSIPEnabled(),
+		];
+
+		if ($roomModified) {
+			$properties['description'] = $room->getDescription();
+		} else {
+			$properties['participant-list'] = 'refresh';
+		}
+
+		$event = new BeforeSignalingRoomPropertiesSentEvent($room, $userId, $properties);
+		$this->dispatcher->dispatchTyped($event);
+		return $event->getProperties();
+	}
+}

--- a/tests/php/Controller/SignalingControllerTest.php
+++ b/tests/php/Controller/SignalingControllerTest.php
@@ -27,6 +27,7 @@ use OCA\Talk\Service\ParticipantService;
 use OCA\Talk\Service\RoomService;
 use OCA\Talk\Service\SessionService;
 use OCA\Talk\Signaling\Messages;
+use OCA\Talk\Signaling\RoomPropertiesHelper;
 use OCA\Talk\TalkSession;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Services\IAppConfig;
@@ -81,6 +82,7 @@ class SignalingControllerTest extends TestCase {
 	protected BanService&MockObject $banService;
 	protected LoggerInterface&MockObject $logger;
 	protected Authenticator&MockObject $authenticator;
+	protected RoomPropertiesHelper&MockObject $roomPropertiesHelper;
 	protected IDBConnection $dbConnection;
 	protected IConfig $serverConfig;
 	protected ?Config $config = null;
@@ -124,6 +126,7 @@ class SignalingControllerTest extends TestCase {
 		$this->banService = $this->createMock(BanService::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->authenticator = $this->createMock(Authenticator::class);
+		$this->roomPropertiesHelper = $this->createMock(RoomPropertiesHelper::class);
 		$this->recreateSignalingController();
 	}
 
@@ -148,6 +151,7 @@ class SignalingControllerTest extends TestCase {
 			$this->banService,
 			$this->logger,
 			$this->authenticator,
+			$this->roomPropertiesHelper,
 			$this->userId,
 		);
 	}
@@ -805,9 +809,9 @@ class SignalingControllerTest extends TestCase {
 		$room->expects($this->once())
 			->method('getToken')
 			->willReturn($roomToken);
-		$room->expects($this->once())
+		$this->roomPropertiesHelper->expects($this->once())
 			->method('getPropertiesForSignaling')
-			->with($this->userId)
+			->with($room, $this->userId)
 			->willReturn([
 				'name' => $roomName,
 				'type' => Room::TYPE_ONE_TO_ONE,
@@ -866,9 +870,9 @@ class SignalingControllerTest extends TestCase {
 		$room->expects($this->once())
 			->method('getToken')
 			->willReturn($roomToken);
-		$room->expects($this->once())
+		$this->roomPropertiesHelper->expects($this->once())
 			->method('getPropertiesForSignaling')
-			->with($this->userId)
+			->with($room, $this->userId)
 			->willReturn([
 				'name' => $roomName,
 				'type' => Room::TYPE_PUBLIC,
@@ -931,9 +935,9 @@ class SignalingControllerTest extends TestCase {
 		$room->expects($this->once())
 			->method('getToken')
 			->willReturn($roomToken);
-		$room->expects($this->once())
+		$this->roomPropertiesHelper->expects($this->once())
 			->method('getPropertiesForSignaling')
-			->with($this->userId)
+			->with($room, $this->userId)
 			->willReturn([
 				'name' => $roomName,
 				'type' => Room::TYPE_PUBLIC,
@@ -994,9 +998,9 @@ class SignalingControllerTest extends TestCase {
 		$room->expects($this->once())
 			->method('getToken')
 			->willReturn($roomToken);
-		$room->expects($this->once())
+		$this->roomPropertiesHelper->expects($this->once())
 			->method('getPropertiesForSignaling')
-			->with('')
+			->with($room, '')
 			->willReturn([
 				'name' => $roomName,
 				'type' => Room::TYPE_PUBLIC,
@@ -1056,9 +1060,9 @@ class SignalingControllerTest extends TestCase {
 		$room->expects($this->once())
 			->method('getToken')
 			->willReturn($roomToken);
-		$room->expects($this->once())
+		$this->roomPropertiesHelper->expects($this->once())
 			->method('getPropertiesForSignaling')
-			->with($this->userId)
+			->with($room, $this->userId)
 			->willReturn([
 				'name' => $roomName,
 				'type' => Room::TYPE_PUBLIC,
@@ -1131,9 +1135,9 @@ class SignalingControllerTest extends TestCase {
 		$room->expects($this->once())
 			->method('getToken')
 			->willReturn($roomToken);
-		$room->expects($this->once())
+		$this->roomPropertiesHelper->expects($this->once())
 			->method('getPropertiesForSignaling')
-			->with($this->userId)
+			->with($room, $this->userId)
 			->willReturn([
 				'name' => $roomName,
 				'type' => Room::TYPE_PUBLIC,
@@ -1226,9 +1230,9 @@ class SignalingControllerTest extends TestCase {
 		$room->expects($this->atLeastOnce())
 			->method('getToken')
 			->willReturn($roomToken);
-		$room->expects($this->once())
+		$this->roomPropertiesHelper->expects($this->once())
 			->method('getPropertiesForSignaling')
-			->with($this->userId)
+			->with($room, $this->userId)
 			->willReturn([
 				'name' => $roomName,
 				'type' => Room::TYPE_ONE_TO_ONE,

--- a/tests/php/Service/RoomServiceTest.php
+++ b/tests/php/Service/RoomServiceTest.php
@@ -349,7 +349,6 @@ class RoomServiceTest extends TestCase {
 
 		$room = new Room(
 			$this->createMock(Manager::class),
-			$dispatcher,
 			$this->createMock(ITimeFactory::class),
 			1,
 			Room::TYPE_PUBLIC,

--- a/tests/php/Signaling/RoomPropertiesHelperTest.php
+++ b/tests/php/Signaling/RoomPropertiesHelperTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Talk\Tests\php\Signaling;
+
+use OCA\Talk\Events\BeforeSignalingRoomPropertiesSentEvent;
+use OCA\Talk\Room;
+use OCA\Talk\Signaling\RoomPropertiesHelper;
+use OCA\Talk\Webinary;
+use OCP\EventDispatcher\IEventDispatcher;
+use PHPUnit\Framework\MockObject\MockObject;
+use Test\TestCase;
+
+class RoomPropertiesHelperTest extends TestCase {
+	private IEventDispatcher&MockObject $dispatcher;
+	private RoomPropertiesHelper $helper;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->dispatcher = $this->createMock(IEventDispatcher::class);
+		$this->helper = new RoomPropertiesHelper($this->dispatcher);
+	}
+
+	private function createRoomMock(string $displayName = 'Room name'): Room&MockObject {
+		$room = $this->createMock(Room::class);
+		$room->method('getDisplayName')->willReturnCallback(fn (string $userId) => $displayName);
+		$room->method('getType')->willReturn(Room::TYPE_GROUP);
+		$room->method('getLobbyState')->willReturn(Webinary::LOBBY_NONE);
+		$room->method('getLobbyTimer')->willReturn(null);
+		$room->method('getReadOnly')->willReturn(Room::READ_WRITE);
+		$room->method('getListable')->willReturn(Room::LISTABLE_NONE);
+		$room->method('getActiveSince')->willReturn(null);
+		$room->method('getSIPEnabled')->willReturn(Webinary::SIP_DISABLED);
+		$room->method('getDescription')->willReturn('A description');
+		return $room;
+	}
+
+	public function testGetPropertiesForSignalingRoomModifiedIncludesDescription(): void {
+		$room = $this->createRoomMock();
+
+		$this->dispatcher->expects($this->once())
+			->method('dispatchTyped')
+			->with($this->isInstanceOf(BeforeSignalingRoomPropertiesSentEvent::class));
+
+		$properties = $this->helper->getPropertiesForSignaling($room, 'alice');
+
+		$this->assertSame('Room name', $properties['name']);
+		$this->assertSame(Room::TYPE_GROUP, $properties['type']);
+		$this->assertSame('A description', $properties['description']);
+		$this->assertArrayNotHasKey('participant-list', $properties);
+	}
+
+	public function testGetPropertiesForSignalingNotRoomModifiedIncludesParticipantList(): void {
+		$room = $this->createRoomMock();
+
+		$this->dispatcher->expects($this->once())
+			->method('dispatchTyped')
+			->with($this->isInstanceOf(BeforeSignalingRoomPropertiesSentEvent::class));
+
+		$properties = $this->helper->getPropertiesForSignaling($room, '', false);
+
+		$this->assertSame('refresh', $properties['participant-list']);
+		$this->assertArrayNotHasKey('description', $properties);
+	}
+
+	public function testGetPropertiesForSignalingEventCanModifyProperties(): void {
+		$room = $this->createRoomMock();
+
+		$this->dispatcher->expects($this->once())
+			->method('dispatchTyped')
+			->with($this->isInstanceOf(BeforeSignalingRoomPropertiesSentEvent::class))
+			->willReturnCallback(function (BeforeSignalingRoomPropertiesSentEvent $event): void {
+				$event->setProperty('custom-key', 'custom-value');
+				$event->unsetProperty('name');
+			});
+
+		$properties = $this->helper->getPropertiesForSignaling($room, 'alice');
+
+		$this->assertSame('custom-value', $properties['custom-key']);
+		$this->assertArrayNotHasKey('name', $properties);
+	}
+
+	public function testGetPropertiesForSignalingPassesUserIdToEvent(): void {
+		$room = $this->createRoomMock();
+
+		$capturedEvent = null;
+		$this->dispatcher->expects($this->once())
+			->method('dispatchTyped')
+			->willReturnCallback(function (BeforeSignalingRoomPropertiesSentEvent $event) use (&$capturedEvent): void {
+				$capturedEvent = $event;
+			});
+
+		$this->helper->getPropertiesForSignaling($room, 'bob');
+
+		$this->assertInstanceOf(BeforeSignalingRoomPropertiesSentEvent::class, $capturedEvent);
+		$this->assertSame('bob', $capturedEvent->getUserId());
+	}
+}


### PR DESCRIPTION
Extract Room::getPropertiesForSignaling() into a new Signaling\RoomPropertiesHelper service. This removes the IEventDispatcher constructor dependency from Room, continuing the preparatory cleanup towards migrating Room to extend OCP\AppFramework\Db\Entity.

BackendNotifier and SignalingController now receive RoomPropertiesHelper via DI and delegate to it for building signaling properties.

AI-Assisted-By: Claude Sonnet 4.6 <noreply@anthropic.com>

### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

<!--
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
░░░███████░░░█████████░░█████░
░░███░░░███░░░███░░░███░░███░░
░░█████████░░░████████░░░███░░
░░███░░░███░░░███░░░░░░░░███░░
░█████░█████░█████░░░░░░█████░
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching frontend/UI code
-->

## 🛠️ API Checklist

### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
