### PR TITLE
fix(sharing): Fix probe attachment call for windows compatible filenames

### DIFF
--- a/lib/Config.php
+++ b/lib/Config.php
@@ -19,6 +19,7 @@ use OCP\AppFramework\Services\IAppConfig;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Config\IUserConfig;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Files\IFilenameValidator;
 use OCP\IConfig;
 use OCP\IGroupManager;
 use OCP\IURLGenerator;
@@ -64,6 +65,7 @@ class Config {
 		private IURLGenerator $urlGenerator,
 		protected ITimeFactory $timeFactory,
 		private IEventDispatcher $dispatcher,
+		private IFilenameValidator $filenameValidator,
 	) {
 	}
 
@@ -370,10 +372,11 @@ class Config {
 		// phpcs:ignore -- control characters are intentional
 		$name = preg_replace('/[\x00-\x1f\/\\\\]+/', ' ', $name);
 		$name = trim((string)$name);
+		$name = $this->filenameValidator->sanitizeFilename($name, '_');
 		if (mb_strlen($name) > $maxChars) {
 			$name = trim(mb_substr($name, 0, $maxChars));
 		}
-		return $name;
+		return rtrim($name, '_-');
 	}
 
 	/**

--- a/lib/Service/ConversationFolderService.php
+++ b/lib/Service/ConversationFolderService.php
@@ -12,6 +12,7 @@ use OCA\Talk\Config as TalkConfig;
 use OCA\Talk\Room;
 use OCP\Constants;
 use OCP\Files\Folder;
+use OCP\Files\IFilenameValidator;
 use OCP\Files\IRootFolder;
 use OCP\Files\Node;
 use OCP\Files\NotEnoughSpaceException;
@@ -35,6 +36,7 @@ class ConversationFolderService {
 		private TalkConfig $talkConfig,
 		private IRootFolder $rootFolder,
 		private IShareManager $shareManager,
+		private IFilenameValidator $filenameValidator,
 		private LoggerInterface $logger,
 	) {
 	}
@@ -202,6 +204,7 @@ class ConversationFolderService {
 	 * @param list<string> $reserved
 	 */
 	private function findUniqueNameForProbe(Folder $folder, string $desiredName, array $reserved): string {
+		$desiredName = $this->filenameValidator->sanitizeFilename($desiredName);
 		if (!$this->isProbeNameTaken($folder, $desiredName, $reserved)) {
 			return $desiredName;
 		}

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -130,6 +130,8 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 
 	protected bool $changedBruteforceSetting = false;
 
+	private array $changedWindowsCompatibleFilenames = ['LOCAL' => false, 'REMOTE' => false];
+
 	private ?SharingContext $sharingContext;
 
 	private array $guestsAppWasEnabled = [];
@@ -3812,6 +3814,17 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 		$this->setCurrentUser($currentUser);
 	}
 
+	#[Given('/^windows compatible filenames are (enabled|disabled)$/')]
+	public function setWindowsCompatibleFilenames(string $action): void {
+		$currentUser = $this->setCurrentUser('admin');
+		$this->sendRequest('POST', '/apps/files/api/v1/filenames/windows-compatibility', [
+			'enabled' => $action === 'enabled' ? '1' : '0',
+		]);
+		$this->assertStatusCode($this->response, 200);
+		$this->changedWindowsCompatibleFilenames[$this->currentServer] = true;
+		$this->setCurrentUser($currentUser);
+	}
+
 	#[Given('/^(enable|disable) query\.log$/')]
 	public function toggleQueryLog(string $enable): void {
 		if ($enable === 'enable') {
@@ -4014,6 +4027,24 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 		} else {
 			$this->runOcc(['app:disable', 'password_policy']);
 		}
+	}
+
+	#[BeforeScenario]
+	#[AfterScenario]
+	public function resetWindowsCompatibleFilenames(): void {
+		foreach (['LOCAL', 'REMOTE'] as $server) {
+			if (!$this->changedWindowsCompatibleFilenames[$server]) {
+				continue;
+			}
+			$this->usingServer($server);
+			$currentUser = $this->setCurrentUser('admin');
+			$this->sendRequest('POST', '/apps/files/api/v1/filenames/windows-compatibility', [
+				'enabled' => '0',
+			]);
+			$this->setCurrentUser($currentUser);
+			$this->changedWindowsCompatibleFilenames[$server] = false;
+		}
+		$this->usingServer('LOCAL');
 	}
 
 	#[BeforeScenario]

--- a/tests/integration/features/bootstrap/SharingContext.php
+++ b/tests/integration/features/bootstrap/SharingContext.php
@@ -128,12 +128,27 @@ class SharingContext implements Context {
 	 * $fileNames is a comma-separated list of desired filenames.
 	 */
 	#[When('/^user "([^"]*)" probes attachment folder for room "([^"]*)" with files "([^"]*)" with (\d+) \(v1\)$/')]
-	public function userProbesAttachmentFolder(string $user, string $room, string $fileNamesCsv, int $statusCode): void {
+	public function userProbesAttachmentFolder(string $user, string $room, string $fileNamesCsv, int $statusCode, ?TableNode $tableNode): void {
 		$this->currentUser = $user;
 		$token = FeatureContext::getTokenForIdentifier($room);
 		$fileNames = array_map('trim', explode(',', $fileNamesCsv));
 		$this->sendingToTalkAttachmentFolderProbe($token, $fileNames);
 		$this->theHTTPStatusCodeShouldBe($statusCode);
+
+		if ($statusCode === 200 && $tableNode !== null) {
+			$content = $this->response->getBody()->getContents();
+			$data = json_decode($content, true, flags: JSON_THROW_ON_ERROR);
+			$renames = $data['ocs']['data']['renames'];
+			$expected = [];
+			foreach ($tableNode->getRowsHash() as $key => $value) {
+				$expected[] = [$key => $value];
+			}
+			\PHPUnit\Framework\Assert::assertEquals(
+				$expected,
+				$renames,
+				'Expected rename list of probe does not match'
+			);
+		}
 	}
 
 	/**

--- a/tests/integration/features/bootstrap/SharingContext.php
+++ b/tests/integration/features/bootstrap/SharingContext.php
@@ -128,7 +128,7 @@ class SharingContext implements Context {
 	 * $fileNames is a comma-separated list of desired filenames.
 	 */
 	#[When('/^user "([^"]*)" probes attachment folder for room "([^"]*)" with files "([^"]*)" with (\d+) \(v1\)$/')]
-	public function userProbesAttachmentFolder(string $user, string $room, string $fileNamesCsv, int $statusCode, ?TableNode $tableNode): void {
+	public function userProbesAttachmentFolder(string $user, string $room, string $fileNamesCsv, int $statusCode, ?TableNode $tableNode = null): void {
 		$this->currentUser = $user;
 		$token = FeatureContext::getTokenForIdentifier($room);
 		$fileNames = array_map('trim', explode(',', $fileNamesCsv));

--- a/tests/integration/features/sharing-1/conversation-folder.feature
+++ b/tests/integration/features/sharing-1/conversation-folder.feature
@@ -177,3 +177,23 @@ Feature: sharing-1/conversation-folder
     And user "participant1" posts file "photo.jpg" from conversation folder of room "group room" with name "Group room" with 200 (v1)
     When user "participant1" probes attachment folder for room "group room" with files "photo.jpg" with 200 (v1)
     Then the probe response renames "photo.jpg" to "photo (1).jpg"
+
+  Scenario: Probe sanitizes user display name when windows compatible filenames are enforced
+    Given windows compatible filenames are enabled
+    And user "participant3" exists
+    And set display name of user "participant3" to "J<o>e"
+    And user "participant3" creates room "one-to-one room" (v4)
+      | roomType | 1            |
+      | invite   | participant1 |
+    When user "participant3" probes attachment folder for room "one-to-one room" with files "rep<o>rt.txt,nul.txt,rep:o:rt.txt" with 200 (v1)
+      | rep<o>rt.txt | rep_o_rt.txt |
+      | nul.txt | nul (renamed).txt |
+      | rep:o:rt.txt | rep_o_rt (1).txt |
+    And user "participant3" uploads file "rep_o_rt.txt" with content "Hello!" to conversation folder for room "one-to-one room" with name "participant1-displayname"
+    And user "participant3" posts file "rep_o_rt.txt" from conversation folder of room "one-to-one room" with name "participant1-displayname" with 200 (v1)
+    Then user "participant1" gets all received shares
+    And share is returned with
+      | uid_owner   | participant3                              |
+      | item_type   | folder                                    |
+      | path        | REGEXP /^\/Talk\/.+\/J_o_e-participant3$/ |
+      | permissions | 1                                         |

--- a/tests/php/ConfigTest.php
+++ b/tests/php/ConfigTest.php
@@ -16,6 +16,7 @@ use OCP\AppFramework\Services\IAppConfig;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Config\IUserConfig;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Files\IFilenameValidator;
 use OCP\IConfig;
 use OCP\IGroupManager;
 use OCP\IURLGenerator;
@@ -44,8 +45,10 @@ class ConfigTest extends TestCase {
 		$urlGenerator = $this->createMock(IURLGenerator::class);
 		/** @var MockObject|IEventDispatcher $dispatcher */
 		$dispatcher = $this->createMock(IEventDispatcher::class);
+		/** @var MockObject|IFilenameValidator $filenameValidator */
+		$filenameValidator = $this->createMock(IFilenameValidator::class);
 
-		$helper = new Config($config, $appConfig, $userConfig, $secureRandom, $groupManager, $userManager, $urlGenerator, $timeFactory, $dispatcher);
+		$helper = new Config($config, $appConfig, $userConfig, $secureRandom, $groupManager, $userManager, $urlGenerator, $timeFactory, $dispatcher, $filenameValidator);
 		return $helper;
 	}
 
@@ -155,6 +158,8 @@ class ConfigTest extends TestCase {
 		$urlGenerator = $this->createMock(IURLGenerator::class);
 		/** @var MockObject|IEventDispatcher $dispatcher */
 		$dispatcher = $this->createMock(IEventDispatcher::class);
+		/** @var MockObject|IFilenameValidator $filenameValidator */
+		$filenameValidator = $this->createMock(IFilenameValidator::class);
 
 		/** @var MockObject|ISecureRandom $secureRandom */
 		$secureRandom = $this->createMock(ISecureRandom::class);
@@ -163,7 +168,7 @@ class ConfigTest extends TestCase {
 			->method('generate')
 			->with(16)
 			->willReturn('abcdefghijklmnop');
-		$helper = new Config($config, $appConfig, $userConfig, $secureRandom, $groupManager, $userManager, $urlGenerator, $timeFactory, $dispatcher);
+		$helper = new Config($config, $appConfig, $userConfig, $secureRandom, $groupManager, $userManager, $urlGenerator, $timeFactory, $dispatcher, $filenameValidator);
 
 		//
 		$settings = $helper->getTurnSettings();
@@ -236,6 +241,8 @@ class ConfigTest extends TestCase {
 
 		/** @var IEventDispatcher $dispatcher */
 		$dispatcher = \OCP\Server::get(IEventDispatcher::class);
+		/** @var MockObject|IFilenameValidator $filenameValidator */
+		$filenameValidator = $this->createMock(IFilenameValidator::class);
 
 		$servers = [
 			[
@@ -256,7 +263,7 @@ class ConfigTest extends TestCase {
 
 		$dispatcher->addServiceListener(BeforeTurnServersGetEvent::class, GetTurnServerListener::class);
 
-		$helper = new Config($config, $appConfig, $userConfig, $secureRandom, $groupManager, $userManager, $urlGenerator, $timeFactory, $dispatcher);
+		$helper = new Config($config, $appConfig, $userConfig, $secureRandom, $groupManager, $userManager, $urlGenerator, $timeFactory, $dispatcher, $filenameValidator);
 
 		$settings = $helper->getTurnSettings();
 		$this->assertSame($servers, $settings);
@@ -383,6 +390,8 @@ class ConfigTest extends TestCase {
 		$urlGenerator = $this->createMock(IURLGenerator::class);
 		/** @var MockObject|IEventDispatcher $dispatcher */
 		$dispatcher = $this->createMock(IEventDispatcher::class);
+		/** @var MockObject|IFilenameValidator $filenameValidator */
+		$filenameValidator = $this->createMock(IFilenameValidator::class);
 		/** @var MockObject|IUser $user */
 		$user = $this->createMock(IUser::class);
 
@@ -410,7 +419,7 @@ class ConfigTest extends TestCase {
 			->method('getDisplayName')
 			->willReturn('Jane Doe');
 
-		$helper = new Config($config, $appConfig, $userConfig, $secureRandom, $groupManager, $userManager, $urlGenerator, $timeFactory, $dispatcher);
+		$helper = new Config($config, $appConfig, $userConfig, $secureRandom, $groupManager, $userManager, $urlGenerator, $timeFactory, $dispatcher, $filenameValidator);
 
 		$config->setAppValue('spreed', 'signaling_token_alg', $algo);
 		// Make sure new keys are generated.
@@ -448,6 +457,8 @@ class ConfigTest extends TestCase {
 		$urlGenerator = $this->createMock(IURLGenerator::class);
 		/** @var MockObject|IEventDispatcher $dispatcher */
 		$dispatcher = $this->createMock(IEventDispatcher::class);
+		/** @var MockObject|IFilenameValidator $filenameValidator */
+		$filenameValidator = $this->createMock(IFilenameValidator::class);
 
 		$now = time();
 		$timeFactory
@@ -460,7 +471,7 @@ class ConfigTest extends TestCase {
 			->with('')
 			->willReturn('https://domain.invalid/nextcloud');
 
-		$helper = new Config($config, $appConfig, $userConfig, $secureRandom, $groupManager, $userManager, $urlGenerator, $timeFactory, $dispatcher);
+		$helper = new Config($config, $appConfig, $userConfig, $secureRandom, $groupManager, $userManager, $urlGenerator, $timeFactory, $dispatcher, $filenameValidator);
 
 		$config->setAppValue('spreed', 'signaling_token_alg', $algo);
 		// Make sure new keys are generated.

--- a/tests/php/ConfigTest.php
+++ b/tests/php/ConfigTest.php
@@ -28,28 +28,44 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 class ConfigTest extends TestCase {
-	private function createConfig(IConfig $config) {
-		/** @var MockObject|IAppConfig $appConfig */
-		$appConfig = $this->createMock(IAppConfig::class);
-		/** @var MockObject|IUserConfig $appConfig */
-		$userConfig = $this->createMock(IUserConfig::class);
-		/** @var MockObject|ITimeFactory $timeFactory */
-		$timeFactory = $this->createMock(ITimeFactory::class);
-		/** @var MockObject|ISecureRandom $secureRandom */
-		$secureRandom = $this->createMock(ISecureRandom::class);
-		/** @var MockObject|IGroupManager $groupManager */
-		$groupManager = $this->createMock(IGroupManager::class);
-		/** @var MockObject|IUserManager $userManager */
-		$userManager = $this->createMock(IUserManager::class);
-		/** @var MockObject|IURLGenerator $urlGenerator */
-		$urlGenerator = $this->createMock(IURLGenerator::class);
-		/** @var MockObject|IEventDispatcher $dispatcher */
-		$dispatcher = $this->createMock(IEventDispatcher::class);
-		/** @var MockObject|IFilenameValidator $filenameValidator */
-		$filenameValidator = $this->createMock(IFilenameValidator::class);
+	protected IConfig $config;
+	protected IAppConfig&MockObject $appConfig;
+	protected IUserConfig&MockObject $userConfig;
+	protected ISecureRandom&MockObject $secureRandom;
+	protected IGroupManager&MockObject $groupManager;
+	protected IUserManager&MockObject $userManager;
+	protected IURLGenerator&MockObject $urlGenerator;
+	protected ITimeFactory&MockObject $timeFactory;
+	protected IEventDispatcher $dispatcher;
+	protected IFilenameValidator&MockObject $filenameValidator;
 
-		$helper = new Config($config, $appConfig, $userConfig, $secureRandom, $groupManager, $userManager, $urlGenerator, $timeFactory, $dispatcher, $filenameValidator);
-		return $helper;
+	public function setUp(): void {
+		parent::setUp();
+		$this->config = $this->createMock(IConfig::class);
+		$this->appConfig = $this->createMock(IAppConfig::class);
+		$this->userConfig = $this->createMock(IUserConfig::class);
+		$this->secureRandom = $this->createMock(ISecureRandom::class);
+		$this->groupManager = $this->createMock(IGroupManager::class);
+		$this->userManager = $this->createMock(IUserManager::class);
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+		$this->timeFactory = $this->createMock(ITimeFactory::class);
+		$this->dispatcher = $this->createMock(IEventDispatcher::class);
+		$this->filenameValidator = $this->createMock(IFilenameValidator::class);
+	}
+
+	protected function getConfig(): Config {
+		return new Config(
+			$this->config,
+			$this->appConfig,
+			$this->userConfig,
+			$this->secureRandom,
+			$this->groupManager,
+			$this->userManager,
+			$this->urlGenerator,
+			$this->timeFactory,
+			$this->dispatcher,
+			$this->filenameValidator,
+		);
 	}
 
 	public function testGetStunServers(): void {
@@ -58,63 +74,55 @@ class ConfigTest extends TestCase {
 			'stun2.example.com:129',
 		];
 
-		/** @var MockObject|IConfig $config */
-		$config = $this->createMock(IConfig::class);
-		$config
+		$this->config
 			->expects($this->once())
 			->method('getAppValue')
 			->with('spreed', 'stun_servers', json_encode(['stun.nextcloud.com:443']))
 			->willReturn(json_encode($servers));
-		$config
+		$this->config
 			->expects($this->once())
 			->method('getSystemValueBool')
 			->with('has_internet_connection', true)
 			->willReturn(true);
 
-		$helper = $this->createConfig($config);
+		$helper = $this->getConfig();
 		$this->assertSame($helper->getStunServers(), $servers);
 	}
 
 	public function testGetDefaultStunServer(): void {
-		/** @var MockObject|IConfig $config */
-		$config = $this->createMock(IConfig::class);
-		$config
+		$this->config
 			->expects($this->once())
 			->method('getAppValue')
 			->with('spreed', 'stun_servers', json_encode(['stun.nextcloud.com:443']))
 			->willReturn(json_encode([]));
-		$config
+		$this->config
 			->expects($this->once())
 			->method('getSystemValueBool')
 			->with('has_internet_connection', true)
 			->willReturn(true);
 
-		$helper = $this->createConfig($config);
+		$helper = $this->getConfig();
 		$this->assertSame(['stun.nextcloud.com:443'], $helper->getStunServers());
 	}
 
 	public function testGetDefaultStunServerNoInternet(): void {
-		/** @var MockObject|IConfig $config */
-		$config = $this->createMock(IConfig::class);
-		$config
+		$this->config
 			->expects($this->once())
 			->method('getAppValue')
 			->with('spreed', 'stun_servers', json_encode(['stun.nextcloud.com:443']))
 			->willReturn(json_encode([]));
-		$config
+		$this->config
 			->expects($this->once())
 			->method('getSystemValueBool')
 			->with('has_internet_connection', true)
 			->willReturn(false);
 
-		$helper = $this->createConfig($config);
+		$helper = $this->getConfig();
 		$this->assertSame([], $helper->getStunServers());
 	}
 
 	public function testGenerateTurnSettings(): void {
-		/** @var MockObject|IConfig $config */
-		$config = $this->createMock(IConfig::class);
-		$config
+		$this->config
 			->expects($this->once())
 			->method('getAppValue')
 			->with('spreed', 'turn_servers', '')
@@ -139,38 +147,19 @@ class ConfigTest extends TestCase {
 				],
 			]));
 
-		/** @var MockObject|ITimeFactory $timeFactory */
-		$timeFactory = $this->createMock(ITimeFactory::class);
-		$timeFactory
+		$this->timeFactory
 			->expects($this->once())
 			->method('getTime')
 			->willReturn(1479743025);
 
-		/** @var MockObject|IAppConfig $appConfig */
-		$appConfig = $this->createMock(IAppConfig::class);
-		/** @var MockObject|IUserConfig $appConfig */
-		$userConfig = $this->createMock(IUserConfig::class);
-		/** @var MockObject|IGroupManager $groupManager */
-		$groupManager = $this->createMock(IGroupManager::class);
-		/** @var MockObject|IUserManager $userManager */
-		$userManager = $this->createMock(IUserManager::class);
-		/** @var MockObject|IURLGenerator $urlGenerator */
-		$urlGenerator = $this->createMock(IURLGenerator::class);
-		/** @var MockObject|IEventDispatcher $dispatcher */
-		$dispatcher = $this->createMock(IEventDispatcher::class);
-		/** @var MockObject|IFilenameValidator $filenameValidator */
-		$filenameValidator = $this->createMock(IFilenameValidator::class);
-
-		/** @var MockObject|ISecureRandom $secureRandom */
-		$secureRandom = $this->createMock(ISecureRandom::class);
-		$secureRandom
+		$this->secureRandom
 			->expects($this->once())
 			->method('generate')
 			->with(16)
 			->willReturn('abcdefghijklmnop');
-		$helper = new Config($config, $appConfig, $userConfig, $secureRandom, $groupManager, $userManager, $urlGenerator, $timeFactory, $dispatcher, $filenameValidator);
 
-		//
+		$helper = $this->getConfig();
+
 		$settings = $helper->getTurnSettings();
 		$this->assertEquals(3, count($settings));
 		$this->assertSame([
@@ -197,52 +186,26 @@ class ConfigTest extends TestCase {
 	}
 
 	public function testGenerateTurnSettingsEmpty(): void {
-		/** @var MockObject|IConfig $config */
-		$config = $this->createMock(IConfig::class);
-		$config
+		$this->config
 			->expects($this->once())
 			->method('getAppValue')
 			->with('spreed', 'turn_servers', '')
 			->willReturn(json_encode([]));
 
-		$helper = $this->createConfig($config);
+		$helper = $this->getConfig();
 
 		$settings = $helper->getTurnSettings();
 		$this->assertEquals(0, count($settings));
 	}
 
 	public function testGenerateTurnSettingsEvent(): void {
-		/** @var MockObject|IConfig $config */
-		$config = $this->createMock(IConfig::class);
-		$config
+		$this->config
 			->expects($this->once())
 			->method('getAppValue')
 			->with('spreed', 'turn_servers', '')
 			->willReturn(json_encode([]));
 
-		/** @var MockObject|IAppConfig $appConfig */
-		$appConfig = $this->createMock(IAppConfig::class);
-		/** @var MockObject|IUserConfig $appConfig */
-		$userConfig = $this->createMock(IUserConfig::class);
-		/** @var MockObject|ITimeFactory $timeFactory */
-		$timeFactory = $this->createMock(ITimeFactory::class);
-
-		/** @var MockObject|IGroupManager $groupManager */
-		$groupManager = $this->createMock(IGroupManager::class);
-
-		/** @var MockObject|IUserManager $userManager */
-		$userManager = $this->createMock(IUserManager::class);
-
-		/** @var MockObject|IURLGenerator $urlGenerator */
-		$urlGenerator = $this->createMock(IURLGenerator::class);
-
-		/** @var MockObject|ISecureRandom $secureRandom */
-		$secureRandom = $this->createMock(ISecureRandom::class);
-
-		/** @var IEventDispatcher $dispatcher */
-		$dispatcher = \OCP\Server::get(IEventDispatcher::class);
-		/** @var MockObject|IFilenameValidator $filenameValidator */
-		$filenameValidator = $this->createMock(IFilenameValidator::class);
+		$this->dispatcher = \OCP\Server::get(IEventDispatcher::class);
 
 		$servers = [
 			[
@@ -261,9 +224,9 @@ class ConfigTest extends TestCase {
 			],
 		];
 
-		$dispatcher->addServiceListener(BeforeTurnServersGetEvent::class, GetTurnServerListener::class);
+		$this->dispatcher->addServiceListener(BeforeTurnServersGetEvent::class, GetTurnServerListener::class);
 
-		$helper = new Config($config, $appConfig, $userConfig, $secureRandom, $groupManager, $userManager, $urlGenerator, $timeFactory, $dispatcher, $filenameValidator);
+		$helper = $this->getConfig();
 
 		$settings = $helper->getTurnSettings();
 		$this->assertSame($servers, $settings);
@@ -349,10 +312,7 @@ class ConfigTest extends TestCase {
 	 */
 	#[DataProvider('dataGetWebSocketDomainForSignalingServer')]
 	public function testGetWebSocketDomainForSignalingServer($url, $expectedWebSocketDomain): void {
-		/** @var MockObject|IConfig $config */
-		$config = $this->createMock(IConfig::class);
-
-		$helper = $this->createConfig($config);
+		$helper = $this->getConfig();
 
 		$this->assertEquals(
 			$expectedWebSocketDomain,
@@ -373,39 +333,22 @@ class ConfigTest extends TestCase {
 
 	#[DataProvider('dataTicketV2Algorithm')]
 	public function testSignalingTicketV2User(string $algo): void {
-		$config = \OCP\Server::get(IConfig::class);
-		/** @var MockObject|IAppConfig $appConfig */
-		$appConfig = $this->createMock(IAppConfig::class);
-		/** @var MockObject|IUserConfig $appConfig */
-		$userConfig = $this->createMock(IUserConfig::class);
-		/** @var MockObject|ITimeFactory $timeFactory */
-		$timeFactory = $this->createMock(ITimeFactory::class);
-		/** @var MockObject|ISecureRandom $secureRandom */
-		$secureRandom = $this->createMock(ISecureRandom::class);
-		/** @var MockObject|IGroupManager $groupManager */
-		$groupManager = $this->createMock(IGroupManager::class);
-		/** @var MockObject|IUserManager $userManager */
-		$userManager = $this->createMock(IUserManager::class);
-		/** @var MockObject|IURLGenerator $urlGenerator */
-		$urlGenerator = $this->createMock(IURLGenerator::class);
-		/** @var MockObject|IEventDispatcher $dispatcher */
-		$dispatcher = $this->createMock(IEventDispatcher::class);
-		/** @var MockObject|IFilenameValidator $filenameValidator */
-		$filenameValidator = $this->createMock(IFilenameValidator::class);
-		/** @var MockObject|IUser $user */
+		$this->config = \OCP\Server::get(IConfig::class);
+
+		/** @var IUser&MockObject $user */
 		$user = $this->createMock(IUser::class);
 
 		$now = time();
-		$timeFactory
+		$this->timeFactory
 			->expects($this->once())
 			->method('getTime')
 			->willReturn($now);
-		$urlGenerator
+		$this->urlGenerator
 			->expects($this->once())
 			->method('getAbsoluteURL')
 			->with('')
 			->willReturn('https://domain.invalid/nextcloud');
-		$userManager
+		$this->userManager
 			->expects($this->once())
 			->method('get')
 			->with('user1')
@@ -419,16 +362,16 @@ class ConfigTest extends TestCase {
 			->method('getDisplayName')
 			->willReturn('Jane Doe');
 
-		$helper = new Config($config, $appConfig, $userConfig, $secureRandom, $groupManager, $userManager, $urlGenerator, $timeFactory, $dispatcher, $filenameValidator);
+		$helper = $this->getConfig();
 
-		$config->setAppValue('spreed', 'signaling_token_alg', $algo);
+		$this->config->setAppValue('spreed', 'signaling_token_alg', $algo);
 		// Make sure new keys are generated.
-		$config->deleteAppValue('spreed', 'signaling_token_privkey_' . strtolower($algo));
-		$config->deleteAppValue('spreed', 'signaling_token_pubkey_' . strtolower($algo));
+		$this->config->deleteAppValue('spreed', 'signaling_token_privkey_' . strtolower($algo));
+		$this->config->deleteAppValue('spreed', 'signaling_token_pubkey_' . strtolower($algo));
 		$ticket = $helper->getSignalingTicket(Config::SIGNALING_TICKET_V2, 'user1');
 		$this->assertNotNull($ticket);
 
-		$key = new Key($config->getAppValue('spreed', 'signaling_token_pubkey_' . strtolower($algo)), $algo);
+		$key = new Key($this->config->getAppValue('spreed', 'signaling_token_pubkey_' . strtolower($algo)), $algo);
 		$decoded = JWT::decode($ticket, $key);
 
 		$this->assertEquals($now, $decoded->iat);
@@ -439,48 +382,29 @@ class ConfigTest extends TestCase {
 
 	#[DataProvider('dataTicketV2Algorithm')]
 	public function testSignalingTicketV2Anonymous(string $algo): void {
-		/** @var IConfig $config */
-		$config = \OCP\Server::get(IConfig::class);
-		/** @var MockObject|IAppConfig $appConfig */
-		$appConfig = $this->createMock(IAppConfig::class);
-		/** @var MockObject|IUserConfig $appConfig */
-		$userConfig = $this->createMock(IUserConfig::class);
-		/** @var MockObject|ITimeFactory $timeFactory */
-		$timeFactory = $this->createMock(ITimeFactory::class);
-		/** @var MockObject|ISecureRandom $secureRandom */
-		$secureRandom = $this->createMock(ISecureRandom::class);
-		/** @var MockObject|IGroupManager $groupManager */
-		$groupManager = $this->createMock(IGroupManager::class);
-		/** @var MockObject|IUserManager $userManager */
-		$userManager = $this->createMock(IUserManager::class);
-		/** @var MockObject|IURLGenerator $urlGenerator */
-		$urlGenerator = $this->createMock(IURLGenerator::class);
-		/** @var MockObject|IEventDispatcher $dispatcher */
-		$dispatcher = $this->createMock(IEventDispatcher::class);
-		/** @var MockObject|IFilenameValidator $filenameValidator */
-		$filenameValidator = $this->createMock(IFilenameValidator::class);
+		$this->config = \OCP\Server::get(IConfig::class);
 
 		$now = time();
-		$timeFactory
+		$this->timeFactory
 			->expects($this->once())
 			->method('getTime')
 			->willReturn($now);
-		$urlGenerator
+		$this->urlGenerator
 			->expects($this->once())
 			->method('getAbsoluteURL')
 			->with('')
 			->willReturn('https://domain.invalid/nextcloud');
 
-		$helper = new Config($config, $appConfig, $userConfig, $secureRandom, $groupManager, $userManager, $urlGenerator, $timeFactory, $dispatcher, $filenameValidator);
+		$helper = $this->getConfig();
 
-		$config->setAppValue('spreed', 'signaling_token_alg', $algo);
+		$this->config->setAppValue('spreed', 'signaling_token_alg', $algo);
 		// Make sure new keys are generated.
-		$config->deleteAppValue('spreed', 'signaling_token_privkey_' . strtolower($algo));
-		$config->deleteAppValue('spreed', 'signaling_token_pubkey_' . strtolower($algo));
+		$this->config->deleteAppValue('spreed', 'signaling_token_privkey_' . strtolower($algo));
+		$this->config->deleteAppValue('spreed', 'signaling_token_pubkey_' . strtolower($algo));
 		$ticket = $helper->getSignalingTicket(Config::SIGNALING_TICKET_V2, null);
 		$this->assertNotNull($ticket);
 
-		$key = new Key($config->getAppValue('spreed', 'signaling_token_pubkey_' . strtolower($algo)), $algo);
+		$key = new Key($this->config->getAppValue('spreed', 'signaling_token_pubkey_' . strtolower($algo)), $algo);
 		$decoded = JWT::decode($ticket, $key);
 
 		$this->assertEquals($now, $decoded->iat);

--- a/tests/php/Controller/SignalingControllerTest.php
+++ b/tests/php/Controller/SignalingControllerTest.php
@@ -34,6 +34,7 @@ use OCP\AppFramework\Services\IAppConfig;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Config\IUserConfig;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Files\IFilenameValidator;
 use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IGroupManager;
@@ -111,7 +112,7 @@ class SignalingControllerTest extends TestCase {
 		$this->userManager = $this->createMock(IUserManager::class);
 		$this->dispatcher = \OCP\Server::get(IEventDispatcher::class);
 		$urlGenerator = $this->createMock(IURLGenerator::class);
-		$this->config = new Config($this->serverConfig, $appConfig, $this->createMock(IUserConfig::class), $this->secureRandom, $groupManager, $this->userManager, $urlGenerator, $timeFactory, $this->dispatcher);
+		$this->config = new Config($this->serverConfig, $appConfig, $this->createMock(IUserConfig::class), $this->secureRandom, $groupManager, $this->userManager, $urlGenerator, $timeFactory, $this->dispatcher, $this->createMock(IFilenameValidator::class));
 		$this->serverSession = $this->createMock(ISession::class);
 		$this->session = $this->createMock(TalkSession::class);
 		$this->dbConnection = \OCP\Server::get(IDBConnection::class);

--- a/tests/php/Recording/BackendNotifierTest.php
+++ b/tests/php/Recording/BackendNotifierTest.php
@@ -24,6 +24,7 @@ use OCP\AppFramework\Services\IAppConfig;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Config\IUserConfig;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Files\IFilenameValidator;
 use OCP\Http\Client\IClientService;
 use OCP\IConfig;
 use OCP\IDBConnection;
@@ -94,7 +95,7 @@ class BackendNotifierTest extends TestCase {
 		$timeFactory = $this->createMock(ITimeFactory::class);
 		$dispatcher = \OCP\Server::get(IEventDispatcher::class);
 
-		$this->config = new Config($config, $appConfig, $userConfig, $this->secureRandom, $groupManager, $userManager, $this->urlGenerator, $timeFactory, $dispatcher);
+		$this->config = new Config($config, $appConfig, $userConfig, $this->secureRandom, $groupManager, $userManager, $this->urlGenerator, $timeFactory, $dispatcher, $this->createMock(IFilenameValidator::class));
 
 		$this->recreateBackendNotifier();
 

--- a/tests/php/Service/ConversationFolderServiceTest.php
+++ b/tests/php/Service/ConversationFolderServiceTest.php
@@ -14,6 +14,7 @@ use OCA\Talk\Service\ConversationFolderService;
 use OCP\Constants;
 use OCP\Files\FileInfo;
 use OCP\Files\Folder;
+use OCP\Files\IFilenameValidator;
 use OCP\Files\IRootFolder;
 use OCP\Files\Node;
 use OCP\Files\NotEnoughSpaceException;
@@ -29,6 +30,7 @@ class ConversationFolderServiceTest extends TestCase {
 	protected TalkConfig&MockObject $talkConfig;
 	protected IRootFolder&MockObject $rootFolder;
 	protected IShareManager&MockObject $shareManager;
+	protected IFilenameValidator&MockObject $filenameValidator;
 	protected LoggerInterface&MockObject $logger;
 	protected ConversationFolderService $service;
 
@@ -38,12 +40,14 @@ class ConversationFolderServiceTest extends TestCase {
 		$this->talkConfig = $this->createMock(TalkConfig::class);
 		$this->rootFolder = $this->createMock(IRootFolder::class);
 		$this->shareManager = $this->createMock(IShareManager::class);
+		$this->filenameValidator = $this->createMock(IFilenameValidator::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
 
 		$this->service = new ConversationFolderService(
 			$this->talkConfig,
 			$this->rootFolder,
 			$this->shareManager,
+			$this->filenameValidator,
 			$this->logger,
 		);
 	}


### PR DESCRIPTION
## ☑️ Resolves

* Fix #17896 

## 🛠️ API Checklist

### 👣 Steps

- Enable windows compatible filesystem only
- Change display name to contain `<>`
- Try to upload files in "per conversation mode"

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
