### PR TITLE
test(integration): Make the lobby test less flaky

### DIFF
--- a/tests/integration/features/federation/lobby.feature
+++ b/tests/integration/features/federation/lobby.feature
@@ -41,6 +41,9 @@ Feature: federation/lobby
     And user "participant2" accepts invite to room "room" of server "LOCAL" with 200 (v1)
       | id          | name | type | remoteServer | remoteToken |
       | LOCAL::room | room | 2    | LOCAL        | room        |
+    And user "participant2" is participant of room "LOCAL::room" (v4)
+      | lobbyState |
+      | 0          |
     And using server "LOCAL"
     When user "participant1" sets lobby state for room "room" to "non moderators" for 5 seconds with 200 (v4)
     Given using server "REMOTE"


### PR DESCRIPTION
Before participant2 had never requested their rooms, this meant that the first call took some time to generate changelog and sample conversations. If that and the time for the actual lobby request took long enough, the lobby expired before participant2 was able to see it :see_no_evil: 


### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
