### PR TITLE
feat: Temporarily mute conversations

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -18,7 +18,7 @@
 * 🌉 **Sync with other chat solutions** With [Matterbridge](https://github.com/42wim/matterbridge/) being integrated in Talk, you can easily sync a lot of other chat solutions to Nextcloud Talk and vice-versa.
 ]]></description>
 
-	<version>24.0.0-dev.2</version>
+	<version>24.0.0-dev.3</version>
 	<licence>agpl</licence>
 
 	<author>Anna Larch</author>

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -226,3 +226,4 @@
 * `config => conversations => group-mode` (local) - User selected grouping mode for conversations (`none`, `group-first` or `private-first`)
 * `private-reply` - Whether clients can link the original message to a private reply in one-to-one conversations
 * `config => attachments => conversation-subfolders` (local) - Whether per-conversation subfolders are used for Talk attachments; when `true` files must be uploaded to `Talk/<ConversationName>-<token>/<DisplayName>-<uid>/` before calling the attachment endpoint
+* `mute-conversations` - Wether conversations can be muted for given time.

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -226,4 +226,4 @@
 * `config => conversations => group-mode` (local) - User selected grouping mode for conversations (`none`, `group-first` or `private-first`)
 * `private-reply` - Whether clients can link the original message to a private reply in one-to-one conversations
 * `config => attachments => conversation-subfolders` (local) - Whether per-conversation subfolders are used for Talk attachments; when `true` files must be uploaded to `Talk/<ConversationName>-<token>/<DisplayName>-<uid>/` before calling the attachment endpoint
-* `mute-conversations` - Wether conversations can be muted for given time.
+* `mute-conversations` - Whether conversations can be muted for a given time

--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -132,6 +132,7 @@ class Capabilities implements IPublicCapability {
 		'scheduled-messages',
 		'conversation-presets',
 		'private-reply',
+		'mute-conversations',
 	];
 
 	public const CONDITIONAL_FEATURES = [

--- a/lib/Chat/Notifier.php
+++ b/lib/Chat/Notifier.php
@@ -692,6 +692,10 @@ class Notifier {
 				return self::PRIORITY_NONE;
 			}
 
+			if ($attendee->getMuteUntil() >= $this->timeFactory->getDateTime()) {
+				return self::PRIORITY_NONE;
+			}
+
 			$notificationLevel = $attendee->getNotificationLevel();
 			$threadId = (int)$comment->getTopmostParentId();
 			if ($threadId !== 0) {
@@ -765,6 +769,10 @@ class Notifier {
 
 		if ($participant->getSession()?->getLastPing() >= $this->timeFactory->getTime() - Session::SESSION_TIMEOUT) {
 			// User is online
+			return self::PRIORITY_NONE;
+		}
+
+		if ($participant->getAttendee()->getMuteUntil() >= $this->timeFactory->getDateTime()) {
 			return self::PRIORITY_NONE;
 		}
 

--- a/lib/Chat/Notifier.php
+++ b/lib/Chat/Notifier.php
@@ -692,7 +692,7 @@ class Notifier {
 				return self::PRIORITY_NONE;
 			}
 
-			if ($attendee->getMuteUntil() >= $this->timeFactory->getDateTime()) {
+			if ($attendee->getMuteUntil() >= $this->timeFactory->getDateTime()->getTimestamp()) {
 				return self::PRIORITY_NONE;
 			}
 
@@ -772,7 +772,7 @@ class Notifier {
 			return self::PRIORITY_NONE;
 		}
 
-		if ($participant->getAttendee()->getMuteUntil() >= $this->timeFactory->getDateTime()) {
+		if ($participant->getAttendee()->getMuteUntil() >= $this->timeFactory->getDateTime()->getTimestamp()) {
 			return self::PRIORITY_NONE;
 		}
 

--- a/lib/Chat/Notifier.php
+++ b/lib/Chat/Notifier.php
@@ -692,7 +692,7 @@ class Notifier {
 				return self::PRIORITY_NONE;
 			}
 
-			if ($attendee->getMuteUntil() >= $this->timeFactory->getDateTime()->getTimestamp()) {
+			if ($attendee->getMuteUntil() >= $this->timeFactory->getTime()) {
 				return self::PRIORITY_NONE;
 			}
 
@@ -772,7 +772,7 @@ class Notifier {
 			return self::PRIORITY_NONE;
 		}
 
-		if ($participant->getAttendee()->getMuteUntil() >= $this->timeFactory->getDateTime()->getTimestamp()) {
+		if ($participant->getAttendee()->getMuteUntil() >= $this->timeFactory->getTime()) {
 			return self::PRIORITY_NONE;
 		}
 

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -3259,7 +3259,7 @@ class RoomController extends AEnvironmentAwareOCSController {
 		'token' => '[a-z0-9]{4,30}',
 	])]
 	public function muteConversation(int $muteUntil): DataResponse {
-		if ($muteUntil <= $this->timeFactory->getDateTime()->getTimestamp()) {
+		if ($muteUntil <= $this->timeFactory->getTime()) {
 			return new DataResponse(['error' => 'mute-until'], Http::STATUS_BAD_REQUEST);
 		}
 

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -3246,9 +3246,10 @@ class RoomController extends AEnvironmentAwareOCSController {
 	 * Required capability: `mute-conversations`
 	 *
 	 * @param int $muteUntil Unix timestamp until notifications are muted
-	 * @return DataResponse<Http::STATUS_OK, TalkRoom, array{}>
+	 * @return DataResponse<Http::STATUS_OK, TalkRoom, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array{error: 'mute-until'}, array{}>
 	 *
 	 * 200: Conversation muted
+	 * 400: Timestamp is in the past
 	 */
 	#[NoAdminRequired]
 	#[FederationSupported]
@@ -3258,10 +3259,11 @@ class RoomController extends AEnvironmentAwareOCSController {
 		'token' => '[a-z0-9]{4,30}',
 	])]
 	public function muteConversation(int $muteUntil): DataResponse {
-		$muteUntilDateTime = $this->timeFactory->getDateTime('@' . $muteUntil);
-		$muteUntilDateTime->setTimezone(new \DateTimeZone('UTC'));
+		if ($muteUntil <= $this->timeFactory->getDateTime()->getTimestamp()) {
+			return new DataResponse(['error' => 'mute-until'], Http::STATUS_BAD_REQUEST);
+		}
 
-		$this->participantService->setMuteUntil($this->participant, $muteUntilDateTime);
+		$this->participantService->setMuteUntil($this->participant, $muteUntil);
 		return new DataResponse($this->formatRoom($this->room, $this->participant));
 	}
 
@@ -3283,10 +3285,7 @@ class RoomController extends AEnvironmentAwareOCSController {
 		'token' => '[a-z0-9]{4,30}',
 	])]
 	public function unmuteConversation(): DataResponse {
-		$muteUntilDateTime = new \DateTime();
-		$muteUntilDateTime->setTimestamp(0);
-
-		$this->participantService->setMuteUntil($this->participant, $muteUntilDateTime);
+		$this->participantService->setMuteUntil($this->participant, 0);
 		return new DataResponse($this->formatRoom($this->room, $this->participant));
 	}
 }

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -3238,4 +3238,55 @@ class RoomController extends AEnvironmentAwareOCSController {
 
 		return new DataResponse(null, Http::STATUS_OK);
 	}
+
+	/**
+	 * Mute all notifications in a conversation until a specific time.
+	 * Does not alter notification settings for the attendee.
+	 *
+	 * Required capability: `mute-conversations`
+	 *
+	 * @param int $muteUntil Unix timestamp until notifications are muted
+	 * @return DataResponse<Http::STATUS_OK, TalkRoom, array{}>
+	 *
+	 * 200: Conversation muted
+	 */
+	#[NoAdminRequired]
+	#[FederationSupported]
+	#[RequireLoggedInParticipant]
+	#[ApiRoute(verb: 'POST', url: '/api/{apiVersion}/room/{token}/mute', requirements: [
+		'apiVersion' => '(v4)',
+		'token' => '[a-z0-9]{4,30}',
+	])]
+	public function muteConversation(int $muteUntil): DataResponse {
+		$muteUntilDateTime = $this->timeFactory->getDateTime('@' . $muteUntil);
+		$muteUntilDateTime->setTimezone(new \DateTimeZone('UTC'));
+
+		$this->participantService->setMuteUntil($this->participant, $muteUntilDateTime);
+		return new DataResponse($this->formatRoom($this->room, $this->participant));
+	}
+
+	/**
+	 * Unmute all notifications in a conversation, when they were muted before.
+	 * Does not alter notification settings for the attendee.
+	 *
+	 * Required capability: `mute-conversations`
+	 *
+	 * @return DataResponse<Http::STATUS_OK, TalkRoom, array{}>
+	 *
+	 * 200: Conversation unmuted
+	 */
+	#[NoAdminRequired]
+	#[FederationSupported]
+	#[RequireLoggedInParticipant]
+	#[ApiRoute(verb: 'DELETE', url: '/api/{apiVersion}/room/{token}/mute', requirements: [
+		'apiVersion' => '(v4)',
+		'token' => '[a-z0-9]{4,30}',
+	])]
+	public function unmuteConversation(): DataResponse {
+		$muteUntilDateTime = new \DateTime();
+		$muteUntilDateTime->setTimestamp(0);
+
+		$this->participantService->setMuteUntil($this->participant, $muteUntilDateTime);
+		return new DataResponse($this->formatRoom($this->room, $this->participant));
+	}
 }

--- a/lib/Migration/Version24000Date20260419190830.php
+++ b/lib/Migration/Version24000Date20260419190830.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Talk\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+use Override;
+
+class Version24000Date20260419190830 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure(): ISchemaWrapper $schemaClosure
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	#[Override]
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$table = $schema->getTable('talk_attendees');
+		if (!$table->hasColumn('mute_until')) {
+			$table->addColumn('mute_until', Types::DATETIME, [
+				'notnull' => true,
+			]);
+		}
+
+		return $schema;
+	}
+}

--- a/lib/Migration/Version24000Date20260419190830.php
+++ b/lib/Migration/Version24000Date20260419190830.php
@@ -31,8 +31,10 @@ class Version24000Date20260419190830 extends SimpleMigrationStep {
 
 		$table = $schema->getTable('talk_attendees');
 		if (!$table->hasColumn('mute_until')) {
-			$table->addColumn('mute_until', Types::DATETIME, [
+			$table->addColumn('mute_until', Types::INTEGER, [
 				'notnull' => true,
+				'length' => 11,
+				'default' => 0,
 			]);
 		}
 

--- a/lib/Migration/Version24000Date20260419190830.php
+++ b/lib/Migration/Version24000Date20260419190830.php
@@ -31,9 +31,8 @@ class Version24000Date20260419190830 extends SimpleMigrationStep {
 
 		$table = $schema->getTable('talk_attendees');
 		if (!$table->hasColumn('mute_until')) {
-			$table->addColumn('mute_until', Types::INTEGER, [
+			$table->addColumn('mute_until', Types::BIGINT, [
 				'notnull' => true,
-				'length' => 11,
 				'default' => 0,
 			]);
 		}

--- a/lib/Model/Attendee.php
+++ b/lib/Model/Attendee.php
@@ -186,7 +186,7 @@ class Attendee extends Entity {
 		$this->addType('hasUnreadThreadDirects', Types::BOOLEAN);
 		$this->addType('hiddenPinnedId', Types::BIGINT);
 		$this->addType('hasScheduledMessages', Types::INTEGER);
-		$this->addType('muteUntil', Types::INTEGER);
+		$this->addType('muteUntil', Types::BIGINT);
 	}
 
 	public function getDisplayName(): string {

--- a/lib/Model/Attendee.php
+++ b/lib/Model/Attendee.php
@@ -74,8 +74,8 @@ use OCP\DB\Types;
  * @method int getHiddenPinnedId()
  * @method void setHasScheduledMessages(int $scheduledMessages)
  * @method int getHasScheduledMessages()
- * @method void setMuteUntil(\DateTime $muteUntil)
- * @method \DateTime getMuteUntil()
+ * @method void setMuteUntil(int $muteUntil)
+ * @method int getMuteUntil()
  */
 class Attendee extends Entity {
 	public const ACTOR_USERS = 'users';
@@ -152,13 +152,9 @@ class Attendee extends Entity {
 	protected bool $hasUnreadThreadDirects = false;
 	protected int $hiddenPinnedId = 0;
 	protected int $hasScheduledMessages = 0;
-	protected \DateTime $muteUntil;
+	protected int $muteUntil = 0;
 
 	public function __construct() {
-		$muteUntilDateTime = new \DateTime();
-		$muteUntilDateTime->setTimestamp(0);
-		$this->muteUntil = $muteUntilDateTime;
-
 		$this->addType('roomId', Types::BIGINT);
 		$this->addType('actorType', Types::STRING);
 		$this->addType('actorId', Types::STRING);
@@ -190,7 +186,7 @@ class Attendee extends Entity {
 		$this->addType('hasUnreadThreadDirects', Types::BOOLEAN);
 		$this->addType('hiddenPinnedId', Types::BIGINT);
 		$this->addType('hasScheduledMessages', Types::INTEGER);
-		$this->addType('muteUntil', Types::DATETIME);
+		$this->addType('muteUntil', Types::INTEGER);
 	}
 
 	public function getDisplayName(): string {

--- a/lib/Model/Attendee.php
+++ b/lib/Model/Attendee.php
@@ -74,6 +74,8 @@ use OCP\DB\Types;
  * @method int getHiddenPinnedId()
  * @method void setHasScheduledMessages(int $scheduledMessages)
  * @method int getHasScheduledMessages()
+ * @method void setMuteUntil(\DateTime $muteUntil)
+ * @method \DateTime getMuteUntil()
  */
 class Attendee extends Entity {
 	public const ACTOR_USERS = 'users';
@@ -150,8 +152,13 @@ class Attendee extends Entity {
 	protected bool $hasUnreadThreadDirects = false;
 	protected int $hiddenPinnedId = 0;
 	protected int $hasScheduledMessages = 0;
+	protected \DateTime $muteUntil;
 
 	public function __construct() {
+		$muteUntilDateTime = new \DateTime();
+		$muteUntilDateTime->setTimestamp(0);
+		$this->muteUntil = $muteUntilDateTime;
+
 		$this->addType('roomId', Types::BIGINT);
 		$this->addType('actorType', Types::STRING);
 		$this->addType('actorId', Types::STRING);
@@ -183,7 +190,7 @@ class Attendee extends Entity {
 		$this->addType('hasUnreadThreadDirects', Types::BOOLEAN);
 		$this->addType('hiddenPinnedId', Types::BIGINT);
 		$this->addType('hasScheduledMessages', Types::INTEGER);
-
+		$this->addType('muteUntil', Types::DATETIME);
 	}
 
 	public function getDisplayName(): string {

--- a/lib/Model/AttendeeMapper.php
+++ b/lib/Model/AttendeeMapper.php
@@ -316,6 +316,7 @@ class AttendeeMapper extends QBMapper {
 			'has_unread_thread_directs' => (bool)$row['has_unread_thread_directs'],
 			'hidden_pinned_id' => (int)$row['hidden_pinned_id'],
 			'has_scheduled_messages' => (int)$row['has_scheduled_messages'],
+			'mute_until' => new \DateTime($row['mute_until']),
 		]);
 	}
 }

--- a/lib/Model/AttendeeMapper.php
+++ b/lib/Model/AttendeeMapper.php
@@ -316,7 +316,7 @@ class AttendeeMapper extends QBMapper {
 			'has_unread_thread_directs' => (bool)$row['has_unread_thread_directs'],
 			'hidden_pinned_id' => (int)$row['hidden_pinned_id'],
 			'has_scheduled_messages' => (int)$row['has_scheduled_messages'],
-			'mute_until' => new \DateTime($row['mute_until']),
+			'mute_until' => (int)$row['mute_until'],
 		]);
 	}
 }

--- a/lib/Model/SelectHelper.php
+++ b/lib/Model/SelectHelper.php
@@ -114,6 +114,7 @@ class SelectHelper {
 			$alias . 'has_unread_thread_directs',
 			$alias . 'hidden_pinned_id',
 			$alias . 'has_scheduled_messages',
+			$alias . 'mute_until',
 		])->selectAlias($alias . 'id', 'a_id');
 	}
 

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -570,6 +570,8 @@ namespace OCA\Talk;
  *     hasScheduledMessages: int,
  *     // Bit-flag of enabled attributes of this conversation (only available with capability: `conversation-attributes`). See [attributes list](https://nextcloud-talk.readthedocs.io/en/latest/constants/#conversation-attributes) for details
  *     attributes: int,
+ *     // Required capability: `mute-conversations`
+ *     muteUntil: int,
  * }
  *
  * @psalm-type TalkDashboardEventAttachment = array{

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -570,7 +570,7 @@ namespace OCA\Talk;
  *     hasScheduledMessages: int,
  *     // Bit-flag of enabled attributes of this conversation (only available with capability: `conversation-attributes`). See [attributes list](https://nextcloud-talk.readthedocs.io/en/latest/constants/#conversation-attributes) for details
  *     attributes: int,
- *     // Required capability: `mute-conversations`
+ *     // Required capability: `mute-conversations`. Timestamp until the conversation is muted, i.e. not receiving notifications
  *     muteUntil: int,
  * }
  *

--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -2065,7 +2065,7 @@ class ParticipantService {
 			->where($query->expr()->eq('a.room_id', $query->createNamedParameter($room->getId(), IQueryBuilder::PARAM_INT)))
 			->andWhere($query->expr()->eq('a.actor_type', $query->createNamedParameter(Attendee::ACTOR_USERS)))
 			->andWhere($query->expr()->eq('a.notification_calls', $query->createNamedParameter(Participant::NOTIFY_CALLS_ON)))
-			->andWhere($query->expr()->lte('a.mute_until', $query->createNamedParameter($this->timeFactory->getDateTime()->getTimestamp(), IQueryBuilder::PARAM_INT)))
+			->andWhere($query->expr()->lte('a.mute_until', $query->createNamedParameter($this->timeFactory->getTime(), IQueryBuilder::PARAM_INT)))
 			->andWhere($query->expr()->isNull('s.in_call'));
 
 		if ($room->getLobbyState() !== Webinary::LOBBY_NONE) {

--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -382,7 +382,7 @@ class ParticipantService {
 		$this->attendeeMapper->update($attendee);
 	}
 
-	public function setMuteUntil(Participant $participant, \DateTime $muteUntil): void {
+	public function setMuteUntil(Participant $participant, int $muteUntil): void {
 		$attendee = $participant->getAttendee();
 		$attendee->setMuteUntil($muteUntil);
 		$attendee->setLastAttendeeActivity($this->timeFactory->getTime());
@@ -519,7 +519,6 @@ class ParticipantService {
 			$attendee->setParticipantType(Participant::GUEST);
 			$attendee->setPermissions(Attendee::PERMISSIONS_DEFAULT);
 			$attendee->setLastReadMessage($lastMessage);
-			$attendee->setMuteUntil((new \DateTime())->setTimestamp(0));
 
 			if ($displayName !== null && $displayName !== '') {
 				$attendee->setDisplayName($displayName);
@@ -675,7 +674,6 @@ class ParticipantService {
 			$attendee->setPermissions(Attendee::PERMISSIONS_DEFAULT);
 			$attendee->setLastReadMessage($participant['lastReadMessage'] ?? $lastMessage);
 			$attendee->setReadPrivacy($readPrivacy);
-			$attendee->setMuteUntil((new \DateTime())->setTimestamp(0));
 			$attendees[] = $attendee;
 		}
 
@@ -834,7 +832,6 @@ class ParticipantService {
 			$attendee->setParticipantType(Participant::USER);
 			$attendee->setPermissions(Attendee::PERMISSIONS_DEFAULT);
 			$attendee->setReadPrivacy(Participant::PRIVACY_PRIVATE);
-			$attendee->setMuteUntil((new \DateTime())->setTimestamp(0));
 			$this->attendeeMapper->insert($attendee);
 
 			$attendeeEvent = new AttendeesAddedEvent($room, [$attendee]);
@@ -973,7 +970,6 @@ class ParticipantService {
 			$attendee->setParticipantType(Participant::USER);
 			$attendee->setPermissions(Attendee::PERMISSIONS_DEFAULT);
 			$attendee->setReadPrivacy(Participant::PRIVACY_PRIVATE);
-			$attendee->setMuteUntil((new \DateTime())->setTimestamp(0));
 			$this->attendeeMapper->insert($attendee);
 
 			$attendeeEvent = new AttendeesAddedEvent($room, [$attendee]);
@@ -1013,7 +1009,6 @@ class ParticipantService {
 
 		$attendee->setParticipantType(Participant::GUEST);
 		$attendee->setLastReadMessage($lastMessage);
-		$attendee->setMuteUntil((new \DateTime())->setTimestamp(0));
 		$this->attendeeMapper->insert($attendee);
 		// FIXME handle duplicate invites gracefully
 
@@ -2070,7 +2065,7 @@ class ParticipantService {
 			->where($query->expr()->eq('a.room_id', $query->createNamedParameter($room->getId(), IQueryBuilder::PARAM_INT)))
 			->andWhere($query->expr()->eq('a.actor_type', $query->createNamedParameter(Attendee::ACTOR_USERS)))
 			->andWhere($query->expr()->eq('a.notification_calls', $query->createNamedParameter(Participant::NOTIFY_CALLS_ON)))
-			->andWhere($query->expr()->lte('a.mute_until', $query->createNamedParameter($this->timeFactory->getDateTime(), IQueryBuilder::PARAM_DATETIME_MUTABLE)))
+			->andWhere($query->expr()->lte('a.mute_until', $query->createNamedParameter($this->timeFactory->getDateTime()->getTimestamp(), IQueryBuilder::PARAM_INT)))
 			->andWhere($query->expr()->isNull('s.in_call'));
 
 		if ($room->getLobbyState() !== Webinary::LOBBY_NONE) {

--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -382,6 +382,13 @@ class ParticipantService {
 		$this->attendeeMapper->update($attendee);
 	}
 
+	public function setMuteUntil(Participant $participant, \DateTime $muteUntil): void {
+		$attendee = $participant->getAttendee();
+		$attendee->setMuteUntil($muteUntil);
+		$attendee->setLastAttendeeActivity($this->timeFactory->getTime());
+		$this->attendeeMapper->update($attendee);
+	}
+
 	/**
 	 * @param RoomService $roomService
 	 * @param Room $room
@@ -512,6 +519,7 @@ class ParticipantService {
 			$attendee->setParticipantType(Participant::GUEST);
 			$attendee->setPermissions(Attendee::PERMISSIONS_DEFAULT);
 			$attendee->setLastReadMessage($lastMessage);
+			$attendee->setMuteUntil((new \DateTime())->setTimestamp(0));
 
 			if ($displayName !== null && $displayName !== '') {
 				$attendee->setDisplayName($displayName);
@@ -667,6 +675,7 @@ class ParticipantService {
 			$attendee->setPermissions(Attendee::PERMISSIONS_DEFAULT);
 			$attendee->setLastReadMessage($participant['lastReadMessage'] ?? $lastMessage);
 			$attendee->setReadPrivacy($readPrivacy);
+			$attendee->setMuteUntil((new \DateTime())->setTimestamp(0));
 			$attendees[] = $attendee;
 		}
 
@@ -825,6 +834,7 @@ class ParticipantService {
 			$attendee->setParticipantType(Participant::USER);
 			$attendee->setPermissions(Attendee::PERMISSIONS_DEFAULT);
 			$attendee->setReadPrivacy(Participant::PRIVACY_PRIVATE);
+			$attendee->setMuteUntil((new \DateTime())->setTimestamp(0));
 			$this->attendeeMapper->insert($attendee);
 
 			$attendeeEvent = new AttendeesAddedEvent($room, [$attendee]);
@@ -963,6 +973,7 @@ class ParticipantService {
 			$attendee->setParticipantType(Participant::USER);
 			$attendee->setPermissions(Attendee::PERMISSIONS_DEFAULT);
 			$attendee->setReadPrivacy(Participant::PRIVACY_PRIVATE);
+			$attendee->setMuteUntil((new \DateTime())->setTimestamp(0));
 			$this->attendeeMapper->insert($attendee);
 
 			$attendeeEvent = new AttendeesAddedEvent($room, [$attendee]);
@@ -1002,6 +1013,7 @@ class ParticipantService {
 
 		$attendee->setParticipantType(Participant::GUEST);
 		$attendee->setLastReadMessage($lastMessage);
+		$attendee->setMuteUntil((new \DateTime())->setTimestamp(0));
 		$this->attendeeMapper->insert($attendee);
 		// FIXME handle duplicate invites gracefully
 
@@ -2058,6 +2070,7 @@ class ParticipantService {
 			->where($query->expr()->eq('a.room_id', $query->createNamedParameter($room->getId(), IQueryBuilder::PARAM_INT)))
 			->andWhere($query->expr()->eq('a.actor_type', $query->createNamedParameter(Attendee::ACTOR_USERS)))
 			->andWhere($query->expr()->eq('a.notification_calls', $query->createNamedParameter(Participant::NOTIFY_CALLS_ON)))
+			->andWhere($query->expr()->lte('a.mute_until', $query->createNamedParameter($this->timeFactory->getDateTime(), IQueryBuilder::PARAM_DATETIME_MUTABLE)))
 			->andWhere($query->expr()->isNull('s.in_call'));
 
 		if ($room->getLobbyState() !== Webinary::LOBBY_NONE) {

--- a/lib/Service/RoomFormatter.php
+++ b/lib/Service/RoomFormatter.php
@@ -252,7 +252,7 @@ class RoomFormatter {
 			'lastPinnedId' => $room->getLastPinnedId(),
 			'hiddenPinnedId' => $attendee->getHiddenPinnedId(),
 			'attributes' => $room->getAttributes(),
-			'muteUntil' => max($attendee->getMuteUntil()->getTimestamp(), 0),
+			'muteUntil' => $attendee->getMuteUntil(),
 		]);
 
 		if ($room->isFederatedConversation()) {

--- a/lib/Service/RoomFormatter.php
+++ b/lib/Service/RoomFormatter.php
@@ -160,6 +160,7 @@ class RoomFormatter {
 			'isSensitive' => false,
 			'hasScheduledMessages' => 0,
 			'attributes' => 0,
+			'muteUntil' => 0,
 		];
 
 		if ($room->isFederatedConversation()) {
@@ -251,6 +252,7 @@ class RoomFormatter {
 			'lastPinnedId' => $room->getLastPinnedId(),
 			'hiddenPinnedId' => $attendee->getHiddenPinnedId(),
 			'attributes' => $room->getAttributes(),
+			'muteUntil' => max($attendee->getMuteUntil()->getTimestamp(), 0),
 		]);
 
 		if ($room->isFederatedConversation()) {

--- a/openapi-backend-sipbridge.json
+++ b/openapi-backend-sipbridge.json
@@ -1260,7 +1260,7 @@
                     "muteUntil": {
                         "type": "integer",
                         "format": "int64",
-                        "description": "Required capability: `mute-conversations`"
+                        "description": "Required capability: `mute-conversations`. Timestamp until the conversation is muted, i.e. not receiving notifications"
                     }
                 }
             },

--- a/openapi-backend-sipbridge.json
+++ b/openapi-backend-sipbridge.json
@@ -941,7 +941,8 @@
                     "lastPinnedId",
                     "hiddenPinnedId",
                     "hasScheduledMessages",
-                    "attributes"
+                    "attributes",
+                    "muteUntil"
                 ],
                 "properties": {
                     "actorId": {
@@ -1255,6 +1256,11 @@
                         "type": "integer",
                         "format": "int64",
                         "description": "Bit-flag of enabled attributes of this conversation (only available with capability: `conversation-attributes`). See [attributes list](https://nextcloud-talk.readthedocs.io/en/latest/constants/#conversation-attributes) for details"
+                    },
+                    "muteUntil": {
+                        "type": "integer",
+                        "format": "int64",
+                        "description": "Required capability: `mute-conversations`"
                     }
                 }
             },

--- a/openapi-federation.json
+++ b/openapi-federation.json
@@ -1006,7 +1006,8 @@
                     "lastPinnedId",
                     "hiddenPinnedId",
                     "hasScheduledMessages",
-                    "attributes"
+                    "attributes",
+                    "muteUntil"
                 ],
                 "properties": {
                     "actorId": {
@@ -1320,6 +1321,11 @@
                         "type": "integer",
                         "format": "int64",
                         "description": "Bit-flag of enabled attributes of this conversation (only available with capability: `conversation-attributes`). See [attributes list](https://nextcloud-talk.readthedocs.io/en/latest/constants/#conversation-attributes) for details"
+                    },
+                    "muteUntil": {
+                        "type": "integer",
+                        "format": "int64",
+                        "description": "Required capability: `mute-conversations`"
                     }
                 }
             },

--- a/openapi-federation.json
+++ b/openapi-federation.json
@@ -1325,7 +1325,7 @@
                     "muteUntil": {
                         "type": "integer",
                         "format": "int64",
-                        "description": "Required capability: `mute-conversations`"
+                        "description": "Required capability: `mute-conversations`. Timestamp until the conversation is muted, i.e. not receiving notifications"
                     }
                 }
             },

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -1990,7 +1990,8 @@
                     "lastPinnedId",
                     "hiddenPinnedId",
                     "hasScheduledMessages",
-                    "attributes"
+                    "attributes",
+                    "muteUntil"
                 ],
                 "properties": {
                     "actorId": {
@@ -2304,6 +2305,11 @@
                         "type": "integer",
                         "format": "int64",
                         "description": "Bit-flag of enabled attributes of this conversation (only available with capability: `conversation-attributes`). See [attributes list](https://nextcloud-talk.readthedocs.io/en/latest/constants/#conversation-attributes) for details"
+                    },
+                    "muteUntil": {
+                        "type": "integer",
+                        "format": "int64",
+                        "description": "Required capability: `mute-conversations`"
                     }
                 }
             },
@@ -25548,6 +25554,246 @@
                                                             ]
                                                         }
                                                     }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Current user is not logged in",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/mute": {
+            "post": {
+                "operationId": "room-mute-conversation",
+                "summary": "Mute all notifications in a conversation until a specific time. Does not alter notification settings for the attendee.",
+                "description": "Required capability: `mute-conversations`",
+                "tags": [
+                    "room"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "muteUntil"
+                                ],
+                                "properties": {
+                                    "muteUntil": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "Unix timestamp until notifications are muted"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v4"
+                            ],
+                            "default": "v4"
+                        }
+                    },
+                    {
+                        "name": "token",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^[a-z0-9]{4,30}$"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Conversation muted",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "$ref": "#/components/schemas/Room"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Current user is not logged in",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "room-unmute-conversation",
+                "summary": "Unmute all notifications in a conversation, when they were muted before. Does not alter notification settings for the attendee.",
+                "description": "Required capability: `mute-conversations`",
+                "tags": [
+                    "room"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v4"
+                            ],
+                            "default": "v4"
+                        }
+                    },
+                    {
+                        "name": "token",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^[a-z0-9]{4,30}$"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Conversation unmuted",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "$ref": "#/components/schemas/Room"
                                                 }
                                             }
                                         }

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -2309,7 +2309,7 @@
                     "muteUntil": {
                         "type": "integer",
                         "format": "int64",
-                        "description": "Required capability: `mute-conversations`"
+                        "description": "Required capability: `mute-conversations`. Timestamp until the conversation is muted, i.e. not receiving notifications"
                     }
                 }
             },
@@ -25685,6 +25685,47 @@
                                                 },
                                                 "data": {
                                                     "$ref": "#/components/schemas/Room"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Timestamp is in the past",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "error"
+                                                    ],
+                                                    "properties": {
+                                                        "error": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "mute-until"
+                                                            ]
+                                                        }
+                                                    }
                                                 }
                                             }
                                         }

--- a/openapi.json
+++ b/openapi.json
@@ -2197,7 +2197,7 @@
                     "muteUntil": {
                         "type": "integer",
                         "format": "int64",
-                        "description": "Required capability: `mute-conversations`"
+                        "description": "Required capability: `mute-conversations`. Timestamp until the conversation is muted, i.e. not receiving notifications"
                     }
                 }
             },
@@ -25573,6 +25573,47 @@
                                                 },
                                                 "data": {
                                                     "$ref": "#/components/schemas/Room"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Timestamp is in the past",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "error"
+                                                    ],
+                                                    "properties": {
+                                                        "error": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "mute-until"
+                                                            ]
+                                                        }
+                                                    }
                                                 }
                                             }
                                         }

--- a/openapi.json
+++ b/openapi.json
@@ -1878,7 +1878,8 @@
                     "lastPinnedId",
                     "hiddenPinnedId",
                     "hasScheduledMessages",
-                    "attributes"
+                    "attributes",
+                    "muteUntil"
                 ],
                 "properties": {
                     "actorId": {
@@ -2192,6 +2193,11 @@
                         "type": "integer",
                         "format": "int64",
                         "description": "Bit-flag of enabled attributes of this conversation (only available with capability: `conversation-attributes`). See [attributes list](https://nextcloud-talk.readthedocs.io/en/latest/constants/#conversation-attributes) for details"
+                    },
+                    "muteUntil": {
+                        "type": "integer",
+                        "format": "int64",
+                        "description": "Required capability: `mute-conversations`"
                     }
                 }
             },
@@ -25436,6 +25442,246 @@
                                                             ]
                                                         }
                                                     }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Current user is not logged in",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/mute": {
+            "post": {
+                "operationId": "room-mute-conversation",
+                "summary": "Mute all notifications in a conversation until a specific time. Does not alter notification settings for the attendee.",
+                "description": "Required capability: `mute-conversations`",
+                "tags": [
+                    "room"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "muteUntil"
+                                ],
+                                "properties": {
+                                    "muteUntil": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "Unix timestamp until notifications are muted"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v4"
+                            ],
+                            "default": "v4"
+                        }
+                    },
+                    {
+                        "name": "token",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^[a-z0-9]{4,30}$"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Conversation muted",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "$ref": "#/components/schemas/Room"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Current user is not logged in",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "room-unmute-conversation",
+                "summary": "Unmute all notifications in a conversation, when they were muted before. Does not alter notification settings for the attendee.",
+                "description": "Required capability: `mute-conversations`",
+                "tags": [
+                    "room"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v4"
+                            ],
+                            "default": "v4"
+                        }
+                    },
+                    {
+                        "name": "token",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^[a-z0-9]{4,30}$"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Conversation unmuted",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "$ref": "#/components/schemas/Room"
                                                 }
                                             }
                                         }

--- a/src/types/openapi/openapi-backend-sipbridge.ts
+++ b/src/types/openapi/openapi-backend-sipbridge.ts
@@ -782,6 +782,11 @@ export type components = {
              * @description Bit-flag of enabled attributes of this conversation (only available with capability: `conversation-attributes`). See [attributes list](https://nextcloud-talk.readthedocs.io/en/latest/constants/#conversation-attributes) for details
              */
             attributes: number;
+            /**
+             * Format: int64
+             * @description Required capability: `mute-conversations`
+             */
+            muteUntil: number;
         };
         RoomLastMessage: components["schemas"]["ChatMessage"] | components["schemas"]["ChatProxyMessage"];
     };

--- a/src/types/openapi/openapi-backend-sipbridge.ts
+++ b/src/types/openapi/openapi-backend-sipbridge.ts
@@ -784,7 +784,7 @@ export type components = {
             attributes: number;
             /**
              * Format: int64
-             * @description Required capability: `mute-conversations`
+             * @description Required capability: `mute-conversations`. Timestamp until the conversation is muted, i.e. not receiving notifications
              */
             muteUntil: number;
         };

--- a/src/types/openapi/openapi-federation.ts
+++ b/src/types/openapi/openapi-federation.ts
@@ -828,7 +828,7 @@ export type components = {
             attributes: number;
             /**
              * Format: int64
-             * @description Required capability: `mute-conversations`
+             * @description Required capability: `mute-conversations`. Timestamp until the conversation is muted, i.e. not receiving notifications
              */
             muteUntil: number;
         };

--- a/src/types/openapi/openapi-federation.ts
+++ b/src/types/openapi/openapi-federation.ts
@@ -826,6 +826,11 @@ export type components = {
              * @description Bit-flag of enabled attributes of this conversation (only available with capability: `conversation-attributes`). See [attributes list](https://nextcloud-talk.readthedocs.io/en/latest/constants/#conversation-attributes) for details
              */
             attributes: number;
+            /**
+             * Format: int64
+             * @description Required capability: `mute-conversations`
+             */
+            muteUntil: number;
         };
         RoomLastMessage: components["schemas"]["ChatMessage"] | components["schemas"]["ChatProxyMessage"];
     };

--- a/src/types/openapi/openapi-full.ts
+++ b/src/types/openapi/openapi-full.ts
@@ -3607,7 +3607,7 @@ export type components = {
             attributes: number;
             /**
              * Format: int64
-             * @description Required capability: `mute-conversations`
+             * @description Required capability: `mute-conversations`. Timestamp until the conversation is muted, i.e. not receiving notifications
              */
             muteUntil: number;
         };
@@ -12997,6 +12997,23 @@ export interface operations {
                         ocs: {
                             meta: components["schemas"]["OCSMeta"];
                             data: components["schemas"]["Room"];
+                        };
+                    };
+                };
+            };
+            /** @description Timestamp is in the past */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: {
+                                /** @enum {string} */
+                                error: "mute-until";
+                            };
                         };
                     };
                 };

--- a/src/types/openapi/openapi-full.ts
+++ b/src/types/openapi/openapi-full.ts
@@ -1782,6 +1782,30 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
+    "/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/mute": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Mute all notifications in a conversation until a specific time. Does not alter notification settings for the attendee.
+         * @description Required capability: `mute-conversations`
+         */
+        post: operations["room-mute-conversation"];
+        /**
+         * Unmute all notifications in a conversation, when they were muted before. Does not alter notification settings for the attendee.
+         * @description Required capability: `mute-conversations`
+         */
+        delete: operations["room-unmute-conversation"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/ocs/v2.php/apps/spreed/api/{apiVersion}/settings/user": {
         parameters: {
             query?: never;
@@ -3581,6 +3605,11 @@ export type components = {
              * @description Bit-flag of enabled attributes of this conversation (only available with capability: `conversation-attributes`). See [attributes list](https://nextcloud-talk.readthedocs.io/en/latest/constants/#conversation-attributes) for details
              */
             attributes: number;
+            /**
+             * Format: int64
+             * @description Required capability: `mute-conversations`
+             */
+            muteUntil: number;
         };
         RoomLastMessage: components["schemas"]["ChatMessage"] | components["schemas"]["ChatProxyMessage"];
         RoomWithInvalidInvitations: components["schemas"]["Room"] & {
@@ -12913,6 +12942,106 @@ export interface operations {
                                 /** @enum {string} */
                                 error: "calendar" | "conversation" | "email" | "end" | "start";
                             };
+                        };
+                    };
+                };
+            };
+            /** @description Current user is not logged in */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: unknown;
+                        };
+                    };
+                };
+            };
+        };
+    };
+    "room-mute-conversation": {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Required to be true for the API request to pass */
+                "OCS-APIRequest": boolean;
+            };
+            path: {
+                apiVersion: "v4";
+                token: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /**
+                     * Format: int64
+                     * @description Unix timestamp until notifications are muted
+                     */
+                    muteUntil: number;
+                };
+            };
+        };
+        responses: {
+            /** @description Conversation muted */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: components["schemas"]["Room"];
+                        };
+                    };
+                };
+            };
+            /** @description Current user is not logged in */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: unknown;
+                        };
+                    };
+                };
+            };
+        };
+    };
+    "room-unmute-conversation": {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Required to be true for the API request to pass */
+                "OCS-APIRequest": boolean;
+            };
+            path: {
+                apiVersion: "v4";
+                token: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Conversation unmuted */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: components["schemas"]["Room"];
                         };
                     };
                 };

--- a/src/types/openapi/openapi.ts
+++ b/src/types/openapi/openapi.ts
@@ -1782,6 +1782,30 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
+    "/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/mute": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Mute all notifications in a conversation until a specific time. Does not alter notification settings for the attendee.
+         * @description Required capability: `mute-conversations`
+         */
+        post: operations["room-mute-conversation"];
+        /**
+         * Unmute all notifications in a conversation, when they were muted before. Does not alter notification settings for the attendee.
+         * @description Required capability: `mute-conversations`
+         */
+        delete: operations["room-unmute-conversation"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/ocs/v2.php/apps/spreed/api/{apiVersion}/settings/user": {
         parameters: {
             query?: never;
@@ -3014,6 +3038,11 @@ export type components = {
              * @description Bit-flag of enabled attributes of this conversation (only available with capability: `conversation-attributes`). See [attributes list](https://nextcloud-talk.readthedocs.io/en/latest/constants/#conversation-attributes) for details
              */
             attributes: number;
+            /**
+             * Format: int64
+             * @description Required capability: `mute-conversations`
+             */
+            muteUntil: number;
         };
         RoomLastMessage: components["schemas"]["ChatMessage"] | components["schemas"]["ChatProxyMessage"];
         RoomWithInvalidInvitations: components["schemas"]["Room"] & {
@@ -12346,6 +12375,106 @@ export interface operations {
                                 /** @enum {string} */
                                 error: "calendar" | "conversation" | "email" | "end" | "start";
                             };
+                        };
+                    };
+                };
+            };
+            /** @description Current user is not logged in */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: unknown;
+                        };
+                    };
+                };
+            };
+        };
+    };
+    "room-mute-conversation": {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Required to be true for the API request to pass */
+                "OCS-APIRequest": boolean;
+            };
+            path: {
+                apiVersion: "v4";
+                token: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /**
+                     * Format: int64
+                     * @description Unix timestamp until notifications are muted
+                     */
+                    muteUntil: number;
+                };
+            };
+        };
+        responses: {
+            /** @description Conversation muted */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: components["schemas"]["Room"];
+                        };
+                    };
+                };
+            };
+            /** @description Current user is not logged in */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: unknown;
+                        };
+                    };
+                };
+            };
+        };
+    };
+    "room-unmute-conversation": {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Required to be true for the API request to pass */
+                "OCS-APIRequest": boolean;
+            };
+            path: {
+                apiVersion: "v4";
+                token: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Conversation unmuted */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: components["schemas"]["Room"];
                         };
                     };
                 };

--- a/src/types/openapi/openapi.ts
+++ b/src/types/openapi/openapi.ts
@@ -3040,7 +3040,7 @@ export type components = {
             attributes: number;
             /**
              * Format: int64
-             * @description Required capability: `mute-conversations`
+             * @description Required capability: `mute-conversations`. Timestamp until the conversation is muted, i.e. not receiving notifications
              */
             muteUntil: number;
         };
@@ -12430,6 +12430,23 @@ export interface operations {
                         ocs: {
                             meta: components["schemas"]["OCSMeta"];
                             data: components["schemas"]["Room"];
+                        };
+                    };
+                };
+            };
+            /** @description Timestamp is in the past */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: {
+                                /** @enum {string} */
+                                error: "mute-until";
+                            };
                         };
                     };
                 };

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -548,6 +548,12 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 						$data['lobbyTimer'] = 'GREATER_THAN_ZERO';
 					}
 				}
+				if (isset($expectedRoom['muteUntil'])) {
+					$data['muteUntil'] = (int)$room['muteUntil'];
+					if ($expectedRoom['muteUntil'] === 'GREATER_THAN_ZERO' && $room['muteUntil'] > 0) {
+						$data['muteUntil'] = 'GREATER_THAN_ZERO';
+					}
+				}
 				if (isset($expectedRoom['breakoutRoomMode'])) {
 					$data['breakoutRoomMode'] = (int)$room['breakoutRoomMode'];
 				}
@@ -4971,6 +4977,26 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 		$this->setCurrentUser($user);
 		$this->sendRequest(
 			$httpMethod, '/apps/spreed/api/' . $apiVersion . '/room/' . self::$identifierToToken[$identifier] . '/sensitive',
+		);
+		$this->assertStatusCode($this->response, $statusCode);
+	}
+
+	#[When('/^user "([^"]*)" mutes room "([^"]*)" until OFFSET\((\d+)\) with (\d+) \((v4)\)$/')]
+	public function userMutesConversationUntil(string $user, string $identifier, int $muteUntil, int $statusCode, string $apiVersion): void {
+		$this->setCurrentUser($user);
+		$this->sendRequest(
+			'POST', '/apps/spreed/api/' . $apiVersion . '/room/' . self::$identifierToToken[$identifier] . '/mute', [
+				'muteUntil' => time() + $muteUntil,
+			],
+		);
+		$this->assertStatusCode($this->response, $statusCode);
+	}
+
+	#[When('/^user "([^"]*)" unmutes room "([^"]*)" with (\d+) \((v4)\)$/')]
+	public function userUnmutesConversationUntil(string $user, string $identifier, int $statusCode, string $apiVersion): void {
+		$this->setCurrentUser($user);
+		$this->sendRequest(
+			'DELETE', '/apps/spreed/api/' . $apiVersion . '/room/' . self::$identifierToToken[$identifier] . '/mute',
 		);
 		$this->assertStatusCode($this->response, $statusCode);
 	}

--- a/tests/integration/features/conversation-5/mute.feature
+++ b/tests/integration/features/conversation-5/mute.feature
@@ -1,0 +1,50 @@
+Feature: conversation-5/mute
+  Background:
+    Given user "participant1" exists
+    Given user "participant2" exists
+
+  Scenario: Mark as (un-)mute
+    Given user "participant1" creates room "group room" (v4)
+      | roomType | 3 |
+      | roomName | room |
+    And user "participant1" is participant of the following unordered rooms (v4)
+      | id              | name         | muteUntil |
+      | group room      | room         | 0         |
+    And user "participant1" mutes room "group room" until OFFSET(3600) with 200 (v4)
+    And user "participant1" is participant of the following unordered rooms (v4)
+      | id              | name         | muteUntil         |
+      | group room      | room         | GREATER_THAN_ZERO |
+    And user "participant1" unmutes room "group room" with 200 (v4)
+    And user "participant1" is participant of the following unordered rooms (v4)
+      | id              | name         | muteUntil |
+      | group room      | room         | 0         |
+
+  Scenario: No notifications for muted rooms
+    When user "participant1" creates room "one-to-one room" (v4)
+      | roomType | 1 |
+      | invite   | participant2 |
+    And user "participant2" creates room "one-to-one room" with 200 (v4)
+      | roomType | 1 |
+      | invite   | participant1 |
+    And user "participant1" sends message "Message1" to room "one-to-one room" with 201
+    And user "participant2" mutes room "one-to-one room" until OFFSET(3600) with 200 (v4)
+    And user "participant1" sends message "Message with mention for @participant2" to room "one-to-one room" with 201
+    Then user "participant2" has the following notifications
+      | app    | object_type | object_id                | subject                                              | message  |
+      | spreed | chat        | one-to-one room/Message1 | participant1-displayname sent you a private message  | Message1 |
+    And user "participant2" unmutes room "one-to-one room" with 200 (v4)
+    Then user "participant2" has the following notifications
+      | app    | object_type | object_id                | subject                                              | message  |
+      | spreed | chat        | one-to-one room/Message1 | participant1-displayname sent you a private message  | Message1 |
+
+  Scenario: Participant1 calls while participant2 has muted the conversation
+    When user "participant1" creates room "room" (v4)
+      | roomType | 3 |
+      | roomName | room |
+    And user "participant1" adds user "participant2" to room "room" with 200 (v4)
+    Then user "participant1" is participant of room "room" (v4)
+    And user "participant2" is participant of room "room" (v4)
+    And user "participant2" mutes room "room" until OFFSET(3600) with 200 (v4)
+    Then user "participant1" joins room "room" with 200 (v4)
+    Then user "participant1" joins call "room" with 200 (v4)
+    Then user "participant2" has the following notifications

--- a/tests/php/Chat/ChatManagerTest.php
+++ b/tests/php/Chat/ChatManagerTest.php
@@ -444,6 +444,7 @@ class ChatManagerTest extends TestCase {
 			'has_unread_thread_directs' => false,
 			'hidden_pinned_id' => 0,
 			'has_scheduled_messages' => 0,
+			'mute_until' => '@0',
 		]);
 		$chat = $this->createMock(Room::class);
 		$chat->expects($this->any())
@@ -514,6 +515,7 @@ class ChatManagerTest extends TestCase {
 			'has_unread_thread_directs' => false,
 			'hidden_pinned_id' => 0,
 			'has_scheduled_messages' => 0,
+			'mute_until' => '@0',
 		]);
 		$chat = $this->createMock(Room::class);
 		$chat->expects($this->any())
@@ -606,6 +608,7 @@ class ChatManagerTest extends TestCase {
 			'has_unread_thread_directs' => false,
 			'hidden_pinned_id' => 0,
 			'has_scheduled_messages' => 0,
+			'mute_until' => '@0',
 		]);
 		$chat = $this->createMock(Room::class);
 		$chat->expects($this->any())

--- a/tests/php/Chat/ChatManagerTest.php
+++ b/tests/php/Chat/ChatManagerTest.php
@@ -444,7 +444,7 @@ class ChatManagerTest extends TestCase {
 			'has_unread_thread_directs' => false,
 			'hidden_pinned_id' => 0,
 			'has_scheduled_messages' => 0,
-			'mute_until' => '@0',
+			'mute_until' => 0,
 		]);
 		$chat = $this->createMock(Room::class);
 		$chat->expects($this->any())
@@ -515,7 +515,7 @@ class ChatManagerTest extends TestCase {
 			'has_unread_thread_directs' => false,
 			'hidden_pinned_id' => 0,
 			'has_scheduled_messages' => 0,
-			'mute_until' => '@0',
+			'mute_until' => 0,
 		]);
 		$chat = $this->createMock(Room::class);
 		$chat->expects($this->any())
@@ -608,7 +608,7 @@ class ChatManagerTest extends TestCase {
 			'has_unread_thread_directs' => false,
 			'hidden_pinned_id' => 0,
 			'has_scheduled_messages' => 0,
-			'mute_until' => '@0',
+			'mute_until' => 0,
 		]);
 		$chat = $this->createMock(Room::class);
 		$chat->expects($this->any())

--- a/tests/php/Chat/NotifierTest.php
+++ b/tests/php/Chat/NotifierTest.php
@@ -178,8 +178,8 @@ class NotifierTest extends TestCase {
 		}
 
 		$current = 1234567;
-		$this->timeFactory->method('getDateTime')
-			->willReturn(new \DateTime('@' . $current));
+		$this->timeFactory->method('getTime')
+			->willReturn($current);
 
 		$room = $this->getRoom();
 		$comment = $this->newComment('108', 'users', 'testUser', new \DateTime('@' . 1000000016), $message);
@@ -230,14 +230,11 @@ class NotifierTest extends TestCase {
 			'mute_until' => $muteUntil,
 		]);
 		$current = 1234567;
-		$this->timeFactory->method('getDateTime')
-			->willReturn(new \DateTime('@' . $current));
+		$this->timeFactory->method('getTime')
+			->willReturn($current);
 
 		$session = null;
 		if ($sessionAge !== null) {
-			$this->timeFactory->method('getTime')
-				->willReturn($current);
-
 			$session = Session::fromRow([
 				'last_ping' => $current - $sessionAge,
 			]);

--- a/tests/php/Chat/NotifierTest.php
+++ b/tests/php/Chat/NotifierTest.php
@@ -177,6 +177,10 @@ class NotifierTest extends TestCase {
 				->method('notify');
 		}
 
+		$current = 1234567;
+		$this->timeFactory->method('getDateTime')
+			->willReturn(new \DateTime('@' . $current));
+
 		$room = $this->getRoom();
 		$comment = $this->newComment('108', 'users', 'testUser', new \DateTime('@' . 1000000016), $message);
 		$notifier = $this->getNotifier([]);
@@ -188,24 +192,30 @@ class NotifierTest extends TestCase {
 
 	public static function dataShouldParticipantBeNotified(): array {
 		return [
-			[Attendee::ACTOR_GROUPS, 'test1', null, Attendee::ACTOR_USERS, 'test1', [], false, Notifier::PRIORITY_NONE],
-			[Attendee::ACTOR_USERS, 'test1', null, Attendee::ACTOR_USERS, 'test1', [], false, Notifier::PRIORITY_NONE],
-			[Attendee::ACTOR_USERS, 'test1', null, Attendee::ACTOR_USERS, 'test2', [], false, Notifier::PRIORITY_NORMAL],
-			[Attendee::ACTOR_USERS, 'test1', null, Attendee::ACTOR_USERS, 'test2', [['id' => 'test1', 'type' => Attendee::ACTOR_USERS]], false, Notifier::PRIORITY_NONE],
-			[Attendee::ACTOR_USERS, 'test1', null, Attendee::ACTOR_USERS, 'test2', [['id' => 'test1', 'type' => Attendee::ACTOR_FEDERATED_USERS]], false, Notifier::PRIORITY_NORMAL],
-			[Attendee::ACTOR_USERS, 'test1', Session::SESSION_TIMEOUT - 5, Attendee::ACTOR_USERS, 'test2', [], false, Notifier::PRIORITY_NONE],
-			[Attendee::ACTOR_USERS, 'test1', Session::SESSION_TIMEOUT + 5, Attendee::ACTOR_USERS, 'test2', [], false, Notifier::PRIORITY_NORMAL],
+			[Attendee::ACTOR_GROUPS, 'test1', null, Attendee::ACTOR_USERS, 'test1', [], false, 0, Notifier::PRIORITY_NONE],
+			[Attendee::ACTOR_USERS, 'test1', null, Attendee::ACTOR_USERS, 'test1', [], false, 0, Notifier::PRIORITY_NONE],
+			[Attendee::ACTOR_USERS, 'test1', null, Attendee::ACTOR_USERS, 'test2', [], false, 0, Notifier::PRIORITY_NORMAL],
+			[Attendee::ACTOR_USERS, 'test1', null, Attendee::ACTOR_USERS, 'test2', [['id' => 'test1', 'type' => Attendee::ACTOR_USERS]], false, 0, Notifier::PRIORITY_NONE],
+			[Attendee::ACTOR_USERS, 'test1', null, Attendee::ACTOR_USERS, 'test2', [['id' => 'test1', 'type' => Attendee::ACTOR_FEDERATED_USERS]], false, 0, Notifier::PRIORITY_NORMAL],
+			[Attendee::ACTOR_USERS, 'test1', Session::SESSION_TIMEOUT - 5, Attendee::ACTOR_USERS, 'test2', [], false, 0, Notifier::PRIORITY_NONE],
+			[Attendee::ACTOR_USERS, 'test1', Session::SESSION_TIMEOUT + 5, Attendee::ACTOR_USERS, 'test2', [], false, 0, Notifier::PRIORITY_NORMAL],
 
 			// Marked as important, still blocked by session and being the author, but otherwise with PRIORITY_IMPORTANT
-			[Attendee::ACTOR_USERS, 'test1', null, Attendee::ACTOR_USERS, 'test1', [], true, Notifier::PRIORITY_NONE],
-			[Attendee::ACTOR_USERS, 'test1', null, Attendee::ACTOR_USERS, 'test2', [], true, Notifier::PRIORITY_IMPORTANT],
-			[Attendee::ACTOR_USERS, 'test1', Session::SESSION_TIMEOUT - 5, Attendee::ACTOR_USERS, 'test2', [], true, Notifier::PRIORITY_NONE],
-			[Attendee::ACTOR_USERS, 'test1', Session::SESSION_TIMEOUT + 5, Attendee::ACTOR_USERS, 'test2', [], true, Notifier::PRIORITY_IMPORTANT],
+			[Attendee::ACTOR_USERS, 'test1', null, Attendee::ACTOR_USERS, 'test1', [], true, 0, Notifier::PRIORITY_NONE],
+			[Attendee::ACTOR_USERS, 'test1', null, Attendee::ACTOR_USERS, 'test2', [], true, 0, Notifier::PRIORITY_IMPORTANT],
+			[Attendee::ACTOR_USERS, 'test1', Session::SESSION_TIMEOUT - 5, Attendee::ACTOR_USERS, 'test2', [], true, 0, Notifier::PRIORITY_NONE],
+			[Attendee::ACTOR_USERS, 'test1', Session::SESSION_TIMEOUT + 5, Attendee::ACTOR_USERS, 'test2', [], true, 0, Notifier::PRIORITY_IMPORTANT],
+
+			// Marked as muted, no notification even with PRIORITY_IMPORTANT
+			[Attendee::ACTOR_USERS, 'test1', null, Attendee::ACTOR_USERS, 'test1', [], true, 9999999, Notifier::PRIORITY_NONE],
+			[Attendee::ACTOR_USERS, 'test1', null, Attendee::ACTOR_USERS, 'test2', [], true, 9999999, Notifier::PRIORITY_NONE],
+			[Attendee::ACTOR_USERS, 'test1', Session::SESSION_TIMEOUT - 5, Attendee::ACTOR_USERS, 'test2', [], true, 9999999, Notifier::PRIORITY_NONE],
+			[Attendee::ACTOR_USERS, 'test1', Session::SESSION_TIMEOUT + 5, Attendee::ACTOR_USERS, 'test2', [], true, 9999999, Notifier::PRIORITY_NONE],
 		];
 	}
 
 	#[DataProvider('dataShouldParticipantBeNotified')]
-	public function testShouldParticipantBeNotified(string $actorType, string $actorId, ?int $sessionAge, string $commentActorType, string $commentActorId, array $alreadyNotifiedUsers, bool $isImportant, int $expected): void {
+	public function testShouldParticipantBeNotified(string $actorType, string $actorId, ?int $sessionAge, string $commentActorType, string $commentActorId, array $alreadyNotifiedUsers, bool $isImportant, int $muteUntil, int $expected): void {
 		$comment = $this->createMock(IComment::class);
 		$comment->method('getActorType')
 			->willReturn($commentActorType);
@@ -217,10 +227,14 @@ class NotifierTest extends TestCase {
 			'actor_type' => $actorType,
 			'actor_id' => $actorId,
 			'important' => $isImportant,
+			'mute_until' => '@' . $muteUntil,
 		]);
+		$current = 1234567;
+		$this->timeFactory->method('getDateTime')
+			->willReturn(new \DateTime('@' . $current));
+
 		$session = null;
 		if ($sessionAge !== null) {
-			$current = 1234567;
 			$this->timeFactory->method('getTime')
 				->willReturn($current);
 

--- a/tests/php/Chat/NotifierTest.php
+++ b/tests/php/Chat/NotifierTest.php
@@ -227,7 +227,7 @@ class NotifierTest extends TestCase {
 			'actor_type' => $actorType,
 			'actor_id' => $actorId,
 			'important' => $isImportant,
-			'mute_until' => '@' . $muteUntil,
+			'mute_until' => $muteUntil,
 		]);
 		$current = 1234567;
 		$this->timeFactory->method('getDateTime')

--- a/tests/php/Model/AttendeeMapperTest.php
+++ b/tests/php/Model/AttendeeMapperTest.php
@@ -356,7 +356,6 @@ class AttendeeMapperTest extends TestCase {
 			$attendee->setActorId($attendeeData['actor_id']);
 			$attendee->setParticipantType($attendeeData['participant_type']);
 			$attendee->setPermissions($attendeeData['permissions']);
-			$attendee->setMuteUntil((new \DateTime)->setTimestamp(0));
 			$this->attendeeMapper->insert($attendee);
 		}
 

--- a/tests/php/Model/AttendeeMapperTest.php
+++ b/tests/php/Model/AttendeeMapperTest.php
@@ -356,6 +356,7 @@ class AttendeeMapperTest extends TestCase {
 			$attendee->setActorId($attendeeData['actor_id']);
 			$attendee->setParticipantType($attendeeData['participant_type']);
 			$attendee->setPermissions($attendeeData['permissions']);
+			$attendee->setMuteUntil((new \DateTime)->setTimestamp(0));
 			$this->attendeeMapper->insert($attendee);
 		}
 

--- a/tests/php/Service/ParticipantServiceTest.php
+++ b/tests/php/Service/ParticipantServiceTest.php
@@ -113,7 +113,6 @@ class ParticipantServiceTest extends TestCase {
 		$attendee->setActorId('test');
 		$attendee->setRoomId(123456789);
 		$attendee->setNotificationLevel(Participant::NOTIFY_MENTION);
-		$attendee->setMuteUntil((new \DateTime)->setTimestamp(0));
 		$this->attendeeMapper->insert($attendee);
 
 		$session1 = new Session();

--- a/tests/php/Service/ParticipantServiceTest.php
+++ b/tests/php/Service/ParticipantServiceTest.php
@@ -113,6 +113,7 @@ class ParticipantServiceTest extends TestCase {
 		$attendee->setActorId('test');
 		$attendee->setRoomId(123456789);
 		$attendee->setNotificationLevel(Participant::NOTIFY_MENTION);
+		$attendee->setMuteUntil((new \DateTime)->setTimestamp(0));
 		$this->attendeeMapper->insert($attendee);
 
 		$session1 = new Session();


### PR DESCRIPTION
## 🛠️ API Checklist

* Fixes the mute part of https://github.com/nextcloud/spreed/issues/14996

### 🚧 Tasks

- [x] Discuss if we should really use non-null DateTime here as it has some (code-)overhead. Either we can use a nullable DateTime (but then we need to have an OR in the call query), or use an int for the timestamp. => Int it is.
- [x] Discuss if this makes sense for 24 at all. => 25 it is.

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
