### PR TITLE
chore(rspack): remove warnings

### DIFF
--- a/rspack.config.js
+++ b/rspack.config.js
@@ -193,6 +193,16 @@ module.exports = defineConfig((env) => {
 			],
 		},
 
+		node: {
+			// Default value is 'warn-mock' which replaces these variables with '' and '/', warning about the usage
+			// These variables are not used in the source code
+			// But the are mentioned in the @matrix-org/olm as a fallback for Node.js environment (unused in browser environment)
+			// Disabling mock completely to remove the warnings
+			// May fail in runtime if the variables are used (they should not be used)
+			__filename: false,
+			__dirname: false,
+		},
+
 		plugins: [
 			new ProgressPlugin(),
 

--- a/rspack.config.js
+++ b/rspack.config.js
@@ -246,5 +246,15 @@ module.exports = defineConfig((env) => {
 		},
 
 		cache: true,
+
+		ignoreWarnings: [
+			// @mediapipe/tasks-vision starting 0.10.35 has `import(s.toString())` in the source which cannot be resolved
+			// It is safe to ignore
+			// This is neither used nor exported in the package
+			{
+				module: /@mediapipe\/tasks-vision/,
+				message: /Critical dependency: the request of a dependency is an expression/,
+			},
+		],
 	}
 })


### PR DESCRIPTION
## ☑️ Resolves

* Regression from: https://github.com/nextcloud/spreed/pull/17884

### `@matrix-org/olm` uses Node.js global variables `__filename` and `__dirname` as a fallback when the Browser environment is not available
```
WARNING in ./node_modules/@matrix-org/olm/olm.js
  ⚠ Module parse warning:
  ╰─▶   ⚠ "__filename" is used and has been mocked. Remove it from your code, or set `node.__filename` to disable this warning.
      


WARNING in ./node_modules/@matrix-org/olm/olm.js
  ⚠ Module parse warning:
  ╰─▶   ⚠ "__dirname" is used and has been mocked. Remove it from your code, or set `node.__dirname` to disable this warning.
```
- RSPack warns about the problem and mocks with an empty string
- Not needed in the browser environment
- Explicitly disabled the mock

### `@mediapipe/tasks-vision` starting 0.10.35 has `import(s.toString())` in the source which cannot be resolved, resulting in
```
WARNING in ./node_modules/@mediapipe/tasks-vision/vision_bundle.mjs
  ⚠ Critical dependency: the request of a dependency is an expression

[the line with the import]

⚠️ Because the package is published minified, the line is the entire `vision_bundle.mjs` content ⚠️
```
- This code is neither used nor exported from the package
- Safe to ignore the warning
- Other bundlers (Vite/Rolldown) just ignore it by default

## 🖌️ UI Checklist

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required