### PR TITLE
refactor(room): Move one-to-one name resolution to RoomService

### DIFF
--- a/lib/Room.php
+++ b/lib/Room.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 
 namespace OCA\Talk;
 
-use OCA\Talk\Service\ParticipantService;
 use OCA\Talk\Service\RecordingService;
 use OCA\Talk\Service\RoomService;
 use OCP\AppFramework\Utility\ITimeFactory;
@@ -244,29 +243,9 @@ class Room {
 	}
 
 	public function getName(): string {
-		if ($this->type === self::TYPE_ONE_TO_ONE) {
-			if ($this->name === '') {
-				// TODO use DI
-				$participantService = Server::get(ParticipantService::class);
-				// Fill the room name with the participants for 1-to-1 conversations
-				$users = $participantService->getParticipantUserIds($this);
-				sort($users);
-				/** @var RoomService $roomService */
-				$roomService = Server::get(RoomService::class);
-				$roomService->setName($this, json_encode($users), '');
-			} elseif (!str_starts_with($this->name, '["')) {
-				// TODO use DI
-				$participantService = Server::get(ParticipantService::class);
-				// Not the json array, but the old fallback when someone left
-				$users = $participantService->getParticipantUserIds($this);
-				if (count($users) !== 2) {
-					$users[] = $this->name;
-				}
-				sort($users);
-				/** @var RoomService $roomService */
-				$roomService = Server::get(RoomService::class);
-				$roomService->setName($this, json_encode($users), '');
-			}
+		if ($this->type === self::TYPE_ONE_TO_ONE && !str_starts_with($this->name, '["')) {
+			// TODO use DI
+			Server::get(RoomService::class)->resolveOneToOneName($this, $this->name);
 		}
 		return $this->name;
 	}

--- a/lib/Service/RoomService.php
+++ b/lib/Service/RoomService.php
@@ -485,6 +485,22 @@ class RoomService {
 		}
 	}
 
+	public function resolveOneToOneName(Room $room, string $currentName): void {
+		if ($currentName === '') {
+			$users = $this->participantService->getParticipantUserIds($room);
+			sort($users);
+			$this->setName($room, json_encode($users), '');
+		} elseif (!str_starts_with($currentName, '["')) {
+			// Legacy format: plain string (other user's ID), not a JSON array
+			$users = $this->participantService->getParticipantUserIds($room);
+			if (count($users) !== 2) {
+				$users[] = $currentName;
+			}
+			sort($users);
+			$this->setName($room, json_encode($users), '');
+		}
+	}
+
 	/**
 	 * @throws NameException
 	 */


### PR DESCRIPTION
Extract the lazy name reconstruction logic from Room::getName() into RoomService::resolveOneToOneName(). Room::getName() now delegates to it via Server::get(), keeping the same behaviour while moving the business logic to where it belongs.

AI-Assisted-By: Claude Sonnet 4.6 <noreply@anthropic.com>

### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

<!--
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
░░░███████░░░█████████░░█████░
░░███░░░███░░░███░░░███░░███░░
░░█████████░░░████████░░░███░░
░░███░░░███░░░███░░░░░░░░███░░
░█████░█████░█████░░░░░░█████░
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching frontend/UI code
-->

## 🛠️ API Checklist

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
