### PR TITLE
chore(release): Changelog and bump for 24.0.0-beta.1

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -18,7 +18,7 @@
 * 🌉 **Sync with other chat solutions** With [Matterbridge](https://github.com/42wim/matterbridge/) being integrated in Talk, you can easily sync a lot of other chat solutions to Nextcloud Talk and vice-versa.
 ]]></description>
 
-	<version>24.0.0-dev.3</version>
+	<version>24.0.0-beta.1</version>
 	<licence>agpl</licence>
 
 	<author>Anna Larch</author>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
-- [Talk 23 for Nextcloud 33](changelogs/changelog-23.md)
+- [Talk 24 for Nextcloud 34 / Hub 26 Spring](changelogs/changelog-24.md)
+- [Talk 23 for Nextcloud 33 / Hub 26 Winter](changelogs/changelog-23.md)
 - [Talk 22 for Nextcloud 32](changelogs/changelog-22.md)
 - [Talk 21 for Nextcloud 31](changelogs/changelog-21.md)
 - [Talk 20 for Nextcloud 30](changelogs/changelog-20.md)

--- a/docs/changelogs/changelog-24.md
+++ b/docs/changelogs/changelog-24.md
@@ -1,0 +1,29 @@
+<!--
+  - SPDX-FileCopyrightText: 2016 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: CC0-1.0
+-->
+# Changelog
+All notable changes to this project will be documented in this file.
+
+## 24.0.0-beta.1 – 2026-05-04
+### Added
+- Call from anywhere - Integration of calls into the avatar menu
+  [#15416](https://github.com/nextcloud/spreed/issues/15416)
+- Permanent call rooms
+  [#15417](https://github.com/nextcloud/spreed/issues/15417)
+- Advanced noise suppression
+  [#17147](https://github.com/nextcloud/spreed/issues/17147)
+- Attachment grouping per conversation
+  [#4340](https://github.com/nextcloud/spreed/issues/4340)
+- Tagging, sorting and grouping options for conversations
+  [#12025](https://github.com/nextcloud/spreed/issues/12025)
+
+### Changed
+- Update dependencies
+- Update translations
+- Require Nextcloud 34 / Hub 26 Spring
+- Improved private reply show the quote now as well
+  [#6301](https://github.com/nextcloud/spreed/issues/6301)
+- Split chat permissions to allow reactions without chat messages
+  [#11329](https://github.com/nextcloud/spreed/issues/11329)
+


### PR DESCRIPTION

## 24.0.0-beta.1 – 2026-05-04
### Added
- Call from anywhere - Integration of calls into the avatar menu [#15416](https://github.com/nextcloud/spreed/issues/15416)
- Permanent call rooms [#15417](https://github.com/nextcloud/spreed/issues/15417)
- Advanced noise suppression [#17147](https://github.com/nextcloud/spreed/issues/17147)
- Attachment grouping per conversation [#4340](https://github.com/nextcloud/spreed/issues/4340)
- Tagging, sorting and grouping options for conversations [#12025](https://github.com/nextcloud/spreed/issues/12025)

### Changed
- Update dependencies
- Update translations
- Require Nextcloud 34 / Hub 26 Spring
- Improved private reply show the quote now as well [#6301](https://github.com/nextcloud/spreed/issues/6301)
- Split chat permissions to allow reactions without chat messages [#11329](https://github.com/nextcloud/spreed/issues/11329)

