### PR TITLE
fix(tags): collapse tag groups by clicking on header

### DIFF
--- a/src/components/LeftSidebar/ConversationsList/ConversationTagHeader.vue
+++ b/src/components/LeftSidebar/ConversationsList/ConversationTagHeader.vue
@@ -94,6 +94,7 @@ async function handleDeleteTag() {
 		allowCollapse
 		:open="!item.collapsed"
 		:forceMenu="isCustomTag"
+		@click="tagsStore.toggleCollapsed(item.id)"
 		@update:open="tagsStore.toggleCollapsed(item.id)">
 		<!-- Invisible child to trigger the collapse chevron -->
 		<li class="tag-header__spacer" />


### PR DESCRIPTION
## ☑️ Resolves

* Follow-up to #17497
* Apply click handler on the whole entry, not the toggle button only

### AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

<img width="224" height="88" alt="image" src="https://github.com/user-attachments/assets/cac8b78c-2080-4475-9ffe-b1567df2552e" />

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required