### PR TITLE
fix: remove Vuex store reference from window object

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -41,8 +41,6 @@ const instance = createApp(App, { fileInfo: null })
 	.use(NextcloudGlobalsVuePlugin)
 	.mount('#content')
 
-window.store = store
-
 // Setup Viewer to be used with Talk sidebar
 /**
  *

--- a/src/mainRecording.js
+++ b/src/mainRecording.js
@@ -33,8 +33,6 @@ __webpack_nonce__ = getCSPNonce()
 // We do not want the index.php since we're loading files
 __webpack_public_path__ = generateFilePath('spreed', '', 'js/')
 
-window.store = store
-
 if (!window.OCA.Talk) {
 	window.OCA.Talk = reactive({})
 }


### PR DESCRIPTION
## ☑️ Resolves

Removes Vuex store reference from window object

<details>
<summary>For debugging</summary>

For debugging this is available:
  * `OCA.Talk.instance.$store`
  * `OCA.Talk.instance.$pinia`

</details>

## 🖌️ UI Checklist

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required