### PR TITLE
fix(sidebar): rework call UI in Talk integrations

### DIFF
--- a/src/PublicShareAuthSidebar.vue
+++ b/src/PublicShareAuthSidebar.vue
@@ -11,8 +11,10 @@
 				<h2>{{ t('spreed', 'This conversation has ended') }}</h2>
 			</div>
 			<template v-else>
-				<TopBar isInCall isSidebar />
-				<CallView :token="token" isSidebar />
+				<div class="talk-sidebar-callview">
+					<TopBar isInCall isSidebar />
+					<CallView :token="token" isSidebar />
+				</div>
 				<InternalSignalingHint />
 				<RouterView />
 				<PollManager />
@@ -247,13 +249,11 @@ export default {
 	& #call-container {
 		position: relative;
 
-		flex-grow: 1;
-
 		/* Prevent shadows of videos from leaking on other elements. */
 		overflow: hidden;
 
-		/* Distribute available height between call container and chat view. */
-		height: 40%;
+		padding-bottom: var(--sidebar-container-height, 56.25%);
+		max-height: var(--sidebar-container-height, 56.25%);
 
 		/* Ensure that the background will be black also in voice only calls. */
 		background-color: $color-call-background;

--- a/src/PublicShareSidebar.vue
+++ b/src/PublicShareSidebar.vue
@@ -21,8 +21,10 @@
 				</NcButton>
 			</div>
 			<template v-else>
-				<TopBar v-if="isInCall" isInCall isSidebar />
-				<CallView v-if="isInCall" :token="token" isSidebar />
+				<div v-if="isInCall" class="talk-sidebar-callview">
+					<TopBar isInCall isSidebar />
+					<CallView :token="token" isSidebar />
+				</div>
 				<InternalSignalingHint />
 				<CallButton v-if="!isInCall" class="call-button" />
 				<CallFailedDialog v-if="connectionFailed" :token="token" />
@@ -322,20 +324,11 @@ footer {
 #talk-sidebar #call-container {
 	position: relative;
 
-	flex-grow: 1;
-
 	/* Prevent shadows of videos from leaking on other elements. */
 	overflow: hidden;
 
-	/* Show the call container in a 16/9 proportion based on the sidebar
-	 * width. This is the same proportion used for previews of images by the
-	 * SidebarPreviewManager. */
-	padding-bottom: 56.25%;
-	max-height: 56.25%;
-
-	/* Override the call container height so it properly adjusts to the 16/9
-	 * proportion. */
-	height: unset;
+	padding-bottom: var(--sidebar-container-height, 56.25%);
+	max-height: var(--sidebar-container-height, 56.25%);
 }
 
 #talk-sidebar #call-container :deep(.videoContainer) {

--- a/src/components/CallView/BottomBar.vue
+++ b/src/components/CallView/BottomBar.vue
@@ -189,7 +189,7 @@ const changeViewLabel = computed(() => {
 		: t('spreed', 'Grid view')
 })
 
-const showCallLayoutSwitch = computed(() => !callViewStore.isEmptyCallView)
+const showCallLayoutSwitch = computed(() => !isSidebar && !callViewStore.isEmptyCallView)
 const isGrid = computed(() => callViewStore.isGrid)
 const userIsInBreakoutRoomAndInCall = computed(() => conversation.value.objectType === CONVERSATION.OBJECT_TYPE.BREAKOUT_ROOM)
 
@@ -198,8 +198,8 @@ type CollapsibleButtons = Record<typeof COLLAPSIBLE_BUTTONS[number], boolean>
 const isActionAvailableMask = computed<CollapsibleButtons>(() => ({
 	fullscreen: !isSidebar,
 	callLayout: showCallLayoutSwitch.value,
-	raiseHand: true,
-	liveTranscription: isLiveTranscriptionSupported.value,
+	raiseHand: !isSidebar,
+	liveTranscription: !isSidebar && isLiveTranscriptionSupported.value,
 	virtualBackground: !isSidebar,
 }))
 const hidingList = ref<CollapsibleButtons>({ ...isActionAvailableMask.value })
@@ -562,13 +562,13 @@ useHotKey('r', toggleHandRaised)
 
 			<!-- Reactions menu -->
 			<ReactionMenu
-				v-if="hasReactionSupport"
+				v-if="!isSidebar && hasReactionSupport"
 				:token="token"
 				:supportedReactions="supportedReactions"
 				:localCallParticipantModel="localCallParticipantModel" />
 
 			<div
-				v-if="isLiveTranscriptionSupported && !hidingList.liveTranscription"
+				v-if="!isSidebar && isLiveTranscriptionSupported && !hidingList.liveTranscription"
 				class="live-transcription-button-wrapper">
 				<NcButton
 					:title="liveTranscriptionButtonLabel"
@@ -650,7 +650,7 @@ useHotKey('r', toggleHandRaised)
 				</NcActions>
 			</div>
 			<div
-				v-else-if="hintTranscriptionSupported"
+				v-else-if="!isSidebar && hintTranscriptionSupported"
 				class="live-transcription-button-wrapper">
 				<NcButton
 					:title="hintTranscriptionButtonLabel"

--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -882,6 +882,8 @@ export default {
 	--top-bar-height: 51px;
 	--wrapper-padding: calc(var(--default-grid-baseline) * 2.5);
 	--bottom-bar-height: calc(var(--default-clickable-area) + var(--wrapper-padding) * 2);
+	// For sidebar integrations: show container in a 16/9 proportion (+ top/bottom bar) based on the sidebar width
+	--sidebar-container-height: calc(56.25% + var(--top-bar-height) + var(--bottom-bar-height));
 
 	&.call-container__blurred {
 		backdrop-filter: blur(25px);

--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -395,6 +395,11 @@ export default {
 		},
 
 		shouldShowPresenterOverlay() {
+			if (this.isSidebar) {
+				// Do not overload small video tile
+				return false
+			}
+
 			return (this.showLocalScreen && this.hasLocalVideo)
 				|| ((this.showRemoteScreen || this.showSelectedScreen)
 					&& (this.shownRemoteScreenCallParticipantModel?.attributes.videoAvailable || this.isModelWithVideo(this.shownRemoteScreenCallParticipantModel)))

--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -945,12 +945,13 @@ export default {
 	position: absolute;
 	inset-inline-end: 0;
 	bottom: 0;
-	width: 300px;
-	height: 250px;
+	width: fit-content;
+	max-width: 300px;
+	max-height: 250px;
 
 	&--sidebar {
-		width: 150px;
-		height: 100px;
+		max-width: 150px;
+		max-height: 100px;
 		bottom: var(--bottom-bar-height);
 		margin: var(--default-grid-baseline);
 	}

--- a/src/components/CallView/shared/LocalVideo.vue
+++ b/src/components/CallView/shared/LocalVideo.vue
@@ -381,6 +381,7 @@ export default {
 .localVideoContainer {
 	grid-row-end: -1;
 	border-radius: var(--border-radius-element, calc(var(--default-clickable-area) / 2));
+	overflow: hidden;
 	z-index: 1;
 }
 

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -131,9 +131,8 @@
 
 			<!-- TopBar menu -->
 			<TopBarMenu
+				v-if="!isSidebar"
 				:token="token"
-				:showActions="!isSidebar"
-				:isSidebar="isSidebar"
 				@openBreakoutRoomsEditor="showBreakoutRoomsEditor = true" />
 
 			<!-- Breakout rooms editor -->

--- a/src/components/TopBar/TopBarMediaControls.vue
+++ b/src/components/TopBar/TopBarMediaControls.vue
@@ -62,7 +62,17 @@
 			variant="tertiary" />
 
 		<NcButton
-			v-if="!hideVirtualBackgroundShortcut"
+			v-if="isSidebar"
+			:aria-label="t('spreed', 'Check devices')"
+			:title="t('spreed', 'Check devices')"
+			variant="tertiary"
+			@click.stop="emit('talk:media-settings:show', 'device-check')">
+			<template #icon>
+				<IconCogOutline :size="20" />
+			</template>
+		</NcButton>
+		<NcButton
+			v-else-if="!hideVirtualBackgroundShortcut"
 			:aria-label="t('spreed', 'Select virtual background')"
 			:title="t('spreed', 'Select virtual background')"
 			variant="tertiary"
@@ -118,12 +128,12 @@
 import { showMessage } from '@nextcloud/dialogs'
 import { emit } from '@nextcloud/event-bus'
 import { t } from '@nextcloud/l10n'
-import escapeHtml from 'escape-html'
 import NcActionButton from '@nextcloud/vue/components/NcActionButton'
 import NcActions from '@nextcloud/vue/components/NcActions'
 import NcButton from '@nextcloud/vue/components/NcButton'
 import NcIconSvgWrapper from '@nextcloud/vue/components/NcIconSvgWrapper'
 import NcPopover from '@nextcloud/vue/components/NcPopover'
+import IconCogOutline from 'vue-material-design-icons/CogOutline.vue'
 import IconMonitor from 'vue-material-design-icons/Monitor.vue'
 import IconMonitorOff from 'vue-material-design-icons/MonitorOff.vue'
 import IconMonitorShare from 'vue-material-design-icons/MonitorShare.vue'
@@ -149,6 +159,7 @@ export default {
 		NcIconSvgWrapper,
 		NcPopover,
 		// Icons
+		IconCogOutline,
 		IconMonitor,
 		IconMonitorOff,
 		IconMonitorShare,

--- a/src/components/TopBar/TopBarMediaControls.vue
+++ b/src/components/TopBar/TopBarMediaControls.vue
@@ -73,7 +73,7 @@
 		</NcButton>
 
 		<NcActions
-			v-if="!isSidebar && isScreensharing"
+			v-if="isScreensharing"
 			id="screensharing-button"
 			v-model:open="screenSharingMenuOpen"
 			:title="screenSharingButtonTitle"
@@ -101,7 +101,7 @@
 			</NcActionButton>
 		</NcActions>
 		<NcButton
-			v-else-if="!isSidebar"
+			v-else
 			:title="screenSharingButtonTitle"
 			variant="tertiary"
 			:aria-label="screenSharingButtonAriaLabel"

--- a/src/components/TopBar/TopBarMenu.vue
+++ b/src/components/TopBar/TopBarMenu.vue
@@ -4,158 +4,143 @@
 -->
 
 <template>
-	<div class="top-bar-menu">
-		<NcActions
-			v-if="!isSidebar"
-			forceMenu
-			:title="t('spreed', 'Conversation actions')"
-			:aria-label="t('spreed', 'Conversation actions')"
-			variant="tertiary">
-			<!-- Menu icon: white if in call -->
-			<template v-if="isInCall" #icon>
-				<IconDotsHorizontal :size="20" />
+	<NcActions
+		forceMenu
+		:title="t('spreed', 'Conversation actions')"
+		:aria-label="t('spreed', 'Conversation actions')"
+		variant="tertiary">
+		<!-- Menu icon: white if in call -->
+		<template v-if="isInCall" #icon>
+			<IconDotsHorizontal :size="20" />
+		</template>
+
+		<template v-if="isInCall && canFullModerate">
+			<!-- Moderator actions -->
+			<template v-if="!isOneToOneConversation">
+				<NcActionButton
+					closeAfterClick
+					@click="forceMuteOthers">
+					<template #icon>
+						<NcIconSvgWrapper :svg="IconMicrophoneOffOutline" :size="20" />
+					</template>
+					{{ t('spreed', 'Mute others') }}
+				</NcActionButton>
 			</template>
 
-			<template v-if="isInCall && canFullModerate">
-				<!-- Moderator actions -->
-				<template v-if="!isOneToOneConversation">
-					<NcActionButton
-						closeAfterClick
-						@click="forceMuteOthers">
-						<template #icon>
-							<NcIconSvgWrapper :svg="IconMicrophoneOffOutline" :size="20" />
-						</template>
-						{{ t('spreed', 'Mute others') }}
-					</NcActionButton>
-				</template>
-
-				<!-- Call recording -->
-				<template v-if="canModerateRecording">
-					<NcActionButton
-						v-if="!isRecording && !isStartingRecording && isInCall"
-						closeAfterClick
-						@click="startRecording">
-						<template #icon>
-							<NcIconSvgWrapper
-								:svg="IconScreenRecordOutline"
-								:size="20" />
-						</template>
-						{{ t('spreed', 'Start recording') }}
-					</NcActionButton>
-					<NcActionButton
-						v-else-if="isStartingRecording && isInCall"
-						closeAfterClick
-						@click="stopRecording">
-						<template #icon>
-							<NcLoadingIcon :size="20" />
-						</template>
-						{{ t('spreed', 'Cancel recording start') }}
-					</NcActionButton>
-					<NcActionButton
-						v-else-if="isRecording && isInCall"
-						closeAfterClick
-						@click="stopRecording">
-						<template #icon>
-							<IconStop :size="20" />
-						</template>
-						{{ t('spreed', 'Stop recording') }}
-					</NcActionButton>
-				</template>
-				<template v-else-if="hintRecording">
-					<NcActionButton
-						disabled
-						:description="t('spreed', 'Recording backend is not installed')">
-						<template #icon>
-							<NcIconSvgWrapper
-								:svg="IconScreenRecordOutline"
-								:size="20" />
-						</template>
-						{{ t('spreed', 'Start recording') }}
-					</NcActionButton>
-				</template>
-
-				<NcActionSeparator v-if="!isOneToOneConversation || canModerateRecording" />
+			<!-- Call recording -->
+			<template v-if="canModerateRecording">
+				<NcActionButton
+					v-if="!isRecording && !isStartingRecording && isInCall"
+					closeAfterClick
+					@click="startRecording">
+					<template #icon>
+						<NcIconSvgWrapper
+							:svg="IconScreenRecordOutline"
+							:size="20" />
+					</template>
+					{{ t('spreed', 'Start recording') }}
+				</NcActionButton>
+				<NcActionButton
+					v-else-if="isStartingRecording && isInCall"
+					closeAfterClick
+					@click="stopRecording">
+					<template #icon>
+						<NcLoadingIcon :size="20" />
+					</template>
+					{{ t('spreed', 'Cancel recording start') }}
+				</NcActionButton>
+				<NcActionButton
+					v-else-if="isRecording && isInCall"
+					closeAfterClick
+					@click="stopRecording">
+					<template #icon>
+						<IconStop :size="20" />
+					</template>
+					{{ t('spreed', 'Stop recording') }}
+				</NcActionButton>
+			</template>
+			<template v-else-if="hintRecording">
+				<NcActionButton
+					disabled
+					:description="t('spreed', 'Recording backend is not installed')">
+					<template #icon>
+						<NcIconSvgWrapper
+							:svg="IconScreenRecordOutline"
+							:size="20" />
+					</template>
+					{{ t('spreed', 'Start recording') }}
+				</NcActionButton>
 			</template>
 
-			<!-- Go to file -->
-			<NcActionLink
-				v-if="isFileConversation"
-				target="_blank"
-				rel="noopener noreferrer"
-				:href="linkToFile">
-				<template #icon>
-					<IconFileOutline :size="20" />
-				</template>
-				{{ t('spreed', 'Go to file') }}
-			</NcActionLink>
+			<NcActionSeparator v-if="!isOneToOneConversation || canModerateRecording" />
+		</template>
 
-			<!-- Device settings -->
-			<NcActionButton
-				v-if="isInCall"
-				closeAfterClick
-				@click="showMediaSettingsDialog">
-				<template #icon>
-					<IconVideoOutline :size="20" />
-				</template>
-				{{ t('spreed', 'Check devices') }}
-			</NcActionButton>
+		<!-- Go to file -->
+		<NcActionLink
+			v-if="isFileConversation"
+			target="_blank"
+			rel="noopener noreferrer"
+			:href="linkToFile">
+			<template #icon>
+				<IconFileOutline :size="20" />
+			</template>
+			{{ t('spreed', 'Go to file') }}
+		</NcActionLink>
 
-			<!-- Breakout rooms -->
-			<NcActionButton
-				v-if="canConfigureBreakoutRooms"
-				closeAfterClick
-				@click="$emit('openBreakoutRoomsEditor')">
-				<template #icon>
-					<IconDotsCircle :size="20" />
-				</template>
-				{{ t('spreed', 'Set up breakout rooms') }}
-			</NcActionButton>
-
-			<NcActionLink
-				v-if="isInCall && canDownloadCallParticipants"
-				:href="downloadCallParticipantsLink"
-				target="_blank">
-				<template #icon>
-					<NcIconSvgWrapper :svg="IconFileDownload" :size="20" />
-				</template>
-				{{ t('spreed', 'Download attendance list') }}
-			</NcActionLink>
-			<!-- Fullscreen -->
-			<NcActionButton
-				v-if="!isInCall"
-				:aria-label="t('spreed', 'Toggle full screen')"
-				closeAfterClick
-				@click="toggleFullscreen">
-				<template #icon>
-					<IconFullscreen v-if="!isFullscreen" :size="20" />
-					<IconFullscreenExit v-else :size="20" />
-				</template>
-				{{ labelFullscreen }}
-			</NcActionButton>
-
-			<!-- Conversation settings -->
-			<NcActionButton
-				closeAfterClick
-				@click="openConversationSettings">
-				<template #icon>
-					<IconCogOutline :size="20" />
-				</template>
-				{{ t('spreed', 'Conversation settings') }}
-			</NcActionButton>
-		</NcActions>
-
-		<NcButton
-			v-else
-			class="top-bar__icon-wrapper"
-			:aria-label="t('spreed', 'Check devices')"
-			:title="t('spreed', 'Check devices')"
-			variant="tertiary"
+		<!-- Device settings -->
+		<NcActionButton
+			v-if="isInCall"
+			closeAfterClick
 			@click="showMediaSettingsDialog">
+			<template #icon>
+				<IconVideoOutline :size="20" />
+			</template>
+			{{ t('spreed', 'Check devices') }}
+		</NcActionButton>
+
+		<!-- Breakout rooms -->
+		<NcActionButton
+			v-if="canConfigureBreakoutRooms"
+			closeAfterClick
+			@click="$emit('openBreakoutRoomsEditor')">
+			<template #icon>
+				<IconDotsCircle :size="20" />
+			</template>
+			{{ t('spreed', 'Set up breakout rooms') }}
+		</NcActionButton>
+
+		<NcActionLink
+			v-if="isInCall && canDownloadCallParticipants"
+			:href="downloadCallParticipantsLink"
+			target="_blank">
+			<template #icon>
+				<NcIconSvgWrapper :svg="IconFileDownload" :size="20" />
+			</template>
+			{{ t('spreed', 'Download attendance list') }}
+		</NcActionLink>
+		<!-- Fullscreen -->
+		<NcActionButton
+			v-if="!isInCall"
+			:aria-label="t('spreed', 'Toggle full screen')"
+			closeAfterClick
+			@click="toggleFullscreen">
+			<template #icon>
+				<IconFullscreen v-if="!isFullscreen" :size="20" />
+				<IconFullscreenExit v-else :size="20" />
+			</template>
+			{{ labelFullscreen }}
+		</NcActionButton>
+
+		<!-- Conversation settings -->
+		<NcActionButton
+			closeAfterClick
+			@click="openConversationSettings">
 			<template #icon>
 				<IconCogOutline :size="20" />
 			</template>
-		</NcButton>
-	</div>
+			{{ t('spreed', 'Conversation settings') }}
+		</NcActionButton>
+	</NcActions>
 </template>
 
 <script>
@@ -166,7 +151,6 @@ import NcActionButton from '@nextcloud/vue/components/NcActionButton'
 import NcActionLink from '@nextcloud/vue/components/NcActionLink'
 import NcActions from '@nextcloud/vue/components/NcActions'
 import NcActionSeparator from '@nextcloud/vue/components/NcActionSeparator'
-import NcButton from '@nextcloud/vue/components/NcButton'
 import NcIconSvgWrapper from '@nextcloud/vue/components/NcIconSvgWrapper'
 import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
 import IconCogOutline from 'vue-material-design-icons/CogOutline.vue'
@@ -202,7 +186,6 @@ export default {
 		NcActionLink,
 		NcActionSeparator,
 		NcActions,
-		NcButton,
 		NcLoadingIcon,
 		NcIconSvgWrapper,
 		// Icons
@@ -224,19 +207,6 @@ export default {
 			type: String,
 			required: true,
 		},
-
-		showActions: {
-			type: Boolean,
-			default: true,
-		},
-
-		/**
-		 * In the sidebar the conversation settings are hidden
-		 */
-		isSidebar: {
-			type: Boolean,
-			default: false,
-		},
 	},
 
 	emits: ['openBreakoutRoomsEditor'],
@@ -246,7 +216,7 @@ export default {
 			IconFileDownload,
 			IconMicrophoneOffOutline,
 			IconScreenRecordOutline,
-			isFullscreen: !props.isSidebar ? useDocumentFullscreen() : undefined,
+			isFullscreen: useDocumentFullscreen(),
 			isInCall: useIsInCall(),
 			toggleFullscreen,
 		}
@@ -367,9 +337,3 @@ export default {
 	},
 }
 </script>
-
-<style lang="scss" scoped>
-.top-bar-menu {
-	display: flex;
-}
-</style>

--- a/src/views/FilesSidebarCallView.vue
+++ b/src/views/FilesSidebarCallView.vue
@@ -92,15 +92,13 @@ header.app-sidebar-header.hidden-by-call > div:not(.talk-sidebar-callview), {
 	/* Prevent shadows of videos from leaking on other elements. */
 	overflow: hidden;
 
-	/* Show the call container in a 16/9 proportion based on the sidebar
-	 * width. */
-	padding-bottom: 56.25%;
-	max-height: 56.25%;
+	padding-bottom: var(--sidebar-container-height, 56.25%);
+	max-height: var(--sidebar-container-height, 56.25%);
 }
 
 .call-loading{
-	padding-bottom: 56.25%;
-	max-height: 56.25%;
+	padding-bottom: var(--sidebar-container-height, 56.25%);
+	max-height: var(--sidebar-container-height, 56.25%);
 	background-color: $color-call-background;
 }
 </style>


### PR DESCRIPTION
## ☑️ Resolves

Lighten and improve call interface (keep only relevant controls, increase video tile area)
Extracted from #17205 comments (cc @nimishavijay):

* round local video corners
* allow screensharing (do not show presenter overlay in this mode)
* increase container height (consider top/bottom bars for preview)
	- keep same size for all integrations
* hide reactions and live-transcription controls
* replace 'virtual-bg' with 'device-check'
	- calling the same dialog, but with more relevant tab for integrations
	- virtual bg is still accessible from dialog

Should be applicable also to 'call from anywhere'

### AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
4:3 | --
<img width="242" height="195" alt="image" src="https://github.com/user-attachments/assets/79d6fce2-6e0b-45ed-83be-df5b8468249f" /> | <img width="239" height="257" alt="image" src="https://github.com/user-attachments/assets/7a050e59-128a-4b6e-9c4b-c0a7db6b07f3" />
16:9 | --
<img width="240" height="196" alt="image" src="https://github.com/user-attachments/assets/47dfc464-cd6a-472f-8780-8cf781b10d3c" /> | <img width="243" height="258" alt="image" src="https://github.com/user-attachments/assets/82e9351e-eca7-40ed-8f1d-ae708cdd843e" />
Floating | --
<img width="254" height="193" alt="image" src="https://github.com/user-attachments/assets/793a55f3-cf14-49b7-80de-6c251fae8bec" /> | <img width="248" height="192" alt="image" src="https://github.com/user-attachments/assets/f782218b-af3e-4703-9a1d-79f6936c1383" />


### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required