### PR TITLE
refactor(room): Move `validateTimer()` out of `getLobbyState()`/`getLobbyTimer()` getters

### DIFF
--- a/lib/Manager.php
+++ b/lib/Manager.php
@@ -159,7 +159,6 @@ class Manager {
 		}
 
 		return new Room(
-			$this->timeFactory,
 			(int)$row['r_id'],
 			(int)$row['type'],
 			(int)$row['read_only'],

--- a/lib/Middleware/InjectionMiddleware.php
+++ b/lib/Middleware/InjectionMiddleware.php
@@ -40,6 +40,7 @@ use OCA\Talk\Participant;
 use OCA\Talk\Room;
 use OCA\Talk\Service\BanService;
 use OCA\Talk\Service\ParticipantService;
+use OCA\Talk\Service\RoomService;
 use OCA\Talk\TalkSession;
 use OCA\Talk\Webinary;
 use OCP\AppFramework\Controller;
@@ -70,6 +71,7 @@ class InjectionMiddleware extends Middleware {
 		protected InvitationMapper $invitationMapper,
 		protected Authenticator $federationAuthenticator,
 		protected BanService $banService,
+		protected RoomService $roomService,
 		protected LoggerInterface $logger,
 		protected ?string $userId,
 	) {
@@ -387,7 +389,11 @@ class InjectionMiddleware extends Middleware {
 		}
 
 		$room = $controller->getRoom();
-		if (!$room instanceof Room || $room->getLobbyState() !== Webinary::LOBBY_NONE) {
+		if (!$room instanceof Room) {
+			throw new LobbyException();
+		}
+		$this->roomService->validateLobbyTimer($room);
+		if ($room->getLobbyState() !== Webinary::LOBBY_NONE) {
 			throw new LobbyException();
 		}
 	}

--- a/lib/Room.php
+++ b/lib/Room.php
@@ -11,7 +11,6 @@ namespace OCA\Talk;
 use OCA\Talk\Service\ParticipantService;
 use OCA\Talk\Service\RecordingService;
 use OCA\Talk\Service\RoomService;
-use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Comments\IComment;
 use OCP\Server;
 
@@ -100,7 +99,6 @@ class Room {
 	 * @psalm-param self::MENTION_PERMISSIONS_* $mentionPermissions
 	 */
 	public function __construct(
-		private ITimeFactory $timeFactory,
 		private int $id,
 		private int $type,
 		private int $readOnly,
@@ -192,10 +190,7 @@ class Room {
 		$this->messageExpiration = $messageExpiration;
 	}
 
-	public function getLobbyState(bool $validateTime = true): int {
-		if ($validateTime) {
-			$this->validateTimer();
-		}
+	public function getLobbyState(): int {
 		return $this->lobbyState;
 	}
 
@@ -203,23 +198,12 @@ class Room {
 		$this->lobbyState = $lobbyState;
 	}
 
-	public function getLobbyTimer(bool $validateTime = true): ?\DateTime {
-		if ($validateTime) {
-			$this->validateTimer();
-		}
+	public function getLobbyTimer(): ?\DateTime {
 		return $this->lobbyTimer;
 	}
 
 	public function setLobbyTimer(?\DateTime $lobbyTimer): void {
 		$this->lobbyTimer = $lobbyTimer;
-	}
-
-	protected function validateTimer(): void {
-		if ($this->lobbyTimer !== null && $this->lobbyTimer < $this->timeFactory->getDateTime()) {
-			/** @var RoomService $roomService */
-			$roomService = Server::get(RoomService::class);
-			$roomService->setLobby($this, Webinary::LOBBY_NONE, null, true);
-		}
 	}
 
 	public function getSIPEnabled(): int {

--- a/lib/Service/RoomFormatter.php
+++ b/lib/Service/RoomFormatter.php
@@ -41,6 +41,7 @@ class RoomFormatter {
 		protected IAppConfig $appConfig,
 		protected AvatarService $avatarService,
 		protected ParticipantService $participantService,
+		protected RoomService $roomService,
 		protected ChatManager $chatManager,
 		protected MessageParser $messageParser,
 		protected IConfig $serverConfig,
@@ -173,6 +174,8 @@ class RoomFormatter {
 		} else {
 			$lastActivity = 0;
 		}
+
+		$this->roomService->validateLobbyTimer($room);
 
 		$lobbyTimer = $room->getLobbyTimer();
 		if ($lobbyTimer instanceof \DateTimeInterface) {

--- a/lib/Service/RoomService.php
+++ b/lib/Service/RoomService.php
@@ -529,8 +529,15 @@ class RoomService {
 	 * @param bool $dispatchEvents (Only skip if the room is created in the same PHP request)
 	 * @throws LobbyException
 	 */
+	public function validateLobbyTimer(Room $room): void {
+		$lobbyTimer = $room->getLobbyTimer();
+		if ($lobbyTimer !== null && $lobbyTimer < $this->timeFactory->getDateTime()) {
+			$this->setLobby($room, Webinary::LOBBY_NONE, null, true);
+		}
+	}
+
 	public function setLobby(Room $room, int $newState, ?\DateTime $dateTime, bool $timerReached = false, bool $dispatchEvents = true): void {
-		$oldState = $room->getLobbyState(false);
+		$oldState = $room->getLobbyState();
 
 		if (!in_array($room->getType(), [Room::TYPE_GROUP, Room::TYPE_PUBLIC], true)) {
 			throw new LobbyException(LobbyException::REASON_TYPE);
@@ -1345,7 +1352,7 @@ class RoomService {
 			$this->setLastActivity($local, $lastActivity);
 			$changed[] = ARoomSyncedEvent::PROPERTY_LAST_ACTIVITY;
 		}
-		if (isset($host['lobbyState'], $host['lobbyTimer']) && ($host['lobbyState'] !== $local->getLobbyState(false) || $host['lobbyTimer'] !== ((int)$local->getLobbyTimer(false)?->getTimestamp()))) {
+		if (isset($host['lobbyState'], $host['lobbyTimer']) && ($host['lobbyState'] !== $local->getLobbyState() || $host['lobbyTimer'] !== ((int)$local->getLobbyTimer()?->getTimestamp()))) {
 			$hostTimer = $host['lobbyTimer'] === 0 ? null : $this->timeFactory->getDateTime('@' . $host['lobbyTimer']);
 			try {
 				$this->setLobby($local, $host['lobbyState'], $hostTimer);

--- a/lib/Signaling/RoomPropertiesHelper.php
+++ b/lib/Signaling/RoomPropertiesHelper.php
@@ -10,16 +10,20 @@ namespace OCA\Talk\Signaling;
 
 use OCA\Talk\Events\BeforeSignalingRoomPropertiesSentEvent;
 use OCA\Talk\Room;
+use OCA\Talk\Service\RoomService;
 use OCP\EventDispatcher\IEventDispatcher;
 
 class RoomPropertiesHelper {
 
 	public function __construct(
 		private IEventDispatcher $dispatcher,
+		private RoomService $roomService,
 	) {
 	}
 
 	public function getPropertiesForSignaling(Room $room, string $userId, bool $roomModified = true): array {
+		$this->roomService->validateLobbyTimer($room);
+
 		$properties = [
 			'name' => $room->getDisplayName($userId),
 			'type' => $room->getType(),

--- a/tests/php/RoomTest.php
+++ b/tests/php/RoomTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Talk\Tests\php;
+
+use OCA\Talk\Model\Attendee;
+use OCA\Talk\Model\BreakoutRoom;
+use OCA\Talk\Participant;
+use OCA\Talk\Room;
+use OCA\Talk\Service\RecordingService;
+use OCA\Talk\Webinary;
+use Test\TestCase;
+
+class RoomTest extends TestCase {
+	private function createRoom(?\DateTime $lobbyTimer = null, int $lobbyState = Webinary::LOBBY_NONE): Room {
+		return new Room(
+			1,
+			Room::TYPE_GROUP,
+			Room::READ_WRITE,
+			Room::LISTABLE_NONE,
+			0,
+			$lobbyState,
+			Webinary::SIP_DISABLED,
+			null,
+			'token',
+			'name',
+			'',
+			'',
+			'',
+			'',
+			'',
+			Attendee::PERMISSIONS_DEFAULT,
+			Participant::FLAG_DISCONNECTED,
+			null,
+			null,
+			0,
+			null,
+			$lobbyTimer,
+			'',
+			'',
+			BreakoutRoom::MODE_NOT_CONFIGURED,
+			BreakoutRoom::STATUS_STOPPED,
+			Room::RECORDING_NONE,
+			RecordingService::CONSENT_REQUIRED_NO,
+			Room::HAS_FEDERATION_NONE,
+			Room::MENTION_PERMISSIONS_EVERYONE,
+			'',
+			0,
+			0,
+		);
+	}
+
+	public function testGetLobbyStateIsPure(): void {
+		$room = $this->createRoom(null, Webinary::LOBBY_NON_MODERATORS);
+		$this->assertSame(Webinary::LOBBY_NON_MODERATORS, $room->getLobbyState());
+		$this->assertSame(Webinary::LOBBY_NON_MODERATORS, $room->getLobbyState());
+	}
+
+	public function testGetLobbyTimerIsPure(): void {
+		$timer = new \DateTime('+1 hour');
+		$room = $this->createRoom($timer);
+		$this->assertEquals($timer, $room->getLobbyTimer());
+		$this->assertEquals($timer, $room->getLobbyTimer());
+	}
+}

--- a/tests/php/Service/RoomServiceTest.php
+++ b/tests/php/Service/RoomServiceTest.php
@@ -312,6 +312,41 @@ class RoomServiceTest extends TestCase {
 		$this->assertSame($expected, $this->service->prepareConversationName($input));
 	}
 
+	public function testValidateLobbyTimerDoesNothingWithNullTimer(): void {
+		$room = $this->createMock(Room::class);
+		$room->method('getLobbyTimer')->willReturn(null);
+		$room->expects($this->never())->method('setLobbyState');
+
+		$this->service->validateLobbyTimer($room);
+	}
+
+	public function testValidateLobbyTimerDoesNothingWithFutureTimer(): void {
+		$future = new \DateTime('+1 hour');
+		$this->timeFactory->method('getDateTime')->willReturn(new \DateTime());
+
+		$room = $this->createMock(Room::class);
+		$room->method('getLobbyTimer')->willReturn($future);
+		$room->expects($this->never())->method('setLobbyState');
+
+		$this->service->validateLobbyTimer($room);
+	}
+
+	public function testValidateLobbyTimerResetsLobbyWhenExpired(): void {
+		$past = new \DateTime('-1 hour');
+		$this->timeFactory->method('getDateTime')->willReturn(new \DateTime());
+
+		$room = $this->createMock(Room::class);
+		$room->method('getLobbyTimer')->willReturn($past);
+		$room->method('getLobbyState')->willReturn(Webinary::LOBBY_NON_MODERATORS);
+		$room->method('getType')->willReturn(Room::TYPE_GROUP);
+		$room->method('getObjectType')->willReturn('');
+		$room->method('getId')->willReturn(0);
+		$room->expects($this->once())->method('setLobbyState')->with(Webinary::LOBBY_NONE);
+		$room->expects($this->once())->method('setLobbyTimer')->with(null);
+
+		$this->service->validateLobbyTimer($room);
+	}
+
 	public function testVerifyPassword(): void {
 		$dispatcher = new EventDispatcher(
 			new \Symfony\Component\EventDispatcher\EventDispatcher(),
@@ -348,7 +383,6 @@ class RoomServiceTest extends TestCase {
 		);
 
 		$room = new Room(
-			$this->createMock(ITimeFactory::class),
 			1,
 			Room::TYPE_PUBLIC,
 			Room::READ_WRITE,

--- a/tests/php/Signaling/RoomPropertiesHelperTest.php
+++ b/tests/php/Signaling/RoomPropertiesHelperTest.php
@@ -10,6 +10,7 @@ namespace OCA\Talk\Tests\php\Signaling;
 
 use OCA\Talk\Events\BeforeSignalingRoomPropertiesSentEvent;
 use OCA\Talk\Room;
+use OCA\Talk\Service\RoomService;
 use OCA\Talk\Signaling\RoomPropertiesHelper;
 use OCA\Talk\Webinary;
 use OCP\EventDispatcher\IEventDispatcher;
@@ -18,12 +19,14 @@ use Test\TestCase;
 
 class RoomPropertiesHelperTest extends TestCase {
 	private IEventDispatcher&MockObject $dispatcher;
+	private RoomService&MockObject $roomService;
 	private RoomPropertiesHelper $helper;
 
 	public function setUp(): void {
 		parent::setUp();
 		$this->dispatcher = $this->createMock(IEventDispatcher::class);
-		$this->helper = new RoomPropertiesHelper($this->dispatcher);
+		$this->roomService = $this->createMock(RoomService::class);
+		$this->helper = new RoomPropertiesHelper($this->dispatcher, $this->roomService);
 	}
 
 	private function createRoomMock(string $displayName = 'Room name'): Room&MockObject {
@@ -99,5 +102,15 @@ class RoomPropertiesHelperTest extends TestCase {
 
 		$this->assertInstanceOf(BeforeSignalingRoomPropertiesSentEvent::class, $capturedEvent);
 		$this->assertSame('bob', $capturedEvent->getUserId());
+	}
+
+	public function testGetPropertiesForSignalingCallsValidateLobbyTimer(): void {
+		$room = $this->createRoomMock();
+
+		$this->roomService->expects($this->once())
+			->method('validateLobbyTimer')
+			->with($room);
+
+		$this->helper->getPropertiesForSignaling($room, 'alice');
 	}
 }


### PR DESCRIPTION
Make `getLobbyState()` and `getLobbyTimer()` pure getters by moving the timer-expiry side effect into an explicit `RoomService::validateLobbyTimer()` method called at the three entry points that gate all interactive user flows.

## What changed

- `getLobbyState()` and `getLobbyTimer()` are now pure getters (removed `bool $validateTime` parameter)
- Timer-expiry logic extracted to `RoomService::validateLobbyTimer(Room $room)` with proper constructor DI
- Called explicitly from `RoomFormatter::formatRoomV4()`, `InjectionMiddleware::checkLobbyState()`, and `RoomPropertiesHelper::getPropertiesForSignaling()`
- `ITimeFactory` is no longer needed in `Room`'s constructor

## On the secondary callers

cc @nickvergessen 

Some callers (`Chat/Notifier`, `Dashboard/TalkWidget`, `Search`, background jobs) read `getLobbyState()` without an explicit `validateLobbyTimer()` call. These callers only use the lobby state for display or notification decisions — not to gate access. Every interactive user flow (joining a room, sending a message, any API response) goes through `InjectionMiddleware` or `RoomFormatter` first, which validates the timer before the secondary callers are reached.

Making `getLobbyState()` auto-validate on every call is not feasible:
- It causes infinite recursion: `getLobbyState()` → `validateLobbyTimer()` → `setLobby()` → `getLobbyState()` (which reads old state before updating)
- It breaks the federation sync comparison in `syncProperties()`, which intentionally reads the raw stored value to diff against the host

A background job running every minute was investigated but rejected — the documented recommendation is a 5-minute cron interval, which is too coarse for lobby timer precision.

### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

## 🛠️ API Checklist

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed