### PR TITLE
[stable31] fix: Use permanent token to do schedule meeting request

### DIFF
--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -2936,13 +2936,17 @@ class RoomController extends AEnvironmentAwareOCSController {
 			$loginname = $this->serverSession->get('loginname');
 			$token = $this->random->generate(72, ISecureRandom::CHAR_UPPER . ISecureRandom::CHAR_LOWER . ISecureRandom::CHAR_DIGITS);
 
+			// PERMANENT_TOKEN needs to be used here to successfully create calendar events. Token will invalidated directly afterwards.
+			// Ref: https://github.com/nextcloud/server/pull/59758
+			// In Talk 22+ we are using the server provided API `createInCalendar` from ICalendarEventBuilder.
+			// TODO: Since `createInCalendar` is Nextcloud 31+, we can use it here as well?
 			$this->authTokenProvider->generateToken(
 				$token,
 				$user->getUID(),
 				$loginname,
 				null,
 				'Nextcloud Spreed Calendar Integration',
-				IToken::TEMPORARY_TOKEN,
+				IToken::PERMANENT_TOKEN,
 				IToken::DO_NOT_REMEMBER
 			);
 		} catch (\Exception $e) {

--- a/tests/stubs/oc_authentication_token_provider.php
+++ b/tests/stubs/oc_authentication_token_provider.php
@@ -11,6 +11,7 @@ namespace OC\Authentication\Token {
 
 	interface IToken extends \JsonSerializable {
 		public const TEMPORARY_TOKEN = 0;
+		public const PERMANENT_TOKEN = 1;
 		public const DO_NOT_REMEMBER = 0;
 
 	}


### PR DESCRIPTION
## 🛠️ API Checklist

https://github.com/nextcloud/talk-ios/actions/runs/24950740725/job/73110213444#step:20:17

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not possible
- [ ] 📘 API documentation in `docs/` has been updated or is not required
- [ ] 🔖 Capability is added or not needed 
