### PR TITLE
[stable33] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -334,12 +334,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "5e155feb45c25111b89680f6120f71ae0a510ba4"
+                "reference": "0dc06ac6646ade7b3eb6d9ee35f55fc422b1e623"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/5e155feb45c25111b89680f6120f71ae0a510ba4",
-                "reference": "5e155feb45c25111b89680f6120f71ae0a510ba4",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/0dc06ac6646ade7b3eb6d9ee35f55fc422b1e623",
+                "reference": "0dc06ac6646ade7b3eb6d9ee35f55fc422b1e623",
                 "shasum": ""
             },
             "require": {
@@ -374,7 +374,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable33"
             },
-            "time": "2026-05-09T01:52:52+00:00"
+            "time": "2026-05-14T02:05:58+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency