### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -335,12 +335,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "69ce9a120906944a58b3953b29c56b809eefc9bd"
+                "reference": "2c7efe24f694d57c6949979f2fbf814386467535"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/69ce9a120906944a58b3953b29c56b809eefc9bd",
-                "reference": "69ce9a120906944a58b3953b29c56b809eefc9bd",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/2c7efe24f694d57c6949979f2fbf814386467535",
+                "reference": "2c7efe24f694d57c6949979f2fbf814386467535",
                 "shasum": ""
             },
             "require": {
@@ -377,7 +377,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2026-04-30T01:55:09+00:00"
+            "time": "2026-05-04T10:28:24+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency