### PR TITLE
fix(guest): replace 'Log in' button with a link

### DIFF
--- a/src/components/GuestWelcomeWindow.vue
+++ b/src/components/GuestWelcomeWindow.vue
@@ -42,14 +42,12 @@
 
 			<div class="separator" />
 
-			<div class="login-info">
-				<span> {{ t('spreed', 'Do you already have an account?') }}</span>
-				<NcButton
-					variant="secondary"
-					:href="getLoginUrl()">
+			<p class="login-info">
+				{{ t('spreed', 'Do you already have an account?') }}
+				<a :href="getLoginUrl()">
 					{{ t('spreed', 'Log in') }}
-				</NcButton>
-			</div>
+				</a>
+			</p>
 		</div>
 	</NcModal>
 </template>
@@ -158,10 +156,11 @@ export default {
 }
 
 .login-info {
-	display: flex;
-	align-items: center;
-	gap: calc(var(--default-grid-baseline) * 2);
 	padding-top: calc(var(--default-grid-baseline) * 2);
+
+	&__link {
+		text-decoration: underline;
+	}
 }
 
 .separator {

--- a/src/components/SetGuestUsername.vue
+++ b/src/components/SetGuestUsername.vue
@@ -8,18 +8,19 @@
 		<!-- eslint-disable-next-line vue/no-v-html -->
 		<h3 v-if="!compact" v-html="displayNameLabel" />
 
-		<NcButton
-			v-if="!isEditingUsername && !compact"
-			@click="toggleEdit">
-			{{ t('spreed', 'Edit display name') }}
-			<template #icon>
-				<IconPencilOutline :size="20" />
-			</template>
-		</NcButton>
-
-		<div v-else class="username-form__display-name">
+		<div class="username-form__display-name">
 			<IconAccountOutline class="username-form__display-name-icon" :size="20" />
+
+			<NcButton
+				v-if="!isEditingUsername && !compact"
+				@click="toggleEdit">
+				{{ t('spreed', 'Edit display name') }}
+				<template #icon>
+					<IconPencilOutline :size="20" />
+				</template>
+			</NcButton>
 			<NcTextField
+				v-else
 				ref="usernameInput"
 				v-model="guestUserName"
 				:placeholder="t('spreed', 'Guest')"
@@ -33,15 +34,12 @@
 				@keydown.esc="toggleEdit" />
 		</div>
 
-		<div class="login-info">
-			<span> {{ t('spreed', 'Do you already have an account?') }}</span>
-			<NcButton
-				class="login-info__button"
-				variant="secondary"
-				:href="loginUrl">
+		<p class="login-info">
+			{{ t('spreed', 'Do you already have an account?') }}
+			<a class="login-info__link" :href="loginUrl">
 				{{ t('spreed', 'Log in') }}
-			</NcButton>
-		</div>
+			</a>
+		</p>
 	</div>
 </template>
 
@@ -167,14 +165,11 @@ function toggleEdit() {
 }
 
 .login-info {
-	display: flex;
-	align-items: center;
-	gap: calc(var(--default-grid-baseline) * 2);
 	padding: calc(var(--default-grid-baseline) * 2) calc(var(--default-grid-baseline) * 2) 0;
 	margin-inline-start: calc(var(--default-grid-baseline) + 20px); // 20px for checkbox alignment
 
-	&__button {
-		flex-shrink: 0;
+	&__link {
+		text-decoration: underline;
 	}
 }
 


### PR DESCRIPTION
## ☑️ Resolves

* Ref #16068 
* Downgrade 'Log in' visuals to make it less prmpting to click

### AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="302" height="137" alt="2026-05-21_15h04_06" src="https://github.com/user-attachments/assets/9f4f24e2-0af6-4341-9d35-ff8043004de9" /> | <img width="287" height="120" alt="2026-05-21_15h08_12" src="https://github.com/user-attachments/assets/31c2a45e-ef6a-4d02-9a22-1aae624ef035" />
<img width="286" height="284" alt="2026-05-21_15h10_29" src="https://github.com/user-attachments/assets/8aa9af31-ec10-45ed-8060-f15da066c381" /> | <img width="270" height="272" alt="2026-05-21_15h13_42" src="https://github.com/user-attachments/assets/5b50d349-dd8e-4483-94f5-6244a637897a" />
<img width="188" height="171" alt="2026-05-21_15h10_49" src="https://github.com/user-attachments/assets/a1182cc8-b4bf-4873-bd63-77ec7655bbff" /> | <img width="187" height="160" alt="2026-05-21_15h20_10" src="https://github.com/user-attachments/assets/05edc1ff-097e-4970-9ddd-96b8da3d4b62" />

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required