### PR TITLE
fix(call): render other user's video while screenshare

### DIFF
--- a/src/components/CallView/Grid/VideosGrid.vue
+++ b/src/components/CallView/Grid/VideosGrid.vue
@@ -59,7 +59,7 @@
 								:isGrid="true"
 								:showTalkingHighlight="!isStripe"
 								:isStripe="isStripe"
-								:isPromoted="sharedDatas[callParticipantModel.attributes.peerId].promoted"
+								:isPromoted="sharedDatas[callParticipantModel.attributes.peerId].promoted && !(isStripe && screens.length)"
 								:isSelected="isSelected(callParticipantModel)"
 								:sharedData="sharedDatas[callParticipantModel.attributes.peerId]"
 								@clickVideo="handleClickVideo($event, callParticipantModel.attributes.peerId)" />


### PR DESCRIPTION
## ☑️ Resolves

* Fix #17972
  * video on stripe still considered promoted, although it's not rendered on Speaker place, as it's taken by screenshare
  * promoted video are not rendered on stripe (assumed they're speakers)
  * quick fix, requires CallView and grid rework for better data management / other tiling support
  * issue source: https://github.com/nextcloud/spreed/blob/3f050c1468d741e24c6cfc95a2a2a6c5a3c38599/src/components/CallView/shared/VideoVue.vue#L497-L513

### AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
Bottom Left with screen share - Alice has no video | Alice should have video
<img width="1842" height="912" alt="image" src="https://github.com/user-attachments/assets/693ea8ec-8bee-4dbd-91de-75a143a654a0" /> | <img width="1844" height="930" alt="image" src="https://github.com/user-attachments/assets/7db096a5-b1df-4293-91c2-a1379d1c1e15" />
No screen share - Promoted do not have video | Same
<img width="1844" height="909" alt="image" src="https://github.com/user-attachments/assets/580ea7f5-b451-41eb-8568-60ae5848df38" />  | <img width="1843" height="906" alt="image" src="https://github.com/user-attachments/assets/c34e0db2-803a-4e03-9ce5-d16552455812" />

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required