### PR TITLE
[stable33] fix: Prepare backport of future PR

### DIFF
--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -455,10 +455,10 @@ class RoomController extends AEnvironmentAwareOCSController {
 
 				try {
 					$participant = $this->participantService->getParticipant($room, $this->userId, $sessionId);
-				} catch (ParticipantNotFoundException $e) {
+				} catch (ParticipantNotFoundException) {
 					try {
 						$participant = $this->participantService->getParticipantBySession($room, $sessionId);
-					} catch (ParticipantNotFoundException $e) {
+					} catch (ParticipantNotFoundException) {
 					}
 				}
 			} else {


### PR DESCRIPTION
Applying rector from main to prepare the backport of https://github.com/nextcloud/spreed/pull/13609 

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
