### PR TITLE
fix(PollViewer): show that the vote is anonymous for moderators

### DIFF
--- a/src/components/PollViewer/PollViewer.vue
+++ b/src/components/PollViewer/PollViewer.vue
@@ -308,9 +308,12 @@ export default {
 				return n('spreed', 'Final results • %n vote', 'Final results • %n votes', this.poll?.numVoters)
 			}
 
-			if (this.selfIsOwnerOrModerator || (this.isPollPublic && this.selfHasVoted)) {
+			if ((this.selfIsOwnerOrModerator || this.selfHasVoted) && this.isPollPublic) {
 				return n('spreed', '%n vote', '%n votes', this.poll?.numVoters)
 			} else if (!this.isPollPublic) {
+				if (this.selfIsOwnerOrModerator) {
+					return n('spreed', '%n vote • Your vote is anonymous', '%n votes • Your vote is anonymous', this.poll?.numVoters)
+				}
 				return t('spreed', 'Your vote is anonymous')
 			}
 


### PR DESCRIPTION
## ☑️ Resolves

* Restore "Your vote is anonymous" for moderators too

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="638" height="448" alt="Bildschirmfoto vom 2026-05-04 13-48-47" src="https://github.com/user-attachments/assets/3340ffd4-3eb3-433a-a43c-72df9de38b1f" /> | <img width="638" height="448" alt="Bildschirmfoto vom 2026-05-04 13-48-52" src="https://github.com/user-attachments/assets/c2f8123e-a781-4f92-99ce-ee8cd128e090" />


### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
