### PR TITLE
fix(call): hide remaining call-related UI when calls are disabled

### DIFF
--- a/src/components/ConversationSettings/ConversationPermissionsSettings.vue
+++ b/src/components/ConversationSettings/ConversationPermissionsSettings.vue
@@ -17,7 +17,7 @@
 		<div class="conversation-permissions-editor__setting">
 			<NcCheckboxRadioSwitch
 				v-model="radioValue"
-				:disabled="loading"
+				:disabled="loading || !isCallEnabled"
 				value="all"
 				name="permission_radio"
 				type="radio"
@@ -35,7 +35,7 @@
 			<NcCheckboxRadioSwitch
 				v-model="radioValue"
 				value="restricted"
-				:disabled="loading"
+				:disabled="loading || !isCallEnabled"
 				name="permission_radio"
 				type="radio"
 				@update:modelValue="handleSubmitPermissions">
@@ -76,6 +76,7 @@
 			:conversationName="conversationName"
 			:permissions="conversationPermissions"
 			:loading="loading"
+			:token="token"
 			nestedContainer=".conversation-permissions-editor"
 			@close="handleClosePermissionsEditor"
 			@submit="handleSubmitPermissions" />
@@ -148,6 +149,10 @@ export default {
 			return hasTalkFeature(this.token, 'react-permission')
 		},
 
+		isCallEnabled() {
+			return getTalkConfig(this.token, 'call', 'enabled')
+		},
+
 		maxDefaultPermission() {
 			const apiValue = getTalkConfig(this.token, 'permissions', 'max-default')
 			if (apiValue !== undefined) {
@@ -189,6 +194,10 @@ export default {
 		 * which case it's a number indicating the permissions value.
 		 */
 		async handleSubmitPermissions(value) {
+			if (!this.isCallEnabled && ['all', 'restricted'].includes(value)) {
+				return
+			}
+
 			let permissions
 
 			// Compute the permissions value

--- a/src/components/ConversationSettings/ConversationPermissionsSettings.vue
+++ b/src/components/ConversationSettings/ConversationPermissionsSettings.vue
@@ -17,7 +17,7 @@
 		<div class="conversation-permissions-editor__setting">
 			<NcCheckboxRadioSwitch
 				v-model="radioValue"
-				:disabled="loading || !isCallEnabled"
+				:disabled="loading"
 				value="all"
 				name="permission_radio"
 				type="radio"
@@ -27,7 +27,9 @@
 			<span v-show="loading && radioValue === 'all'" class="icon-loading-small" />
 		</div>
 		<p class="conversation-permissions-editor__hint">
-			{{ t('spreed', 'Participants have permissions to start a call, join a call, enable audio and video, and share screen.') }}
+			{{ isCallEnabled
+				? t('spreed', 'Participants have permissions to start a call, join a call, enable audio and video, and share screen.')
+				: t('spreed', 'Participants can use all available features.') }}
 		</p>
 
 		<!-- No permissions -->
@@ -35,7 +37,7 @@
 			<NcCheckboxRadioSwitch
 				v-model="radioValue"
 				value="restricted"
-				:disabled="loading || !isCallEnabled"
+				:disabled="loading"
 				name="permission_radio"
 				type="radio"
 				@update:modelValue="handleSubmitPermissions">
@@ -44,7 +46,9 @@
 			<span v-show="loading && radioValue === 'restricted'" class="icon-loading-small" />
 		</div>
 		<p class="conversation-permissions-editor__hint">
-			{{ t('spreed', 'Participants can join calls, but cannot enable audio nor video nor share screen until a moderator manually grants them permissions.') }}
+			{{ isCallEnabled
+				? t('spreed', 'Participants can join calls, but cannot enable audio nor video nor share screen until a moderator manually grants them permissions.')
+				: t('spreed', 'Participants get a reduced feature set until a moderator manually grants additional permissions.') }}
 		</p>
 
 		<!-- Advanced permissions -->
@@ -194,10 +198,6 @@ export default {
 		 * which case it's a number indicating the permissions value.
 		 */
 		async handleSubmitPermissions(value) {
-			if (!this.isCallEnabled && ['all', 'restricted'].includes(value)) {
-				return
-			}
-
 			let permissions
 
 			// Compute the permissions value

--- a/src/components/ConversationSettings/ConversationSettingsDialog.vue
+++ b/src/components/ConversationSettings/ConversationSettingsDialog.vue
@@ -43,7 +43,7 @@
 
 			<!-- Meeting: lobby and sip -->
 			<NcAppSettingsSection
-				v-if="canFullModerate && !isNoteToSelf"
+				v-if="isCallEnabled && canFullModerate && !isNoteToSelf"
 				id="meeting"
 				:name="meetingHeader">
 				<LobbySettings :token="token" />
@@ -208,7 +208,11 @@ export default {
 
 	computed: {
 		canUserEnableSIP() {
-			return this.conversation.canEnableSIP
+			return this.isCallEnabled && this.conversation.canEnableSIP
+		},
+
+		isCallEnabled() {
+			return getTalkConfig(this.token, 'call', 'enabled')
 		},
 
 		isNoteToSelf() {
@@ -278,25 +282,29 @@ export default {
 		},
 
 		canConfigureLiveTranscription() {
-			return this.isLiveTranscriptionSupported
+			return this.isCallEnabled
+				&& this.isLiveTranscriptionSupported
 				&& this.selfIsOwnerOrModerator
 		},
 
 		hintLiveTranscription() {
-			return !this.isLiveTranscriptionSupported
+			return this.isCallEnabled
+				&& !this.isLiveTranscriptionSupported
 				&& this.selfIsOwnerOrModerator
 				&& showTalkFeatureHint(34)
 		},
 
 		canConfigureBreakoutRooms() {
-			return !this.isVoiceRoom
+			return this.isCallEnabled
+				&& !this.isVoiceRoom
 				&& this.canFullModerate
 				&& (getTalkConfig(this.token, 'call', 'breakout-rooms') || false)
 				&& this.conversation.type === CONVERSATION.TYPE.GROUP
 		},
 
 		recordingConsentAvailable() {
-			return (getTalkConfig(this.token, 'call', 'recording') || false)
+			return this.isCallEnabled
+				&& (getTalkConfig(this.token, 'call', 'recording') || false)
 				&& hasTalkFeature(this.token, 'recording-consent')
 				&& getTalkConfig(this.token, 'call', 'recording-consent') !== CONFIG.RECORDING_CONSENT.OFF
 		},

--- a/src/components/ConversationSettings/ConversationSettingsDialog.vue
+++ b/src/components/ConversationSettings/ConversationSettingsDialog.vue
@@ -43,7 +43,7 @@
 
 			<!-- Meeting: lobby and sip -->
 			<NcAppSettingsSection
-				v-if="isCallEnabled && canFullModerate && !isNoteToSelf"
+				v-if="canFullModerate && !isNoteToSelf"
 				id="meeting"
 				:name="meetingHeader">
 				<LobbySettings :token="token" />
@@ -208,7 +208,7 @@ export default {
 
 	computed: {
 		canUserEnableSIP() {
-			return this.isCallEnabled && this.conversation.canEnableSIP
+			return this.conversation.canEnableSIP
 		},
 
 		isCallEnabled() {
@@ -295,8 +295,7 @@ export default {
 		},
 
 		canConfigureBreakoutRooms() {
-			return this.isCallEnabled
-				&& !this.isVoiceRoom
+			return !this.isVoiceRoom
 				&& this.canFullModerate
 				&& (getTalkConfig(this.token, 'call', 'breakout-rooms') || false)
 				&& this.conversation.type === CONVERSATION.TYPE.GROUP

--- a/src/components/ConversationSettings/NotificationsSettings.vue
+++ b/src/components/ConversationSettings/NotificationsSettings.vue
@@ -14,7 +14,7 @@ import IconBellOffOutline from 'vue-material-design-icons/BellOffOutline.vue'
 import IconBellOutline from 'vue-material-design-icons/BellOutline.vue'
 import IconBellRingOutline from 'vue-material-design-icons/BellRingOutline.vue'
 import { PARTICIPANT } from '../../constants.ts'
-import { hasTalkFeature } from '../../services/CapabilitiesManager.ts'
+import { getTalkConfig, hasTalkFeature } from '../../services/CapabilitiesManager.ts'
 
 const props = defineProps<{
 	conversation: Conversation
@@ -44,7 +44,8 @@ const notificationLevels = [
 const store = useStore()
 
 const showCallNotificationSettings = computed(() => {
-	return !props.conversation.remoteServer || hasTalkFeature(props.conversation.token, 'federation-v2')
+	return getTalkConfig(props.conversation.token, 'call', 'enabled')
+		&& (!props.conversation.remoteServer || hasTalkFeature(props.conversation.token, 'federation-v2'))
 })
 
 const loading = reactive({

--- a/src/components/Dashboard/EventCard.vue
+++ b/src/components/Dashboard/EventCard.vue
@@ -24,7 +24,7 @@ import ConversationIcon from '../ConversationIcon.vue'
 import IconTalk from '../../../img/app-dark.svg?raw'
 import { useIsInCall } from '../../composables/useIsInCall.js'
 import { CONVERSATION } from '../../constants.ts'
-import { getTalkConfig, localCapabilities } from '../../services/CapabilitiesManager.ts'
+import { localCapabilities } from '../../services/CapabilitiesManager.ts'
 import { formattedTime, ONE_DAY_IN_MS } from '../../utils/formattedTime.ts'
 
 type ConversationFromEvent = Pick<Conversation, 'token' | 'type' | 'name' | 'displayName' | 'avatarVersion' | 'callStartTime' | 'hasCall'>
@@ -34,7 +34,6 @@ const props = defineProps<{
 }>()
 
 const isCalendarEnabled = localCapabilities.calendar?.webui ?? false
-const isCallEnabled = getTalkConfig('local', 'call', 'enabled')
 
 const store = useStore()
 const router = useRouter()
@@ -220,7 +219,7 @@ function handleJoin({ call }: { call: boolean }) {
 				{{ invitesLabel }}
 			</span>
 			<NcButton
-				v-if="isCallEnabled && hasCall && !isInCall"
+				v-if="hasCall && !isInCall"
 				variant="primary"
 				@click="handleJoin({ call: true })">
 				<template #icon>

--- a/src/components/Dashboard/EventCard.vue
+++ b/src/components/Dashboard/EventCard.vue
@@ -24,7 +24,7 @@ import ConversationIcon from '../ConversationIcon.vue'
 import IconTalk from '../../../img/app-dark.svg?raw'
 import { useIsInCall } from '../../composables/useIsInCall.js'
 import { CONVERSATION } from '../../constants.ts'
-import { localCapabilities } from '../../services/CapabilitiesManager.ts'
+import { getTalkConfig, localCapabilities } from '../../services/CapabilitiesManager.ts'
 import { formattedTime, ONE_DAY_IN_MS } from '../../utils/formattedTime.ts'
 
 type ConversationFromEvent = Pick<Conversation, 'token' | 'type' | 'name' | 'displayName' | 'avatarVersion' | 'callStartTime' | 'hasCall'>
@@ -34,6 +34,7 @@ const props = defineProps<{
 }>()
 
 const isCalendarEnabled = localCapabilities.calendar?.webui ?? false
+const isCallEnabled = getTalkConfig('local', 'call', 'enabled')
 
 const store = useStore()
 const router = useRouter()
@@ -219,7 +220,7 @@ function handleJoin({ call }: { call: boolean }) {
 				{{ invitesLabel }}
 			</span>
 			<NcButton
-				v-if="(hasCall && !isInCall)"
+				v-if="isCallEnabled && hasCall && !isInCall"
 				variant="primary"
 				@click="handleJoin({ call: true })">
 				<template #icon>

--- a/src/components/Dashboard/TalkDashboard.vue
+++ b/src/components/Dashboard/TalkDashboard.vue
@@ -254,6 +254,7 @@ function scrollEventCards({ direction }: { direction: 'backward' | 'forward' }) 
 					{{ t('spreed', 'Call a phone number') }}
 				</NcButton>
 				<NcButton
+					v-if="isCallEnabled"
 					variant="secondary"
 					@click="emit('talk:media-settings:show', 'device-check')">
 					<template #icon>

--- a/src/components/LeftSidebar/ConversationsList/ConversationItem.vue
+++ b/src/components/LeftSidebar/ConversationsList/ConversationItem.vue
@@ -265,7 +265,7 @@ import ConversationIcon from './../../ConversationIcon.vue'
 import IconMarkChatRead from '../../../../img/material-icons/mark-chat-read.svg?raw'
 import { useConversationInfo } from '../../../composables/useConversationInfo.ts'
 import { AVATAR, CONVERSATION, PARTICIPANT } from '../../../constants.ts'
-import { hasTalkFeature } from '../../../services/CapabilitiesManager.ts'
+import { getTalkConfig, hasTalkFeature } from '../../../services/CapabilitiesManager.ts'
 import { copyConversationLinkToClipboard } from '../../../utils/handleUrl.ts'
 
 const supportsArchive = hasTalkFeature('local', 'archived-conversations-v2')
@@ -407,7 +407,8 @@ export default {
 		},
 
 		showCallNotificationSettings() {
-			return !this.item.remoteServer || hasTalkFeature(this.item.token, 'federation-v2')
+			return getTalkConfig(this.item.token, 'call', 'enabled')
+				&& (!this.item.remoteServer || hasTalkFeature(this.item.token, 'federation-v2'))
 		},
 
 		iconType() {

--- a/src/components/PermissionsEditor/PermissionsEditor.vue
+++ b/src/components/PermissionsEditor/PermissionsEditor.vue
@@ -16,6 +16,7 @@
 				<form @submit.prevent="handleSubmitPermissions">
 					<NcCheckboxRadioSwitch
 						v-model="callStart"
+						:disabled="!isCallEnabled"
 						class="checkbox">
 						{{ t('spreed', 'Start a call') }}
 					</NcCheckboxRadioSwitch>
@@ -37,16 +38,19 @@
 					</NcCheckboxRadioSwitch>
 					<NcCheckboxRadioSwitch
 						v-model="publishAudio"
+						:disabled="!isCallEnabled"
 						class="checkbox">
 						{{ t('spreed', 'Enable the microphone') }}
 					</NcCheckboxRadioSwitch>
 					<NcCheckboxRadioSwitch
 						v-model="publishVideo"
+						:disabled="!isCallEnabled"
 						class="checkbox">
 						{{ t('spreed', 'Enable the camera') }}
 					</NcCheckboxRadioSwitch>
 					<NcCheckboxRadioSwitch
 						v-model="publishScreen"
+						:disabled="!isCallEnabled"
 						class="checkbox">
 						{{ t('spreed', 'Share the screen') }}
 					</NcCheckboxRadioSwitch>
@@ -123,6 +127,11 @@ export default {
 			type: Boolean,
 			default: false,
 		},
+
+		token: {
+			type: String,
+			default: 'local',
+		},
 	},
 
 	emits: ['close', 'submit'],
@@ -177,6 +186,18 @@ export default {
 			return hasTalkFeature('local', 'react-permission')
 		},
 
+		isCallEnabled() {
+			return getTalkConfig(this.token, 'call', 'enabled')
+		},
+
+		callPermissions() {
+			return PERMISSIONS.CALL_START
+				| PERMISSIONS.CALL_JOIN
+				| PERMISSIONS.PUBLISH_AUDIO
+				| PERMISSIONS.PUBLISH_VIDEO
+				| PERMISSIONS.PUBLISH_SCREEN
+		},
+
 		maxDefaultPermission() {
 			// Use API value if available, otherwise compute from constants
 			const apiValue = getTalkConfig('local', 'permissions', 'max-default')
@@ -217,14 +238,18 @@ export default {
 		 * accordingly.
 		 */
 		formPermissions() {
-			return (this.callStart ? PERMISSIONS.CALL_START : 0)
+			const callPermissions = this.isCallEnabled
+				? (this.callStart ? PERMISSIONS.CALL_START : 0)
 				| PERMISSIONS.CALL_JOIN // Currently not handled, just adding it, so that manually selecting all checkboxes goes to the "All" permissions state
-				| (this.lobbyIgnore ? PERMISSIONS.LOBBY_IGNORE : 0)
-				| (this.chatMessages ? PERMISSIONS.CHAT : 0)
-				| ((this.hasReactPermissions && this.chatReactions) ? PERMISSIONS.REACT : 0)
 				| (this.publishAudio ? PERMISSIONS.PUBLISH_AUDIO : 0)
 				| (this.publishVideo ? PERMISSIONS.PUBLISH_VIDEO : 0)
 				| (this.publishScreen ? PERMISSIONS.PUBLISH_SCREEN : 0)
+				: this.permissionsWithDefault & this.callPermissions
+
+			return callPermissions
+				| (this.lobbyIgnore ? PERMISSIONS.LOBBY_IGNORE : 0)
+				| (this.chatMessages ? PERMISSIONS.CHAT : 0)
+				| ((this.hasReactPermissions && this.chatReactions) ? PERMISSIONS.REACT : 0)
 				| PERMISSIONS.CUSTOM
 		},
 

--- a/src/components/PermissionsEditor/PermissionsEditor.vue
+++ b/src/components/PermissionsEditor/PermissionsEditor.vue
@@ -130,7 +130,7 @@ export default {
 
 		token: {
 			type: String,
-			default: 'local',
+			required: true,
 		},
 	},
 
@@ -190,14 +190,6 @@ export default {
 			return getTalkConfig(this.token, 'call', 'enabled')
 		},
 
-		callPermissions() {
-			return PERMISSIONS.CALL_START
-				| PERMISSIONS.CALL_JOIN
-				| PERMISSIONS.PUBLISH_AUDIO
-				| PERMISSIONS.PUBLISH_VIDEO
-				| PERMISSIONS.PUBLISH_SCREEN
-		},
-
 		maxDefaultPermission() {
 			// Use API value if available, otherwise compute from constants
 			const apiValue = getTalkConfig('local', 'permissions', 'max-default')
@@ -238,18 +230,14 @@ export default {
 		 * accordingly.
 		 */
 		formPermissions() {
-			const callPermissions = this.isCallEnabled
-				? (this.callStart ? PERMISSIONS.CALL_START : 0)
+			return (this.callStart ? PERMISSIONS.CALL_START : 0)
 				| PERMISSIONS.CALL_JOIN // Currently not handled, just adding it, so that manually selecting all checkboxes goes to the "All" permissions state
-				| (this.publishAudio ? PERMISSIONS.PUBLISH_AUDIO : 0)
-				| (this.publishVideo ? PERMISSIONS.PUBLISH_VIDEO : 0)
-				| (this.publishScreen ? PERMISSIONS.PUBLISH_SCREEN : 0)
-				: this.permissionsWithDefault & this.callPermissions
-
-			return callPermissions
 				| (this.lobbyIgnore ? PERMISSIONS.LOBBY_IGNORE : 0)
 				| (this.chatMessages ? PERMISSIONS.CHAT : 0)
 				| ((this.hasReactPermissions && this.chatReactions) ? PERMISSIONS.REACT : 0)
+				| (this.publishAudio ? PERMISSIONS.PUBLISH_AUDIO : 0)
+				| (this.publishVideo ? PERMISSIONS.PUBLISH_VIDEO : 0)
+				| (this.publishScreen ? PERMISSIONS.PUBLISH_SCREEN : 0)
 				| PERMISSIONS.CUSTOM
 		},
 

--- a/src/components/RightSidebar/Participants/ParticipantPermissionsEditor.vue
+++ b/src/components/RightSidebar/Participants/ParticipantPermissionsEditor.vue
@@ -8,6 +8,7 @@
 		<PermissionEditor
 			:displayName="displayName"
 			:permissions="permissions"
+			:token="token"
 			@close="$emit('close')"
 			@submit="handleSubmitPermissions" />
 	</div>

--- a/src/components/RightSidebar/Participants/ParticipantsTab.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsTab.vue
@@ -246,7 +246,6 @@ export default {
 
 		hintAddPhones() {
 			const canModerateSipDialOut = hasTalkFeature(this.token, 'sip-support-dialout')
-				&& getTalkConfig(this.token, 'call', 'enabled')
 				&& getTalkConfig(this.token, 'call', 'sip-enabled')
 				&& getTalkConfig(this.token, 'call', 'sip-dialout-enabled')
 				&& getTalkConfig(this.token, 'call', 'can-enable-sip')

--- a/src/components/RightSidebar/Participants/ParticipantsTab.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsTab.vue
@@ -237,6 +237,7 @@ export default {
 
 		canAddPhones() {
 			const canModerateSipDialOut = hasTalkFeature(this.token, 'sip-support-dialout')
+				&& getTalkConfig(this.token, 'call', 'enabled')
 				&& getTalkConfig(this.token, 'call', 'sip-enabled')
 				&& getTalkConfig(this.token, 'call', 'sip-dialout-enabled')
 				&& getTalkConfig(this.token, 'call', 'can-enable-sip')
@@ -245,10 +246,11 @@ export default {
 
 		hintAddPhones() {
 			const canModerateSipDialOut = hasTalkFeature(this.token, 'sip-support-dialout')
+				&& getTalkConfig(this.token, 'call', 'enabled')
 				&& getTalkConfig(this.token, 'call', 'sip-enabled')
 				&& getTalkConfig(this.token, 'call', 'sip-dialout-enabled')
 				&& getTalkConfig(this.token, 'call', 'can-enable-sip')
-			return !canModerateSipDialOut && showTalkFeatureHint(34)
+			return getTalkConfig(this.token, 'call', 'enabled') && !canModerateSipDialOut && showTalkFeatureHint(34)
 		},
 
 		isSearching() {

--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -336,7 +336,8 @@ export default {
 		},
 
 		showSIPSettings() {
-			return this.conversation.sipEnabled !== WEBINAR.SIP.DISABLED
+			return getTalkConfig(this.token, 'call', 'enabled')
+				&& this.conversation.sipEnabled !== WEBINAR.SIP.DISABLED
 				&& this.conversation.attendeePin
 		},
 
@@ -359,7 +360,7 @@ export default {
 		},
 
 		showBreakoutRoomsTab() {
-			return this.getUserId && !this.isOneToOne
+			return getTalkConfig(this.token, 'call', 'enabled') && this.getUserId && !this.isOneToOne
 				&& !this.conversation.remoteServer // no breakout rooms support in federated conversations
 				&& (this.breakoutRoomsConfigured || this.conversation.breakoutRoomMode === CONVERSATION.BREAKOUT_ROOM_MODE.FREE || this.conversation.objectType === CONVERSATION.OBJECT_TYPE.BREAKOUT_ROOM)
 		},

--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -336,8 +336,7 @@ export default {
 		},
 
 		showSIPSettings() {
-			return getTalkConfig(this.token, 'call', 'enabled')
-				&& this.conversation.sipEnabled !== WEBINAR.SIP.DISABLED
+			return this.conversation.sipEnabled !== WEBINAR.SIP.DISABLED
 				&& this.conversation.attendeePin
 		},
 
@@ -360,7 +359,7 @@ export default {
 		},
 
 		showBreakoutRoomsTab() {
-			return getTalkConfig(this.token, 'call', 'enabled') && this.getUserId && !this.isOneToOne
+			return this.getUserId && !this.isOneToOne
 				&& !this.conversation.remoteServer // no breakout rooms support in federated conversations
 				&& (this.breakoutRoomsConfigured || this.conversation.breakoutRoomMode === CONVERSATION.BREAKOUT_ROOM_MODE.FREE || this.conversation.objectType === CONVERSATION.OBJECT_TYPE.BREAKOUT_ROOM)
 		},

--- a/src/components/SettingsDialog/AppearanceSettings.vue
+++ b/src/components/SettingsDialog/AppearanceSettings.vue
@@ -24,6 +24,7 @@ import { useSoundsStore } from '../../stores/sounds.js'
 const settingsUrl = generateUrl('/settings/user/notifications')
 const supportConversationsListStyle = getTalkConfig('local', 'conversations', 'list-style') !== undefined
 const supportChatStyle = getTalkConfig('local', 'chat', 'style') !== undefined
+const isCallEnabled = getTalkConfig('local', 'call', 'enabled')
 
 const actorStore = useActorStore()
 const settingsStore = useSettingsStore()
@@ -135,6 +136,7 @@ async function togglePlaySounds(value: boolean) {
 
 	<NcFormBox>
 		<NcFormBoxSwitch
+			v-if="isCallEnabled"
 			:modelValue="shouldPlaySounds"
 			:label="t('spreed', 'Play sounds when participants join or leave a call')"
 			:description="t('spreed', 'Currently not available on iPhone and iPad due to technical restrictions by the manufacturer')"

--- a/src/components/SettingsDialog/SettingsDialog.vue
+++ b/src/components/SettingsDialog/SettingsDialog.vue
@@ -18,6 +18,7 @@
 		</NcAppSettingsSection>
 
 		<NcAppSettingsSection
+			v-if="isCallEnabled"
 			id="devices"
 			:name="t('spreed', 'Devices')">
 			<NcFormBox>
@@ -101,7 +102,7 @@
 		</NcAppSettingsSection>
 
 		<NcAppSettingsSection
-			v-if="supportLiveTranslation"
+			v-if="isCallEnabled && supportLiveTranslation"
 			id="live_transcription"
 			:name="t('spreed', 'Live transcription')">
 			<NcFormBox v-slot="{ itemClass }">
@@ -124,7 +125,9 @@
 				<NcHotkey v-if="!isGuest" :label="t('spreed', 'Edit your last message')" hotkey="Control ArrowUp" />
 			</NcHotkeyList>
 
-			<NcHotkeyList :label="t('spreed', 'Shortcuts while in a call')">
+			<NcHotkeyList
+				v-if="isCallEnabled"
+				:label="t('spreed', 'Shortcuts while in a call')">
 				<NcHotkey :label="t('spreed', 'Camera on and off')" hotkey="V" />
 				<NcHotkey :label="t('spreed', 'Microphone on and off')" hotkey="M" />
 				<NcHotkey :label="t('spreed', 'Raise or lower hand')" hotkey="R" />
@@ -171,6 +174,7 @@ import { useSettingsStore } from '../../stores/settings.ts'
 const disableKeyboardShortcuts = OCP.Accessibility.disableKeyboardShortcuts()
 
 const supportTypingStatus = getTalkConfig('local', 'chat', 'typing-privacy') !== undefined
+const isCallEnabled = getTalkConfig('local', 'call', 'enabled')
 const supportStartWithoutMedia = getTalkConfig('local', 'call', 'start-without-media') !== undefined
 const supportDefaultBlurVirtualBackground = getTalkConfig('local', 'call', 'blur-virtual-background') !== undefined
 const supportLiveTranslation = getTalkConfig('local', 'call', 'live-translation') === true
@@ -206,6 +210,7 @@ export default {
 			settingsStore,
 			supportTypingStatus,
 			customSettingsSections,
+			isCallEnabled,
 			supportStartWithoutMedia,
 			supportDefaultBlurVirtualBackground,
 			supportLiveTranslation,


### PR DESCRIPTION
Hello! This is my first contribution to this repository. Looking forward to your feedback

## ☑️ Resolves

* Fix #17390

### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

#### Dashboard actions and upcoming meetings

🏚️ Before | 🏡 After
-- | --
<img width="900" alt="Dashboard before" src="https://github.com/user-attachments/assets/ac9b6937-1273-480e-99bd-40b48329de44" /> | <img width="900" alt="Dashboard after" src="https://github.com/user-attachments/assets/04928028-df80-463c-b611-d6ce2f50eb47" />

#### App settings: devices / appearance

🏚️ Before | 🏡 After
-- | --
<img width="900" alt="App settings before" src="https://github.com/user-attachments/assets/914fd33b-16c0-407f-8b2a-9a593859831c" /> | <img width="900" alt="App settings after" src="https://github.com/user-attachments/assets/1760eccc-a00b-4967-8375-63de7bd6f12d" />

#### Keyboard shortcuts

🏚️ Before | 🏡 After
-- | --
<img width="900" alt="Keyboard shortcuts before" src="https://github.com/user-attachments/assets/5c2ef296-43ba-4e78-b595-4b9a0917777d" /> | <img width="900" alt="Keyboard shortcuts after" src="https://github.com/user-attachments/assets/c9ad59df-65af-4ab6-89b2-9c5a23b76244" />


#### Participant permissions

🏚️ Before | 🏡 After
-- | --
<img width="700" alt="Participant permissions before" src="https://github.com/user-attachments/assets/77926f4e-6f6a-4224-ba53-28fd4a54c7f2" /> | <img width="700" alt="Participant permissions after" src="https://github.com/user-attachments/assets/1daafca3-0bee-444b-81a3-77c45c7703e8" />

#### Conversation notification settings

🏚️ Before | 🏡 After
-- | --
<img width="700" alt="Conversation notifications before" src="https://github.com/user-attachments/assets/62e7c0ee-1915-4555-b191-6c849b78d14f" /> | <img width="700" alt="Conversation notifications after" src="https://github.com/user-attachments/assets/84a19656-c6b6-464c-aae1-b210b95c8d8d" />


<!-- ☀️ Light theme | 🌑 Dark Theme -->

### 🚧 Tasks

- [x] Hide remaining call-related dashboard actions when calls are disabled
- [x] Hide dashboard join buttons for upcoming meetings when calls are disabled
- [x] Hide call-only app settings sections and shortcuts when calls are disabled
- [x] Hide conversation call-related settings and SIP-related sidebar actions when calls are disabled
- [x] Disable call-related permission controls when calls are disabled while keeping non-call permissions editable

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
