### PR TITLE
Changelogs for 21.1.11, 22.0.12 and 23.0.4

### DIFF
--- a/docs/changelogs/changelog-21.md
+++ b/docs/changelogs/changelog-21.md
@@ -5,6 +5,17 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 21.1.11 – 2026-04-30
+### Changed
+- Update dependencies
+- Update translations
+
+### Fixed
+- fix(calendar): Fix calendar meeting integration after a session related change in server
+  [#17818](https://github.com/nextcloud/spreed/pull/17818)
+- fix(federation): Check session id when leaving a conversation
+  [#17866](https://github.com/nextcloud/spreed/pull/17866)
+
 ## 21.1.10 – 2026-04-02
 ### Changed
 - Update dependencies

--- a/docs/changelogs/changelog-22.md
+++ b/docs/changelogs/changelog-22.md
@@ -5,6 +5,39 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 22.0.12 – 2026-04-30
+### Changed
+- Update dependencies
+- Update translations
+
+### Fixed
+- fix(bots): Hide bots from apps when their app is disabled
+  [#17668](https://github.com/nextcloud/spreed/pull/17668)
+- fix(bots): Don't soft-fail when creating incompatible bots
+  [#17665](https://github.com/nextcloud/spreed/pull/17665)
+- fix(calendar): Make appointment conversations meetings so they expire after the appointment
+  [#17646](https://github.com/nextcloud/spreed/pull/17646)
+- fix(call): Fix joining the conversation with breakout rooms or extending 1-1
+  [#17785](https://github.com/nextcloud/spreed/pull/17785)
+  [#17710](https://github.com/nextcloud/spreed/pull/17710)
+  [#17779](https://github.com/nextcloud/spreed/pull/17779)
+- fix(chat): Improve "language detection" option in the translation dialogue
+  [#17677](https://github.com/nextcloud/spreed/pull/17677)
+- fix(commands): Correctly exclude only 1-1 from managing via occ
+  [#17740](https://github.com/nextcloud/spreed/pull/17740)
+- fix(conversation): Show filtered conversations right away when searching
+  [#17841](https://github.com/nextcloud/spreed/pull/17841)
+- fix(conversation): Make conversation order consistent when searching
+  [#17658](https://github.com/nextcloud/spreed/pull/17658)
+- fix(conversation): Gracefully handle cases when the conversation list is too big for the browser storage
+  [#17650](https://github.com/nextcloud/spreed/pull/17650)
+- fix(federation): Check session id when leaving a conversation
+  [#17867](https://github.com/nextcloud/spreed/pull/17867)
+- fix(recording): Allow MP4 as recording mimetype
+  [#17648](https://github.com/nextcloud/spreed/pull/17648)
+- fix(transcriptions): Fix live transcription app getting the signaling settings
+  [#17739](https://github.com/nextcloud/spreed/pull/17739)
+
 ## 22.0.11 – 2026-04-02
 ### Changed
 - Update dependencies

--- a/docs/changelogs/changelog-23.md
+++ b/docs/changelogs/changelog-23.md
@@ -5,6 +5,48 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 23.0.4 – 2026-04-30
+### Changed
+- Update dependencies
+- Update translations
+
+### Fixed
+- fix(bots): Hide bots from apps when their app is disabled
+  [#17669](https://github.com/nextcloud/spreed/pull/17669)
+- fix(bots): Don't soft-fail when creating incompatible bots
+  [#17664](https://github.com/nextcloud/spreed/pull/17664)
+- fix(calendar): Make appointment conversations meetings so they expire after the appointment
+  [#17645](https://github.com/nextcloud/spreed/pull/17645)
+- fix(call): Hide noise suppression option with Safari as it's not applicable
+  [#17859](https://github.com/nextcloud/spreed/pull/17859)
+- fix(call): Fix joining the conversation with breakout rooms or extending 1-1
+  [#17784](https://github.com/nextcloud/spreed/pull/17784)
+  [#17781](https://github.com/nextcloud/spreed/pull/17781)
+  [#17780](https://github.com/nextcloud/spreed/pull/17780)
+- fix(chat): Emoji autocomplete hidden behind modal in some cases
+  [#17834](https://github.com/nextcloud/spreed/pull/17834)
+- fix(chat): Improve "language detection" option in the translation dialogue
+  [#17678](https://github.com/nextcloud/spreed/pull/17678)
+- fix(commands): Correctly exclude only 1-1 from managing via occ
+  [#17741](https://github.com/nextcloud/spreed/pull/17741)
+- fix(conversation): Show filtered conversations right away when searching
+  [#17840](https://github.com/nextcloud/spreed/pull/17840)
+- fix(conversation): Make conversation order consistent when searching
+  [#17659](https://github.com/nextcloud/spreed/pull/17659)
+- fix(conversation): Gracefully handle cases when the conversation list is too big for the browser storage
+  [#17651](https://github.com/nextcloud/spreed/pull/17651)
+- fix(federation): Migrate to new OCM provider interface
+  [#17720](https://github.com/nextcloud/spreed/pull/17720)
+- fix(federation): Check session id when leaving a conversation
+  [#17868](https://github.com/nextcloud/spreed/pull/17868)
+- fix(recording): Allow MP4 as recording mimetype
+  [#17647](https://github.com/nextcloud/spreed/pull/17647)
+- fix(sharing): Multiple improvements to better scale with many shares
+  [#17770](https://github.com/nextcloud/spreed/pull/17770)
+  [#17673](https://github.com/nextcloud/spreed/pull/17673)
+- fix(transcriptions): Fix live transcription app getting the signaling settings
+  [#17738](https://github.com/nextcloud/spreed/pull/17738)
+
 ## 23.0.3 – 2026-04-02
 ### Changed
 - Update dependencies


### PR DESCRIPTION

## 21.1.11 – 2026-04-30
### Changed
- Update dependencies
- Update translations

### Fixed
- fix(calendar): Fix calendar meeting integration after a session related change in server [#17818](https://github.com/nextcloud/spreed/pull/17818)
- fix(federation): Check session id when leaving a conversation [#17866](https://github.com/nextcloud/spreed/pull/17866)


## 22.0.12 – 2026-04-30
### Changed
- Update dependencies
- Update translations

### Fixed
- fix(bots): Hide bots from apps when their app is disabled [#17668](https://github.com/nextcloud/spreed/pull/17668)
- fix(bots): Don't soft-fail when creating incompatible bots [#17665](https://github.com/nextcloud/spreed/pull/17665)
- fix(calendar): Make appointment conversations meetings so they expire after the appointment [#17646](https://github.com/nextcloud/spreed/pull/17646)
- fix(call): Fix joining the conversation with breakout rooms or extending 1-1 [#17785](https://github.com/nextcloud/spreed/pull/17785) [#17710](https://github.com/nextcloud/spreed/pull/17710) [#17779](https://github.com/nextcloud/spreed/pull/17779)
- fix(chat): Improve "language detection" option in the translation dialogue [#17677](https://github.com/nextcloud/spreed/pull/17677)
- fix(commands): Correctly exclude only 1-1 from managing via occ [#17740](https://github.com/nextcloud/spreed/pull/17740)
- fix(conversation): Show filtered conversations right away when searching [#17841](https://github.com/nextcloud/spreed/pull/17841)
- fix(conversation): Make conversation order consistent when searching [#17658](https://github.com/nextcloud/spreed/pull/17658)
- fix(conversation): Gracefully handle cases when the conversation list is too big for the browser storage [#17650](https://github.com/nextcloud/spreed/pull/17650)
- fix(federation): Check session id when leaving a conversation [#17867](https://github.com/nextcloud/spreed/pull/17867)
- fix(recording): Allow MP4 as recording mimetype [#17648](https://github.com/nextcloud/spreed/pull/17648)
- fix(transcriptions): Fix live transcription app getting the signaling settings [#17739](https://github.com/nextcloud/spreed/pull/17739)


## 23.0.4 – 2026-04-30
### Changed
- Update dependencies
- Update translations

### Fixed
- fix(bots): Hide bots from apps when their app is disabled [#17669](https://github.com/nextcloud/spreed/pull/17669)
- fix(bots): Don't soft-fail when creating incompatible bots [#17664](https://github.com/nextcloud/spreed/pull/17664)
- fix(calendar): Make appointment conversations meetings so they expire after the appointment [#17645](https://github.com/nextcloud/spreed/pull/17645)
- fix(call): Hide noise suppression option with Safari as it's not applicable [#17859](https://github.com/nextcloud/spreed/pull/17859)
- fix(call): Fix joining the conversation with breakout rooms or extending 1-1 [#17784](https://github.com/nextcloud/spreed/pull/17784) [#17781](https://github.com/nextcloud/spreed/pull/17781) [#17780](https://github.com/nextcloud/spreed/pull/17780)
- fix(chat): Emoji autocomplete hidden behind modal in some cases [#17834](https://github.com/nextcloud/spreed/pull/17834)
- fix(chat): Improve "language detection" option in the translation dialogue [#17678](https://github.com/nextcloud/spreed/pull/17678)
- fix(commands): Correctly exclude only 1-1 from managing via occ [#17741](https://github.com/nextcloud/spreed/pull/17741)
- fix(conversation): Show filtered conversations right away when searching [#17840](https://github.com/nextcloud/spreed/pull/17840)
- fix(conversation): Make conversation order consistent when searching [#17659](https://github.com/nextcloud/spreed/pull/17659)
- fix(conversation): Gracefully handle cases when the conversation list is too big for the browser storage [#17651](https://github.com/nextcloud/spreed/pull/17651)
- fix(federation): Migrate to new OCM provider interface [#17720](https://github.com/nextcloud/spreed/pull/17720)
- fix(federation): Check session id when leaving a conversation [#17868](https://github.com/nextcloud/spreed/pull/17868)
- fix(recording): Allow MP4 as recording mimetype [#17647](https://github.com/nextcloud/spreed/pull/17647)
- fix(sharing): Multiple improvements to better scale with many shares [#17770](https://github.com/nextcloud/spreed/pull/17770) [#17673](https://github.com/nextcloud/spreed/pull/17673)
- fix(transcriptions): Fix live transcription app getting the signaling settings [#17738](https://github.com/nextcloud/spreed/pull/17738)
