### PR TITLE
fix(federation): Check session owner when closing a conversation

### DIFF
--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -2601,6 +2601,16 @@ class RoomController extends AEnvironmentAwareOCSController {
 					$room,
 					$sessionId,
 				);
+
+				if (
+					$participant->getAttendee()->getActorType() !== Attendee::ACTOR_FEDERATED_USERS
+					|| $participant->getAttendee()->getActorId() !== $this->federationAuthenticator->getCloudId()
+					|| !hash_equals($participant->getAttendee()->getAccessToken(), $this->federationAuthenticator->getAccessToken())
+				) {
+					$response = new DataResponse(null, Http::STATUS_NOT_FOUND);
+					$response->throttle(['token' => $token, 'action' => 'talkRoomToken']);
+					return $response;
+				}
 				$this->federationAuthenticator->authenticated($room, $participant);
 			}
 

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -1442,6 +1442,36 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 		$this->assertStatusCode($this->response, $statusCode);
 	}
 
+	#[Then('/^user "([^"]*)" forges a request for user "([^"]*)" to room "([^"]*)" with (\d+) \((v4)\)$/')]
+	public function userExitsRoomWithAForgedInvalidRequest(string $user1, string $user2, string $identifier, int $statusCode, string $apiVersion): void {
+		$currentUser = $this->setCurrentUser('admin');
+		$this->sendRequest('DELETE', '/apps/spreedcheats/forged/federation/active', [
+			'token' => self::$identifierToToken[$identifier],
+			'actingUser' => $user1,
+			'targetUser' => $user2,
+		]);
+
+		$this->assertStatusCode($this->response, 200);
+		$data = $this->getDataFromResponse($this->response);
+		$this->setCurrentUser(null);
+
+		$currentServer = $this->currentServer;
+		$this->usingServer($currentServer === 'LOCAL' ? 'REMOTE' : 'LOCAL');
+
+		[, $hostIdentifier] = explode('::', $identifier);
+		$this->sendRequest('DELETE', '/apps/spreed/api/' . $apiVersion . '/room/' . self::$identifierToToken[$hostIdentifier] . '/federation/active', [
+			'sessionId' => $data['session']['session_id'],
+		], [
+			'x-nextcloud-federation' => 'true',
+		], [
+			'auth' => [urlencode($data['access']['invited_cloud_id']), $data['access']['access_token']],
+		]);
+		$this->assertStatusCode($this->response, $statusCode);
+
+		$this->setCurrentUser($currentUser);
+		$this->usingServer($currentServer);
+	}
+
 	#[Then('/^user "([^"]*)" removes themselves from room "([^"]*)" with (\d+) \((v4)\)$/')]
 	public function userLeavesRoom(string $user, string $identifier, int $statusCode, string $apiVersion): void {
 		$this->setCurrentUser($user);

--- a/tests/integration/features/federation/join-leave.feature
+++ b/tests/integration/features/federation/join-leave.feature
@@ -108,3 +108,52 @@ Feature: federation/join-leave
       | actorType       | actorId                   | participantType | sessionIds |
       | federated_users | participant1@{$LOCAL_URL} | 1               | [SESSION,] |
       | users           | participant2              | 3               | []         |
+
+  Scenario: leave a room with the session of another user
+    Given using server "REMOTE"
+    And user "participant3" exists
+    And using server "LOCAL"
+    Given user "participant1" creates room "room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    And user "participant1" adds federated_user "participant2" to room "room" with 200 (v4)
+    And user "participant1" adds federated_user "participant3" to room "room" with 200 (v4)
+    And using server "REMOTE"
+    And user "participant2" has the following invitations (v1)
+      | remoteServerUrl | remoteToken | state | inviterCloudId     | inviterDisplayName       |
+      | LOCAL           | room        | 0     | participant1@LOCAL | participant1-displayname |
+    And user "participant2" accepts invite to room "room" of server "LOCAL" with 200 (v1)
+      | id          | name | type | remoteServer | remoteToken |
+      | LOCAL::room | room | 2    | LOCAL        | room        |
+    And user "participant3" has the following invitations (v1)
+      | remoteServerUrl | remoteToken | state | inviterCloudId     | inviterDisplayName       |
+      | LOCAL           | room        | 0     | participant1@LOCAL | participant1-displayname |
+    And user "participant3" accepts invite to room "room" of server "LOCAL" with 200 (v1)
+      | id          | name | type | remoteServer | remoteToken |
+      | LOCAL::room | room | 2    | LOCAL        | room        |
+    And user "participant2" joins room "LOCAL::room" with 200 (v4)
+    And user "participant3" joins room "LOCAL::room" with 200 (v4)
+    And using server "LOCAL"
+    And user "participant1" sees the following attendees in room "room" with 200 (v4)
+      | actorType       | actorId                    | participantType | sessionIds                            |
+      | users           | participant1               | 1               | []                                    |
+      | federated_users | participant2@{$REMOTE_URL} | 3               | [SESSION#participant2@{$REMOTE_URL},] |
+      | federated_users | participant3@{$REMOTE_URL} | 3               | [SESSION#participant3@{$REMOTE_URL},] |
+    And using server "REMOTE"
+    And user "participant2" sees the following attendees in room "LOCAL::room" with 200 (v4)
+      | actorType       | actorId                    | participantType | sessionIds                            |
+      | federated_users | participant1@{$LOCAL_URL}  | 1               | []                                    |
+      | users           | participant2               | 3               | [SESSION#participant2@{$REMOTE_URL},] |
+      | users           | participant3               | 3               | [SESSION#participant3@{$REMOTE_URL},] |
+    When user "participant2" forges a request for user "participant3" to room "LOCAL::room" with 404 (v4)
+    And user "participant2" sees the following attendees in room "LOCAL::room" with 200 (v4)
+      | actorType       | actorId                    | participantType | sessionIds                            |
+      | federated_users | participant1@{$LOCAL_URL}  | 1               | []                                    |
+      | users           | participant2               | 3               | [SESSION#participant2@{$REMOTE_URL},] |
+      | users           | participant3               | 3               | [SESSION#participant3@{$REMOTE_URL},] |
+    Then using server "LOCAL"
+    And user "participant1" sees the following attendees in room "room" with 200 (v4)
+      | actorType       | actorId                    | participantType | sessionIds                            |
+      | users           | participant1               | 1               | []                                    |
+      | federated_users | participant2@{$REMOTE_URL} | 3               | [SESSION#participant2@{$REMOTE_URL},] |
+      | federated_users | participant3@{$REMOTE_URL} | 3               | [SESSION#participant3@{$REMOTE_URL},] |

--- a/tests/integration/spreedcheats/appinfo/routes.php
+++ b/tests/integration/spreedcheats/appinfo/routes.php
@@ -10,6 +10,7 @@ return [
 	'ocs' => [
 		['name' => 'Api#resetSpreed', 'url' => '/', 'verb' => 'DELETE'],
 		['name' => 'Api#ageChat', 'url' => '/age', 'verb' => 'POST'],
+		['name' => 'Api#forgedFederationLeave', 'url' => '/forged/federation/active', 'verb' => 'DELETE'],
 		['name' => 'Api#createEventInCalendar', 'url' => '/calendar', 'verb' => 'POST'],
 		['name' => 'Api#createDashboardEvents', 'url' => '/dashboardEvents', 'verb' => 'POST'],
 		['name' => 'Api#createEventAndInviteParticipant', 'url' => '/mutualEvents', 'verb' => 'POST'],

--- a/tests/integration/spreedcheats/lib/Controller/ApiController.php
+++ b/tests/integration/spreedcheats/lib/Controller/ApiController.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace OCA\SpreedCheats\Controller;
 
 use OCA\SpreedCheats\Calendar\EventGenerator;
+use OCA\Talk\Model\Attendee;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
@@ -212,6 +213,45 @@ class ApiController extends OCSController {
 		$result->closeCursor();
 
 		return new DataResponse();
+	}
+
+	public function forgedFederationLeave(string $token, string $actingUser, string $targetUser): DataResponse {
+		$query = $this->db->getQueryBuilder();
+		$query->select('id')
+			->from('talk_rooms')
+			->where($query->expr()->eq('token', $query->createNamedParameter($token)));
+
+		$result = $query->executeQuery();
+		$roomId = (int)$result->fetchOne();
+		$result->closeCursor();
+
+		$query = $this->db->getQueryBuilder();
+		$query->select('access_token', 'invited_cloud_id')
+			->from('talk_attendees')
+			->where($query->expr()->eq('actor_id', $query->createNamedParameter($actingUser)))
+			->andWhere($query->expr()->eq('actor_type', $query->createNamedParameter(Attendee::ACTOR_USERS)))
+			->andWhere($query->expr()->eq('room_id', $query->createNamedParameter($roomId)));
+
+		$result = $query->executeQuery();
+		$access = $result->fetch();
+		$result->closeCursor();
+
+		$query = $this->db->getQueryBuilder();
+		$query->select('s.session_id')
+			->from('talk_attendees', 'a')
+			->leftJoin('a', 'talk_sessions', 's', $query->expr()->eq('a.id', 's.attendee_id'))
+			->where($query->expr()->eq('actor_id', $query->createNamedParameter($targetUser)))
+			->andWhere($query->expr()->eq('actor_type', $query->createNamedParameter(Attendee::ACTOR_USERS)))
+			->andWhere($query->expr()->eq('room_id', $query->createNamedParameter($roomId)));
+
+		$result = $query->executeQuery();
+		$session = $result->fetch();
+		$result->closeCursor();
+
+		return new DataResponse([
+			'access' => $access,
+			'session' => $session,
+		]);
 	}
 
 	#[NoAdminRequired]


### PR DESCRIPTION
### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
