### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -335,12 +335,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "f3fddf2af92f48d3f53569074f69f0ae4bad52b6"
+                "reference": "07722b9013ea9e57f79d3a75ccc68d4278bd7fd6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/f3fddf2af92f48d3f53569074f69f0ae4bad52b6",
-                "reference": "f3fddf2af92f48d3f53569074f69f0ae4bad52b6",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/07722b9013ea9e57f79d3a75ccc68d4278bd7fd6",
+                "reference": "07722b9013ea9e57f79d3a75ccc68d4278bd7fd6",
                 "shasum": ""
             },
             "require": {
@@ -355,7 +355,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "34.0.0-dev"
+                    "dev-master": "35.0.0-dev"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -377,7 +377,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2026-05-09T01:52:54+00:00"
+            "time": "2026-05-15T08:42:57+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency