### PR TITLE
fix: remove style loading for Talk integrations

### DIFF
--- a/lib/Files/TemplateLoader.php
+++ b/lib/Files/TemplateLoader.php
@@ -61,7 +61,8 @@ class TemplateLoader implements IEventListener {
 		Util::addStyle(Application::APP_ID, 'talk-icons');
 		if (!str_starts_with($this->request->getPathInfo(), '/apps/maps')) {
 			Util::addScript(Application::APP_ID, 'talk-files-sidebar');
-			Util::addStyle(Application::APP_ID, 'talk-files-sidebar');
+			// Styles are loaded asynchronously, initially no CSS file is bundled
+			// Util::addStyle(Application::APP_ID, 'talk-files-sidebar');
 		}
 
 		$this->initialState->provideInitialState(

--- a/lib/FloatingCall/FloatingCallPluginLoader.php
+++ b/lib/FloatingCall/FloatingCallPluginLoader.php
@@ -43,7 +43,8 @@ class FloatingCallPluginLoader implements IEventListener {
 			&& $this->appConfig->getAppValueInt('start_calls') !== Room::START_CALL_NOONE
 		) {
 			Util::addScript('spreed', 'talk-floating-call');
-			Util::addStyle('spreed', 'talk-floating-call');
+			// Styles are loaded asynchronously, initially no CSS file is bundled
+			// Util::addStyle('spreed', 'talk-floating-call');
 		}
 	}
 }


### PR DESCRIPTION
## ☑️ Resolves

* Components / init are loaded asyncronously, so no styles bundled and no 'talk-floating-call.css' and 'talk-files-sidebar.css' file exists
* Util::addStyle doesn't have file-check / safe-load mechanism? So commenting for now in case there would be changes to the feature that might affect bundling

<img width="290" height="138" alt="image" src="https://github.com/user-attachments/assets/19062a5a-a304-4836-9a6c-8da999454e45" />

## 🛠️ API Checklist

### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not possible
- [ ] 📘 API documentation in `docs/` has been updated or is not required
- [ ] 🔖 Capability is added or not needed 
