### PR TITLE
refactor(room): Remove Manager constructor dependency from Room

### DIFF
--- a/lib/Manager.php
+++ b/lib/Manager.php
@@ -159,7 +159,6 @@ class Manager {
 		}
 
 		return new Room(
-			$this,
 			$this->timeFactory,
 			(int)$row['r_id'],
 			(int)$row['type'],

--- a/lib/Room.php
+++ b/lib/Room.php
@@ -100,7 +100,6 @@ class Room {
 	 * @psalm-param self::MENTION_PERMISSIONS_* $mentionPermissions
 	 */
 	public function __construct(
-		private Manager $manager,
 		private ITimeFactory $timeFactory,
 		private int $id,
 		private int $type,
@@ -291,7 +290,8 @@ class Room {
 	}
 
 	public function getDisplayName(string $userId, bool $forceName = false): string {
-		return $this->manager->resolveRoomDisplayName($this, $userId, $forceName);
+		// TODO use DI
+		return Server::get(Manager::class)->resolveRoomDisplayName($this, $userId, $forceName);
 	}
 
 	public function getDescription(): string {
@@ -345,7 +345,8 @@ class Room {
 		}
 
 		if ($this->lastMessageId && $this->lastMessage === null) {
-			$this->lastMessage = $this->manager->loadLastCommentInfo($this->lastMessageId);
+			// TODO use DI
+			$this->lastMessage = Server::get(Manager::class)->loadLastCommentInfo($this->lastMessageId);
 			if ($this->lastMessage === null) {
 				$this->lastMessageId = 0;
 			}

--- a/tests/php/Service/RoomServiceTest.php
+++ b/tests/php/Service/RoomServiceTest.php
@@ -348,7 +348,6 @@ class RoomServiceTest extends TestCase {
 		);
 
 		$room = new Room(
-			$this->createMock(Manager::class),
 			$this->createMock(ITimeFactory::class),
 			1,
 			Room::TYPE_PUBLIC,


### PR DESCRIPTION
Replace $this->manager in getDisplayName() with Server::get(Manager::class), matching the existing pattern used by getName() for ParticipantService. This removes the last injected service dependency from Room's constructor, leaving only ITimeFactory alongside the data fields.

AI-Assisted-By: Claude Sonnet 4.6 <noreply@anthropic.com>

### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

<!--
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
░░░███████░░░█████████░░█████░
░░███░░░███░░░███░░░███░░███░░
░░█████████░░░████████░░░███░░
░░███░░░███░░░███░░░░░░░░███░░
░█████░█████░█████░░░░░░█████░
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching frontend/UI code
-->

## 🛠️ API Checklist

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
