### PR TITLE
fix(tags): put new created tag above 'Other'

### DIFF
--- a/src/stores/__tests__/conversationTags.spec.js
+++ b/src/stores/__tests__/conversationTags.spec.js
@@ -43,6 +43,14 @@ const favoritesTag = {
 	collapsed: false,
 }
 
+const otherTag = {
+	id: 'other',
+	name: 'Other',
+	type: 'other',
+	sortOrder: 2,
+	collapsed: false,
+}
+
 const customTagOne = {
 	id: 'tag-1',
 	name: 'Alpha',
@@ -115,6 +123,7 @@ describe('conversationTagsStore', () => {
 	})
 
 	it('creates a tag and persists it', async () => {
+		BrowserStorage.getItem.mockReturnValueOnce(JSON.stringify([favoritesTag, otherTag]))
 		conversationTagsStore = useConversationTagsStore()
 		createTagApi.mockResolvedValue(generateOCSResponse({ payload: customTagOne }))
 
@@ -123,8 +132,9 @@ describe('conversationTagsStore', () => {
 
 		expect(createTagApi).toHaveBeenCalledWith(customTagOne.name)
 		expect(tag).toEqual(customTagOne)
-		expect(conversationTagsStore.tags[customTagOne.id]).toEqual(customTagOne)
-		expect(getPersistedTags()).toEqual([customTagOne])
+		// Other's sortOrder bumped from 2 to 3, so new tag (2) appears before Other (3)
+		expect(conversationTagsStore.sortedTags.map((t) => t.id)).toEqual([favoritesTag.id, customTagOne.id, otherTag.id])
+		expect(conversationTagsStore.tags[otherTag.id].sortOrder).toBe(3)
 	})
 
 	it('updates a tag name', async () => {

--- a/src/stores/conversationTags.ts
+++ b/src/stores/conversationTags.ts
@@ -75,6 +75,11 @@ export const useConversationTagsStore = defineStore('conversationTags', () => {
 	async function createTag(name: string) {
 		const response = await createTagApi(name)
 		const tag = response.data.ocs.data
+		// Mirror backend logic: if Other's sortOrder collides with the new tag's, bump it by 1.
+		const otherTag = Object.values(tags).find((t) => t.type === 'other')
+		if (otherTag && otherTag.sortOrder === tag.sortOrder) {
+			otherTag.sortOrder += 1
+		}
 		tags[tag.id] = tag
 		return tag
 	}


### PR DESCRIPTION
## ☑️ Resolves

* Fix bug with showing new tag on the bottom
* Mirror backend logic by bumping 'Other' order by 1 on client side

### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required