### PR TITLE
fix(release): Fix changelog extraction without version argument

### DIFF
--- a/.github/workflows/appstore-build-publish.yml
+++ b/.github/workflows/appstore-build-publish.yml
@@ -138,7 +138,7 @@ jobs:
         if: steps.krankerl.outputs.files_exists != 'true'
         run: |
           cd ${{ env.APP_NAME }}
-          make appstore
+          make appstore version=${{ env.APP_VERSION }}
 
       - name: Check server download link for ${{ fromJSON(steps.appinfo.outputs.result).nextcloud.min-version }}
         run: |

--- a/.github/workflows/appstore-build-publish.yml.patch
+++ b/.github/workflows/appstore-build-publish.yml.patch
@@ -1,0 +1,13 @@
+diff --git a/.github/workflows/appstore-build-publish.yml b/.github/workflows/appstore-build-publish.yml
+index 31086eaf2f..16834c4893 100644
+--- a/.github/workflows/appstore-build-publish.yml
++++ b/.github/workflows/appstore-build-publish.yml
+@@ -138,7 +138,7 @@ jobs:
+         if: steps.krankerl.outputs.files_exists != 'true'
+         run: |
+           cd ${{ env.APP_NAME }}
+-          make appstore
++          make appstore version=${{ env.APP_VERSION }}
+ 
+       - name: Check server download link for ${{ fromJSON(steps.appinfo.outputs.result).nextcloud.min-version }}
+         run: |


### PR DESCRIPTION
## ☑️ Resolves

* Fix #17895 

```
  Root cause: Makefile:15 defaults version to main (version+=main), and the changelog copy on lines 118-120 uses $(firstword $(subst .,
   ,$(version))) to extract the major. Locally you presumably run make appstore version=24.0.0-beta.1, which extracts 24 and finds     
  changelog-24.md. On CI, .github/workflows/appstore-build-publish.yml:141 runs plain make appstore with no version= — so it tries to  
  copy changelog-main.md, which doesn't exist, and the silent @if [ -f ... ] swallows it. 
```

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
