### PR TITLE
fix: Refresh all conversations when deleted from one not active in

### DIFF
--- a/src/utils/signaling.js
+++ b/src/utils/signaling.js
@@ -1505,7 +1505,9 @@ Signaling.Standalone.prototype.processRoomListEvent = function(data) {
 				EventBus.emit('deleted-session-detected')
 				break
 			}
-		// eslint-disable-next-line no-fallthrough
+
+			EventBus.emit('should-refresh-conversations', { all: true })
+			break
 		default:
 			console.debug('Room list event', data)
 			EventBus.emit('should-refresh-conversations')


### PR DESCRIPTION
This looks like a regression probably introduced in https://github.com/nextcloud/spreed/pull/8726 (so, by now, it could be just called a bug :-P )

When the HPB is used and a user is removed from a conversation that user receives a `disinvite` signaling message. This triggered a `should-refresh-conversations` event, but (unless it coincides with the periodical forced refresh) only [those conversations modified since the last fetch will be got](https://github.com/nextcloud/spreed/blob/6ccb2418ebd4c26601de92b3a6d17bdf0d8514c7/src/components/LeftSidebar/LeftSidebar.vue#L1109). As the deleted conversation is no longer accessible by the user it will not be returned in the _modified since_ response, and the conversation list will not be properly updated. Due to that a `disinvite` message for a conversation that the user is not active in should trigger [a forced refresh of all the conversations](https://github.com/nextcloud/spreed/blob/6ccb2418ebd4c26601de92b3a6d17bdf0d8514c7/src/components/LeftSidebar/LeftSidebar.vue#L1080-L1083) instead of a normal refresh.

Note that although found while reviewing https://github.com/nextcloud/spreed/pull/16759 it is unrelated, as `disinvite` messages will still be sent to users removed from a conversation.

## How to test

- Setup the HPB
- Login as user A
- Open Talk
- Create a conversation
- In a private window, login as user B
- Open Talk
- Enter in any conversation (as there is no signaling connection in the dashboard)
- In the original window, add user B to the conversation
- In the private window, check that the conversation is added to the sidebar
- In the original window, remove user B from the conversation

### Result with this pull request

In the private window the conversation is removed from the left sidebar

### Result without this pull request

In the private window the conversation is not removed from the left sidebar until a few minutes have passed (at most 5, when [all the conversations are force refreshed](https://github.com/nextcloud/spreed/blob/6ccb2418ebd4c26601de92b3a6d17bdf0d8514c7/src/components/LeftSidebar/LeftSidebar.vue#L1096-L1101))
