### PR TITLE
fix: Allow accessing some admin endpoints to admins that can not use Talk

### DIFF
--- a/lib/Middleware/CanUseTalkMiddleware.php
+++ b/lib/Middleware/CanUseTalkMiddleware.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace OCA\Talk\Middleware;
 
 use OCA\Talk\Config;
+use OCA\Talk\Controller\BotController;
 use OCA\Talk\Controller\HostedSignalingServerController;
 use OCA\Talk\Controller\RecordingController;
 use OCA\Talk\Controller\SignalingController;
@@ -97,6 +98,12 @@ class CanUseTalkMiddleware extends Middleware {
 			}
 
 			if ($controller instanceof HostedSignalingServerController
+				&& $this->groupManager->isAdmin($user->getUID())) {
+				return;
+			}
+
+			if ($methodName === 'adminListBots'
+				&& $controller instanceof BotController
 				&& $this->groupManager->isAdmin($user->getUID())) {
 				return;
 			}

--- a/lib/Middleware/CanUseTalkMiddleware.php
+++ b/lib/Middleware/CanUseTalkMiddleware.php
@@ -90,6 +90,12 @@ class CanUseTalkMiddleware extends Middleware {
 				return;
 			}
 
+			if ($methodName === 'getSettings'
+				&& $controller instanceof SignalingController
+				&& $this->groupManager->isAdmin($user->getUID())) {
+				return;
+			}
+
 			if ($controller instanceof HostedSignalingServerController
 				&& $this->groupManager->isAdmin($user->getUID())) {
 				return;


### PR DESCRIPTION
Follow up to #8330 and #13973

Since Talk 21 the connection check for the signaling server in Talk administration settings fetches the signaling settings, so admins should be allowed to access the endpoint even if they do not belong to any of the groups allowed to use Talk.

Similarly, Talk administration settings [fetches the list of all bots](https://github.com/nextcloud/spreed/blob/2a4e9c6d0848fa04a4dd9abceb6656bc8c3cb77a/src/components/AdminSettings/BotsSettings.vue#L137), so [that endpoint](https://github.com/nextcloud/spreed/blob/37cf4baae213b1914078b4976ef1821754957dbf/lib/Controller/BotController.php#L334-L363) should be allowed too.

## How to test (scenario 1)

- Log in as an admin
- Open the Account settings and create a group
- Open Talk administration settings
- Configure a signaling server; the check should succeed
- Limit using Talk to the created group
- Perform again the connection check of the signaling server

### Result with this pull request

The connection check still succeeds and returns the signaling server information

### Result without this pull request

The connection check now fails with `Error: unknown error occurred`; in the Network tab of the browser it can be seen that the request to `ocs/v2.php/apps/spreed/api/v3/signaling/settings?token=` fails with 403 Forbidden and the message `Can not use Talk` in the response.

## How to test (scenario 2)

- Log in as an admin
- Open the Account settings and create a group
- Open Talk administration settings
- Limit using Talk to the created group
- Open the Network tab in the developer tools of the browser
- Reload the page

### Result with this pull request

The request to `ocs/v2.php/apps/spreed/api/v1/bot/admin` succeeds

### Result without this pull request

The request to `ocs/v2.php/apps/spreed/api/v1/bot/admin` fails with 403 Forbidden and the message `Can not use Talk` in the response.
