### PR TITLE
fix(teams): use event initiator in system messages

### DIFF
--- a/lib/Listener/CircleMembershipListener.php
+++ b/lib/Listener/CircleMembershipListener.php
@@ -59,14 +59,15 @@ class CircleMembershipListener extends AMembershipListener {
 	}
 
 	protected function addingCircleMemberEvent(AddingCircleMemberEvent $event): void {
-		$roomsForTargetCircle = $this->manager->getRoomsForActor(Attendee::ACTOR_CIRCLES, $event->getCircle()->getSingleId());
+		$circle = $event->getCircle();
+		$roomsForTargetCircle = $this->manager->getRoomsForActor(Attendee::ACTOR_CIRCLES, $circle->getSingleId());
 		$roomsToAdd = [];
 		foreach ($roomsForTargetCircle as $room) {
 			$roomsToAdd[$room->getId()] = $room;
 		}
 
 		// Check nested circles
-		$memberships = $event->getCircle()->getMemberships();
+		$memberships = $circle->getMemberships();
 		foreach ($memberships as $membership) {
 			$parentId = $membership->getCircleId();
 			$parentRooms = $this->manager->getRoomsForActor(Attendee::ACTOR_CIRCLES, $parentId);
@@ -91,7 +92,7 @@ class CircleMembershipListener extends AMembershipListener {
 		// Get all (nested) memberships in the added $newMember as a flat list
 		$userMembers = $basedOnCircle->getInheritedMembers();
 
-		$invitedBy = $newMember->getInvitedBy();
+		$invitedBy = $circle->hasInitiator() ? $circle->getInitiator() : $newMember->getInvitedBy();
 		if ($invitedBy->getUserType() === Member::TYPE_USER && $invitedBy->getUserId() !== '') {
 			$this->session->set('talk-overwrite-actor-id', $invitedBy->getUserId());
 			$this->session->set('talk-overwrite-actor-displayname', $invitedBy->getDisplayName());
@@ -159,7 +160,7 @@ class CircleMembershipListener extends AMembershipListener {
 			return;
 		}
 
-		$removedBy = $removedMember->getInvitedBy();
+		$removedBy = $circle->hasInitiator() ? $circle->getInitiator() : $removedMember->getInvitedBy();
 		if ($removedBy->getUserType() === Member::TYPE_USER && $removedBy->getUserId() !== '') {
 			$this->session->set('talk-overwrite-actor-id', $removedBy->getUserId());
 			$this->session->set('talk-overwrite-actor-displayname', $removedBy->getDisplayName());


### PR DESCRIPTION
## ☑️ Resolves

* Fix system messages content for added/removed participants (as team members)
  * circles app uses `circle->getInitiator()` in ActivityService.php
  * we should be able to reuse the same approach instead of `member->getInvitedBy()` (as it's incorrect for DELETE operation actor)

### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="182" height="43" alt="2026-04-28_14h21_56" src="https://github.com/user-attachments/assets/8703042a-4fd7-49c8-b8d9-6b6c112e6f5b" /> | <img width="181" height="46" alt="2026-04-28_14h21_46" src="https://github.com/user-attachments/assets/5c661ee5-d708-4197-a2d6-a2ac75d50c20" />

## 🛠️ API Checklist

### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not possible
- [ ] 📘 API documentation in `docs/` has been updated or is not required
- [ ] 🔖 Capability is added or not needed 
