### PR TITLE
fix(conversations): system messages won't bump activity in room / thread order anymore

### DIFF
--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -232,3 +232,4 @@
 * `preserve-conversation` - Whether the owner can preserve a conversation
 * `recording-chunked-upload` (local) - Whether the recording backend can request a temporary upload share to upload large recordings via chunked public WebDAV before finishing with the store endpoint
 * `config => call => external-call-service` (local) - The target URL for an external call service if one is configured
+* `last-metadata-activity` - Keeps track when the room was last changed as opposed to last-room-activity set by new messages (which is used for thread sorting)

--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -42,6 +42,7 @@ class Capabilities implements IPublicCapability {
 		'multi-room-users',
 		'favorites',
 		'last-room-activity',
+		'last-metadata-activity',
 		'no-ping',
 		'system-messages',
 		'delete-messages',

--- a/lib/Chat/ChatManager.php
+++ b/lib/Chat/ChatManager.php
@@ -154,7 +154,7 @@ class ChatManager {
 		bool $sendNotifications,
 		?string $referenceId = null,
 		?IComment $replyTo = null,
-		bool $shouldSkipLastMessageUpdate = false,
+		bool $shouldSkipLastMessageUpdate = true,
 		bool $silent = false,
 		int $threadId = 0,
 	): IComment {
@@ -473,15 +473,15 @@ class ChatManager {
 			if (!$fromScheduledMessage && $participant instanceof Participant) {
 				$this->participantService->updateLastReadMessage($participant, $messageId);
 			}
-
 			// Update last_message
 			if ($comment->getActorType() !== Attendee::ACTOR_BOTS
 				|| $comment->getActorId() === Attendee::ACTOR_ID_CHANGELOG
 				|| str_starts_with((string)$comment->getActorId(), Attendee::ACTOR_BOT_PREFIX)) {
-				$this->roomService->setLastMessage($chat, $comment);
+				$this->roomService->setLastMessageInfo($chat, (int)$comment->getId(), $comment->getCreationDateTime());
+				$this->roomService->setLastMetadataActivity($chat, $comment->getCreationDateTime());
 				$this->unreadCountCache->clear($chat->getId() . '-');
 			} else {
-				$this->roomService->setLastActivity($chat, $comment->getCreationDateTime());
+				$this->roomService->setLastMetadataActivity($chat, $comment->getCreationDateTime);
 			}
 
 			$alreadyNotifiedUsers = [];

--- a/lib/Chat/ChatManager.php
+++ b/lib/Chat/ChatManager.php
@@ -481,7 +481,7 @@ class ChatManager {
 				$this->roomService->setLastMetadataActivity($chat, $comment->getCreationDateTime());
 				$this->unreadCountCache->clear($chat->getId() . '-');
 			} else {
-				$this->roomService->setLastMetadataActivity($chat, $comment->getCreationDateTime);
+				$this->roomService->setLastMetadataActivity($chat, $comment->getCreationDateTime());
 			}
 
 			$alreadyNotifiedUsers = [];

--- a/lib/Chat/SystemMessage/Listener.php
+++ b/lib/Chat/SystemMessage/Listener.php
@@ -489,7 +489,7 @@ class Listener implements IEventListener {
 	}
 
 	protected function attendeesAddedEvent(AttendeesAddedEvent $event): void {
-		$event->setShouldSkipLastActivityUpdate(true);
+		$event->setShouldSkipLastMessageUpdate(true);
 		foreach ($event->getAttendees() as $attendee) {
 			$this->logger->debug($attendee->getActorType() . ' "' . $attendee->getActorId() . '" added to room "' . $event->getRoom()->getToken() . '"', ['app' => 'spreed-bfp']);
 			if ($attendee->getActorType() === Attendee::ACTOR_GROUPS) {

--- a/lib/Chat/SystemMessage/Listener.php
+++ b/lib/Chat/SystemMessage/Listener.php
@@ -476,7 +476,7 @@ class Listener implements IEventListener {
 	}
 
 	protected function attendeesAddedEvent(AttendeesAddedEvent $event): void {
-		$event->shouldSkipLastMessageUpdate = true;
+		$event->setShouldSkipLastActivityUpdate(true);
 		foreach ($event->getAttendees() as $attendee) {
 			$this->logger->debug($attendee->getActorType() . ' "' . $attendee->getActorId() . '" added to room "' . $event->getRoom()->getToken() . '"', ['app' => 'spreed-bfp']);
 			if ($attendee->getActorType() === Attendee::ACTOR_GROUPS) {
@@ -494,7 +494,7 @@ class Listener implements IEventListener {
 	}
 
 	protected function attendeesRemovedEvent(AttendeesRemovedEvent $event): void {
-		$event->shouldSkipLastMessageUpdate = true;
+		$event->setShouldSkipLastActivityUpdate(true);
 		foreach ($event->getAttendees() as $attendee) {
 			$this->logger->debug($attendee->getActorType() . ' "' . $attendee->getActorId() . '" removed from room "' . $event->getRoom()->getToken() . '"', ['app' => 'spreed-bfp']);
 			if ($attendee->getActorType() === Attendee::ACTOR_GROUPS) {

--- a/lib/Chat/SystemMessage/Listener.php
+++ b/lib/Chat/SystemMessage/Listener.php
@@ -476,6 +476,7 @@ class Listener implements IEventListener {
 	}
 
 	protected function attendeesAddedEvent(AttendeesAddedEvent $event): void {
+		$event->shouldSkipLastMessageUpdate = true;
 		foreach ($event->getAttendees() as $attendee) {
 			$this->logger->debug($attendee->getActorType() . ' "' . $attendee->getActorId() . '" added to room "' . $event->getRoom()->getToken() . '"', ['app' => 'spreed-bfp']);
 			if ($attendee->getActorType() === Attendee::ACTOR_GROUPS) {
@@ -493,6 +494,7 @@ class Listener implements IEventListener {
 	}
 
 	protected function attendeesRemovedEvent(AttendeesRemovedEvent $event): void {
+		$event->shouldSkipLastMessageUpdate = true;
 		foreach ($event->getAttendees() as $attendee) {
 			$this->logger->debug($attendee->getActorType() . ' "' . $attendee->getActorId() . '" removed from room "' . $event->getRoom()->getToken() . '"', ['app' => 'spreed-bfp']);
 			if ($attendee->getActorType() === Attendee::ACTOR_GROUPS) {
@@ -512,7 +514,7 @@ class Listener implements IEventListener {
 		string $message,
 		array $parameters = [],
 		?Participant $participant = null,
-		bool $shouldSkipLastMessageUpdate = false,
+		bool $shouldSkipLastMessageUpdate = true,
 		bool $silent = false,
 		bool $forceSystemAsActor = false,
 		?int $replyTo = null,

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -274,6 +274,10 @@ class RoomController extends AEnvironmentAwareOCSController {
 					// Include rooms which had activity
 					return true;
 				}
+				if ($room->getLastMetadataActivity() && $room->getLastMetadataActivity()->getTimestamp() >= $modifiedSince) {
+					// Include rooms which had metadata activity
+					return true;
+				}
 
 				// Include rooms where only attendee level things changed,
 				// e.g. favorite, read-marker update, notification setting

--- a/lib/Controller/ThreadController.php
+++ b/lib/Controller/ThreadController.php
@@ -121,7 +121,7 @@ class ThreadController extends AEnvironmentAwareOCSController {
 			}
 		}
 
-		// Sort by last activity again
+		// Sort by last message activity again
 		usort($threads, static function (Thread $a, Thread $b): int {
 			if ($b->getLastActivity() === $a->getLastActivity()) {
 				return $b->getId() <=> $a->getId();

--- a/lib/Events/ARoomSyncedEvent.php
+++ b/lib/Events/ARoomSyncedEvent.php
@@ -10,4 +10,5 @@ namespace OCA\Talk\Events;
 
 abstract class ARoomSyncedEvent extends ARoomEvent {
 	public const PROPERTY_LAST_ACTIVITY = 'lastActivity';
+	public const PROPERTY_LAST_METADATA_ACTIVITY = 'lastMetadataActivity';
 }

--- a/lib/Events/ASystemMessageSentEvent.php
+++ b/lib/Events/ASystemMessageSentEvent.php
@@ -49,7 +49,7 @@ abstract class ASystemMessageSentEvent extends AMessageSentEvent {
 	 * public setter for shouldSkipLastAcitvityUpdate
 	 * @param bool $ShouldSkipLastActivity
 	 */
-	public function setShouldSkipLastActivityUpdate(bool $ShouldSkipLastActivity) {
-		$this->skipLastActivityUpdate = $ShouldSkipLastactivity;
+	public function setShouldSkipLastActivityUpdate(bool $shouldSkipLastActivity) {
+		$this->skipLastActivityUpdate = $shouldSkipLastActivity;
 	}
 }

--- a/lib/Events/ASystemMessageSentEvent.php
+++ b/lib/Events/ASystemMessageSentEvent.php
@@ -19,7 +19,7 @@ abstract class ASystemMessageSentEvent extends AMessageSentEvent {
 		?Participant $participant = null,
 		bool $silent = false,
 		?IComment $parent = null,
-		protected bool $skipLastActivityUpdate = true,
+		private bool $skipLastActivityUpdate = true,
 	) {
 		parent::__construct(
 			$room,
@@ -43,5 +43,13 @@ abstract class ASystemMessageSentEvent extends AMessageSentEvent {
 	 */
 	public function shouldSkipLastActivityUpdate(): bool {
 		return $this->skipLastActivityUpdate;
+	}
+
+	/**
+	 * public setter for shouldSkipLastAcitvityUpdate
+	 * @param bool $pShouldSkipLastActivity
+	 */
+	public function setShouldSkipLastActivityUpdate(bool $pShouldSkipLastActivity) {
+		$this->$skipLastActivityUpdate = $pShouldSkipLastactivity;
 	}
 }

--- a/lib/Events/ASystemMessageSentEvent.php
+++ b/lib/Events/ASystemMessageSentEvent.php
@@ -47,9 +47,9 @@ abstract class ASystemMessageSentEvent extends AMessageSentEvent {
 
 	/**
 	 * public setter for shouldSkipLastAcitvityUpdate
-	 * @param bool $pShouldSkipLastActivity
+	 * @param bool $ShouldSkipLastActivity
 	 */
-	public function setShouldSkipLastActivityUpdate(bool $pShouldSkipLastActivity) {
-		$this->$skipLastActivityUpdate = $pShouldSkipLastactivity;
+	public function setShouldSkipLastActivityUpdate(bool $ShouldSkipLastActivity) {
+		$this->skipLastActivityUpdate = $ShouldSkipLastactivity;
 	}
 }

--- a/lib/Events/ASystemMessageSentEvent.php
+++ b/lib/Events/ASystemMessageSentEvent.php
@@ -19,7 +19,7 @@ abstract class ASystemMessageSentEvent extends AMessageSentEvent {
 		?Participant $participant = null,
 		bool $silent = false,
 		?IComment $parent = null,
-		protected bool $skipLastActivityUpdate = false,
+		protected bool $skipLastActivityUpdate = true,
 	) {
 		parent::__construct(
 			$room,

--- a/lib/Events/AttendeesAddedEvent.php
+++ b/lib/Events/AttendeesAddedEvent.php
@@ -30,8 +30,8 @@ class AttendeesAddedEvent extends AttendeesEvent {
 		return $this->skipLastMessageUpdate;
 	}
 
-	public function setShouldSkipLastMessageUpdate(bool $ShouldSkipLastActivityUpdate) {
-		$this->shouldSkipLastMessageUpdate = $ShouldSkipLastMessageUpdate;
+	public function setShouldSkipLastMessageUpdate(bool $shouldSkipLastMessageUpdate) {
+		$this->skipLastMessageUpdate = $shouldSkipLastMessageUpdate;
 	}
 
 	public function setLastMessage(IComment $lastMessage): void {

--- a/lib/Events/AttendeesAddedEvent.php
+++ b/lib/Events/AttendeesAddedEvent.php
@@ -21,7 +21,7 @@ class AttendeesAddedEvent extends AttendeesEvent {
 	public function __construct(
 		Room $room,
 		array $attendees,
-		private readonly bool $skipLastMessageUpdate = false,
+		private readonly bool $skipLastMessageUpdate = true,
 	) {
 		parent::__construct($room, $attendees);
 	}

--- a/lib/Events/AttendeesAddedEvent.php
+++ b/lib/Events/AttendeesAddedEvent.php
@@ -21,13 +21,17 @@ class AttendeesAddedEvent extends AttendeesEvent {
 	public function __construct(
 		Room $room,
 		array $attendees,
-		private readonly bool $skipLastMessageUpdate = true,
+		private bool $skipLastMessageUpdate = true,
 	) {
 		parent::__construct($room, $attendees);
 	}
 
 	public function shouldSkipLastMessageUpdate(): bool {
 		return $this->skipLastMessageUpdate;
+	}
+
+	public function setShouldSkipLastActivityUpdate(bool $pShouldSkipLastActivityUpdate) {
+		$this->shouldSkipLastMessageUpdate = $pShouldSkipLastActivityUpdate;
 	}
 
 	public function setLastMessage(IComment $lastMessage): void {

--- a/lib/Events/AttendeesAddedEvent.php
+++ b/lib/Events/AttendeesAddedEvent.php
@@ -30,8 +30,8 @@ class AttendeesAddedEvent extends AttendeesEvent {
 		return $this->skipLastMessageUpdate;
 	}
 
-	public function setShouldSkipLastActivityUpdate(bool $pShouldSkipLastActivityUpdate) {
-		$this->shouldSkipLastMessageUpdate = $pShouldSkipLastActivityUpdate;
+	public function setShouldSkipLastMessageUpdate(bool $ShouldSkipLastActivityUpdate) {
+		$this->shouldSkipLastMessageUpdate = $ShouldSkipLastMessageUpdate;
 	}
 
 	public function setLastMessage(IComment $lastMessage): void {

--- a/lib/Events/AttendeesRemovedEvent.php
+++ b/lib/Events/AttendeesRemovedEvent.php
@@ -9,4 +9,14 @@ declare(strict_types=1);
 namespace OCA\Talk\Events;
 
 class AttendeesRemovedEvent extends AttendeesEvent {
+
+	private bool $shouldSkipLastMessageUpdate = true;
+
+	public function shouldSkipLastMessageUpdate() : bool {
+		return $this->shouldSkipLastMessageUpdate;
+	}
+
+	public function setShouldSkipLastActivityUpdate(bool $pShouldSkipLastActivityUpdate) {
+		$this->shouldSkipLastMessageUpdate = $pShouldSkipLastActivityUpdate;
+	}
 }

--- a/lib/Manager.php
+++ b/lib/Manager.php
@@ -104,6 +104,7 @@ class Manager {
 			'call_flag' => 0,
 			'active_since' => null,
 			'last_activity' => null,
+			'last_metadata_activity' => null,
 			'last_message' => 0,
 			'comment_id' => null,
 			'lobby_timer' => null,
@@ -134,6 +135,10 @@ class Manager {
 		$lastActivity = null;
 		if (!empty($row['last_activity'])) {
 			$lastActivity = $this->timeFactory->getDateTime($row['last_activity']);
+		}
+		$lastMetadataActivity = null;
+		if (!empty($row['last_metadata_activity'])) {
+			$lastMetadataActivity = $this->timeFactory->getDateTime($row['last_metadata_activity']);
 		}
 
 		$lobbyTimer = null;
@@ -171,6 +176,7 @@ class Manager {
 			(int)$row['call_flag'],
 			$activeSince,
 			$lastActivity,
+			$lastMetadataActivity,
 			(int)$row['last_message'],
 			$lastMessage,
 			$lobbyTimer,
@@ -321,6 +327,7 @@ class Manager {
 		$helper->selectRoomsTable($query);
 		$query->from('talk_rooms', 'r')
 			->andWhere($query->expr()->lte('r.last_activity', $query->createNamedParameter($inactiveSince, IQueryBuilder::PARAM_DATETIME_MUTABLE)))
+			->andWhere($query->expr()->lte('r.last_metadata_activity', $query->createNamedParameter($inactiveSince, IQueryBuilder::PARAM_DATETIME_MUTABLE)))
 			->andWhere($query->expr()->neq('r.read_only', $query->createNamedParameter(Room::READ_ONLY, IQueryBuilder::PARAM_INT)))
 			->andWhere($query->expr()->in('r.type', $query->createNamedParameter([Room::TYPE_PUBLIC, Room::TYPE_GROUP], IQueryBuilder::PARAM_INT_ARRAY)))
 			->andWhere($query->expr()->emptyString('remoteServer'))

--- a/lib/Migration/Version24000Date20260510193300.php
+++ b/lib/Migration/Version24000Date20260510193300.php
@@ -42,8 +42,17 @@ class Version24000Date20260510193300 extends SimpleMigrationStep {
 			$table->addColumn('last_metadata_activity', Types::DATETIME, [
 				'notnull' => false,
 			]);
-			$table->addIndex(['last_metadata_activity'], 'talkthread_lastmetadataactive');
+			$table->addIndex(['last_metadata_activity'], 'talkroom_lastmetadataactive');
 
+		}
+		
+		$table = $schema->getTable('talk_threads');
+
+		if (!$table->hasColumn('last_metadata_activity')) {
+			$table->addColumn('last_metadata_activity', Types::DATETIME, [
+				'notnull' => false,
+			]);
+			$table->addIndex(['last_metadata_activity'], 'talkthread_lastmetadataactive');
 		}
 
 		return $schema;
@@ -56,10 +65,14 @@ class Version24000Date20260510193300 extends SimpleMigrationStep {
 	 */
 	#[Override]
 	public function postSchemaChange(IOutput $output, \Closure $schemaClosure, array $options) : void {
-	   $update = $this->connection->getQueryBuilder();
-	   $update->update('talk_rooms')
-               ->set('last_metadata_activity', 'last_activity');
-       $update->executeStatement();
+		$update = $this->connection->getQueryBuilder();
+		$update->update('talk_rooms')
+			->set('last_metadata_activity', 'last_activity');
+		$update->executeStatement();
+		$update = $this->connection->getQueryBuilder();
+		$update->update('talk_threads')
+			->set('last_metadata_activity', 'last_activity');
+		$update->executeStatement();
 	}	
 
 }

--- a/lib/Migration/Version24000Date20260510193300.php
+++ b/lib/Migration/Version24000Date20260510193300.php
@@ -42,26 +42,8 @@ class Version24000Date20260510193300 extends SimpleMigrationStep {
 			$table->addColumn('last_metadata_activity', Types::DATETIME, [
 				'notnull' => false,
 			]);
-<<<<<<< HEAD
-<<<<<<< HEAD
 			$table->addIndex(['last_metadata_activity'], 'talkroom_lastmetadataactive');
 
-		}
-		
-		$table = $schema->getTable('talk_threads');
-
-		if (!$table->hasColumn('last_metadata_activity')) {
-			$table->addColumn('last_metadata_activity', Types::DATETIME, [
-				'notnull' => false,
-			]);
-			$table->addIndex(['last_metadata_activity'], 'talkthread_lastmetadataactive');
-=======
-			$table->addIndex(['last_metadata_activity'], 'talkthread_lastmetadataactive');
-=======
-			$table->addIndex(['last_metadata_activity'], 'talkroom_lastmetadataactive');
->>>>>>> a798ce9366 (change(conversations): change behavior in all necessary places for Rooms and Threads to use / set lastMetadataActivity instaed of lastActivity where appropriate, i.e. where system messages are signalled and not real chat messages.)
-
->>>>>>> 2ed52550f0 (feature(api): Add a new field and corresponding functionality for lastMetadaActivity for Rooms and Threads, similar to lastActivity. This also adds a database migration for the oc_talk_rooms and oc_talk_threads tables as well. Functions are introduced and prepared for later use. The use of the field lastActivity to signal when the last real message in a conversation appeared remains unchanged to keep the API stable. The intended use of this feature is to better distinguish between real messages (lastActivity) to notify and bump conversations in the thread list to the top, and other status / metadata related messages (lastMetadataActivity) like room state and participant list changes that shall get synced and be updated in the clients, but not trigger an activity bump of its conversations in the thread list.)
 		}
 		
 		$table = $schema->getTable('talk_threads');
@@ -83,10 +65,6 @@ class Version24000Date20260510193300 extends SimpleMigrationStep {
 	 */
 	#[Override]
 	public function postSchemaChange(IOutput $output, \Closure $schemaClosure, array $options) : void {
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> a798ce9366 (change(conversations): change behavior in all necessary places for Rooms and Threads to use / set lastMetadataActivity instaed of lastActivity where appropriate, i.e. where system messages are signalled and not real chat messages.)
 		$update = $this->connection->getQueryBuilder();
 		$update->update('talk_rooms')
 			->set('last_metadata_activity', 'last_activity');
@@ -95,15 +73,6 @@ class Version24000Date20260510193300 extends SimpleMigrationStep {
 		$update->update('talk_threads')
 			->set('last_metadata_activity', 'last_activity');
 		$update->executeStatement();
-<<<<<<< HEAD
-=======
-	   $update = $this->connection->getQueryBuilder();
-	   $update->update('talk_rooms')
-               ->set('last_metadata_activity', 'last_activity');
-       $update->executeStatement();
->>>>>>> 2ed52550f0 (feature(api): Add a new field and corresponding functionality for lastMetadaActivity for Rooms and Threads, similar to lastActivity. This also adds a database migration for the oc_talk_rooms and oc_talk_threads tables as well. Functions are introduced and prepared for later use. The use of the field lastActivity to signal when the last real message in a conversation appeared remains unchanged to keep the API stable. The intended use of this feature is to better distinguish between real messages (lastActivity) to notify and bump conversations in the thread list to the top, and other status / metadata related messages (lastMetadataActivity) like room state and participant list changes that shall get synced and be updated in the clients, but not trigger an activity bump of its conversations in the thread list.)
-=======
->>>>>>> a798ce9366 (change(conversations): change behavior in all necessary places for Rooms and Threads to use / set lastMetadataActivity instaed of lastActivity where appropriate, i.e. where system messages are signalled and not real chat messages.)
 	}	
 
 }

--- a/lib/Migration/Version24000Date20260510193300.php
+++ b/lib/Migration/Version24000Date20260510193300.php
@@ -42,8 +42,26 @@ class Version24000Date20260510193300 extends SimpleMigrationStep {
 			$table->addColumn('last_metadata_activity', Types::DATETIME, [
 				'notnull' => false,
 			]);
+<<<<<<< HEAD
+<<<<<<< HEAD
 			$table->addIndex(['last_metadata_activity'], 'talkroom_lastmetadataactive');
 
+		}
+		
+		$table = $schema->getTable('talk_threads');
+
+		if (!$table->hasColumn('last_metadata_activity')) {
+			$table->addColumn('last_metadata_activity', Types::DATETIME, [
+				'notnull' => false,
+			]);
+			$table->addIndex(['last_metadata_activity'], 'talkthread_lastmetadataactive');
+=======
+			$table->addIndex(['last_metadata_activity'], 'talkthread_lastmetadataactive');
+=======
+			$table->addIndex(['last_metadata_activity'], 'talkroom_lastmetadataactive');
+>>>>>>> a798ce9366 (change(conversations): change behavior in all necessary places for Rooms and Threads to use / set lastMetadataActivity instaed of lastActivity where appropriate, i.e. where system messages are signalled and not real chat messages.)
+
+>>>>>>> 2ed52550f0 (feature(api): Add a new field and corresponding functionality for lastMetadaActivity for Rooms and Threads, similar to lastActivity. This also adds a database migration for the oc_talk_rooms and oc_talk_threads tables as well. Functions are introduced and prepared for later use. The use of the field lastActivity to signal when the last real message in a conversation appeared remains unchanged to keep the API stable. The intended use of this feature is to better distinguish between real messages (lastActivity) to notify and bump conversations in the thread list to the top, and other status / metadata related messages (lastMetadataActivity) like room state and participant list changes that shall get synced and be updated in the clients, but not trigger an activity bump of its conversations in the thread list.)
 		}
 		
 		$table = $schema->getTable('talk_threads');
@@ -65,6 +83,10 @@ class Version24000Date20260510193300 extends SimpleMigrationStep {
 	 */
 	#[Override]
 	public function postSchemaChange(IOutput $output, \Closure $schemaClosure, array $options) : void {
+<<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> a798ce9366 (change(conversations): change behavior in all necessary places for Rooms and Threads to use / set lastMetadataActivity instaed of lastActivity where appropriate, i.e. where system messages are signalled and not real chat messages.)
 		$update = $this->connection->getQueryBuilder();
 		$update->update('talk_rooms')
 			->set('last_metadata_activity', 'last_activity');
@@ -73,6 +95,15 @@ class Version24000Date20260510193300 extends SimpleMigrationStep {
 		$update->update('talk_threads')
 			->set('last_metadata_activity', 'last_activity');
 		$update->executeStatement();
+<<<<<<< HEAD
+=======
+	   $update = $this->connection->getQueryBuilder();
+	   $update->update('talk_rooms')
+               ->set('last_metadata_activity', 'last_activity');
+       $update->executeStatement();
+>>>>>>> 2ed52550f0 (feature(api): Add a new field and corresponding functionality for lastMetadaActivity for Rooms and Threads, similar to lastActivity. This also adds a database migration for the oc_talk_rooms and oc_talk_threads tables as well. Functions are introduced and prepared for later use. The use of the field lastActivity to signal when the last real message in a conversation appeared remains unchanged to keep the API stable. The intended use of this feature is to better distinguish between real messages (lastActivity) to notify and bump conversations in the thread list to the top, and other status / metadata related messages (lastMetadataActivity) like room state and participant list changes that shall get synced and be updated in the clients, but not trigger an activity bump of its conversations in the thread list.)
+=======
+>>>>>>> a798ce9366 (change(conversations): change behavior in all necessary places for Rooms and Threads to use / set lastMetadataActivity instaed of lastActivity where appropriate, i.e. where system messages are signalled and not real chat messages.)
 	}	
 
 }

--- a/lib/Migration/Version24000Date20260510193300.php
+++ b/lib/Migration/Version24000Date20260510193300.php
@@ -45,15 +45,6 @@ class Version24000Date20260510193300 extends SimpleMigrationStep {
 			$table->addIndex(['last_metadata_activity'], 'talkroom_lastmetadataactive');
 
 		}
-		
-		$table = $schema->getTable('talk_threads');
-
-		if (!$table->hasColumn('last_metadata_activity')) {
-			$table->addColumn('last_metadata_activity', Types::DATETIME, [
-				'notnull' => false,
-			]);
-			$table->addIndex(['last_metadata_activity'], 'talkthread_lastmetadataactive');
-		}
 
 		return $schema;
 	}
@@ -67,10 +58,6 @@ class Version24000Date20260510193300 extends SimpleMigrationStep {
 	public function postSchemaChange(IOutput $output, \Closure $schemaClosure, array $options) : void {
 		$update = $this->connection->getQueryBuilder();
 		$update->update('talk_rooms')
-			->set('last_metadata_activity', 'last_activity');
-		$update->executeStatement();
-		$update = $this->connection->getQueryBuilder();
-		$update->update('talk_threads')
 			->set('last_metadata_activity', 'last_activity');
 		$update->executeStatement();
 	}	

--- a/lib/Migration/Version24000Date20260510193300.php
+++ b/lib/Migration/Version24000Date20260510193300.php
@@ -12,10 +12,9 @@ namespace OCA\Talk\Migration;
 use Closure;
 use OCP\DB\ISchemaWrapper;
 use OCP\DB\Types;
+use OCP\IDBConnection;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
-use OCP\DB\QueryBuilder\IQueryBuilder;
-use OCP\IDBConnection;
 use Override;
 
 class Version24000Date20260510193300 extends SimpleMigrationStep {
@@ -48,9 +47,9 @@ class Version24000Date20260510193300 extends SimpleMigrationStep {
 
 		return $schema;
 	}
-	
+
 	/**
- 	 * @param IOutput $output
+	 * @param IOutput $output
 	 * @param Closure(): ISchemaWrapper $schemaClosure
 	 * @param array $options
 	 */
@@ -60,6 +59,6 @@ class Version24000Date20260510193300 extends SimpleMigrationStep {
 		$update->update('talk_rooms')
 			->set('last_metadata_activity', 'last_activity');
 		$update->executeStatement();
-	}	
+	}
 
 }

--- a/lib/Migration/Version24000Date20260510193300.php
+++ b/lib/Migration/Version24000Date20260510193300.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Talk\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+use Override;
+
+class Version24000Date20260510193300 extends SimpleMigrationStep {
+
+	public function __construct(
+		private readonly IDBConnection $connection,
+	) {
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure(): ISchemaWrapper $schemaClosure
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	#[Override]
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$table = $schema->getTable('talk_rooms');
+
+		if (!$table->hasColumn('last_metadata_activity')) {
+			$table->addColumn('last_metadata_activity', Types::DATETIME, [
+				'notnull' => false,
+			]);
+			$table->addIndex(['last_metadata_activity'], 'talkthread_lastmetadataactive');
+
+		}
+
+		return $schema;
+	}
+	
+	/**
+ 	 * @param IOutput $output
+	 * @param Closure(): ISchemaWrapper $schemaClosure
+	 * @param array $options
+	 */
+	#[Override]
+	public function postSchemaChange(IOutput $output, \Closure $schemaClosure, array $options) : void {
+	   $update = $this->connection->getQueryBuilder();
+	   $update->update('talk_rooms')
+               ->set('last_metadata_activity', 'last_activity');
+       $update->executeStatement();
+	}	
+
+}

--- a/lib/Model/SelectHelper.php
+++ b/lib/Model/SelectHelper.php
@@ -30,6 +30,7 @@ class SelectHelper {
 			$alias . 'default_permissions',
 			$alias . 'call_flag',
 			$alias . 'last_activity',
+			$alias . 'last_metadata_activity',
 			$alias . 'last_message',
 			$alias . 'lobby_timer',
 			$alias . 'object_type',
@@ -61,6 +62,7 @@ class SelectHelper {
 				->selectAlias($alias . 'last_message_id', 'th_last_message_id')
 				->selectAlias($alias . 'num_replies', 'th_num_replies')
 				->selectAlias($alias . 'last_activity', 'th_last_activity')
+				->selectAlias($alias . 'last_metadata_activity', 'th_last_metadata_activity')
 				->selectAlias($alias . 'name', 'th_name')
 				->selectAlias($alias . 'id', 'th_id');
 			return;
@@ -71,6 +73,7 @@ class SelectHelper {
 			$alias . 'last_message_id',
 			$alias . 'num_replies',
 			$alias . 'last_activity',
+			$alias . 'last_metadata_activity',
 			$alias . 'name',
 		])->selectAlias($alias . 'id', 'th_id');
 

--- a/lib/Model/SelectHelper.php
+++ b/lib/Model/SelectHelper.php
@@ -30,7 +30,6 @@ class SelectHelper {
 			$alias . 'default_permissions',
 			$alias . 'call_flag',
 			$alias . 'last_activity',
-			$alias . 'last_metadata_activity',
 			$alias . 'last_message',
 			$alias . 'lobby_timer',
 			$alias . 'object_type',
@@ -62,7 +61,6 @@ class SelectHelper {
 				->selectAlias($alias . 'last_message_id', 'th_last_message_id')
 				->selectAlias($alias . 'num_replies', 'th_num_replies')
 				->selectAlias($alias . 'last_activity', 'th_last_activity')
-				->selectAlias($alias . 'last_metadata_activity', 'th_last_metadata_activity')
 				->selectAlias($alias . 'name', 'th_name')
 				->selectAlias($alias . 'id', 'th_id');
 			return;
@@ -73,7 +71,6 @@ class SelectHelper {
 			$alias . 'last_message_id',
 			$alias . 'num_replies',
 			$alias . 'last_activity',
-			$alias . 'last_metadata_activity',
 			$alias . 'name',
 		])->selectAlias($alias . 'id', 'th_id');
 

--- a/lib/Model/Thread.php
+++ b/lib/Model/Thread.php
@@ -22,9 +22,7 @@ use OCP\DB\Types;
  * @method void setNumReplies(int $numReplies)
  * @method int getNumReplies()
  * @method void setLastActivity(\DateTime $lastActivity)
- * @method void setLastMetadataActivity(\DateTime $lastMetadataActivity)
  * @method \DateTime|null getLastActivity()
- * @method \DateTime|null getLastMetadataActivity()
  * @method void setName(string $name)
  *
  * @psalm-import-type TalkThread from ResponseDefinitions
@@ -36,7 +34,6 @@ class Thread extends Entity {
 	protected int $lastMessageId = 0;
 	protected int $numReplies = 0;
 	protected ?\DateTime $lastActivity = null;
-	protected ?\DateTime $lastMetadataActivity = null;
 	protected string $name = '';
 
 	public function __construct() {
@@ -44,7 +41,6 @@ class Thread extends Entity {
 		$this->addType('lastMessageId', Types::BIGINT);
 		$this->addType('numReplies', Types::BIGINT);
 		$this->addType('lastActivity', Types::DATETIME);
-		$this->addType('lastMetadataActivity', Types::DATETIME);
 		$this->addType('name', Types::STRING);
 	}
 
@@ -55,7 +51,6 @@ class Thread extends Entity {
 		$thread->setLastMessageId((int)$row['last_message_id']);
 		$thread->setNumReplies((int)$row['num_replies']);
 		$thread->setLastActivity(new \DateTime($row['last_activity']));
-		$thread->setLastMetadataActivity(new \DateTime($row['last_metadata_activity']));
 		$thread->setName($row['name']);
 		return $thread;
 	}
@@ -73,7 +68,6 @@ class Thread extends Entity {
 		$thread->setLastMessageId((int)$row['last_message_id']);
 		$thread->setNumReplies((int)$row['num_replies']);
 		$thread->setLastActivity(new \DateTime('@' . $row['last_activity']));
-		$thread->setLastMetadataActivity(new \DateTime('@' . $row['last_metadata_activity']));
 		$thread->setName($row['name']);
 		return $thread;
 	}
@@ -89,7 +83,6 @@ class Thread extends Entity {
 			'last_message_id' => $this->getLastMessageId(),
 			'num_replies' => $this->getNumReplies(),
 			'last_activity' => $this->getLastActivity()?->getTimestamp() ?? 0,
-			'last_metadata_activity' => $this->getLastMetadataActivity()?->getTimestamp() ?? 0,
 			'name' => $this->getName(),
 		], flags: JSON_THROW_ON_ERROR);
 	}
@@ -114,7 +107,6 @@ class Thread extends Entity {
 			'lastMessageId' => max(0, $this->getLastMessageId()),
 			'numReplies' => max(0, $this->getNumReplies()),
 			'lastActivity' => max(0, $this->getLastActivity()?->getTimestamp() ?? 0),
-			'lastMetadataActivity' => max(0, $this->getLastMetadataActivity()?->getTimestamp() ?? 0),
 			'title' => $this->getName(),
 		];
 	}

--- a/lib/Model/Thread.php
+++ b/lib/Model/Thread.php
@@ -22,7 +22,9 @@ use OCP\DB\Types;
  * @method void setNumReplies(int $numReplies)
  * @method int getNumReplies()
  * @method void setLastActivity(\DateTime $lastActivity)
+ * @method void setLastMetadataActivity(\DateTime $lastMetadataActivity)
  * @method \DateTime|null getLastActivity()
+ * @method \DateTime|null getLastMetadataActivity()
  * @method void setName(string $name)
  *
  * @psalm-import-type TalkThread from ResponseDefinitions
@@ -34,6 +36,7 @@ class Thread extends Entity {
 	protected int $lastMessageId = 0;
 	protected int $numReplies = 0;
 	protected ?\DateTime $lastActivity = null;
+	protected ?\DateTime $lastMetadataActivity = null;
 	protected string $name = '';
 
 	public function __construct() {
@@ -41,6 +44,7 @@ class Thread extends Entity {
 		$this->addType('lastMessageId', Types::BIGINT);
 		$this->addType('numReplies', Types::BIGINT);
 		$this->addType('lastActivity', Types::DATETIME);
+		$this->addType('lastMetadataActivity', Types::DATETIME);
 		$this->addType('name', Types::STRING);
 	}
 
@@ -51,6 +55,7 @@ class Thread extends Entity {
 		$thread->setLastMessageId((int)$row['last_message_id']);
 		$thread->setNumReplies((int)$row['num_replies']);
 		$thread->setLastActivity(new \DateTime($row['last_activity']));
+		$thread->setLastMetadataActivity(new \DateTime($row['last_metadata_activity']));
 		$thread->setName($row['name']);
 		return $thread;
 	}
@@ -68,6 +73,7 @@ class Thread extends Entity {
 		$thread->setLastMessageId((int)$row['last_message_id']);
 		$thread->setNumReplies((int)$row['num_replies']);
 		$thread->setLastActivity(new \DateTime('@' . $row['last_activity']));
+		$thread->setLastMetadataActivity(new \DateTime('@' . $row['last_metadata_activity']));
 		$thread->setName($row['name']);
 		return $thread;
 	}
@@ -83,6 +89,7 @@ class Thread extends Entity {
 			'last_message_id' => $this->getLastMessageId(),
 			'num_replies' => $this->getNumReplies(),
 			'last_activity' => $this->getLastActivity()?->getTimestamp() ?? 0,
+			'last_metadata_activity' => $this->getLastMetadataActivity()?->getTimestamp() ?? 0,
 			'name' => $this->getName(),
 		], flags: JSON_THROW_ON_ERROR);
 	}
@@ -107,6 +114,7 @@ class Thread extends Entity {
 			'lastMessageId' => max(0, $this->getLastMessageId()),
 			'numReplies' => max(0, $this->getNumReplies()),
 			'lastActivity' => max(0, $this->getLastActivity()?->getTimestamp() ?? 0),
+			'lastMetadataActivity' => max(0, $this->getLastMetadataActivity()?->getTimestamp() ?? 0),
 			'title' => $this->getName(),
 		];
 	}

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -506,7 +506,7 @@ namespace OCA\Talk;
  *     // Timestamp of the last message activity in the conversation, in seconds and UTC time zone
  *     lastActivity: int,
  *     // Timestamp of the last activity (metadata, not messages) in the conversation, in seconds and UTC time zone
- *     lastMetadataActivity: int
+ *     lastMetadataActivity: int,
  *     // ID of the last message read by every user that has read privacy set to public in a room. When the user themself has it set to private the value is `0` (only available with `chat-read-status` capability)
  *     lastCommonReadMessage: int,
  * 	   // Last message in a conversation if available, otherwise empty. **Note:** Even when given the message will not contain the `parent` or `reactionsSelf` attribute due to performance reasons

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -503,8 +503,10 @@ namespace OCA\Talk;
  *     isCustomAvatar: bool,
  *     // Flag if the conversation is favorited by the user
  *     isFavorite: bool,
- *     // Timestamp of the last activity in the conversation, in seconds and UTC time zone
+ *     // Timestamp of the last message activity in the conversation, in seconds and UTC time zone
  *     lastActivity: int,
+ *     // Timestamp of the last activity (metadata, not messages) in the conversation, in seconds and UTC time zone
+ *     lastMetadataActivity: int
  *     // ID of the last message read by every user that has read privacy set to public in a room. When the user themself has it set to private the value is `0` (only available with `chat-read-status` capability)
  *     lastCommonReadMessage: int,
  * 	   // Last message in a conversation if available, otherwise empty. **Note:** Even when given the message will not contain the `parent` or `reactionsSelf` attribute due to performance reasons
@@ -725,8 +727,9 @@ namespace OCA\Talk;
  *     title: string,
  *     // ID of the last message in the thread
  *     lastMessageId: non-negative-int,
- *     // UNIX timestamp of the last activity in the thread
+ *     // UNIX timestamp of the last message activity in the thread
  *     lastActivity: non-negative-int,
+ *	   // UNIX timestamp of the last metadata, not message, activity in the thread
  *     // Number of replies in the thread
  *     numReplies: non-negative-int,
  * }

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -730,6 +730,7 @@ namespace OCA\Talk;
  *     // UNIX timestamp of the last message activity in the thread
  *     lastActivity: non-negative-int,
  *	   // UNIX timestamp of the last metadata, not message, activity in the thread
+ *	   lastMetadataActivity: int
  *     // Number of replies in the thread
  *     numReplies: non-negative-int,
  * }

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -730,7 +730,7 @@ namespace OCA\Talk;
  *     // UNIX timestamp of the last message activity in the thread
  *     lastActivity: non-negative-int,
  *	   // UNIX timestamp of the last metadata, not message, activity in the thread
- *	   lastMetadataActivity: int
+ *	   lastMetadataActivity: non-negative-int,
  *     // Number of replies in the thread
  *     numReplies: non-negative-int,
  * }

--- a/lib/Room.php
+++ b/lib/Room.php
@@ -118,6 +118,7 @@ class Room {
 		private int $callFlag,
 		private ?\DateTime $activeSince,
 		private ?\DateTime $lastActivity,
+		private ?\DateTime $lastMetadataActivity,
 		private int $lastMessageId,
 		private ?IComment $lastMessage,
 		private ?\DateTime $lobbyTimer,
@@ -313,6 +314,13 @@ class Room {
 
 	public function setLastActivity(\DateTime $now): void {
 		$this->lastActivity = $now;
+	}
+	public function getLastMetadataActivity(): ?\DateTime {
+		return $this->lastMetadataActivity;
+	}
+
+	public function setLastMetadataActivity(\DateTime $now): void {
+		$this->lastMetadataActivity = $now;
 	}
 
 	public function getLastMessageId(): int {

--- a/lib/Service/BreakoutRoomService.php
+++ b/lib/Service/BreakoutRoomService.php
@@ -388,7 +388,7 @@ class BreakoutRoomService {
 		}
 
 		$this->roomService->setBreakoutRoomStatus($breakoutRoom, $status);
-		$this->roomService->setLastActivity($breakoutRoom, $this->timeFactory->getDateTime());
+		$this->roomService->setLastMetadataActivity($breakoutRoom, $this->timeFactory->getDateTime());
 	}
 
 	/**

--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -738,9 +738,16 @@ class ParticipantService {
 		$this->dispatcher->dispatchTyped($event);
 
 		$lastMessage = $event->getLastMessage();
-		if ($lastMessage instanceof IComment) {
+		// TODO: is there any better getter / way to access message type?
+		$lastMessageType = json_decode($lastMessage->getMessage(), true)['message'] ?? '';
+		if ($lastMessage instanceof IComment || !in_array($lastMessageType, ['user_added', 'user_removed', 'moderator_promoted', 'moderator_demoted'], true)) {
+			// do not update the room message to the status message, so the conversion / thread will not be bumped by activity to the top
+			// left to do is to update the last message in the preview in the room list, without bumping it up.
+		} elseif ($lastMessage instanceof IComment) {
 			$this->updateRoomLastMessage($room, $lastMessage);
 		}
+		$now = $this->timeFactory->getDateTime();
+		$room->setLastMetadataActivity($now);
 
 		return $attendees;
 	}
@@ -748,14 +755,16 @@ class ParticipantService {
 	protected function updateRoomLastMessage(Room $room, IComment $message): void {
 		/** @var RoomService $roomService */
 		$roomService = Server::get(RoomService::class);
-		$roomService->setLastMessage($room, $message);
+		$roomService->setLastMessageInfo($room, (int)$message->getId(), $message->getCreationDateTime());
+		$now = $this->timeFactory->getDateTime();
+		$room->setLastMetadataActivity($now);
 
 		$lastMessageCache = $this->cacheFactory->createDistributed(CachePrefix::CHAT_LAST_MESSAGE_ID);
 		$lastMessageCache->remove($room->getToken());
 		$unreadCountCache = $this->cacheFactory->createDistributed(CachePrefix::CHAT_UNREAD_COUNT);
 		$unreadCountCache->clear($room->getId() . '-');
 
-		$event = new SystemMessagesMultipleSentEvent($room, $message);
+		$event = new SystemMessagesMultipleSentEvent($room, $message, skipLastActivityUpdate: true);
 		$this->dispatcher->dispatchTyped($event);
 	}
 
@@ -1254,6 +1263,9 @@ class ParticipantService {
 		} catch (ParticipantNotFoundException) {
 			return;
 		}
+
+		$now = $this->timeFactory->getDateTime();
+		$room->setLastMetadataActivity($now);
 
 		$attendee = $participant->getAttendee();
 		$sessions = $this->sessionService->getAllSessionsForAttendee($attendee);

--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -737,14 +737,17 @@ class ParticipantService {
 		$event = new AttendeesAddedEvent($room, $attendees, true);
 		$this->dispatcher->dispatchTyped($event);
 
-		$lastMessage = $event->getLastMessage();
-		// TODO: is there any better getter / way to access message type?
-		$lastMessageType = json_decode($lastMessage->getMessage(), true)['message'] ?? '';
-		if ($lastMessage instanceof IComment || !in_array($lastMessageType, ['user_added', 'user_removed', 'moderator_promoted', 'moderator_demoted'], true)) {
-			// do not update the room message to the status message, so the conversion / thread will not be bumped by activity to the top
-			// left to do is to update the last message in the preview in the room list, without bumping it up.
-		} elseif ($lastMessage instanceof IComment) {
-			$this->updateRoomLastMessage($room, $lastMessage);
+		// getLastMessage doesn't exist for all event types, e.g. room creation
+		if (($event->getLastMessage() ?? null) !== null) {
+			$lastMessage = $event->getLastMessage();
+			// TODO: is there any better getter / way to access message type?
+			$lastMessageType = json_decode($lastMessage->getMessage(), true)['message'] ?? '';
+			if ($lastMessage instanceof IComment || !in_array($lastMessageType, ['user_added', 'user_removed', 'moderator_promoted', 'moderator_demoted'], true)) {
+				// do not update the room message to the status message, so the conversion / thread will not be bumped by activity to the top
+				// left to do is to update the last message in the preview in the room list, without bumping it up.
+			} elseif ($lastMessage instanceof IComment) {
+				$this->updateRoomLastMessage($room, $lastMessage);
+			}
 		}
 		$now = $this->timeFactory->getDateTime();
 		$room->setLastMetadataActivity($now);

--- a/lib/Service/RoomFormatter.php
+++ b/lib/Service/RoomFormatter.php
@@ -117,6 +117,7 @@ class RoomFormatter {
 			'callRecording' => Room::RECORDING_NONE,
 			'canStartCall' => false,
 			'lastActivity' => 0,
+			'lastMetadataActivity' => 0,
 			'lastReadMessage' => 0,
 			'unreadMessages' => 0,
 			'unreadMention' => false,
@@ -172,6 +173,12 @@ class RoomFormatter {
 		} else {
 			$lastActivity = 0;
 		}
+		$lastMetadataActivity = $room->getLastMetadataActivity();
+		if ($lastMetadataActivity instanceof \DateTimeInterface) {
+			$lastMetadataActivity = $lastMetadataActivity->getTimestamp();
+		} else {
+			$lastMetadataActivity = 0;
+		}
 
 		$this->roomService->validateLobbyTimer($room);
 
@@ -195,6 +202,7 @@ class RoomFormatter {
 				'readOnly' => $room->getReadOnly(),
 				'hasCall' => $room->getActiveSince() instanceof \DateTimeInterface,
 				'lastActivity' => $lastActivity,
+				'lastMetadataActivity' => $lastMetadataActivity,
 				'callFlag' => $room->getCallFlag(),
 				'lobbyState' => $room->getLobbyState(),
 				'lobbyTimer' => $lobbyTimer,
@@ -227,6 +235,7 @@ class RoomFormatter {
 			'callRecording' => $room->getCallRecording(),
 			'recordingConsent' => $this->talkConfig->recordingConsentRequired() === RecordingService::CONSENT_REQUIRED_OPTIONAL ? $room->getRecordingConsent() : $this->talkConfig->recordingConsentRequired(),
 			'lastActivity' => $lastActivity,
+			'lastMetadataActivity' => $lastMetadataActivity,
 			'callFlag' => $room->getCallFlag(),
 			'isFavorite' => $attendee->isFavorite(),
 			'notificationLevel' => $attendee->getNotificationLevel(),

--- a/lib/Service/RoomService.php
+++ b/lib/Service/RoomService.php
@@ -1429,7 +1429,7 @@ class RoomService {
 		if (isset($host['lastMetadataActivity']) && $host['lastMetadataActivity'] !== 0 && $host['lastMetadataActivity'] !== ((int)$local->getLastMetadataActivity()?->getTimestamp())) {
 			$lastMetadataActivity = $this->timeFactory->getDateTime('@' . $host['lastMetadataActivity']);
 			$this->setLastMetadataActivity($local, $lastMetadataActivity);
-			$changed[] = ARoomSyncEvent::PROPERTY_LAST_METADATA_ACTIVITY;
+			$changed[] = ARoomSyncedEvent::PROPERTY_LAST_METADATA_ACTIVITY;
 		}
 		if (isset($host['lobbyState'], $host['lobbyTimer']) && ($host['lobbyState'] !== $local->getLobbyState() || $host['lobbyTimer'] !== ((int)$local->getLobbyTimer()?->getTimestamp()))) {
 			$hostTimer = $host['lobbyTimer'] === 0 ? null : $this->timeFactory->getDateTime('@' . $host['lobbyTimer']);

--- a/lib/Service/RoomService.php
+++ b/lib/Service/RoomService.php
@@ -464,12 +464,12 @@ class RoomService {
 		$update = $this->db->getQueryBuilder();
 		$update->update('talk_rooms')
 			->set('recording_consent', $update->createNamedParameter($recordingConsent, IQueryBuilder::PARAM_INT))
-			->set('last_activity', $update->createNamedParameter($now, IQueryBuilder::PARAM_DATETIME_MUTABLE))
+			->set('last_metadata_activity', $update->createNamedParameter($now, IQueryBuilder::PARAM_DATETIME_MUTABLE))
 			->where($update->expr()->eq('id', $update->createNamedParameter($room->getId(), IQueryBuilder::PARAM_INT)));
 		$update->executeStatement();
 
 		$room->setRecordingConsent($recordingConsent);
-		$room->setLastActivity($now);
+		$room->setLastMetaDataActivity($now);
 
 		$event = new RoomModifiedEvent($room, ARoomModifiedEvent::PROPERTY_RECORDING_CONSENT, $recordingConsent, $oldRecordingConsent);
 		$this->dispatcher->dispatchTyped($event);
@@ -1233,11 +1233,13 @@ class RoomService {
 		$update->update('talk_rooms')
 			->set('last_message', $update->createNamedParameter((int)$message->getId()))
 			->set('last_activity', $update->createNamedParameter($message->getCreationDateTime(), 'datetime'))
+			->set('last_metadata_activity', $update->createNamedParameter($message->getCreationDateTime(), 'datetime'))
 			->where($update->expr()->eq('id', $update->createNamedParameter($room->getId(), IQueryBuilder::PARAM_INT)));
 		$update->executeStatement();
 
 		$room->setLastMessage($message);
 		$room->setLastActivity($message->getCreationDateTime());
+		$room->setLastMetadataActivity($message->getCreationDateTime());
 	}
 
 	public function setLastMessageInfo(Room $room, int $messageId, \DateTime $dateTime): void {
@@ -1245,11 +1247,13 @@ class RoomService {
 		$update->update('talk_rooms')
 			->set('last_message', $update->createNamedParameter($messageId))
 			->set('last_activity', $update->createNamedParameter($dateTime, 'datetime'))
+			->set('last_metadata_activity', $update->createNamedParameter($dateTime, 'datetime'))
 			->where($update->expr()->eq('id', $update->createNamedParameter($room->getId(), IQueryBuilder::PARAM_INT)));
 		$update->executeStatement();
 
 		$room->setLastMessageId($messageId);
 		$room->setLastActivity($dateTime);
+		$room->setLastMetadataActivity($dateTime);
 	}
 
 	/**
@@ -1281,6 +1285,16 @@ class RoomService {
 		$update->executeStatement();
 
 		$room->setLastActivity($now);
+	}
+
+	public function setLastMetadataActivity(Room $room, \DateTime $now): void {
+		$update = $this->db->getQueryBuilder();
+		$update->update('talk_rooms')
+			->set('last_metadata_activity', $update->createNamedParameter($now, 'datetime'))
+			->where($update->expr()->eq('id', $update->createNamedParameter($room->getId(), IQueryBuilder::PARAM_INT)));
+		$update->executeStatement();
+
+		$room->setLastMetadataActivity($now);
 	}
 
 	/**
@@ -1349,6 +1363,11 @@ class RoomService {
 			$lastActivity = $this->timeFactory->getDateTime('@' . $host['lastActivity']);
 			$this->setLastActivity($local, $lastActivity);
 			$changed[] = ARoomSyncedEvent::PROPERTY_LAST_ACTIVITY;
+		}
+		if (isset($host['lastMetadataActivity']) && $host['lastMetadataActivity'] !== 0 && $host['lastMetadataActivity'] !== ((int)$local->getLastMetadataActivity()?->getTimestamp())) {
+			$lastMetadataActivity = $this->timeFactory->getDateTime('@' . $host['lastMetadataActivity']);
+			$this->setLastMetadataActivity($local, $lastMetadataActivity);
+			$changed[] = ARoomSyncEvent::PROPERTY_LAST_METADATA_ACTIVITY;
 		}
 		if (isset($host['lobbyState'], $host['lobbyTimer']) && ($host['lobbyState'] !== $local->getLobbyState() || $host['lobbyTimer'] !== ((int)$local->getLobbyTimer()?->getTimestamp()))) {
 			$hostTimer = $host['lobbyTimer'] === 0 ? null : $this->timeFactory->getDateTime('@' . $host['lobbyTimer']);

--- a/lib/Service/ThreadService.php
+++ b/lib/Service/ThreadService.php
@@ -45,7 +45,7 @@ class ThreadService {
 		$thread->setId($threadId);
 		$thread->setName($title);
 		$thread->setRoomId($room->getId());
-		$thread->setLastActivity($this->timeFactory->getDateTime());
+		$thread->setLastMetadataActivity($this->timeFactory->getDateTime());
 		$thread = $this->threadMapper->insert($thread);
 
 		$this->cache->set(self::CACHE_PREFIX . $room->getId() . '/' . $threadId, $thread->toJson(), 60 * 15);

--- a/lib/Service/ThreadService.php
+++ b/lib/Service/ThreadService.php
@@ -45,6 +45,7 @@ class ThreadService {
 		$thread->setId($threadId);
 		$thread->setName($title);
 		$thread->setRoomId($room->getId());
+		$thread->setLastActivity($this->timeFactory->getDateTime());
 		$thread = $this->threadMapper->insert($thread);
 
 		$this->cache->set(self::CACHE_PREFIX . $room->getId() . '/' . $threadId, $thread->toJson(), 60 * 15);

--- a/lib/Service/ThreadService.php
+++ b/lib/Service/ThreadService.php
@@ -45,7 +45,6 @@ class ThreadService {
 		$thread->setId($threadId);
 		$thread->setName($title);
 		$thread->setRoomId($room->getId());
-		$thread->setLastMetadataActivity($this->timeFactory->getDateTime());
 		$thread = $this->threadMapper->insert($thread);
 
 		$this->cache->set(self::CACHE_PREFIX . $room->getId() . '/' . $threadId, $thread->toJson(), 60 * 15);

--- a/lib/Service/ThreadService.php
+++ b/lib/Service/ThreadService.php
@@ -46,6 +46,7 @@ class ThreadService {
 		$thread->setName($title);
 		$thread->setRoomId($room->getId());
 		$thread->setLastActivity($this->timeFactory->getDateTime());
+		$thread->setLastMetadataActivity($this->timeFactory->getDateTime());
 		$thread = $this->threadMapper->insert($thread);
 
 		$this->cache->set(self::CACHE_PREFIX . $room->getId() . '/' . $threadId, $thread->toJson(), 60 * 15);

--- a/lib/Signaling/Listener.php
+++ b/lib/Signaling/Listener.php
@@ -557,7 +557,7 @@ class Listener implements IEventListener {
 		$messageType = $messageDecoded['message'] ?? '';
 
 		if ($event->shouldSkipLastActivityUpdate() === true
-			&& !in_array($messageType, ['message_deleted', 'message_edited', 'thread_created', 'thread_renamed'], true)
+			&& !in_array($messageType, ['message_deleted', 'message_edited', 'thread_created', 'thread_renamed', 'user_added', 'user_removed', 'moderator_promoted', 'moderator_demoted'], true)
 		) {
 			return;
 		}

--- a/openapi-backend-sipbridge.json
+++ b/openapi-backend-sipbridge.json
@@ -913,6 +913,7 @@
                     "isCustomAvatar",
                     "isFavorite",
                     "lastActivity",
+                    "lastMetadataActivity",
                     "lastCommonReadMessage",
                     "lastPing",
                     "lastReadMessage",
@@ -1071,7 +1072,12 @@
                     "lastActivity": {
                         "type": "integer",
                         "format": "int64",
-                        "description": "Timestamp of the last activity in the conversation, in seconds and UTC time zone"
+                        "description": "Timestamp of the last message activity in the conversation, in seconds and UTC time zone"
+                    },
+                    "lastMetadataActivity": {
+                        "type": "integer",
+                        "format": "int64",
+                        "description": "Timestamp of the last activity (metadata, not messages) in the conversation, in seconds and UTC time zone"
                     },
                     "lastCommonReadMessage": {
                         "type": "integer",

--- a/openapi-federation.json
+++ b/openapi-federation.json
@@ -978,6 +978,7 @@
                     "isCustomAvatar",
                     "isFavorite",
                     "lastActivity",
+                    "lastMetadataActivity",
                     "lastCommonReadMessage",
                     "lastPing",
                     "lastReadMessage",
@@ -1136,7 +1137,12 @@
                     "lastActivity": {
                         "type": "integer",
                         "format": "int64",
-                        "description": "Timestamp of the last activity in the conversation, in seconds and UTC time zone"
+                        "description": "Timestamp of the last message activity in the conversation, in seconds and UTC time zone"
+                    },
+                    "lastMetadataActivity": {
+                        "type": "integer",
+                        "format": "int64",
+                        "description": "Timestamp of the last activity (metadata, not messages) in the conversation, in seconds and UTC time zone"
                     },
                     "lastCommonReadMessage": {
                         "type": "integer",

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -2000,6 +2000,7 @@
                     "isCustomAvatar",
                     "isFavorite",
                     "lastActivity",
+                    "lastMetadataActivity",
                     "lastCommonReadMessage",
                     "lastPing",
                     "lastReadMessage",
@@ -2158,7 +2159,12 @@
                     "lastActivity": {
                         "type": "integer",
                         "format": "int64",
-                        "description": "Timestamp of the last activity in the conversation, in seconds and UTC time zone"
+                        "description": "Timestamp of the last message activity in the conversation, in seconds and UTC time zone"
+                    },
+                    "lastMetadataActivity": {
+                        "type": "integer",
+                        "format": "int64",
+                        "description": "Timestamp of the last activity (metadata, not messages) in the conversation, in seconds and UTC time zone"
                     },
                     "lastCommonReadMessage": {
                         "type": "integer",
@@ -2678,6 +2684,7 @@
                     "title",
                     "lastMessageId",
                     "lastActivity",
+                    "lastMetadataActivity",
                     "numReplies"
                 ],
                 "properties": {
@@ -2704,7 +2711,13 @@
                     "lastActivity": {
                         "type": "integer",
                         "format": "int64",
-                        "description": "UNIX timestamp of the last activity in the thread",
+                        "description": "UNIX timestamp of the last message activity in the thread",
+                        "minimum": 0
+                    },
+                    "lastMetadataActivity": {
+                        "type": "integer",
+                        "format": "int64",
+                        "description": "UNIX timestamp of the last metadata, not message, activity in the thread",
                         "minimum": 0
                     },
                     "numReplies": {

--- a/openapi.json
+++ b/openapi.json
@@ -1888,6 +1888,7 @@
                     "isCustomAvatar",
                     "isFavorite",
                     "lastActivity",
+                    "lastMetadataActivity",
                     "lastCommonReadMessage",
                     "lastPing",
                     "lastReadMessage",
@@ -2046,7 +2047,12 @@
                     "lastActivity": {
                         "type": "integer",
                         "format": "int64",
-                        "description": "Timestamp of the last activity in the conversation, in seconds and UTC time zone"
+                        "description": "Timestamp of the last message activity in the conversation, in seconds and UTC time zone"
+                    },
+                    "lastMetadataActivity": {
+                        "type": "integer",
+                        "format": "int64",
+                        "description": "Timestamp of the last activity (metadata, not messages) in the conversation, in seconds and UTC time zone"
                     },
                     "lastCommonReadMessage": {
                         "type": "integer",
@@ -2566,6 +2572,7 @@
                     "title",
                     "lastMessageId",
                     "lastActivity",
+                    "lastMetadataActivity",
                     "numReplies"
                 ],
                 "properties": {
@@ -2592,7 +2599,13 @@
                     "lastActivity": {
                         "type": "integer",
                         "format": "int64",
-                        "description": "UNIX timestamp of the last activity in the thread",
+                        "description": "UNIX timestamp of the last message activity in the thread",
+                        "minimum": 0
+                    },
+                    "lastMetadataActivity": {
+                        "type": "integer",
+                        "format": "int64",
+                        "description": "UNIX timestamp of the last metadata, not message, activity in the thread",
                         "minimum": 0
                     },
                     "numReplies": {

--- a/src/types/openapi/openapi-backend-sipbridge.ts
+++ b/src/types/openapi/openapi-backend-sipbridge.ts
@@ -633,9 +633,14 @@ export type components = {
             isFavorite: boolean;
             /**
              * Format: int64
-             * @description Timestamp of the last activity in the conversation, in seconds and UTC time zone
+             * @description Timestamp of the last message activity in the conversation, in seconds and UTC time zone
              */
             lastActivity: number;
+            /**
+             * Format: int64
+             * @description Timestamp of the last activity (metadata, not messages) in the conversation, in seconds and UTC time zone
+             */
+            lastMetadataActivity: number;
             /**
              * Format: int64
              * @description ID of the last message read by every user that has read privacy set to public in a room. When the user themself has it set to private the value is `0` (only available with `chat-read-status` capability)

--- a/src/types/openapi/openapi-federation.ts
+++ b/src/types/openapi/openapi-federation.ts
@@ -677,9 +677,14 @@ export type components = {
             isFavorite: boolean;
             /**
              * Format: int64
-             * @description Timestamp of the last activity in the conversation, in seconds and UTC time zone
+             * @description Timestamp of the last message activity in the conversation, in seconds and UTC time zone
              */
             lastActivity: number;
+            /**
+             * Format: int64
+             * @description Timestamp of the last activity (metadata, not messages) in the conversation, in seconds and UTC time zone
+             */
+            lastMetadataActivity: number;
             /**
              * Format: int64
              * @description ID of the last message read by every user that has read privacy set to public in a room. When the user themself has it set to private the value is `0` (only available with `chat-read-status` capability)

--- a/src/types/openapi/openapi-full.ts
+++ b/src/types/openapi/openapi-full.ts
@@ -3635,9 +3635,14 @@ export type components = {
             isFavorite: boolean;
             /**
              * Format: int64
-             * @description Timestamp of the last activity in the conversation, in seconds and UTC time zone
+             * @description Timestamp of the last message activity in the conversation, in seconds and UTC time zone
              */
             lastActivity: number;
+            /**
+             * Format: int64
+             * @description Timestamp of the last activity (metadata, not messages) in the conversation, in seconds and UTC time zone
+             */
+            lastMetadataActivity: number;
             /**
              * Format: int64
              * @description ID of the last message read by every user that has read privacy set to public in a room. When the user themself has it set to private the value is `0` (only available with `chat-read-status` capability)
@@ -3927,9 +3932,14 @@ export type components = {
             lastMessageId: number;
             /**
              * Format: int64
-             * @description UNIX timestamp of the last activity in the thread
+             * @description UNIX timestamp of the last message activity in the thread
              */
             lastActivity: number;
+            /**
+             * Format: int64
+             * @description UNIX timestamp of the last metadata, not message, activity in the thread
+             */
+            lastMetadataActivity: number;
             /**
              * Format: int64
              * @description Number of replies in the thread

--- a/src/types/openapi/openapi.ts
+++ b/src/types/openapi/openapi.ts
@@ -3040,9 +3040,14 @@ export type components = {
             isFavorite: boolean;
             /**
              * Format: int64
-             * @description Timestamp of the last activity in the conversation, in seconds and UTC time zone
+             * @description Timestamp of the last message activity in the conversation, in seconds and UTC time zone
              */
             lastActivity: number;
+            /**
+             * Format: int64
+             * @description Timestamp of the last activity (metadata, not messages) in the conversation, in seconds and UTC time zone
+             */
+            lastMetadataActivity: number;
             /**
              * Format: int64
              * @description ID of the last message read by every user that has read privacy set to public in a room. When the user themself has it set to private the value is `0` (only available with `chat-read-status` capability)
@@ -3332,9 +3337,14 @@ export type components = {
             lastMessageId: number;
             /**
              * Format: int64
-             * @description UNIX timestamp of the last activity in the thread
+             * @description UNIX timestamp of the last message activity in the thread
              */
             lastActivity: number;
+            /**
+             * Format: int64
+             * @description UNIX timestamp of the last metadata, not message, activity in the thread
+             */
+            lastMetadataActivity: number;
             /**
              * Format: int64
              * @description Number of replies in the thread


### PR DESCRIPTION
## ☑️ Resolves

* Fix #11882 

### AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
-> none used

## UI

- this only changes backend behavior but nothing in the ui / client side

## 🛠️ API Checklist

### Test Plan

- [x] behavior of chat messages is unchanged
- [x] adding and removing users, promoting and demoting users in rooms works as before
- [x] chat messages still trigger activity bumps
- [x] system messages are still shown in the client, but don't trigger activity bumps and conversations reorderings

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 

This Pull request solves the issue in #11882:
Currently, system messages like user_added, user_removed, moderator_promoted, moderator_demoted bumped activity / reordered the room / thread list on each update.
With these changes, system messages are still signaled to the client, but won't bump the activity anymore.
This also introduces a differentiation between lastActivity and a new attribute lastMetadaActivity. lastActivity will still be updated on new chat messages, all other state changes like participant list will only change lastMetadataActivity. Later on this can be useful to handle different kinds of events independently on the backend.
The API to the frontend remains unchanged and there are no changes necessary client-side.

I tested it in my local development setup, @nickvergessen please review & check if the changes now reflect the desired behavior or if we need further changes. Thanks!