### PR TITLE
Release v24.0.0 rc.1

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -18,7 +18,7 @@
 * 🌉 **Sync with other chat solutions** With [Matterbridge](https://github.com/42wim/matterbridge/) being integrated in Talk, you can easily sync a lot of other chat solutions to Nextcloud Talk and vice-versa.
 ]]></description>
 
-	<version>24.0.0-beta.1</version>
+	<version>24.0.0-rc.1</version>
 	<licence>agpl</licence>
 
 	<author>Anna Larch</author>

--- a/docs/changelogs/changelog-24.md
+++ b/docs/changelogs/changelog-24.md
@@ -5,6 +5,30 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 24.0.0-rc.1 – 2026-05-13
+### Added
+- feat(email): Allow email guests without public link
+  [#13609](https://github.com/nextcloud/spreed/issues/13609)
+- feat(preset): Allow to force the lobby
+  [#17935](https://github.com/nextcloud/spreed/issues/17935)
+
+### Changed
+- Update dependencies
+- Update translations
+
+### Fixed
+- fix(navigation): adjust active "Home" link to the new design
+  [#17932](https://github.com/nextcloud/spreed/issues/17932)
+- fix(sidebar): rework call UI in Talk integrations
+  [#17860](https://github.com/nextcloud/spreed/issues/17860)
+- fix(files-sidebar): reduce initial loading size of Files sidebar
+  [#11551](https://github.com/nextcloud/spreed/issues/11551)
+- fix(sharing): Fix probe attachment call for windows compatible filenames
+  [#17925](https://github.com/nextcloud/spreed/issues/17925)
+- fix(voice-rooms): Hide preset when calls are disabled
+  [#17933](https://github.com/nextcloud/spreed/issues/17933)
+
+
 ## 24.0.0-beta.1 – 2026-05-04
 ### Added
 - Call from anywhere - Integration of calls into the avatar menu

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "talk",
-  "version": "24.0.0-beta.1",
+  "version": "24.0.0-rc.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "talk",
-      "version": "24.0.0-beta.1",
+      "version": "24.0.0-rc.1",
       "license": "agpl",
       "dependencies": {
         "@matrix-org/olm": "^3.2.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "talk",
-  "version": "24.0.0-beta.1",
+  "version": "24.0.0-rc.1",
   "private": true,
   "description": "",
   "license": "agpl",


### PR DESCRIPTION
## Added
- feat(email): Allow email guests without public link [#13609](https://github.com/nextcloud/spreed/issues/13609)
- feat(preset): Allow to force the lobby [#17935](https://github.com/nextcloud/spreed/issues/17935)

## Changed
- Update dependencies
- Update translations

## Fixed
- fix(navigation): adjust active "Home" link to the new design [#17932](https://github.com/nextcloud/spreed/issues/17932)
- fix(sidebar): rework call UI in Talk integrations [#17860](https://github.com/nextcloud/spreed/issues/17860)
- fix(files-sidebar): reduce initial loading size of Files sidebar [#11551](https://github.com/nextcloud/spreed/issues/11551)
- fix(sharing): Fix probe attachment call for windows compatible filenames [#17925](https://github.com/nextcloud/spreed/issues/17925)
- fix(voice-rooms): Hide preset when calls are disabled [#17933](https://github.com/nextcloud/spreed/issues/17933)