### PR TITLE
fix(release): Use version var without leading v

### DIFF
--- a/.github/workflows/appstore-build-publish.yml
+++ b/.github/workflows/appstore-build-publish.yml
@@ -138,7 +138,7 @@ jobs:
         if: steps.krankerl.outputs.files_exists != 'true'
         run: |
           cd ${{ env.APP_NAME }}
-          make appstore version=${{ env.APP_VERSION }}
+          make appstore version=${{ fromJSON(steps.app-version.outputs.result).version }}
 
       - name: Check server download link for ${{ fromJSON(steps.appinfo.outputs.result).nextcloud.min-version }}
         run: |

--- a/.github/workflows/appstore-build-publish.yml.patch
+++ b/.github/workflows/appstore-build-publish.yml.patch
@@ -7,7 +7,7 @@ index 31086eaf2f..16834c4893 100644
          run: |
            cd ${{ env.APP_NAME }}
 -          make appstore
-+          make appstore version=${{ env.APP_VERSION }}
- 
++          make appstore version=${{ fromJSON(steps.app-version.outputs.result).version }}
+
        - name: Check server download link for ${{ fromJSON(steps.appinfo.outputs.result).nextcloud.min-version }}
          run: |

--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,9 @@ appstore:
 	--exclude=webpack.config.js \
 	$(project_dir)/  $(sign_dir)/$(app_name)
 	@if [ -f $(project_dir)/docs/changelogs/changelog-$(firstword $(subst ., ,$(version))).md ]; then \
-		cp $(project_dir)/docs/changelogs/changelog-$(firstword $(subst ., ,$(version))).md $(sign_dir)/$(app_name)/CHANGELOG.md; \
+		cp -v $(project_dir)/docs/changelogs/changelog-$(firstword $(subst ., ,$(version))).md $(sign_dir)/$(app_name)/CHANGELOG.md; \
+	else \
+		echo "changelog-$(firstword $(subst ., ,$(version))).md not found"; \
 	fi
 	@if [ -f $(cert_dir)/$(app_name).key ]; then \
 		echo "Signing app files…"; \


### PR DESCRIPTION
- Follow up to #17909 
- Noticed after https://github.com/nextcloud-releases/spreed/actions/runs/25338194460/job/74288733287 failed again, that the old var had the leading v on it.