### PR TITLE
fix(chat): update cached guest names for email guests from server req…

### DIFF
--- a/src/composables/useGetMessages.ts
+++ b/src/composables/useGetMessages.ts
@@ -20,10 +20,11 @@ import { t } from '@nextcloud/l10n'
 import { computed, inject, onBeforeUnmount, provide, ref, watch } from 'vue'
 import { START_LOCATION, useRoute } from 'vue-router'
 import { useStore } from 'vuex'
-import { CHAT, MESSAGE } from '../constants.ts'
+import { ATTENDEE, CHAT, MESSAGE } from '../constants.ts'
 import { EventBus } from '../services/EventBus.ts'
 import { useChatStore } from '../stores/chat.ts'
 import { useChatExtrasStore } from '../stores/chatExtras.ts'
+import { useGuestNameStore } from '../stores/guestName.ts'
 import { isAxiosErrorResponse } from '../types/guards.ts'
 import { debugTimer } from '../utils/debugTimer.ts'
 import { tryLocalizeSystemMessage } from '../utils/message.ts'
@@ -58,6 +59,7 @@ export function useGetMessagesProvider() {
 	const route = useRoute()
 	const chatStore = useChatStore()
 	const chatExtrasStore = useChatExtrasStore()
+	const guestNameStore = useGuestNameStore()
 
 	const currentToken = useGetToken()
 	const contextThreadId = useGetThreadId()
@@ -677,6 +679,13 @@ export function useGetMessagesProvider() {
 			// Guard: Message is for another conversation
 			// e.g., user switched conversation while messages were in-flight
 			return
+		}
+
+		if ([ATTENDEE.ACTOR_TYPE.GUESTS, ATTENDEE.ACTOR_TYPE.EMAILS].includes(message.actorType)) {
+			// update guest display names cache
+			// force in case the display name has changed since
+			// the last fetch
+			guestNameStore.addGuestName(message, { noUpdate: false })
 		}
 
 		const conversation: Conversation | undefined = store.getters.conversation(token)

--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -971,7 +971,7 @@ const actions = {
 
 		// Process each messages and adds it to the store
 		response.data.ocs.data.forEach((message) => {
-			if (message.actorType === ATTENDEE.ACTOR_TYPE.GUESTS) {
+			if ([ATTENDEE.ACTOR_TYPE.GUESTS, ATTENDEE.ACTOR_TYPE.EMAILS].includes(message.actorType)) {
 				// update guest display names cache
 				const guestNameStore = useGuestNameStore()
 				guestNameStore.addGuestName(message, { noUpdate: true })
@@ -1060,7 +1060,7 @@ const actions = {
 
 		// Process each messages and adds it to the store
 		response.data.ocs.data.forEach((message) => {
-			if (message.actorType === ATTENDEE.ACTOR_TYPE.GUESTS) {
+			if ([ATTENDEE.ACTOR_TYPE.GUESTS, ATTENDEE.ACTOR_TYPE.EMAILS].includes(message.actorType)) {
 				// update guest display names cache
 				const guestNameStore = useGuestNameStore()
 				guestNameStore.addGuestName(message, { noUpdate: true })
@@ -1183,7 +1183,7 @@ const actions = {
 		})
 		// Process each messages and adds it to the store
 		response.data.ocs.data.forEach((message) => {
-			if (message.actorType === ATTENDEE.ACTOR_TYPE.GUESTS) {
+			if ([ATTENDEE.ACTOR_TYPE.GUESTS, ATTENDEE.ACTOR_TYPE.EMAILS].includes(message.actorType)) {
 				// update guest display names cache,
 				// force in case the display name has changed since
 				// the last fetch


### PR DESCRIPTION
## ☑️ Resolves

* Fix guest name resolving for email guests
  * Room response with actor type 'emails' assigned doesn't satisfy the condition, so function is never called

### AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI



## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="815" height="142" alt="image" src="https://github.com/user-attachments/assets/35b95172-9045-4c3c-945a-9b6f48a44a34" /> | <img width="803" height="147" alt="image" src="https://github.com/user-attachments/assets/50953204-4e67-4b99-a1d4-bc1a49d468b4" />

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required