### PR TITLE
chore(deps): bump @nextcloud/vue from 9.8.1 to 9.8.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@nextcloud/router": "^3.0.1",
         "@nextcloud/sharing": "^0.4.0",
         "@nextcloud/upload": "^2.0.0-rc.0",
-        "@nextcloud/vue": "^9.8.1",
+        "@nextcloud/vue": "^9.8.2",
         "@sapphi-red/web-noise-suppressor": "^0.3.5",
         "@vue-leaflet/vue-leaflet": "^0.10.1",
         "@vueuse/components": "^14.3.0",
@@ -1587,9 +1587,9 @@
       }
     },
     "node_modules/@nextcloud/vue": {
-      "version": "9.8.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-9.8.1.tgz",
-      "integrity": "sha512-/nMpkNos46GePx7NvreEM0Uf2QjkICaxzKlSqlRkI7ktDO9S/BNBnpDMeukuMTNbU/Z9XaItyEj6IND62g/Gxg==",
+      "version": "9.8.2",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-9.8.2.tgz",
+      "integrity": "sha512-bkU6E/AyMXzNHk4BnUCL8QGfpT0BZkS7fooKhClHa9VK8wR6Mml/yO6/1Nd+E71dEiDKJP8B7TsvEXgytZsVQQ==",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@ckpack/vue-color": "^1.6.0",
@@ -1611,14 +1611,14 @@
         "blurhash": "^2.0.5",
         "clone": "^2.1.2",
         "debounce": "^3.0.0",
-        "dompurify": "^3.4.3",
+        "dompurify": "^3.4.7",
         "emoji-mart-vue-fast": "^15.0.5",
         "escape-html": "^1.0.3",
         "floating-vue": "^5.2.2",
-        "focus-trap": "^8.2.0",
+        "focus-trap": "^8.2.1",
         "linkifyjs": "^4.3.3",
         "mdast-util-to-string": "^4.0.0",
-        "p-queue": "^9.2.0",
+        "p-queue": "^9.3.0",
         "rehype-external-links": "^3.0.0",
         "rehype-highlight": "^7.0.2",
         "rehype-react": "^8.0.0",
@@ -1698,9 +1698,9 @@
       }
     },
     "node_modules/@nextcloud/vue/node_modules/p-queue": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.2.0.tgz",
-      "integrity": "sha512-dWgLE8AH0HjQ9fe74pUkKkvzzYT18Inp4zra3lKHnnwqGvcfcUBrvF2EAVX+envufDNBOzpPq/IBUONDbI7+3g==",
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.0.tgz",
+      "integrity": "sha512-7NED7xhQ74Ngp4JP/2e0VZHp7vSWfJfqeiR92jPgxsz6m0Se4P03YoTKa9dDXyZ3r6P616gUXttrB6nnHYKang==",
       "license": "MIT",
       "dependencies": {
         "eventemitter3": "^5.0.4",
@@ -16418,9 +16418,9 @@
       }
     },
     "@nextcloud/vue": {
-      "version": "9.8.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-9.8.1.tgz",
-      "integrity": "sha512-/nMpkNos46GePx7NvreEM0Uf2QjkICaxzKlSqlRkI7ktDO9S/BNBnpDMeukuMTNbU/Z9XaItyEj6IND62g/Gxg==",
+      "version": "9.8.2",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-9.8.2.tgz",
+      "integrity": "sha512-bkU6E/AyMXzNHk4BnUCL8QGfpT0BZkS7fooKhClHa9VK8wR6Mml/yO6/1Nd+E71dEiDKJP8B7TsvEXgytZsVQQ==",
       "requires": {
         "@ckpack/vue-color": "^1.6.0",
         "@floating-ui/dom": "^1.7.6",
@@ -16441,14 +16441,14 @@
         "blurhash": "^2.0.5",
         "clone": "^2.1.2",
         "debounce": "^3.0.0",
-        "dompurify": "^3.4.3",
+        "dompurify": "^3.4.7",
         "emoji-mart-vue-fast": "^15.0.5",
         "escape-html": "^1.0.3",
         "floating-vue": "^5.2.2",
-        "focus-trap": "^8.2.0",
+        "focus-trap": "^8.2.1",
         "linkifyjs": "^4.3.3",
         "mdast-util-to-string": "^4.0.0",
-        "p-queue": "^9.2.0",
+        "p-queue": "^9.3.0",
         "rehype-external-links": "^3.0.0",
         "rehype-highlight": "^7.0.2",
         "rehype-react": "^8.0.0",
@@ -16497,9 +16497,9 @@
           }
         },
         "p-queue": {
-          "version": "9.2.0",
-          "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.2.0.tgz",
-          "integrity": "sha512-dWgLE8AH0HjQ9fe74pUkKkvzzYT18Inp4zra3lKHnnwqGvcfcUBrvF2EAVX+envufDNBOzpPq/IBUONDbI7+3g==",
+          "version": "9.3.0",
+          "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.0.tgz",
+          "integrity": "sha512-7NED7xhQ74Ngp4JP/2e0VZHp7vSWfJfqeiR92jPgxsz6m0Se4P03YoTKa9dDXyZ3r6P616gUXttrB6nnHYKang==",
           "requires": {
             "eventemitter3": "^5.0.4",
             "p-timeout": "^7.0.0"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@nextcloud/router": "^3.0.1",
     "@nextcloud/sharing": "^0.4.0",
     "@nextcloud/upload": "^2.0.0-rc.0",
-    "@nextcloud/vue": "^9.8.1",
+    "@nextcloud/vue": "^9.8.2",
     "@sapphi-red/web-noise-suppressor": "^0.3.5",
     "@vue-leaflet/vue-leaflet": "^0.10.1",
     "@vueuse/components": "^14.3.0",


### PR DESCRIPTION
## ☑️ Resolves

- fix CSS modules scoping (prevent applying of styles from other apps)
- Ref #18182 

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

<img width="358" height="221" alt="image" src="https://github.com/user-attachments/assets/ce6f795e-0dcb-4579-81ed-159914340a47" />

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
