### PR TITLE
feat: include 'Raise hand' in call reactions menu

### DIFF
--- a/src/components/CallView/BottomBar.vue
+++ b/src/components/CallView/BottomBar.vue
@@ -8,11 +8,10 @@ import {
 	showError,
 } from '@nextcloud/dialogs'
 import { t } from '@nextcloud/l10n'
-import { useHotKey } from '@nextcloud/vue/composables/useHotKey'
 import { useIsMobile } from '@nextcloud/vue/composables/useIsMobile'
 import { useResizeObserver } from '@vueuse/core'
 import debounce from 'debounce'
-import { computed, onMounted, onUnmounted, ref, toValue, useTemplateRef, watch } from 'vue'
+import { computed, onMounted, onUnmounted, ref, toValue, useTemplateRef } from 'vue'
 import { useStore } from 'vuex'
 import NcActionButton from '@nextcloud/vue/components/NcActionButton'
 import NcActions from '@nextcloud/vue/components/NcActions'
@@ -22,8 +21,6 @@ import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
 import IconChevronUp from 'vue-material-design-icons/ChevronUp.vue'
 import IconFullscreen from 'vue-material-design-icons/Fullscreen.vue'
 import IconFullscreenExit from 'vue-material-design-icons/FullscreenExit.vue'
-import IconHandBackLeft from 'vue-material-design-icons/HandBackLeft.vue' // Filled for better indication
-import IconHandBackLeftOutline from 'vue-material-design-icons/HandBackLeftOutline.vue'
 import IconSubtitles from 'vue-material-design-icons/Subtitles.vue'
 import IconSubtitlesOutline from 'vue-material-design-icons/SubtitlesOutline.vue'
 import IconViewGalleryOutline from 'vue-material-design-icons/ViewGalleryOutline.vue'
@@ -36,13 +33,12 @@ import {
 	useDocumentFullscreen,
 } from '../../composables/useDocumentFullscreen.ts'
 import { useGetToken } from '../../composables/useGetToken.ts'
-import { ATTENDEE, CONVERSATION, PARTICIPANT } from '../../constants.ts'
+import { ATTENDEE, CONVERSATION } from '../../constants.ts'
 import {
 	getTalkConfig,
 	showTalkFeatureHint,
 } from '../../services/CapabilitiesManager.ts'
 import { useActorStore } from '../../stores/actor.ts'
-import { useBreakoutRoomsStore } from '../../stores/breakoutRooms.ts'
 import { useCallViewStore } from '../../stores/callView.ts'
 import { useLiveTranscriptionStore } from '../../stores/liveTranscription.ts'
 import { useSettingsStore } from '../../stores/settings.ts'
@@ -51,13 +47,10 @@ import { localCallParticipantModel, localMediaModel } from '../../utils/webrtc/i
 const { isSidebar = false } = defineProps<{
 	isSidebar: boolean
 }>()
-const AUTO_LOWER_HAND_THRESHOLD = 3000
-const disableKeyboardShortcuts = OCP.Accessibility.disableKeyboardShortcuts()
 
 const store = useStore()
 const token = useGetToken()
 const actorStore = useActorStore()
-const breakoutRoomsStore = useBreakoutRoomsStore()
 const isFullscreen = !isSidebar && useDocumentFullscreen()
 const callViewStore = useCallViewStore()
 const liveTranscriptionStore = useLiveTranscriptionStore()
@@ -73,13 +66,6 @@ const conversation = computed(() => {
 })
 const isGuestActor = computed(() => actorStore.actorType === ATTENDEE.ACTOR_TYPE.GUESTS)
 const isVoiceRoom = computed(() => Boolean(conversation.value.attributes & CONVERSATION.ATTRIBUTE.VOICE_ROOM))
-
-const supportedReactions = computed(() => getTalkConfig(token.value, 'call', 'supported-reactions') || [])
-
-const hasReactionSupport = computed(() => supportedReactions.value && supportedReactions.value.length > 0)
-
-const canModerate = computed(() => [PARTICIPANT.TYPE.OWNER, PARTICIPANT.TYPE.MODERATOR, PARTICIPANT.TYPE.GUEST_MODERATOR]
-	.includes(conversation.value.participantType))
 
 const isLiveTranscriptionSupported = computed(() => getTalkConfig(token.value, 'call', 'live-transcription') || false)
 const hintTranscriptionSupported = computed(() => !isLiveTranscriptionSupported.value && showTalkFeatureHint(34))
@@ -164,19 +150,6 @@ const LanguageType = {
 
 const languageType = ref<typeof LanguageType[keyof typeof LanguageType]>(LanguageType.Original)
 
-const isHandRaised = computed(() => localMediaModel.attributes.raisedHand.state === true)
-
-const raiseHandButtonLabel = computed(() => {
-	if (!isHandRaised.value) {
-		return disableKeyboardShortcuts
-			? t('spreed', 'Raise hand')
-			: t('spreed', 'Raise hand (R)')
-	}
-	return disableKeyboardShortcuts
-		? t('spreed', 'Lower hand')
-		: t('spreed', 'Lower hand (R)')
-})
-
 const fullscreenLabel = computed(() => {
 	return toValue(isFullscreen)
 		? t('spreed', 'Exit full screen (F)')
@@ -191,14 +164,12 @@ const changeViewLabel = computed(() => {
 
 const showCallLayoutSwitch = computed(() => !isSidebar && !callViewStore.isEmptyCallView)
 const isGrid = computed(() => callViewStore.isGrid)
-const userIsInBreakoutRoomAndInCall = computed(() => conversation.value.objectType === CONVERSATION.OBJECT_TYPE.BREAKOUT_ROOM)
 
-const COLLAPSIBLE_BUTTONS = ['virtualBackground', 'liveTranscription', 'raiseHand', 'callLayout', 'fullscreen'] as const
+const COLLAPSIBLE_BUTTONS = ['virtualBackground', 'liveTranscription', 'callLayout', 'fullscreen'] as const
 type CollapsibleButtons = Record<typeof COLLAPSIBLE_BUTTONS[number], boolean>
 const isActionAvailableMask = computed<CollapsibleButtons>(() => ({
 	fullscreen: !isSidebar,
 	callLayout: showCallLayoutSwitch.value,
-	raiseHand: !isSidebar,
 	liveTranscription: !isSidebar && isLiveTranscriptionSupported.value,
 	virtualBackground: !isSidebar,
 }))
@@ -448,68 +419,6 @@ async function disableLiveTranslation() {
 	languageType.value = LanguageType.Original
 }
 
-let lowerHandDelay = AUTO_LOWER_HAND_THRESHOLD
-let speakingTimestamp: number | null = null
-let lowerHandTimeout: ReturnType<typeof setTimeout> | null = null
-
-// Hand raising functionality
-/**
- * Toggle the hand raised state for the local media model and update the store.
- * If the user is in a breakout room, it also handles the request for assistance.
- */
-function toggleHandRaised() {
-	const newState = !isHandRaised.value
-	localMediaModel.toggleHandRaised(newState)
-	store.dispatch('setParticipantHandRaised', {
-		sessionId: actorStore.sessionId,
-		raisedHand: localMediaModel.attributes.raisedHand,
-	})
-
-	// Handle breakout room assistance requests
-	if (userIsInBreakoutRoomAndInCall.value && !canModerate.value) {
-		const hasRaisedHands = Object.keys(store.getters.participantRaisedHandList)
-			.filter((sessionId) => sessionId !== actorStore.sessionId)
-			.length !== 0
-
-		if (hasRaisedHands) {
-			return // Assistance is already requested by someone in the room
-		}
-
-		const hasAssistanceRequested = conversation.value.breakoutRoomStatus === CONVERSATION.BREAKOUT_ROOM_STATUS.STATUS_ASSISTANCE_REQUESTED
-		if (newState && !hasAssistanceRequested) {
-			breakoutRoomsStore.requestAssistance(token.value)
-		} else if (!newState && hasAssistanceRequested) {
-			breakoutRoomsStore.dismissRequestAssistance(token.value)
-		}
-	}
-}
-
-// Auto-lower hand when speaking
-watch(() => localMediaModel.attributes.speaking, (speaking) => {
-	if (lowerHandTimeout !== null && !speaking) {
-		lowerHandDelay = Math.max(0, lowerHandDelay - (Date.now() - speakingTimestamp!))
-		clearTimeout(lowerHandTimeout)
-		lowerHandTimeout = null
-		return
-	}
-
-	// User is not speaking OR timeout is already running OR hand is not raised
-	if (!speaking || lowerHandTimeout !== null || !isHandRaised.value) {
-		return
-	}
-
-	speakingTimestamp = Date.now()
-	lowerHandTimeout = setTimeout(() => {
-		lowerHandTimeout = null
-		speakingTimestamp = null
-		lowerHandDelay = AUTO_LOWER_HAND_THRESHOLD
-
-		if (isHandRaised.value) {
-			toggleHandRaised()
-		}
-	}, lowerHandDelay)
-})
-
 /**
  * Switches the call view mode between grid and speaker view.
  */
@@ -517,9 +426,6 @@ function changeView() {
 	callViewStore.setCallViewMode({ token: token.value, isGrid: !isGrid.value, clearLast: false })
 	callViewStore.setSelectedVideoPeerId(null)
 }
-
-// Keyboard shortcuts
-useHotKey('r', toggleHandRaised)
 </script>
 
 <template>
@@ -562,9 +468,9 @@ useHotKey('r', toggleHandRaised)
 
 			<!-- Reactions menu -->
 			<ReactionMenu
-				v-if="!isSidebar && hasReactionSupport"
+				v-if="!isSidebar"
 				:token="token"
-				:supportedReactions="supportedReactions"
+				:localMediaModel="localMediaModel"
 				:localCallParticipantModel="localCallParticipantModel" />
 
 			<div
@@ -663,20 +569,6 @@ useHotKey('r', toggleHandRaised)
 					</template>
 				</NcButton>
 			</div>
-
-			<NcButton
-				v-if="!isSidebar && !hidingList.raiseHand"
-				:title="raiseHandButtonLabel"
-				:aria-label="raiseHandButtonLabel"
-				:variant="isHandRaised ? 'secondary' : 'tertiary'"
-				@click="toggleHandRaised">
-				<!-- The following icon is much bigger than all the others
-					so we reduce its size -->
-				<template #icon>
-					<IconHandBackLeft v-if="isHandRaised" :size="18" />
-					<IconHandBackLeftOutline v-else :size="18" />
-				</template>
-			</NcButton>
 		</div>
 		<div ref="callButtonWithActions" class="bottom-bar-options call-options">
 			<!-- Collapsed actions -->
@@ -746,20 +638,6 @@ useHotKey('r', toggleHandRaised)
 							:size="20" />
 					</template>
 					{{ liveTranslationButtonLabel }}
-				</NcActionButton>
-				<NcActionButton
-					v-if="!isSidebar && hidingList.raiseHand"
-					:title="raiseHandButtonLabel"
-					:aria-label="raiseHandButtonLabel"
-					:variant="isHandRaised ? 'secondary' : 'tertiary'"
-					@click="toggleHandRaised">
-					<!-- The following icon is much bigger than all the others
-						so we reduce its size -->
-					<template #icon>
-						<IconHandBackLeft v-if="isHandRaised" :size="18" />
-						<IconHandBackLeftOutline v-else :size="18" />
-					</template>
-					{{ raiseHandButtonLabel }}
 				</NcActionButton>
 			</NcActions>
 

--- a/src/components/TopBar/ReactionMenu.vue
+++ b/src/components/TopBar/ReactionMenu.vue
@@ -4,28 +4,70 @@
 -->
 
 <script setup lang="ts">
-import type { LocalCallParticipantModel } from '../../types/index.ts'
+import type { LocalCallParticipantModel, LocalMediaModel } from '../../types/index.ts'
 
 import { emit } from '@nextcloud/event-bus'
 import { t } from '@nextcloud/l10n'
-import { computed } from 'vue'
+import { useHotKey } from '@nextcloud/vue/composables/useHotKey'
+import { computed, watch } from 'vue'
+import { useStore } from 'vuex'
 import NcActionButton from '@nextcloud/vue/components/NcActionButton'
 import NcActionButtonGroup from '@nextcloud/vue/components/NcActionButtonGroup'
 import NcActions from '@nextcloud/vue/components/NcActions'
+import NcActionSeparator from '@nextcloud/vue/components/NcActionSeparator'
 import IconEmoticonOutline from 'vue-material-design-icons/EmoticonOutline.vue'
+import IconHandBackLeft from 'vue-material-design-icons/HandBackLeft.vue'
+import IconHandBackLeftOutline from 'vue-material-design-icons/HandBackLeftOutline.vue'
+import { CONVERSATION, PARTICIPANT } from '../../constants.ts'
+import { getTalkConfig } from '../../services/CapabilitiesManager.ts'
+import { useActorStore } from '../../stores/actor.ts'
+import { useBreakoutRoomsStore } from '../../stores/breakoutRooms.ts'
 
 const props = defineProps<{
 	/* The conversation token */
 	token: string
 	/* Signaling participant model */
+	localMediaModel: LocalMediaModel
+	/* Signaling participant model */
 	localCallParticipantModel: LocalCallParticipantModel
-	/* Supported reactions */
-	supportedReactions: string[]
 }>()
 
-let throttleTimer: NodeJS.Timeout | undefined
+const actorStore = useActorStore()
+const breakoutRoomsStore = useBreakoutRoomsStore()
+const vuexStore = useStore()
 
-const reactionsInSingleRow = computed(() => Math.ceil(props.supportedReactions.length / 2))
+const AUTO_LOWER_HAND_THRESHOLD = 3_000
+const disableKeyboardShortcuts = OCP.Accessibility.disableKeyboardShortcuts()
+useHotKey('r', toggleHandRaised)
+
+let throttleTimer: ReturnType<typeof setTimeout> | undefined
+let lowerHandDelay = AUTO_LOWER_HAND_THRESHOLD
+let speakingTimestamp: number | null = null
+let lowerHandTimeout: ReturnType<typeof setTimeout> | undefined
+
+const supportedReactions = computed(() => getTalkConfig(props.token, 'call', 'supported-reactions') || [])
+const hasReactionSupport = computed(() => supportedReactions.value && supportedReactions.value.length > 0)
+const reactionsInSingleRow = computed(() => Math.ceil(supportedReactions.value.length / 2))
+
+const conversation = computed(() => {
+	return vuexStore.getters.conversation(props.token) || vuexStore.getters.dummyConversation
+})
+const canModerate = computed(() => [PARTICIPANT.TYPE.OWNER, PARTICIPANT.TYPE.MODERATOR, PARTICIPANT.TYPE.GUEST_MODERATOR]
+	.includes(conversation.value.participantType))
+const userIsInBreakoutRoomAndInCall = computed(() => conversation.value.objectType === CONVERSATION.OBJECT_TYPE.BREAKOUT_ROOM)
+const isHandRaised = computed(() => props.localMediaModel.attributes.raisedHand.state === true)
+const raiseHandButtonLabel = computed(() => {
+	if (!isHandRaised.value) {
+		return disableKeyboardShortcuts
+			? t('spreed', 'Raise hand')
+			: t('spreed', 'Raise hand (R)')
+	}
+	return disableKeyboardShortcuts
+		? t('spreed', 'Lower hand')
+		: t('spreed', 'Lower hand (R)')
+})
+
+const actionsLabel = computed(() => hasReactionSupport.value ? t('spreed', 'Send a reaction') : raiseHandButtonLabel.value)
 
 /**
  * Throttle reaction sending from a single use (to 1 reaction every 2 seconds)
@@ -58,19 +100,77 @@ function sendReaction(reaction: string) {
 		reaction,
 	})
 }
+
+/**
+ * Toggle the hand raised state for the local media model and update the store.
+ * If the user is in a breakout room, it also handles the request for assistance.
+ */
+function toggleHandRaised() {
+	const newState = !isHandRaised.value
+	props.localMediaModel.toggleHandRaised(newState)
+	vuexStore.dispatch('setParticipantHandRaised', {
+		sessionId: actorStore.sessionId,
+		raisedHand: props.localMediaModel.attributes.raisedHand,
+	})
+
+	// Handle breakout room assistance requests
+	if (userIsInBreakoutRoomAndInCall.value && !canModerate.value) {
+		const hasRaisedHands = Object.keys(vuexStore.getters.participantRaisedHandList)
+			.filter((sessionId) => sessionId !== actorStore.sessionId)
+			.length !== 0
+
+		if (hasRaisedHands) {
+			return // Assistance is already requested by someone in the room
+		}
+
+		const hasAssistanceRequested = conversation.value.breakoutRoomStatus === CONVERSATION.BREAKOUT_ROOM_STATUS.STATUS_ASSISTANCE_REQUESTED
+		if (newState && !hasAssistanceRequested) {
+			breakoutRoomsStore.requestAssistance(props.token)
+		} else if (!newState && hasAssistanceRequested) {
+			breakoutRoomsStore.dismissRequestAssistance(props.token)
+		}
+	}
+}
+
+/* Auto-lower hand when speaking */
+watch(() => props.localMediaModel.attributes.speaking, (speaking: boolean) => {
+	if (lowerHandTimeout !== undefined && !speaking) {
+		lowerHandDelay = Math.max(0, lowerHandDelay - (Date.now() - speakingTimestamp!))
+		clearTimeout(lowerHandTimeout)
+		lowerHandTimeout = undefined
+		return
+	}
+
+	// User is not speaking OR timeout is already running OR hand is not raised
+	if (!speaking || lowerHandTimeout !== undefined || !isHandRaised.value) {
+		return
+	}
+
+	speakingTimestamp = Date.now()
+	lowerHandTimeout = setTimeout(() => {
+		lowerHandTimeout = undefined
+		speakingTimestamp = null
+		lowerHandDelay = AUTO_LOWER_HAND_THRESHOLD
+
+		if (isHandRaised.value) {
+			toggleHandRaised()
+		}
+	}, lowerHandDelay)
+})
 </script>
 
 <template>
 	<NcActions
 		variant="tertiary"
-		:title="t('spreed', 'Send a reaction')"
-		:aria-label="t('spreed', 'Send a reaction')"
+		:title="actionsLabel"
+		:aria-label="actionsLabel"
 		class="reaction">
 		<template #icon>
 			<IconEmoticonOutline :size="20" />
 		</template>
 
 		<NcActionButtonGroup
+			v-if="hasReactionSupport"
 			class="reaction__group"
 			:style="{ '--reactions-in-single-row': reactionsInSingleRow }">
 			<NcActionButton
@@ -84,6 +184,23 @@ function sendReaction(reaction: string) {
 				</template>
 			</NcActionButton>
 		</NcActionButtonGroup>
+
+		<NcActionSeparator v-if="hasReactionSupport" />
+
+		<NcActionButton
+			:title="raiseHandButtonLabel"
+			:aria-label="raiseHandButtonLabel"
+			class="raise-hand__button"
+			:variant="isHandRaised ? 'secondary' : 'tertiary'"
+			@click="toggleHandRaised">
+			<!-- The following icon is much bigger than all the others
+				so we reduce its size -->
+			<template #icon>
+				<IconHandBackLeft v-if="isHandRaised" :size="18" />
+				<IconHandBackLeftOutline v-else :size="18" />
+			</template>
+			{{ raiseHandButtonLabel }}
+		</NcActionButton>
 	</NcActions>
 </template>
 
@@ -95,12 +212,16 @@ function sendReaction(reaction: string) {
 			flex-wrap: wrap;
 			justify-content: flex-start;
 			gap: 0 !important;
-			width: calc(var(--reactions-in-single-row) * var(--default-clickable-area))
+			min-width: calc(var(--reactions-in-single-row) * var(--default-clickable-area))
 		}
 	}
 
 	&__button {
 		flex: 0 0 calc(100% / var(--reactions-in-single-row)) !important;
 	}
+}
+
+.raise-hand__button :deep(.action-button) {
+	justify-content: center;
 }
 </style>


### PR DESCRIPTION
## ☑️ Resolves

* Fix #17477
  * Mostly moved code, no significant changes

### AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="309" height="110" alt="image" src="https://github.com/user-attachments/assets/30a1943b-5790-4eac-aa3e-a3d7964d4ee4" /> | <img width="247" height="120" alt="image" src="https://github.com/user-attachments/assets/52554632-cfcd-4e9f-8c5f-dd268eb5936a" />
No reactions available | <img width="276" height="124" alt="2026-05-13_11h57_45" src="https://github.com/user-attachments/assets/c802b394-3db3-4c4b-8ad1-e6af155c9134" />


<!-- ☀️ Light theme | 🌑 Dark Theme -->

### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required