### PR TITLE
[stable33] fix: rework controls for noise suppression / auto-gain in Safari

### DIFF
--- a/src/components/MediaSettings/AdvancedAudioDialog.vue
+++ b/src/components/MediaSettings/AdvancedAudioDialog.vue
@@ -10,6 +10,7 @@ import NcFormBox from '@nextcloud/vue/components/NcFormBox'
 import NcFormBoxSwitch from '@nextcloud/vue/components/NcFormBoxSwitch'
 import { useDevices } from '../../composables/useDevices.js'
 import { useSettingsStore } from '../../stores/settings.ts'
+import { isSafari } from '../../utils/browserCheck.ts'
 
 const props = defineProps<{
 	container?: string
@@ -78,6 +79,7 @@ function onClosing(result?: unknown) {
 		@closing="onClosing">
 		<NcFormBox>
 			<NcFormBoxSwitch
+				v-if="!isSafari"
 				:modelValue="settingsStore.noiseSuppression"
 				:label="noiseSuppressionLabel"
 				:description="noiseSuppressionDescription"
@@ -88,6 +90,7 @@ function onClosing(result?: unknown) {
 				:description="echoCancellationDescription"
 				@update:modelValue="settingsStore.setEchoCancellation" />
 			<NcFormBoxSwitch
+				v-if="!isSafari"
 				:modelValue="settingsStore.autoGainControl"
 				:label="autoGainControlLabel"
 				:description="autoGainControlDescription"

--- a/src/init.js
+++ b/src/init.js
@@ -9,13 +9,14 @@
 import { showError } from '@nextcloud/dialogs'
 import { t } from '@nextcloud/l10n'
 import { reactive } from 'vue'
-import { CALL, PARTICIPANT, VIRTUAL_BACKGROUND } from './constants.ts'
+import { CALL, PARTICIPANT } from './constants.ts'
 import BrowserStorage from './services/BrowserStorage.js'
 import { EventBus } from './services/EventBus.ts'
 import store from './store/index.js'
 import { useIntegrationsStore } from './stores/integrations.js'
 import pinia from './stores/pinia.ts'
 import { useTokenStore } from './stores/token.ts'
+import { isSafari } from './utils/browserCheck.ts'
 
 import '@nextcloud/dialogs/style.css'
 
@@ -110,6 +111,11 @@ function cleanOutdatedBrowserStorageKeys() {
 			localStorage.removeItem(key)
 		}
 	})
+
+	if (isSafari) {
+		BrowserStorage.removeItem('noiseSuppression') // Not supported by Safari browsers
+		BrowserStorage.removeItem('autoGainControl') // Not supported by Safari browsers
+	}
 }
 
 if (window.requestIdleCallback) {

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -20,6 +20,7 @@ import {
 	setStartWithoutMedia,
 	setTypingStatusPrivacy,
 } from '../services/settingsService.ts'
+import { isSafari } from '../utils/browserCheck.ts'
 
 type PRIVACY_KEYS = typeof PRIVACY[keyof typeof PRIVACY]
 type LIST_STYLE_OPTIONS = 'two-lines' | 'compact'
@@ -36,9 +37,9 @@ export const useSettingsStore = defineStore('settings', () => {
 	const readStatusPrivacy = ref<PRIVACY_KEYS>(loadState('spreed', 'read_status_privacy', PRIVACY.PRIVATE))
 	const typingStatusPrivacy = ref<PRIVACY_KEYS>(loadState('spreed', 'typing_privacy', PRIVACY.PRIVATE))
 	const showMediaSettings = ref<boolean>(BrowserStorage.getItem('showMediaSettings') !== 'false')
-	const noiseSuppression = ref<boolean>(BrowserStorage.getItem('noiseSuppression') !== 'false')
+	const noiseSuppression = ref<boolean>(BrowserStorage.getItem('noiseSuppression') !== 'false' && !isSafari)
 	const echoCancellation = ref<boolean>(BrowserStorage.getItem('echoCancellation') !== 'false')
-	const autoGainControl = ref<boolean>(BrowserStorage.getItem('autoGainControl') !== 'false')
+	const autoGainControl = ref<boolean>(BrowserStorage.getItem('autoGainControl') !== 'false' && !isSafari)
 	const startWithoutMedia = ref<boolean | undefined>(getTalkConfig('local', 'call', 'start-without-media'))
 	const blurVirtualBackgroundEnabled = ref<boolean | undefined>(getTalkConfig('local', 'call', 'blur-virtual-background'))
 	const conversationsListStyle = ref<LIST_STYLE_OPTIONS | undefined>(getTalkConfig('local', 'conversations', 'list-style'))


### PR DESCRIPTION
## ☑️ Resolves

* Parial backport from #17672
	- 'autoGainControl' - 'On' not supported and hidden
	- 'noiseSuppression' - 'On' not supported and hidden

### AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="458" height="232" alt="image" src="https://github.com/user-attachments/assets/766fb0d8-ebb4-49f9-a1c3-d9a851d5545a" /> | <img width="459" height="135" alt="image" src="https://github.com/user-attachments/assets/9e92c76a-1c15-4a4d-a40b-6cc1ee2436d8" />

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [x] Safari ⚠️ (with a hardcoded flag)
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required