### PR TITLE
fix(navigation): adjust active "Home" link to the new design

### DIFF
--- a/src/components/LeftSidebar/LeftSidebarButton.vue
+++ b/src/components/LeftSidebar/LeftSidebarButton.vue
@@ -31,7 +31,8 @@ const iconSize = computed(() => (isCompact.value ? AVATAR.SIZE.COMPACT : AVATAR.
 <template>
 	<NcButton
 		class="left-sidebar-button"
-		:variant="active ? 'primary' : 'tertiary'"
+		:class="{ 'left-sidebar-button--active': active }"
+		:variant="active ? 'secondary' : 'tertiary'"
 		alignment="start"
 		wide>
 		<template #icon>
@@ -48,6 +49,8 @@ const iconSize = computed(() => (isCompact.value ? AVATAR.SIZE.COMPACT : AVATAR.
 
 <style lang="scss" scoped>
 .left-sidebar-button {
+	position: relative;
+
 	// Align the padding with navigation items and list items
 	// TODO: make it s public variable or add a way to customize content without having the pre-defined padding
 	--button-padding: calc(var(--default-grid-baseline) - 1px /* transparent border */);
@@ -62,6 +65,19 @@ const iconSize = computed(() => (isCompact.value ? AVATAR.SIZE.COMPACT : AVATAR.
 	:deep(.button-vue__text) {
 		flex: 1 0 auto;
 	}
+}
+
+// Copy from: nextcloud-vue/src/components/NcAppNavigationItem/NcAppNavigationItem.scss
+// TODO: Either add this variant to NcButton or support buttons and customization in NcAppNavigationItem
+.left-sidebar-button--active:before {
+	content: '';
+	position: absolute;
+	inset-block: calc(var(--default-grid-baseline) * 2);
+	inset-inline-start: 0;
+	width: 3px;
+	background-color: var(--color-primary-element);
+	border-radius: 999px;
+	animation: nc-nav-stripe-in var(--animation-quick) ease-out;
 }
 
 .left-sidebar-button__content {


### PR DESCRIPTION
## ☑️ Resolves

* Ref: https://github.com/nextcloud-libraries/nextcloud-vue/pull/8448
* To be merged after the next nextcloud-vue update

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="296" height="179" alt="image" src="https://github.com/user-attachments/assets/209fa0b1-95d0-4161-a4f1-64b49a2480a0" /> | <img width="296" height="178" alt="image" src="https://github.com/user-attachments/assets/fa4837d9-a947-4888-9be9-bcd47abc5da0" />

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
