### PR TITLE
chore: prepare release changelogs for 22.0.12, 23.0.5, 24.0.0-rc.3

### DIFF
--- a/docs/changelogs/changelog-22.md
+++ b/docs/changelogs/changelog-22.md
@@ -5,6 +5,25 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 22.0.13 – 2026-05-28
+### Changed
+- Update dependencies
+- Update translations
+
+### Fixed
+- fix(call): Render other user's video while screensharing
+  [#18063](https://github.com/nextcloud/spreed/pull/18063)
+- fix(notifications): Fix name in reaction notification for federated users
+  [#18066](https://github.com/nextcloud/spreed/pull/18066)
+- fix(admin): Allow accessing admin settings in limited Talk configuration environment
+  [#18125](https://github.com/nextcloud/spreed/pull/18125)
+- fix(sipbridge): Authenticate internal request from SIP Bridge
+  [#18117](https://github.com/nextcloud/spreed/pull/18117)
+- fix(conversation): Refresh list on disinvite event 
+  [#18130](https://github.com/nextcloud/spreed/pull/18130)
+- fix(chat): Fix email guests name caching 
+  [#18135](https://github.com/nextcloud/spreed/pull/18135)
+
 ## 22.0.12 – 2026-04-30
 ### Changed
 - Update dependencies

--- a/docs/changelogs/changelog-23.md
+++ b/docs/changelogs/changelog-23.md
@@ -5,6 +5,31 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 23.0.5 – 2026-05-28
+### Changed
+- Fuzzy conversation search
+  [#17897](https://github.com/nextcloud/spreed/pull/17897)
+- Better indication of anonymous polls in UI
+  [#17927](https://github.com/nextcloud/spreed/pull/17927)
+- Update dependencies
+- Update translations
+
+### Fixed
+- fix(call): Render other user's video while screensharing
+  [#18064](https://github.com/nextcloud/spreed/pull/18064)
+- fix(notifications): Fix name in reaction notification for federated users
+  [#18067](https://github.com/nextcloud/spreed/pull/18067)
+- fix(admin): Allow accessing admin settings in limited Talk configuration environment
+  [#18126](https://github.com/nextcloud/spreed/pull/18126)
+- fix(sipbridge): Authenticate internal request from SIP Bridge
+  [#18118](https://github.com/nextcloud/spreed/pull/18118)
+- fix(conversation): Refresh list on disinvite event 
+  [#18131](https://github.com/nextcloud/spreed/pull/18131)
+- fix(chat): Fix email guests name caching 
+  [#18136](https://github.com/nextcloud/spreed/pull/18136)
+- fix(call): Respect participant permissions for hardware access
+  [#17980](https://github.com/nextcloud/spreed/pull/17980)
+
 ## 23.0.4 – 2026-04-30
 ### Changed
 - Update dependencies

--- a/docs/changelogs/changelog-24.md
+++ b/docs/changelogs/changelog-24.md
@@ -5,6 +5,29 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 24.0.0-rc.3 – 2026-05-28
+### Changed
+- Update dependencies
+- Update translations
+
+### Fixed
+- fix(call): Render other user's video while screensharing
+  [#18065](https://github.com/nextcloud/spreed/pull/18065)
+- fix(notifications): Fix name in reaction notification for federated users
+  [#18068](https://github.com/nextcloud/spreed/pull/18068)
+- fix(admin): Allow accessing admin settings in limited Talk configuration environment
+  [#18127](https://github.com/nextcloud/spreed/pull/18127)
+- fix(sipbridge): Authenticate internal request from SIP Bridge
+  [#18119](https://github.com/nextcloud/spreed/pull/18119)
+- fix(conversation): Refresh list on disinvite event 
+  [#18132](https://github.com/nextcloud/spreed/pull/18132)
+- fix(chat): Fix email guests name caching 
+  [#18136](https://github.com/nextcloud/spreed/pull/18136)
+- fix(conversations): Adjust logic for 'Unread mentions' navigation
+  [#18134](https://github.com/nextcloud/spreed/pull/18134)
+- fix(call): Respect participant permissions for hardware access
+  [#18137](https://github.com/nextcloud/spreed/pull/18137)
+
 ## 24.0.0-rc.2 – 2026-05-21
 ### Added
 - feat(call): Move "Raise hand" in call reactions menu


### PR DESCRIPTION
## 22.0.13 – 2026-05-28
### Changed
- Update dependencies
- Update translations

### Fixed
- fix(call): Render other user's video while screensharing
  [#18063](https://github.com/nextcloud/spreed/pull/18063)
- fix(notifications): Fix name in reaction notification for federated users
  [#18066](https://github.com/nextcloud/spreed/pull/18066)
- fix(admin): Allow accessing admin settings in limited Talk configuration environment
  [#18125](https://github.com/nextcloud/spreed/pull/18125)
- fix(sipbridge): Authenticate internal request from SIP Bridge
  [#18117](https://github.com/nextcloud/spreed/pull/18117)
- fix(conversation): Refresh list on disinvite event 
  [#18130](https://github.com/nextcloud/spreed/pull/18130)
- fix(chat): Fix email guests name caching 
  [#18135](https://github.com/nextcloud/spreed/pull/18135)

---

## 23.0.5 – 2026-05-28
### Changed
- Fuzzy conversation search
  [#17897](https://github.com/nextcloud/spreed/pull/17897)
- Better indication of anonymous polls in UI
  [#17927](https://github.com/nextcloud/spreed/pull/17927)
- Update dependencies
- Update translations

### Fixed
- fix(call): Render other user's video while screensharing
  [#18064](https://github.com/nextcloud/spreed/pull/18064)
- fix(notifications): Fix name in reaction notification for federated users
  [#18067](https://github.com/nextcloud/spreed/pull/18067)
- fix(admin): Allow accessing admin settings in limited Talk configuration environment
  [#18126](https://github.com/nextcloud/spreed/pull/18126)
- fix(sipbridge): Authenticate internal request from SIP Bridge
  [#18118](https://github.com/nextcloud/spreed/pull/18118)
- fix(conversation): Refresh list on disinvite event 
  [#18131](https://github.com/nextcloud/spreed/pull/18131)
- fix(chat): Fix email guests name caching 
  [#18136](https://github.com/nextcloud/spreed/pull/18136)
- fix(call): Respect participant permissions for hardware access
  [#17980](https://github.com/nextcloud/spreed/pull/17980)

---

## 24.0.0-rc.3 – 2026-05-28
### Changed
- Update dependencies
- Update translations

### Fixed
- fix(call): Render other user's video while screensharing
  [#18065](https://github.com/nextcloud/spreed/pull/18065)
- fix(notifications): Fix name in reaction notification for federated users
  [#18068](https://github.com/nextcloud/spreed/pull/18068)
- fix(admin): Allow accessing admin settings in limited Talk configuration environment
  [#18127](https://github.com/nextcloud/spreed/pull/18127)
- fix(sipbridge): Authenticate internal request from SIP Bridge
  [#18119](https://github.com/nextcloud/spreed/pull/18119)
- fix(conversation): Refresh list on disinvite event 
  [#18132](https://github.com/nextcloud/spreed/pull/18132)
- fix(chat): Fix email guests name caching 
  [#18136](https://github.com/nextcloud/spreed/pull/18136)
- fix(conversations): Adjust logic for 'Unread mentions' navigation
  [#18134](https://github.com/nextcloud/spreed/pull/18134)
- fix(call): Respect participant permissions for hardware access
  [#18137](https://github.com/nextcloud/spreed/pull/18137)
