### PR TITLE
fix: apply preset parameters

### DIFF
--- a/src/components/NewConversationDialog/NewConversationDialog.vue
+++ b/src/components/NewConversationDialog/NewConversationDialog.vue
@@ -126,7 +126,7 @@ import LoadingComponent from '../LoadingComponent.vue'
 import NewConversationContactsPage from './NewConversationContactsPage.vue'
 import NewConversationSetupPage from './NewConversationSetupPage.vue'
 import { useIsInCall } from '../../composables/useIsInCall.js'
-import { CONVERSATION, WEBINAR, CALL, PARTICIPANT } from '../../constants.ts'
+import { CALL, CONVERSATION, PARTICIPANT, WEBINAR } from '../../constants.ts'
 import { getTalkConfig } from '../../services/CapabilitiesManager.ts'
 import { copyConversationLinkToClipboard } from '../../utils/handleUrl.ts'
 
@@ -138,6 +138,7 @@ const NEW_CONVERSATION = {
 	type: CONVERSATION.TYPE.GROUP,
 	isDummyConversation: true,
 	attributes: CONVERSATION.ATTRIBUTE.NONE,
+	preset: CONVERSATION.PRESET.DEFAULT,
 	messageExpiration: 0,
 	readOnly: CONVERSATION.STATE.READ_WRITE,
 	lobbyState: WEBINAR.LOBBY.NONE,
@@ -319,7 +320,7 @@ export default {
 						avatar.file = await this.$refs.setupPage.$refs.conversationAvatar.getPictureFormData()
 					}
 				}
-				const preset = this.newConversation.attributes & CONVERSATION.ATTRIBUTE.VOICE_ROOM ? CONVERSATION.PRESET.VOICE_ROOM : undefined
+				const preset = this.newConversation.preset !== CONVERSATION.PRESET.DEFAULT ? this.newConversation.preset : undefined
 				const conversation = await this.$store.dispatch('createGroupConversation', {
 					roomName: this.conversationName,
 					roomType: this.isPublic ? CONVERSATION.TYPE.PUBLIC : CONVERSATION.TYPE.GROUP,

--- a/src/components/NewConversationDialog/NewConversationDialog.vue
+++ b/src/components/NewConversationDialog/NewConversationDialog.vue
@@ -126,7 +126,7 @@ import LoadingComponent from '../LoadingComponent.vue'
 import NewConversationContactsPage from './NewConversationContactsPage.vue'
 import NewConversationSetupPage from './NewConversationSetupPage.vue'
 import { useIsInCall } from '../../composables/useIsInCall.js'
-import { CONVERSATION } from '../../constants.ts'
+import { CONVERSATION, WEBINAR, CALL, PARTICIPANT } from '../../constants.ts'
 import { getTalkConfig } from '../../services/CapabilitiesManager.ts'
 import { copyConversationLinkToClipboard } from '../../utils/handleUrl.ts'
 
@@ -138,6 +138,14 @@ const NEW_CONVERSATION = {
 	type: CONVERSATION.TYPE.GROUP,
 	isDummyConversation: true,
 	attributes: CONVERSATION.ATTRIBUTE.NONE,
+	messageExpiration: 0,
+	readOnly: CONVERSATION.STATE.READ_WRITE,
+	lobbyState: WEBINAR.LOBBY.NONE,
+	lobbyTimer: null,
+	recordingConsent: CALL.RECORDING_CONSENT.DISABLED,
+	sipEnabled: WEBINAR.SIP.DISABLED,
+	permissions: PARTICIPANT.PERMISSIONS.DEFAULT,
+	mentionPermissions: CONVERSATION.MENTION_PERMISSIONS.EVERYONE,
 }
 const maxDescriptionLength = getTalkConfig('local', 'conversations', 'description-length') || 500
 export default {
@@ -318,6 +326,14 @@ export default {
 					password: this.password,
 					description: this.newConversation.description,
 					listable: this.listable,
+					messageExpiration: this.newConversation.messageExpiration,
+					readOnly: this.newConversation.readOnly,
+					lobbyState: this.newConversation.lobbyState,
+					lobbyTimer: this.newConversation.lobbyTimer,
+					recordingConsent: this.newConversation.recordingConsent,
+					sipEnabled: this.newConversation.sipEnabled,
+					permissions: this.newConversation.permissions,
+					mentionPermissions: this.newConversation.mentionPermissions,
 					participants: this.selectedParticipants,
 					avatar,
 					preset,

--- a/src/components/NewConversationDialog/NewConversationSetupPage.vue
+++ b/src/components/NewConversationDialog/NewConversationSetupPage.vue
@@ -58,13 +58,16 @@
 					<span class="conversation-type-selector__description">{{ option.description }}</span>
 				</button>
 			</div>
-			<p v-if="presetHiddenParameters.length" class="conversation-type-selector__summary">
-				<span>{{ t('spreed', 'Default parameters are: {parameters}', { parameters: presetHiddenParameters.join(', ') }) }}</span>
-				<span>
-					{{ t('spreed', 'These settings can be changed once the conversation is created.') }}
-				</span>
-			</p>
 		</template>
+		<div v-if="presetHiddenParameters.length" class="conversation-type-selector__summary">
+			<span>{{ t('spreed', 'Default parameters are:') }}</span>
+			<ul class="conversation-type-selector__summary-list">
+				<li v-for="parameter in presetHiddenParameters" :key="parameter">
+					{{ parameter }}
+				</li>
+			</ul>
+			<span>{{ t('spreed', 'These settings can be changed once the conversation is created.') }}</span>
+		</div>
 
 		<label class="new-group-conversation__label">
 			{{ t('spreed', 'Conversation visibility') }}
@@ -274,8 +277,12 @@ export default {
 			if (!preset) {
 				return []
 			}
+			const forcedParameters = { ...this.settingsStore.presets.find((p) => p.identifier === CONVERSATION.PRESET.FORCED)?.parameters }
 			const labels = []
 			for (const [key, value] of Object.entries(preset.parameters)) {
+				if (key in forcedParameters) {
+					continue
+				}
 				const label = formatHiddenParameter(key, value)
 				if (label) {
 					labels.push(...(Array.isArray(label) ? label : [label]))
@@ -385,7 +392,7 @@ export default {
 	&__wrapper {
 		display: flex;
 		gap: var(--default-grid-baseline);
-		align-items: flex-start;
+		align-items: flex-end;
 
 		.checkbox__label {
 			white-space: nowrap;
@@ -409,11 +416,10 @@ export default {
 }
 
 .conversation-type-selector {
-	display: flex;
-	gap: var(--default-grid-baseline);
+	display: grid;
+	grid-template-columns: repeat(2, minmax(200px, 1fr));
 
 	&__option {
-		flex: 1;
 		display: flex;
 		flex-direction: column;
 		align-items: flex-start;
@@ -431,6 +437,10 @@ export default {
 
 		&--active {
 			border-color: var(--color-primary-element);
+		}
+
+		&:only-child {
+			grid-column: 1 / -1; // span a single card
 		}
 	}
 
@@ -452,12 +462,15 @@ export default {
 	}
 
 	&__summary {
-		display: flex;
-		flex-direction: column;
-		gap: 2px;
 		margin-top: var(--default-grid-baseline);
 		color: var(--color-text-maxcontrast);
 		font-size: small;
+	}
+
+	&__summary-list {
+		margin: 0;
+		padding-inline-start: calc(var(--default-grid-baseline) * 5);
+		list-style: disc;
 	}
 }
 </style>

--- a/src/components/NewConversationDialog/NewConversationSetupPage.vue
+++ b/src/components/NewConversationDialog/NewConversationSetupPage.vue
@@ -236,7 +236,7 @@ export default {
 				} else {
 					attributes &= ~CONVERSATION.ATTRIBUTE.VOICE_ROOM
 				}
-				this.updateNewConversation({ attributes })
+				this.applyPresetParameters(preset, attributes)
 			},
 		},
 
@@ -283,6 +283,37 @@ export default {
 		// Inner method to update parent object
 		updateNewConversation(data) {
 			this.$emit('update:newConversation', { ...this.newConversation, ...data })
+		},
+
+		applyPresetParameters(preset, attributes) {
+			const parameters = this.settingsStore.presets.find((p) => p.identifier === preset)?.parameters ?? {}
+
+			const update = { attributes }
+			let nextListable = this.listable
+
+			for (const [key, value] of Object.entries(parameters)) {
+				if (key === 'listable') {
+					nextListable = value
+				} else if (key === 'roomType') {
+					update.type = value
+					if (value !== CONVERSATION.TYPE.PUBLIC) {
+						update.hasPassword = false
+					} else if (forcePasswordProtection) {
+						update.hasPassword = true
+					}
+				} else {
+					update[key] = value
+				}
+			}
+
+			this.updateNewConversation(update)
+
+			if (nextListable !== this.listable) {
+				this.$emit('update:listable', nextListable)
+			}
+			if (update.type && update.type !== CONVERSATION.TYPE.PUBLIC) {
+				this.$emit('update:password', '')
+			}
 		},
 	},
 }

--- a/src/components/NewConversationDialog/NewConversationSetupPage.vue
+++ b/src/components/NewConversationDialog/NewConversationSetupPage.vue
@@ -48,8 +48,8 @@
 					v-for="option in conversationTypeOptions"
 					:key="option.value"
 					class="conversation-type-selector__option"
-					:class="[{ 'conversation-type-selector__option--active': conversationType === option.value }]"
-					@click="conversationType = option.value">
+					:class="[{ 'conversation-type-selector__option--active': preset === option.value }]"
+					@click="preset = option.value">
 					<span class="conversation-type-selector__header">
 						<NcIconSvgWrapper v-if="option.svg" :svg="option.svg" :size="20" />
 						<component :is="option.icon" v-else-if="option.icon" :size="20" />
@@ -270,7 +270,7 @@ export default {
 		},
 
 		presetHiddenParameters() {
-			const preset = this.settingsStore.presets.find((p) => p.identifier === this.conversationType)
+			const preset = this.settingsStore.presets.find((p) => p.identifier === this.preset)
 			if (!preset) {
 				return []
 			}
@@ -284,23 +284,13 @@ export default {
 			return labels
 		},
 
-		conversationType: {
+		preset: {
 			get() {
-				const attributes = this.newConversation.attributes
-				if (attributes & CONVERSATION.ATTRIBUTE.VOICE_ROOM) {
-					return CONVERSATION.PRESET.VOICE_ROOM
-				}
-				return CONVERSATION.PRESET.DEFAULT
+				return this.newConversation.preset ?? CONVERSATION.PRESET.DEFAULT
 			},
 
 			set(preset) {
-				let attributes = this.newConversation.attributes
-				if (preset === CONVERSATION.PRESET.VOICE_ROOM) {
-					attributes |= CONVERSATION.ATTRIBUTE.VOICE_ROOM
-				} else {
-					attributes &= ~CONVERSATION.ATTRIBUTE.VOICE_ROOM
-				}
-				this.applyPresetParameters(preset, attributes)
+				this.applyPresetParameters(preset)
 			},
 		},
 
@@ -349,10 +339,17 @@ export default {
 			this.$emit('update:newConversation', { ...this.newConversation, ...data })
 		},
 
-		applyPresetParameters(preset, attributes) {
+		applyPresetParameters(preset) {
 			const parameters = this.settingsStore.presets.find((p) => p.identifier === preset)?.parameters ?? {}
 
-			const update = { attributes }
+			let attributes = this.newConversation.attributes
+			if (preset === CONVERSATION.PRESET.VOICE_ROOM) {
+				attributes |= CONVERSATION.ATTRIBUTE.VOICE_ROOM
+			} else {
+				attributes &= ~CONVERSATION.ATTRIBUTE.VOICE_ROOM
+			}
+
+			const update = { attributes, preset }
 			let nextListable = this.listable
 
 			for (const [key, value] of Object.entries(parameters)) {

--- a/src/components/NewConversationDialog/NewConversationSetupPage.vue
+++ b/src/components/NewConversationDialog/NewConversationSetupPage.vue
@@ -58,6 +58,12 @@
 					<span class="conversation-type-selector__description">{{ option.description }}</span>
 				</button>
 			</div>
+			<p v-if="presetHiddenParameters.length" class="conversation-type-selector__summary">
+				<span>{{ t('spreed', 'Default parameters are: {parameters}', { parameters: presetHiddenParameters.join(', ') }) }}</span>
+				<span>
+					{{ t('spreed', 'These settings can be changed once the conversation is created.') }}
+				</span>
+			</p>
 		</template>
 
 		<label class="new-group-conversation__label">
@@ -103,6 +109,7 @@ import IconVolumeHighOutline from '../../../img/material-icons/volume-high-outli
 import { CONVERSATION } from '../../constants.ts'
 import { getTalkConfig, hasTalkFeature } from '../../services/CapabilitiesManager.ts'
 import { useSettingsStore } from '../../stores/settings.ts'
+import { messageExpirationOptions } from '../../utils/formattedTime.ts'
 import generatePassword from '../../utils/generatePassword.ts'
 
 const supportsAvatar = hasTalkFeature('local', 'avatar')
@@ -112,6 +119,49 @@ const maxDescriptionLength = getTalkConfig('local', 'conversations', 'descriptio
 const presetIcons = {
 	[CONVERSATION.PRESET.DEFAULT]: { icon: IconForumOutline },
 	[CONVERSATION.PRESET.VOICE_ROOM]: { svg: IconVolumeHighOutline },
+}
+
+/**
+ *
+ * @param seconds
+ */
+function formatExpiration(seconds) {
+	const duration = messageExpirationOptions.find((option) => option.id === seconds)?.label
+		?? t('spreed', 'Custom expiration time')
+	return t('spreed', 'Message expiration set: {duration}', { duration })
+}
+
+/**
+ *
+ * @param key
+ * @param value
+ */
+function formatHiddenParameter(key, value) {
+	switch (key) {
+		case 'messageExpiration':
+			return value > 0 ? formatExpiration(value) : null
+		case 'readOnly':
+			return value === 1 ? t('spreed', 'This conversation is read-only') : null
+		case 'lobbyState':
+			return value === 1 ? t('spreed', 'Enable lobby, restricting the conversation to moderators') : null
+		case 'recordingConsent':
+			return value === 1 ? t('spreed', 'Require recording consent before joining call in this conversation') : null
+		case 'sipEnabled':
+			if (value === 1) {
+				return t('spreed', 'Enable phone and SIP dial-in')
+			}
+			if (value === 2) {
+				return [
+					t('spreed', 'Enable phone and SIP dial-in'),
+					t('spreed', 'Allow to dial-in without a PIN'),
+				]
+			}
+			return null
+		case 'mentionPermissions':
+			return value === 1 ? t('spreed', 'Only moderators are allowed to mention @all') : null
+		default:
+			return null
+	}
 }
 export default {
 
@@ -218,6 +268,21 @@ export default {
 					description: preset.description,
 					...presetIcons[preset.identifier],
 				}))
+		},
+
+		presetHiddenParameters() {
+			const preset = this.settingsStore.presets.find((p) => p.identifier === this.conversationType)
+			if (!preset) {
+				return []
+			}
+			const labels = []
+			for (const [key, value] of Object.entries(preset.parameters)) {
+				const label = formatHiddenParameter(key, value)
+				if (label) {
+					labels.push(...(Array.isArray(label) ? label : [label]))
+				}
+			}
+			return labels
 		},
 
 		conversationType: {
@@ -388,6 +453,15 @@ export default {
 		color: var(--color-text-maxcontrast);
 		font-size: small;
 		font-weight: normal;
+	}
+
+	&__summary {
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+		margin-top: var(--default-grid-baseline);
+		color: var(--color-text-maxcontrast);
+		font-size: small;
 	}
 }
 </style>

--- a/src/components/NewConversationDialog/NewConversationSetupPage.vue
+++ b/src/components/NewConversationDialog/NewConversationSetupPage.vue
@@ -260,8 +260,7 @@ export default {
 		},
 
 		conversationTypeOptions() {
-			return this.settingsStore.presets
-				.filter((preset) => preset.identifier in presetIcons)
+			return this.settingsStore.visiblePresets
 				.map((preset) => ({
 					value: preset.identifier,
 					label: preset.name,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -89,6 +89,7 @@ export const CONVERSATION = {
 		FORCED: 'forced',
 		VOICE_ROOM: 'voiceroom',
 		PRESENTATION: 'presentation',
+		WEBINAR: 'webinar',
 	},
 
 	STATE: {

--- a/src/store/conversationsStore.js
+++ b/src/store/conversationsStore.js
@@ -1126,9 +1126,17 @@ const actions = {
 	 * @param {string} [payload.password] password for a public conversation
 	 * @param {string} [payload.description] description for a new conversation
 	 * @param {number} [payload.listable] whether a conversation is opened to registered users
+	 * @param {number} [payload.messageExpiration] message expiration time for the conversation
+	 * @param {boolean} [payload.readOnly] whether the conversation is read-only
+	 * @param {string} [payload.lobbyState] lobby state for the conversation
+	 * @param {number} [payload.lobbyTimer] lobby timer for the conversation
+	 * @param {boolean} [payload.recordingConsent] whether recording consent is required
+	 * @param {boolean} [payload.sipEnabled] whether SIP is enabled
+	 * @param {object} [payload.permissions] permissions for the conversation
+	 * @param {object} [payload.mentionPermissions] mention permissions for the conversation
 	 * @param {Array} [payload.participants] list of participants
 	 * @param {object} [payload.avatar] avatar object: { emoji, color } | { file }
-	 * @param payload.preset
+	 * @param {string} [payload.preset] preset for the conversation
 	 * @return {object} new conversation object
 	 */
 	async createGroupConversation(context, {
@@ -1139,6 +1147,14 @@ const actions = {
 		password,
 		description,
 		listable,
+		messageExpiration,
+		readOnly,
+		lobbyState,
+		lobbyTimer,
+		recordingConsent,
+		sipEnabled,
+		permissions,
+		mentionPermissions,
 		participants,
 		avatar,
 		preset,
@@ -1172,6 +1188,14 @@ const actions = {
 					password,
 					description,
 					listable,
+					messageExpiration,
+					readOnly,
+					lobbyState,
+					lobbyTimer,
+					recordingConsent,
+					sipEnabled,
+					permissions,
+					mentionPermissions,
 					emoji: avatar?.emoji,
 					avatarColor: avatar?.color,
 					participants: participantsMap,

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -7,7 +7,7 @@ import type { ConversationPreset } from '../types/index.ts'
 
 import { getCurrentUser } from '@nextcloud/auth'
 import { defineStore } from 'pinia'
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import { CHAT_STYLE, CONVERSATION, PRIVACY } from '../constants.ts'
 import BrowserStorage from '../services/BrowserStorage.js'
 import { getTalkConfig, hasTalkFeature } from '../services/CapabilitiesManager.ts'
@@ -230,6 +230,15 @@ export const useSettingsStore = defineStore('settings', () => {
 		presets.value = response.data.ocs.data
 	}
 
+	const EXCLUDED_PRESETS = new Set([CONVERSATION.PRESET.FORCED]) // Should not be shown in UI
+	const HIDDEN_PRESETS = new Set<string>([CONVERSATION.PRESET.WEBINAR, CONVERSATION.PRESET.PRESENTATION])
+	const callsEnabled = getTalkConfig('local', 'call', 'enabled') !== false
+	if (!callsEnabled) {
+		HIDDEN_PRESETS.add(CONVERSATION.PRESET.VOICE_ROOM)
+	}
+
+	const visiblePresets = computed(() => presets.value.filter((preset) => !HIDDEN_PRESETS.has(preset.identifier) && !EXCLUDED_PRESETS.has(preset.identifier)))
+
 	return {
 		readStatusPrivacy,
 		typingStatusPrivacy,
@@ -247,6 +256,7 @@ export const useSettingsStore = defineStore('settings', () => {
 		groupMode,
 		liveTranscriptionTargetLanguageId,
 		presets,
+		visiblePresets,
 
 		fetchPresets,
 		updateSortOrder,


### PR DESCRIPTION
## ☑️ Resolves

* Applied the predefined parameters of presets upon selection (User clicking the button).
* Removed Voice room when call is disabled 
  * Fix #17878
* Added hints on what default special parameters are applied. 

### AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="585" height="370" alt="image" src="https://github.com/user-attachments/assets/8de6b168-c193-46de-8679-a3587dfa4485" /> | <img width="563" height="418" alt="image" src="https://github.com/user-attachments/assets/b2db4bbb-23e5-4f1d-9fda-b32cfecfeba5" />
<!-- ☀️ Light theme | 🌑 Dark Theme -->

### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required

