### PR TITLE
fix(voice-rooms): Fix system messages in voice rooms

### DIFF
--- a/lib/Activity/Listener.php
+++ b/lib/Activity/Listener.php
@@ -17,6 +17,7 @@ use OCA\Talk\Events\CallEndedForEveryoneEvent;
 use OCA\Talk\Model\Attendee;
 use OCA\Talk\Participant;
 use OCA\Talk\Room;
+use OCA\Talk\RoomAttributes;
 use OCA\Talk\Service\ParticipantService;
 use OCA\Talk\Service\RecordingService;
 use OCA\Talk\Service\RoomService;
@@ -65,6 +66,11 @@ class Listener implements IEventListener {
 	 */
 	protected function generateCallActivity(ACallEndedEvent $event): void {
 		$room = $event->getRoom();
+		$isVoiceRoom = $room->getAttributes() & RoomAttributes::VOICE_ROOM->value;
+		if ($isVoiceRoom) {
+			return;
+		}
+
 		$actor = $event->getActor();
 		$activeSince = $event->getOldValue();
 

--- a/lib/Chat/SystemMessage/Listener.php
+++ b/lib/Chat/SystemMessage/Listener.php
@@ -32,6 +32,7 @@ use OCA\Talk\Model\Message;
 use OCA\Talk\Model\Session;
 use OCA\Talk\Participant;
 use OCA\Talk\Room;
+use OCA\Talk\RoomAttributes;
 use OCA\Talk\Service\NoteToSelfService;
 use OCA\Talk\Service\ParticipantService;
 use OCA\Talk\Service\SampleConversationsService;
@@ -156,7 +157,8 @@ class Listener implements IEventListener {
 			return;
 		}
 
-		if ($this->participantService->hasActiveSessionsInCall($event->getRoom())) {
+		$isVoiceRoom = $event->getRoom()->getAttributes() & RoomAttributes::VOICE_ROOM->value;
+		if ($isVoiceRoom || $this->participantService->hasActiveSessionsInCall($event->getRoom())) {
 			$this->sendSystemMessage($event->getRoom(), 'call_joined', [], $event->getParticipant());
 		} else {
 			$silent = $event->getDetail(AParticipantModifiedEvent::DETAIL_IN_CALL_SILENT) ?? false;

--- a/lib/Controller/CallController.php
+++ b/lib/Controller/CallController.php
@@ -26,6 +26,7 @@ use OCA\Talk\Model\PhoneNumberMapper;
 use OCA\Talk\Model\Session;
 use OCA\Talk\Participant;
 use OCA\Talk\ResponseDefinitions;
+use OCA\Talk\RoomAttributes;
 use OCA\Talk\Service\ConsentService;
 use OCA\Talk\Service\ParticipantService;
 use OCA\Talk\Service\RecordingService;
@@ -275,6 +276,10 @@ class CallController extends AEnvironmentAwareOCSController {
 
 			return $response;
 		}
+
+		// Force silent join for voice rooms
+		$silent = $silent || ($this->room->getAttributes() & RoomAttributes::VOICE_ROOM->value);
+
 
 		try {
 			$this->participantService->changeInCall($this->room, $this->participant, $flags, silent: $silent, lastJoinedCall: $lastJoinedCall->getTimestamp());

--- a/tests/integration/features/conversation-4/presets.feature
+++ b/tests/integration/features/conversation-4/presets.feature
@@ -34,6 +34,17 @@ Feature: conversation-4/presets
     Then user "participant1" is participant of the following rooms (v4)
       | id   | type | participantType | attributes | messageExpiration | listable |
       | room | 3    | 1               | 1          | 3600              | 1        |
+    # No start call message and no call_ended message
+    Then user "participant1" joins room "room" with 200 (v4)
+    Then user "participant1" joins call "room" with 200 (v4)
+      | flags | 1 |
+    Then user "participant1" leaves call "room" with 200 (v4)
+    Then user "participant1" leaves room "room" with 200 (v4)
+    Then user "participant1" sees the following system messages in room "room" with 200
+      | room | actorType | actorId      | actorDisplayName         | systemMessage        |
+      | room | users     | participant1 | participant1-displayname | call_left            |
+      | room | users     | participant1 | participant1-displayname | call_joined          |
+      | room | users     | participant1 | participant1-displayname | conversation_created |
 
   Scenario: Create a voice room with overriding default values of the preset
     Given user "participant1" creates room "room" (v4)


### PR DESCRIPTION
## ☑️ Resolves


## 🛠️ API Checklist

### :footprints: Steps

- Join call: before `call_started` after  `call_joined`
- Leave call: before `call_ended` after  `call_left`
- Activity: before :ballot_box_with_check: after :no_entry_sign: 

---

- [ ] Hide "call notifications" option in UI
- [ ] Prevent selecting call notifications level on API
- [ ] Prevent "ringing someone"?


### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
