### PR TITLE
fix(App): wait to leave previous call before joining new one

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -334,7 +334,8 @@ export default {
 			}
 
 			if (from.name === 'conversation' && from.params.token !== to.params.token) {
-				this.$store.dispatch('leaveConversation', { token: from.params.token })
+				// Await to properly close session / leave call before joining another one
+				await this.$store.dispatch('leaveConversation', { token: from.params.token })
 			}
 
 			/**


### PR DESCRIPTION
## ☑️ Resolves

- Fix possible race condition
- Fix #15336

### Example  for switching rooms:
  * `leaveConversation` might trigger `leaveCall` -> 'release webrtc media'
  * `joinConversation` might be followed by `joinCall` -> 'start webrtc media'
  * If processes are not executed in the right order, that might kill just started media and break joining the call

Drawbacks: longer visual switching.

### AI (if applicable)

- [x] Analysis of this PR was partly or fully done using AI

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
Screenshot before | Screenshot after

<!-- ☀️ Light theme | 🌑 Dark Theme -->

### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required