### PR TITLE
fix: align buttons in the navigation

### DIFF
--- a/src/components/LeftSidebar/ConversationsList/ConversationsListVirtual.vue
+++ b/src/components/LeftSidebar/ConversationsList/ConversationsListVirtual.vue
@@ -13,6 +13,7 @@ import ConversationItem from './ConversationItem.vue'
 import { AVATAR } from '../../../constants.ts'
 
 const props = defineProps<{
+	listAriaLabelledBy?: string
 	conversations: Conversation[]
 	loading?: boolean
 	compact?: boolean
@@ -120,6 +121,7 @@ defineExpose({
 		<LoadingPlaceholder v-if="loading" type="conversations" />
 		<ul
 			v-else
+			:aria-labelledby="listAriaLabelledBy"
 			:style="wrapperProps.style">
 			<ConversationItem
 				v-for="item in list"

--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -249,9 +249,6 @@
 							</template>
 							{{ t('spreed', 'Back to conversations') }}
 						</LeftSidebarButton>
-						<NcAppNavigationCaption
-							class="navigation-caption"
-							:name="showArchived ? t('spreed', 'Archived conversations') : t('spreed', 'Threads')" />
 					</template>
 					<LeftSidebarButton
 						v-else-if="supportThreads && !showThreadsList && !isSearching && !isFiltered"
@@ -272,6 +269,20 @@
 							<NcCounterBubble type="highlighted" :count="pendingInvitationsCount" />
 						</template>
 					</LeftSidebarButton>
+				</div>
+
+				<div v-if="!isSearching" class="navigation-buttons-container" :class="{ 'hidden-visually': !showArchived && !showThreadsList }">
+					<div
+						:id="LIST_HEADING_ID"
+						class="navigation-caption"
+						role="heading"
+						aria-level="3">
+						{{
+							showArchived && t('spreed', 'Archived conversations')
+								|| showThreadsList && t('spreed', 'Threads')
+								|| t('spreed', 'Conversations')
+						}}
+					</div>
 				</div>
 			</div>
 		</template>
@@ -301,7 +312,7 @@
 				</NcEmptyContent>
 				<template v-if="showThreadsList">
 					<LoadingPlaceholder v-if="!followedThreadsInitialised" type="conversations" />
-					<ul v-else class="threads-tab__list">
+					<ul v-else class="threads-tab__list" :aria-labelledby="LIST_HEADING_ID">
 						<ThreadItem
 							v-for="thread of followedThreads"
 							:key="`thread_${thread.thread.id}`"
@@ -322,6 +333,7 @@
 					v-else
 					v-show="sortedConversationsList.length > 0"
 					ref="scroller"
+					:listAriaLabelledBy="LIST_HEADING_ID"
 					:conversations="sortedConversationsList"
 					:loading="!conversationsInitialised"
 					:compact="isCompact"
@@ -395,7 +407,6 @@ import NcActionCaption from '@nextcloud/vue/components/NcActionCaption'
 import NcActions from '@nextcloud/vue/components/NcActions'
 import NcActionSeparator from '@nextcloud/vue/components/NcActionSeparator'
 import NcAppNavigation from '@nextcloud/vue/components/NcAppNavigation'
-import NcAppNavigationCaption from '@nextcloud/vue/components/NcAppNavigationCaption'
 import NcAppNavigationItem from '@nextcloud/vue/components/NcAppNavigationItem'
 import NcButton from '@nextcloud/vue/components/NcButton'
 import NcChip from '@nextcloud/vue/components/NcChip'
@@ -506,7 +517,6 @@ export default {
 		CallPhoneDialog,
 		InvitationHandler,
 		NcAppNavigation,
-		NcAppNavigationCaption,
 		NcButton,
 		NcCounterBubble,
 		NcChip,
@@ -561,6 +571,8 @@ export default {
 		const { initializeNavigation, resetNavigation } = useArrowNavigation(leftSidebar, searchBox)
 		const isMobile = useIsMobile()
 
+		const LIST_HEADING_ID = 'left-sidebar-list-heading'
+
 		return {
 			token: useGetToken(),
 			initializeNavigation,
@@ -585,6 +597,7 @@ export default {
 			HOME_BUTTON_LABEL,
 			FILTER_LABELS,
 			SORT_LABELS,
+			LIST_HEADING_ID,
 			actorStore: useActorStore(),
 			chatExtrasStore: useChatExtrasStore(),
 			tokenStore: useTokenStore(),
@@ -1295,12 +1308,11 @@ export default {
 }
 
 .navigation-caption {
-	margin-block: var(--default-grid-baseline) !important;
-	margin-inline-start: calc(var(--default-grid-baseline) * 2);
-
-	:deep(.app-navigation-caption__name) {
-		margin: 0;
-	}
+	display: flex;
+	align-items: center;
+	padding-inline: var(--default-grid-baseline);
+	height: var(--default-clickable-area);
+	font-weight: bold;
 }
 
 .threads-tab__list {

--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -6,272 +6,277 @@
 <template>
 	<NcAppNavigation ref="leftSidebar" :aria-label="t('spreed', 'Conversation list')">
 		<template #search>
-			<div class="new-conversation">
-				<div
-					class="conversations-search"
-					:class="{ 'conversations-search--expanded': isSearching }">
-					<SearchBox
-						ref="searchBox"
-						v-model:value="searchText"
-						v-model:isFocused="isFocused"
-						:listRef="[scroller, searchResults]"
-						@input="debounceFetchSearchResults"
-						@abortSearch="abortSearch" />
+			<div class="navigation-top">
+				<div class="navigation-buttons-container">
+					<div class="new-conversation">
+						<div
+							class="conversations-search"
+							:class="{ 'conversations-search--expanded': isSearching }">
+							<SearchBox
+								ref="searchBox"
+								v-model:value="searchText"
+								v-model:isFocused="isFocused"
+								:listRef="[scroller, searchResults]"
+								@input="debounceFetchSearchResults"
+								@abortSearch="abortSearch" />
+						</div>
+
+						<TransitionWrapper name="radial-reveal">
+							<!-- Filters -->
+							<NcActions
+								v-show="searchText === ''"
+								:variant="isFiltered ? 'secondary' : 'tertiary'"
+								class="filters"
+								:class="{ 'hidden-visually': isSearching }">
+								<template #icon>
+									<IconFilterCogOutline :size="20" />
+								</template>
+								<NcActionCaption :name="t('spreed', 'Filter conversations by')" />
+
+								<NcActionButton
+									closeAfterClick
+									type="checkbox"
+									:modelValue="filters.includes('mentions')"
+									@click="handleFilter('mentions')">
+									<template #icon>
+										<IconAt :size="20" />
+									</template>
+									{{ t('spreed', 'Unread mentions') }}
+								</NcActionButton>
+
+								<NcActionButton
+									closeAfterClick
+									type="checkbox"
+									:modelValue="filters.includes('unread')"
+									@click="handleFilter('unread')">
+									<template #icon>
+										<IconMessageBadgeOutline :size="20" />
+									</template>
+									{{ t('spreed', 'Unread messages') }}
+								</NcActionButton>
+
+								<NcActionButton
+									closeAfterClick
+									type="checkbox"
+									:modelValue="filters.includes('events')"
+									@click="handleFilter('events')">
+									<template #icon>
+										<IconCalendarBlankOutline :size="20" />
+									</template>
+									{{ t('spreed', 'Meeting conversations') }}
+								</NcActionButton>
+
+								<NcActionButton
+									v-if="isFiltered"
+									closeAfterClick
+									class="filter-actions__clearbutton"
+									@click="handleFilter(null)">
+									<template #icon>
+										<IconFilterRemoveOutline :size="20" />
+									</template>
+									{{ t('spreed', 'Clear filters') }}
+								</NcActionButton>
+
+								<template v-if="supportSortOrder">
+									<NcActionSeparator />
+
+									<NcActionCaption :name="SORT_LABELS.SORTBY_HEADER" />
+
+									<NcActionButton
+										closeAfterClick
+										type="radio"
+										:value="CONVERSATION.SORT_ORDER.ACTIVITY"
+										:modelValue="sortOrder"
+										@update:modelValue="handleSortOrder">
+										<template #icon>
+											<IconClockOutline :size="20" />
+										</template>
+										{{ SORT_LABELS.SORTBY_ACTIVITY }}
+									</NcActionButton>
+
+									<NcActionButton
+										closeAfterClick
+										type="radio"
+										:value="CONVERSATION.SORT_ORDER.ALPHABETICAL"
+										:modelValue="sortOrder"
+										@update:modelValue="handleSortOrder">
+										<template #icon>
+											<IconSortAlphabeticalAscending :size="20" />
+										</template>
+										{{ SORT_LABELS.SORTBY_ALPHABET }}
+									</NcActionButton>
+
+									<NcActionSeparator />
+
+									<NcActionButton
+										closeAfterClick
+										type="radio"
+										:value="CONVERSATION.GROUP_MODE.NONE"
+										:modelValue="groupMode"
+										@update:modelValue="handleGroupMode">
+										<template #icon>
+											<IconFormatListBulleted :size="20" />
+										</template>
+										{{ SORT_LABELS.GROUPBY_NONE }}
+									</NcActionButton>
+
+									<NcActionButton
+										closeAfterClick
+										type="radio"
+										:value="CONVERSATION.GROUP_MODE.PRIVATE_FIRST"
+										:modelValue="groupMode"
+										@update:modelValue="handleGroupMode">
+										<template #icon>
+											<IconAccountOutline :size="20" />
+										</template>
+										{{ SORT_LABELS.GROUPBY_PRIVATE_FIRST }}
+									</NcActionButton>
+
+									<NcActionButton
+										closeAfterClick
+										type="radio"
+										:value="CONVERSATION.GROUP_MODE.GROUP_FIRST"
+										:modelValue="groupMode"
+										@update:modelValue="handleGroupMode">
+										<template #icon>
+											<IconAccountMultipleOutline :size="20" />
+										</template>
+										{{ SORT_LABELS.GROUPBY_GROUP_FIRST }}
+									</NcActionButton>
+								</template>
+							</NcActions>
+						</TransitionWrapper>
+
+						<!-- Actions -->
+						<TransitionWrapper name="radial-reveal">
+							<NcActions
+								v-show="searchText === ''"
+								class="actions"
+								:class="{ 'hidden-visually': isSearching }">
+								<template #icon>
+									<IconChatPlusOutline :size="20" />
+								</template>
+								<NcActionButton
+									v-if="canStartConversations"
+									closeAfterClick
+									@click="showModalNewConversation">
+									<template #icon>
+										<IconPlus :size="20" />
+									</template>
+									{{ t('spreed', 'Create a new conversation') }}
+								</NcActionButton>
+
+								<NcActionButton
+									v-if="canNoteToSelf && !hasNoteToSelf"
+									closeAfterClick
+									@click="restoreNoteToSelfConversation">
+									<template #icon>
+										<IconNoteEditOutline :size="20" />
+									</template>
+									{{ t('spreed', 'New personal note') }}
+								</NcActionButton>
+
+								<NcActionButton
+									closeAfterClick
+									@click="showModalListConversations">
+									<template #icon>
+										<IconFormatListBulleted :size="20" />
+									</template>
+									{{ t('spreed', 'Join open conversations') }}
+								</NcActionButton>
+
+								<NcActionButton
+									v-if="canModerateSipDialOut"
+									closeAfterClick
+									@click="showModalCallPhoneDialog">
+									<template #icon>
+										<IconPhoneOutline :size="20" />
+									</template>
+									{{ t('spreed', 'Call a phone number') }}
+								</NcActionButton>
+								<NcActionButton
+									v-else-if="hintSipDialOut"
+									disabled
+									:description="t('spreed', 'SIP backend is not installed')">
+									<template #icon>
+										<IconPhoneOutline :size="20" />
+									</template>
+									{{ t('spreed', 'Call a phone number') }}
+								</NcActionButton>
+							</NcActions>
+						</TransitionWrapper>
+
+						<!-- All open conversations list -->
+						<OpenConversationsList ref="openConversationsList" />
+
+						<!-- New Conversation dialog -->
+						<NewConversationDialog ref="newConversationDialog" :canModerateSipDialOut="canModerateSipDialOut" />
+
+						<!-- New phone (SIP dial-out) dialog -->
+						<CallPhoneDialog v-if="canModerateSipDialOut" ref="callPhoneDialog" />
+
+						<!-- New Pending Invitations dialog -->
+						<InvitationHandler v-if="pendingInvitationsCount" ref="invitationHandler" />
+					</div>
+					<TransitionWrapper
+						class="conversations__filters"
+						name="zoom"
+						tag="div"
+						group>
+						<NcChip
+							v-for="filter in filters"
+							:key="filter"
+							:text="FILTER_LABELS[filter]"
+							@close="handleFilter(filter)" />
+					</TransitionWrapper>
 				</div>
 
-				<TransitionWrapper name="radial-reveal">
-					<!-- Filters -->
-					<NcActions
-						v-show="searchText === ''"
-						:variant="isFiltered ? 'secondary' : 'tertiary'"
-						class="filters"
-						:class="{ 'hidden-visually': isSearching }">
-						<template #icon>
-							<IconFilterCogOutline :size="20" />
-						</template>
-						<NcActionCaption :name="t('spreed', 'Filter conversations by')" />
-
-						<NcActionButton
-							closeAfterClick
-							type="checkbox"
-							:modelValue="filters.includes('mentions')"
-							@click="handleFilter('mentions')">
-							<template #icon>
-								<IconAt :size="20" />
-							</template>
-							{{ t('spreed', 'Unread mentions') }}
-						</NcActionButton>
-
-						<NcActionButton
-							closeAfterClick
-							type="checkbox"
-							:modelValue="filters.includes('unread')"
-							@click="handleFilter('unread')">
-							<template #icon>
-								<IconMessageBadgeOutline :size="20" />
-							</template>
-							{{ t('spreed', 'Unread messages') }}
-						</NcActionButton>
-
-						<NcActionButton
-							closeAfterClick
-							type="checkbox"
-							:modelValue="filters.includes('events')"
-							@click="handleFilter('events')">
-							<template #icon>
-								<IconCalendarBlankOutline :size="20" />
-							</template>
-							{{ t('spreed', 'Meeting conversations') }}
-						</NcActionButton>
-
-						<NcActionButton
-							v-if="isFiltered"
-							closeAfterClick
-							class="filter-actions__clearbutton"
-							@click="handleFilter(null)">
-							<template #icon>
-								<IconFilterRemoveOutline :size="20" />
-							</template>
-							{{ t('spreed', 'Clear filters') }}
-						</NcActionButton>
-
-						<template v-if="supportSortOrder">
-							<NcActionSeparator />
-
-							<NcActionCaption :name="SORT_LABELS.SORTBY_HEADER" />
-
-							<NcActionButton
-								closeAfterClick
-								type="radio"
-								:value="CONVERSATION.SORT_ORDER.ACTIVITY"
-								:modelValue="sortOrder"
-								@update:modelValue="handleSortOrder">
-								<template #icon>
-									<IconClockOutline :size="20" />
-								</template>
-								{{ SORT_LABELS.SORTBY_ACTIVITY }}
-							</NcActionButton>
-
-							<NcActionButton
-								closeAfterClick
-								type="radio"
-								:value="CONVERSATION.SORT_ORDER.ALPHABETICAL"
-								:modelValue="sortOrder"
-								@update:modelValue="handleSortOrder">
-								<template #icon>
-									<IconSortAlphabeticalAscending :size="20" />
-								</template>
-								{{ SORT_LABELS.SORTBY_ALPHABET }}
-							</NcActionButton>
-
-							<NcActionSeparator />
-
-							<NcActionButton
-								closeAfterClick
-								type="radio"
-								:value="CONVERSATION.GROUP_MODE.NONE"
-								:modelValue="groupMode"
-								@update:modelValue="handleGroupMode">
-								<template #icon>
-									<IconFormatListBulleted :size="20" />
-								</template>
-								{{ SORT_LABELS.GROUPBY_NONE }}
-							</NcActionButton>
-
-							<NcActionButton
-								closeAfterClick
-								type="radio"
-								:value="CONVERSATION.GROUP_MODE.PRIVATE_FIRST"
-								:modelValue="groupMode"
-								@update:modelValue="handleGroupMode">
-								<template #icon>
-									<IconAccountOutline :size="20" />
-								</template>
-								{{ SORT_LABELS.GROUPBY_PRIVATE_FIRST }}
-							</NcActionButton>
-
-							<NcActionButton
-								closeAfterClick
-								type="radio"
-								:value="CONVERSATION.GROUP_MODE.GROUP_FIRST"
-								:modelValue="groupMode"
-								@update:modelValue="handleGroupMode">
-								<template #icon>
-									<IconAccountMultipleOutline :size="20" />
-								</template>
-								{{ SORT_LABELS.GROUPBY_GROUP_FIRST }}
-							</NcActionButton>
-						</template>
-					</NcActions>
-				</TransitionWrapper>
-
-				<!-- Actions -->
-				<TransitionWrapper name="radial-reveal">
-					<NcActions
-						v-show="searchText === ''"
-						class="actions"
-						:class="{ 'hidden-visually': isSearching }">
-						<template #icon>
-							<IconChatPlusOutline :size="20" />
-						</template>
-						<NcActionButton
-							v-if="canStartConversations"
-							closeAfterClick
-							@click="showModalNewConversation">
-							<template #icon>
-								<IconPlus :size="20" />
-							</template>
-							{{ t('spreed', 'Create a new conversation') }}
-						</NcActionButton>
-
-						<NcActionButton
-							v-if="canNoteToSelf && !hasNoteToSelf"
-							closeAfterClick
-							@click="restoreNoteToSelfConversation">
-							<template #icon>
-								<IconNoteEditOutline :size="20" />
-							</template>
-							{{ t('spreed', 'New personal note') }}
-						</NcActionButton>
-
-						<NcActionButton
-							closeAfterClick
-							@click="showModalListConversations">
-							<template #icon>
-								<IconFormatListBulleted :size="20" />
-							</template>
-							{{ t('spreed', 'Join open conversations') }}
-						</NcActionButton>
-
-						<NcActionButton
-							v-if="canModerateSipDialOut"
-							closeAfterClick
-							@click="showModalCallPhoneDialog">
-							<template #icon>
-								<IconPhoneOutline :size="20" />
-							</template>
-							{{ t('spreed', 'Call a phone number') }}
-						</NcActionButton>
-						<NcActionButton
-							v-else-if="hintSipDialOut"
-							disabled
-							:description="t('spreed', 'SIP backend is not installed')">
-							<template #icon>
-								<IconPhoneOutline :size="20" />
-							</template>
-							{{ t('spreed', 'Call a phone number') }}
-						</NcActionButton>
-					</NcActions>
-				</TransitionWrapper>
-
-				<!-- All open conversations list -->
-				<OpenConversationsList ref="openConversationsList" />
-
-				<!-- New Conversation dialog -->
-				<NewConversationDialog ref="newConversationDialog" :canModerateSipDialOut="canModerateSipDialOut" />
-
-				<!-- New phone (SIP dial-out) dialog -->
-				<CallPhoneDialog v-if="canModerateSipDialOut" ref="callPhoneDialog" />
-
-				<!-- New Pending Invitations dialog -->
-				<InvitationHandler v-if="pendingInvitationsCount" ref="invitationHandler" />
-			</div>
-			<TransitionWrapper
-				class="conversations__filters"
-				name="zoom"
-				tag="div"
-				group>
-				<NcChip
-					v-for="filter in filters"
-					:key="filter"
-					:text="FILTER_LABELS[filter]"
-					@close="handleFilter(filter)" />
-			</TransitionWrapper>
-			<template v-if="!isSearching">
-				<NcAppNavigationItem
-					class="navigation-item"
-					:to="{ name: 'root' }"
-					:name="HOME_BUTTON_LABEL"
-					@click="refreshTalkDashboard">
-					<template #icon>
-						<IconHomeOutline :size="20" />
-					</template>
-				</NcAppNavigationItem>
-				<template v-if="showArchived || showThreadsList">
+				<div v-if="!isSearching" class="navigation-buttons-container">
 					<NcAppNavigationItem
 						class="navigation-item"
-						:name="t('spreed', 'Back to conversations')"
-						@click.prevent="handleBackToConversations">
+						:to="{ name: 'root' }"
+						:name="HOME_BUTTON_LABEL"
+						@click="refreshTalkDashboard">
 						<template #icon>
-							<IconArrowLeft class="bidirectional-icon" :size="20" />
+							<IconHomeOutline :size="20" />
 						</template>
 					</NcAppNavigationItem>
-					<NcAppNavigationCaption
-						class="navigation-caption"
-						:name="showArchived ? t('spreed', 'Archived conversations') : t('spreed', 'Threads')" />
-				</template>
-				<NcAppNavigationItem
-					v-else-if="supportThreads && !showThreadsList && !isSearching && !isFiltered"
-					class="navigation-item"
-					:name="t('spreed', 'Threads')"
-					@click.prevent="handleShowThreadsList">
-					<template #icon>
-						<IconForumOutline :size="20" />
+					<template v-if="showArchived || showThreadsList">
+						<NcAppNavigationItem
+							class="navigation-item"
+							:name="t('spreed', 'Back to conversations')"
+							@click.prevent="handleBackToConversations">
+							<template #icon>
+								<IconArrowLeft class="bidirectional-icon" :size="20" />
+							</template>
+						</NcAppNavigationItem>
+						<NcAppNavigationCaption
+							class="navigation-caption"
+							:name="showArchived ? t('spreed', 'Archived conversations') : t('spreed', 'Threads')" />
 					</template>
-				</NcAppNavigationItem>
-				<NcAppNavigationItem
-					v-if="pendingInvitationsCount && !isSearching && !showArchived && !showThreadsList"
-					class="navigation-item"
-					:name="t('spreed', 'Pending invitations')"
-					@click.prevent="showInvitationHandler">
-					<template #icon>
-						<IconAccountMultiplePlusOutline :size="20" />
-					</template>
-					<template #counter>
-						<NcCounterBubble type="highlighted" :count="pendingInvitationsCount" />
-					</template>
-				</NcAppNavigationItem>
-			</template>
+					<NcAppNavigationItem
+						v-else-if="supportThreads && !showThreadsList && !isSearching && !isFiltered"
+						class="navigation-item"
+						:name="t('spreed', 'Threads')"
+						@click.prevent="handleShowThreadsList">
+						<template #icon>
+							<IconForumOutline :size="20" />
+						</template>
+					</NcAppNavigationItem>
+					<NcAppNavigationItem
+						v-if="pendingInvitationsCount && !isSearching && !showArchived && !showThreadsList"
+						class="navigation-item"
+						:name="t('spreed', 'Pending invitations')"
+						@click.prevent="showInvitationHandler">
+						<template #icon>
+							<IconAccountMultiplePlusOutline :size="20" />
+						</template>
+						<template #counter>
+							<NcCounterBubble type="highlighted" :count="pendingInvitationsCount" />
+						</template>
+					</NcAppNavigationItem>
+				</div>
+			</div>
 		</template>
 
 		<template #list>
@@ -349,27 +354,29 @@
 		</template>
 
 		<template #footer>
-			<div class="left-sidebar__settings-button-container">
-				<NcButton
-					v-if="supportsArchive && !isSearching && !showArchived && !showThreadsList && archivedConversationsList.length"
-					variant="tertiary"
-					wide
-					@click="showArchived = true; showThreadsList = false">
-					<template #icon>
-						<IconArchiveOutline :size="20" />
-					</template>
-					{{ t('spreed', 'Archived conversations') }}
-					<span v-if="showArchivedConversationsBubble" class="left-sidebar__settings-button-bubble">
-						⬤
-					</span>
-				</NcButton>
+			<div class="navigation-bottom">
+				<div class="navigation-buttons-container">
+					<NcButton
+						v-if="supportsArchive && !isSearching && !showArchived && !showThreadsList && archivedConversationsList.length"
+						variant="tertiary"
+						wide
+						@click="showArchived = true; showThreadsList = false">
+						<template #icon>
+							<IconArchiveOutline :size="20" />
+						</template>
+						{{ t('spreed', 'Archived conversations') }}
+						<span v-if="showArchivedConversationsBubble" class="left-sidebar__settings-button-bubble">
+							⬤
+						</span>
+					</NcButton>
 
-				<NcButton variant="tertiary" wide @click="showSettings">
-					<template #icon>
-						<IconCogOutline :size="20" />
-					</template>
-					{{ t('spreed', 'App settings') }}
-				</NcButton>
+					<NcButton variant="tertiary" wide @click="showSettings">
+						<template #icon>
+							<IconCogOutline :size="20" />
+						</template>
+						{{ t('spreed', 'App settings') }}
+					</NcButton>
+				</div>
 			</div>
 		</template>
 	</NcAppNavigation>
@@ -1250,10 +1257,28 @@ export default {
 	line-height: 20px;
 }
 
+.navigation-top {
+	display: flex;
+	flex-direction: column;
+	gap: calc(2 * var(--default-grid-baseline));
+	padding-block: calc(2 * var(--default-grid-baseline)) var(--default-grid-baseline);
+}
+
+.navigation-bottom {
+	padding-block: var(--default-grid-baseline) calc(2 * var(--default-grid-baseline));
+}
+
+.navigation-buttons-container {
+	display: flex;
+	flex-direction: column;
+	gap: var(--default-grid-baseline);
+	// Inline with NcAppNavigation list
+	padding-inline: calc(2 * var(--default-grid-baseline));
+}
+
 .new-conversation {
 	position: relative;
 	display: flex;
-	margin: calc(var(--default-grid-baseline) * 2);
 	align-items: center;
 
 	.filters {
@@ -1334,14 +1359,6 @@ export default {
 	display: flex;
 	flex-wrap: wrap;
 	gap: var(--default-grid-baseline);
-	margin: var(--default-grid-baseline) calc(var(--default-grid-baseline) * 2);
-}
-
-.left-sidebar__settings-button-container {
-	display: flex;
-	flex-direction: column;
-	gap: var(--default-grid-baseline);
-	padding: calc(2 * var(--default-grid-baseline));
 }
 
 .left-sidebar__settings-button-bubble {

--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -233,49 +233,45 @@
 				</div>
 
 				<div v-if="!isSearching" class="navigation-buttons-container">
-					<NcAppNavigationItem
-						class="navigation-item"
+					<LeftSidebarButton
 						:to="{ name: 'root' }"
-						:name="HOME_BUTTON_LABEL"
+						:active="$route.name === 'root'"
 						@click="refreshTalkDashboard">
 						<template #icon>
 							<IconHomeOutline :size="20" />
 						</template>
-					</NcAppNavigationItem>
+						{{ HOME_BUTTON_LABEL }}
+					</LeftSidebarButton>
 					<template v-if="showArchived || showThreadsList">
-						<NcAppNavigationItem
-							class="navigation-item"
-							:name="t('spreed', 'Back to conversations')"
-							@click.prevent="handleBackToConversations">
+						<LeftSidebarButton @click="handleBackToConversations">
 							<template #icon>
 								<IconArrowLeft class="bidirectional-icon" :size="20" />
 							</template>
-						</NcAppNavigationItem>
+							{{ t('spreed', 'Back to conversations') }}
+						</LeftSidebarButton>
 						<NcAppNavigationCaption
 							class="navigation-caption"
 							:name="showArchived ? t('spreed', 'Archived conversations') : t('spreed', 'Threads')" />
 					</template>
-					<NcAppNavigationItem
+					<LeftSidebarButton
 						v-else-if="supportThreads && !showThreadsList && !isSearching && !isFiltered"
-						class="navigation-item"
-						:name="t('spreed', 'Threads')"
-						@click.prevent="handleShowThreadsList">
+						@click="handleShowThreadsList">
 						<template #icon>
 							<IconForumOutline :size="20" />
 						</template>
-					</NcAppNavigationItem>
-					<NcAppNavigationItem
+						{{ t('spreed', 'Threads') }}
+					</LeftSidebarButton>
+					<LeftSidebarButton
 						v-if="pendingInvitationsCount && !isSearching && !showArchived && !showThreadsList"
-						class="navigation-item"
-						:name="t('spreed', 'Pending invitations')"
-						@click.prevent="showInvitationHandler">
+						@click="showInvitationHandler">
 						<template #icon>
 							<IconAccountMultiplePlusOutline :size="20" />
 						</template>
-						<template #counter>
+						{{ t('spreed', 'Pending invitations') }}
+						<template #badge>
 							<NcCounterBubble type="highlighted" :count="pendingInvitationsCount" />
 						</template>
-					</NcAppNavigationItem>
+					</LeftSidebarButton>
 				</div>
 			</div>
 		</template>
@@ -310,16 +306,17 @@
 							v-for="thread of followedThreads"
 							:key="`thread_${thread.thread.id}`"
 							:thread="thread" />
-						<NcAppNavigationItem
-							v-if="!allFollowedThreadsReceived"
-							class="navigation-item"
-							:name="t('spreed', 'Show more threads')"
-							@click.prevent="loadMoreFollowedThreads">
+					</ul>
+					<div v-if="!allFollowedThreadsReceived" class="navigation-buttons-container">
+						<LeftSidebarButton
+							:compact="false /* ThreadItem-s are never compact */"
+							@click="loadMoreFollowedThreads">
 							<template #icon>
 								<IconForumOutline :size="20" />
 							</template>
-						</NcAppNavigationItem>
-					</ul>
+							{{ t('spreed', 'Show more threads') }}
+						</LeftSidebarButton>
+					</div>
 				</template>
 				<ConversationsListVirtual
 					v-else
@@ -357,26 +354,27 @@
 		<template #footer>
 			<div class="navigation-bottom">
 				<div class="navigation-buttons-container">
-					<NcButton
+					<LeftSidebarButton
 						v-if="supportsArchive && !isSearching && !showArchived && !showThreadsList && archivedConversationsList.length"
-						variant="tertiary"
-						wide
 						@click="showArchived = true; showThreadsList = false">
 						<template #icon>
 							<IconArchiveOutline :size="20" />
 						</template>
 						{{ t('spreed', 'Archived conversations') }}
-						<span v-if="showArchivedConversationsBubble" class="left-sidebar__settings-button-bubble">
-							⬤
-						</span>
-					</NcButton>
+						<template #badge>
+							<span v-if="showArchivedConversationsBubble" class="archived-conversations-bubble">
+								⬤
+							</span>
+						</template>
+					</LeftSidebarButton>
 
-					<NcButton variant="tertiary" wide @click="showSettings">
+					<LeftSidebarButton
+						@click="showSettings">
 						<template #icon>
 							<IconCogOutline :size="20" />
 						</template>
 						{{ t('spreed', 'App settings') }}
-					</NcButton>
+					</LeftSidebarButton>
 				</div>
 			</div>
 		</template>
@@ -432,6 +430,7 @@ import TransitionWrapper from '../UIShared/TransitionWrapper.vue'
 import CallPhoneDialog from './CallPhoneDialog/CallPhoneDialog.vue'
 import ConversationsListVirtual from './ConversationsList/ConversationsListVirtual.vue'
 import InvitationHandler from './InvitationHandler.vue'
+import LeftSidebarButton from './LeftSidebarButton.vue'
 import OpenConversationsList from './OpenConversationsList/OpenConversationsList.vue'
 import SearchConversationsResults from './SearchConversationsResults/SearchConversationsResults.vue'
 import { useArrowNavigation } from '../../composables/useArrowNavigation.js'
@@ -508,7 +507,6 @@ export default {
 		InvitationHandler,
 		NcAppNavigation,
 		NcAppNavigationCaption,
-		NcAppNavigationItem,
 		NcButton,
 		NcCounterBubble,
 		NcChip,
@@ -523,6 +521,7 @@ export default {
 		TransitionWrapper,
 		ConversationsListVirtual,
 		SearchConversationsResults,
+		LeftSidebarButton,
 		// Icons
 		IconAccountMultiplePlusOutline,
 		IconAt,
@@ -1304,30 +1303,8 @@ export default {
 	}
 }
 
-.navigation-item {
-	padding-inline: calc(var(--default-grid-baseline) * 2);
-	margin-block: var(--default-grid-baseline);
-
-	:deep(.app-navigation-entry-link) {
-		padding-inline-start: var(--default-grid-baseline);
-	}
-
-	:deep(.app-navigation-entry-icon) {
-		flex: 0 0 40px !important; // AVATAR.SIZE.DEFAULT
-	}
-
-	:deep(.app-navigation-entry__name) {
-		padding-inline-start: calc(2 * var(--default-grid-baseline));
-		font-weight: 500;
-	}
-}
-
 .threads-tab__list {
 	padding-inline: var(--default-grid-baseline);
-
-	& > .navigation-item {
-		padding-inline: var(--default-grid-baseline);
-	}
 }
 
 .unread-mention-button {
@@ -1362,7 +1339,7 @@ export default {
 	gap: var(--default-grid-baseline);
 }
 
-.left-sidebar__settings-button-bubble {
+.archived-conversations-bubble {
 	margin-inline: var(--default-grid-baseline);
 	color: var(--color-primary-element);
 }

--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -219,6 +219,7 @@
 						<InvitationHandler v-if="pendingInvitationsCount" ref="invitationHandler" />
 					</div>
 					<TransitionWrapper
+						v-if="filters.length"
 						class="conversations__filters"
 						name="zoom"
 						tag="div"

--- a/src/components/LeftSidebar/LeftSidebarButton.vue
+++ b/src/components/LeftSidebar/LeftSidebarButton.vue
@@ -1,0 +1,81 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<script setup lang="ts">
+import type { Slot } from 'vue'
+
+import { computed } from 'vue'
+import NcButton from '@nextcloud/vue/components/NcButton'
+import { AVATAR, CONVERSATION } from '../../constants.ts'
+import { useSettingsStore } from '../../stores/settings.ts'
+
+const { compact = undefined } = defineProps<{
+	compact?: boolean | undefined
+	active?: boolean
+}>()
+
+defineSlots<{
+	default?: Slot
+	icon?: Slot
+	badge?: Slot
+}>()
+
+const settingsStore = useSettingsStore()
+const isCompact = computed(() => compact ?? (settingsStore.conversationsListStyle === CONVERSATION.LIST_STYLE.COMPACT))
+
+const iconSize = computed(() => (isCompact.value ? AVATAR.SIZE.COMPACT : AVATAR.SIZE.DEFAULT) + 'px')
+</script>
+
+<template>
+	<NcButton
+		class="left-sidebar-button"
+		:variant="active ? 'primary' : 'tertiary'"
+		alignment="start"
+		wide>
+		<template #icon>
+			<slot name="icon" />
+		</template>
+		<span class="left-sidebar-button__content">
+			<span class="left-sidebar-button__text">
+				<slot />
+			</span>
+			<slot name="badge" />
+		</span>
+	</NcButton>
+</template>
+
+<style lang="scss" scoped>
+.left-sidebar-button {
+	// Align the padding with navigation items and list items
+	// TODO: make it s public variable or add a way to customize content without having the pre-defined padding
+	--button-padding: calc(var(--default-grid-baseline) - 1px /* transparent border */);
+
+	// TODO: fix upstream - allow custom icon size
+	:deep(.button-vue__icon) {
+		width: v-bind(iconSize);
+		min-width: v-bind(iconSize);
+	}
+
+	// TODO: fix upstream - the text container is not stretched
+	:deep(.button-vue__text) {
+		flex: 1 0 auto;
+	}
+}
+
+.left-sidebar-button__content {
+	display: inline-flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: calc(2 * var(--default-grid-baseline));
+	padding-inline-start: calc(2 * var(--default-grid-baseline));
+	width: 100%;
+	// Reset NcButton's font-weight
+	font-weight: unset;
+}
+
+.left-sidebar-button__text {
+	font-weight: 500;
+}
+</style>


### PR DESCRIPTION
## ☑️ Resolves

* Fix https://github.com/nextcloud/spreed/issues/16320
* Fix https://github.com/nextcloud/spreed/issues/13924
* 👁️👃👁️ Review without whitespaces by commits
* Alignment:
  * Icons aligned by width and icons' centers
  * Text aligned by the position on the left
  * Adapts to the compact mode
* Counter/badge style mention on `Archived conversations`
* Paddings:
  * 2x padding on entire navigation perimeter
  * 2x padding between search block and buttons
  * 1x padding between items, including visual padding between top buttons and the list, the list and the bottom block
* Chips aligned with the search and moved closer

### AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="294" height="576" alt="image" src="https://github.com/user-attachments/assets/39e57a77-4b54-4df9-845d-769dd56a933d" /> | <img width="294" height="570" alt="image" src="https://github.com/user-attachments/assets/d5c6cc5b-7781-46cb-907e-71dc06356f26" />
<img width="293" height="574" alt="image" src="https://github.com/user-attachments/assets/a4d7fc49-ca49-4126-a40b-f0422c50227c" /> | <img width="297" height="572" alt="image" src="https://github.com/user-attachments/assets/1e9e9080-c4f2-47a8-bba4-8ad6c5fbe758" />
<img width="293" height="576" alt="image" src="https://github.com/user-attachments/assets/5b9976f7-5348-4151-9f76-33bad6c2081e" /> | <img width="296" height="573" alt="image" src="https://github.com/user-attachments/assets/5a6994a2-94ac-4111-aabd-8c0a80af42cc" />
<img width="297" height="573" alt="image" src="https://github.com/user-attachments/assets/aa39e606-7dbc-4a26-bb29-5245c5242dd0" /> | <img width="295" height="570" alt="image" src="https://github.com/user-attachments/assets/c4ae1d25-e978-4d10-af56-b651acb418ef" />

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required