### PR TITLE
fix(chat): handle Ctrl+Up hotkey for deleted and scheduled messages

### DIFF
--- a/src/components/NewMessage/NewMessage.vue
+++ b/src/components/NewMessage/NewMessage.vue
@@ -360,7 +360,7 @@ import NewMessageTypingIndicator from './NewMessageTypingIndicator.vue'
 import { useChatMentions } from '../../composables/useChatMentions.ts'
 import { useGetThreadId } from '../../composables/useGetThreadId.ts'
 import { useTemporaryMessage } from '../../composables/useTemporaryMessage.ts'
-import { CONVERSATION, PARTICIPANT, PRIVACY } from '../../constants.ts'
+import { CONVERSATION, MESSAGE, PARTICIPANT, PRIVACY } from '../../constants.ts'
 import BrowserStorage from '../../services/BrowserStorage.js'
 import { getTalkConfig, hasTalkFeature } from '../../services/CapabilitiesManager.ts'
 import { EventBus } from '../../services/EventBus.ts'
@@ -1333,12 +1333,17 @@ export default {
 				return
 			}
 
+			const messagesList = this.showScheduledMessages
+				? this.chatExtrasStore.getScheduledMessagesList(this.token)
+				: this.chatStore.getMessagesList(this.token, {
+						threadId: this.threadId,
+					})
 			// last message within 24 hours
-			const lastMessageByCurrentUser = this.chatStore.getMessagesList(this.token, {
-				threadId: this.threadId,
-			}).findLast((message) => {
-				return this.actorStore.checkIfSelfIsActor(message)
-					&& !message.isTemporary && !message.systemMessage
+			const lastMessageByCurrentUser = messagesList.findLast((message) => {
+				return this.actorStore.checkIfSelfIsActor(message) // From same actor
+					&& message.messageType !== MESSAGE.TYPE.COMMENT_DELETED // Not deleted
+					&& message.timestamp !== 0 // Not temporary
+					&& !message.systemMessage // Not system message
 					&& (Date.now() - message.timestamp * 1000 < ONE_DAY_IN_MS)
 			})
 


### PR DESCRIPTION
## ☑️ Resolves

* Fix #17988
* Allow shortcut for scheduled messages

### AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

<img width="593" height="227" alt="image" src="https://github.com/user-attachments/assets/1fde46fe-419b-4a3c-b70a-4c071e0ce569" />

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required