### PR TITLE
fix: ascyncronously load leaflet library

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessageItem.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageItem.vue
@@ -95,7 +95,7 @@
 import { showError, showSuccess, showWarning, TOAST_DEFAULT_TIMEOUT } from '@nextcloud/dialogs'
 import { t } from '@nextcloud/l10n'
 import { useIsSmallMobile } from '@nextcloud/vue/composables/useIsMobile'
-import { inject } from 'vue'
+import { defineAsyncComponent, inject } from 'vue'
 import IconPin from 'vue-material-design-icons/PinOutline.vue'
 import MessageButtonsBar from './MessageButtonsBar/MessageButtonsBar.vue'
 import MessageForwarder from './MessageButtonsBar/MessageForwarder.vue'
@@ -104,7 +104,6 @@ import ContactCard from './MessagePart/ContactCard.vue'
 import DeckCard from './MessagePart/DeckCard.vue'
 import DefaultParameter from './MessagePart/DefaultParameter.vue'
 import FilePreview from './MessagePart/FilePreview.vue'
-import LocationCard from './MessagePart/LocationCard.vue'
 import MentionChip from './MessagePart/MentionChip.vue'
 import MessageBody from './MessagePart/MessageBody.vue'
 import PollCard from './MessagePart/PollCard.vue'
@@ -116,6 +115,8 @@ import { EventBus } from '../../../../services/EventBus.ts'
 import { useActorStore } from '../../../../stores/actor.ts'
 import { useChatExtrasStore } from '../../../../stores/chatExtras.ts'
 import { getItemTypeFromMessage } from '../../../../utils/getItemTypeFromMessage.ts'
+
+const LocationCard = defineAsyncComponent(() => import('./MessagePart/LocationCard.vue'))
 
 export default {
 	name: 'MessageItem',

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/LocationCard.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/LocationCard.vue
@@ -47,6 +47,11 @@ import {
 	LTileLayer,
 } from '@vue-leaflet/vue-leaflet'
 
+// Leaflet icon patch | re-uses images from ~leaflet package
+import 'leaflet/dist/leaflet.css'
+import 'leaflet-defaulticon-compatibility/dist/leaflet-defaulticon-compatibility.webpack.css'
+import 'leaflet-defaulticon-compatibility'
+
 export default {
 	name: 'LocationCard',
 

--- a/src/components/RightSidebar/SharedItems/SharedItems.vue
+++ b/src/components/RightSidebar/SharedItems/SharedItems.vue
@@ -56,12 +56,14 @@
 </template>
 
 <script>
+import { defineAsyncComponent } from 'vue'
 import DeckCard from '../../MessagesList/MessagesGroup/Message/MessagePart/DeckCard.vue'
 import FilePreview from '../../MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue'
-import LocationCard from '../../MessagesList/MessagesGroup/Message/MessagePart/LocationCard.vue'
 import PollCard from '../../MessagesList/MessagesGroup/Message/MessagePart/PollCard.vue'
 import PinnedMessageItem from '../PinnedMessages/PinnedMessageItem.vue'
 import { SHARED_ITEM } from '../../../constants.ts'
+
+const LocationCard = defineAsyncComponent(() => import('../../MessagesList/MessagesGroup/Message/MessagePart/LocationCard.vue'))
 
 export default {
 	name: 'SharedItems',

--- a/src/main.js
+++ b/src/main.js
@@ -16,10 +16,6 @@ import { useSidebarStore } from './stores/sidebar.ts'
 import { NextcloudGlobalsVuePlugin } from './utils/NextcloudGlobalsVuePlugin.js'
 
 import './init.js'
-// Leaflet icon patch
-import 'leaflet/dist/leaflet.css'
-import 'leaflet-defaulticon-compatibility/dist/leaflet-defaulticon-compatibility.webpack.css' // Re-uses images from ~leaflet package
-import 'leaflet-defaulticon-compatibility'
 
 if (!IS_DESKTOP) {
 	// CSP config for webpack dynamic chunk loading

--- a/src/mainFilesSidebar.js
+++ b/src/mainFilesSidebar.js
@@ -13,10 +13,6 @@ import pinia from './stores/pinia.ts'
 import { NextcloudGlobalsVuePlugin } from './utils/NextcloudGlobalsVuePlugin.js'
 
 import './init.js'
-// Leaflet icon patch
-import 'leaflet/dist/leaflet.css'
-import 'leaflet-defaulticon-compatibility/dist/leaflet-defaulticon-compatibility.webpack.css' // Re-uses images from ~leaflet package
-import 'leaflet-defaulticon-compatibility'
 
 // CSP config for webpack dynamic chunk loading
 __webpack_nonce__ = getCSPNonce()

--- a/src/mainPublicShareAuthSidebar.js
+++ b/src/mainPublicShareAuthSidebar.js
@@ -14,10 +14,6 @@ import pinia from './stores/pinia.ts'
 import { NextcloudGlobalsVuePlugin } from './utils/NextcloudGlobalsVuePlugin.js'
 
 import './init.js'
-// Leaflet icon patch
-import 'leaflet/dist/leaflet.css'
-import 'leaflet-defaulticon-compatibility/dist/leaflet-defaulticon-compatibility.webpack.css' // Re-uses images from ~leaflet package
-import 'leaflet-defaulticon-compatibility'
 
 // CSP config for webpack dynamic chunk loading
 __webpack_nonce__ = getCSPNonce()

--- a/src/mainPublicShareSidebar.js
+++ b/src/mainPublicShareSidebar.js
@@ -15,10 +15,6 @@ import pinia from './stores/pinia.ts'
 import { NextcloudGlobalsVuePlugin } from './utils/NextcloudGlobalsVuePlugin.js'
 
 import './init.js'
-// Leaflet icon patch
-import 'leaflet/dist/leaflet.css'
-import 'leaflet-defaulticon-compatibility/dist/leaflet-defaulticon-compatibility.webpack.css' // Re-uses images from ~leaflet package
-import 'leaflet-defaulticon-compatibility'
 
 // CSP config for webpack dynamic chunk loading
 __webpack_nonce__ = getCSPNonce()

--- a/src/mainRecording.js
+++ b/src/mainRecording.js
@@ -19,10 +19,6 @@ import {
 } from './utils/webrtc/index.js'
 
 import '@nextcloud/dialogs/style.css'
-// Leaflet icon patch
-import 'leaflet/dist/leaflet.css'
-import 'leaflet-defaulticon-compatibility/dist/leaflet-defaulticon-compatibility.webpack.css' // Re-uses images from ~leaflet package
-import 'leaflet-defaulticon-compatibility'
 
 // CSP config for webpack dynamic chunk loading
 __webpack_nonce__ = getCSPNonce()


### PR DESCRIPTION
## ☑️ Resolves

* Move code out of main*.js loaders to sole component that uses it
* Make component load async where used (2 places)

### AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

<img width="654" height="122" alt="2026-05-06_13h30_38" src="https://github.com/user-attachments/assets/04722608-ff37-4697-8d5e-ca5a14e4f1ed" />
<img width="292" height="168" alt="image" src="https://github.com/user-attachments/assets/f4e461c9-2500-402c-a55b-8ec4c64d6d3f" />


### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [x] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client