### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -335,12 +335,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "1e8078631ee2c4da77e39fd7addebd1837889298"
+                "reference": "85a2b59a1988278324e0b41bc78ad64e0d1f627e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/1e8078631ee2c4da77e39fd7addebd1837889298",
-                "reference": "1e8078631ee2c4da77e39fd7addebd1837889298",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/85a2b59a1988278324e0b41bc78ad64e0d1f627e",
+                "reference": "85a2b59a1988278324e0b41bc78ad64e0d1f627e",
                 "shasum": ""
             },
             "require": {
@@ -377,7 +377,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2026-04-25T01:21:25+00:00"
+            "time": "2026-04-28T01:53:20+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency