### PR TITLE
fix(upload): reduce the length of fillename in Draft

### DIFF
--- a/src/stores/__tests__/upload.spec.js
+++ b/src/stores/__tests__/upload.spec.js
@@ -422,10 +422,11 @@ describe('fileUploadStore', () => {
 				expect(client.createDirectory).not.toHaveBeenCalled()
 				expect(findUniquePath).not.toHaveBeenCalled()
 
-				// File is uploaded under a temp name inside the Draft folder.
+				// File is uploaded under a random UUID temp name inside the Draft folder.
 				expect(uploadMock).toHaveBeenCalledTimes(1)
 				const uploadedPath = uploadMock.mock.calls[0][0]
-				expect(uploadedPath).toMatch(new RegExp('^/' + DRAFT_PATH + '/upload-id1-.*-' + file.name + '$'))
+				const uuidRe = '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+				expect(uploadedPath).toMatch(new RegExp('^/' + DRAFT_PATH + '/' + uuidRe + '$'))
 
 				// File is posted via the Talk attachment endpoint with the
 				// original name for rename-on-conflict on the backend.
@@ -433,7 +434,7 @@ describe('fileUploadStore', () => {
 				expect(postAttachment).toHaveBeenCalledWith(expect.objectContaining({
 					token: TOKEN,
 					fileName: file.name,
-					filePath: expect.stringMatching(new RegExp('^' + DRAFT_PATH + '/upload-id1-.*-' + file.name + '$')),
+					filePath: expect.stringMatching(new RegExp('^' + DRAFT_PATH + '/' + uuidRe + '$')),
 				}))
 				expect(shareFile).not.toHaveBeenCalled()
 			})

--- a/src/stores/upload.ts
+++ b/src/stores/upload.ts
@@ -460,11 +460,11 @@ export const useUploadStore = defineStore('upload', () => {
 	async function prepareUploadPaths({ token, uploadId }: { token: string, uploadId: string }) {
 		const draftFolderPath = uploads[uploadId]?.draftFolderPath
 		if (draftFolderPath) {
-			// Assign a guaranteed-unique temp name; the backend resolves the
-			// final name and any conflicts when postAttachment is called.
-			for (const [index, uploadedFile] of getInitialisedUploads(uploadId)) {
-				const fileName = uploadedFile.file.newName || uploadedFile.file.name
-				const tempName = `${uploadId}-${index}-${fileName}`
+			// Upload to a random temp name inside the Draft folder; the backend
+			// resolves the final name (and any conflicts) when postAttachment
+			// moves the file out of Draft.
+			for (const [index] of getInitialisedUploads(uploadId)) {
+				const tempName = crypto.randomUUID()
 				markFileAsPendingUpload({ uploadId, index, sharePath: '/' + draftFolderPath + '/' + tempName })
 			}
 			return


### PR DESCRIPTION
## ☑️ Resolves

* Fix part of #17896 

### AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
Screenshot before | Screenshot after

<!-- ☀️ Light theme | 🌑 Dark Theme -->

### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required

