### PR TITLE
chore: prepare release changelogs for 23.0.6, 24.0.0-rc.4

### DIFF
--- a/docs/changelogs/changelog-23.md
+++ b/docs/changelogs/changelog-23.md
@@ -5,6 +5,17 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 23.0.6 – 2026-06-02
+### Changed
+- Update dependencies
+- Update translations
+
+### Fixed
+- fix(chat): Fix hotkeys handling for editing chat messages
+  [#18188](https://github.com/nextcloud/spreed/pull/18188)
+- fix(sipbridge): End dial-out calls if rejected by recipient
+  [#18192](https://github.com/nextcloud/spreed/pull/18192)
+
 ## 23.0.5 – 2026-05-28
 ### Changed
 - Fuzzy conversation search

--- a/docs/changelogs/changelog-24.md
+++ b/docs/changelogs/changelog-24.md
@@ -5,6 +5,17 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 24.0.0-rc.4 – 2026-06-02
+### Changed
+- Update dependencies
+- Update translations
+
+### Fixed
+- fix(chat): Fix hotkeys handling for editing chat messages
+  [#18189](https://github.com/nextcloud/spreed/pull/18189)
+- fix(sipbridge): End dial-out calls if rejected by recipient
+  [#18193](https://github.com/nextcloud/spreed/pull/18193)
+
 ## 24.0.0-rc.3 – 2026-05-28
 ### Changed
 - Update dependencies


### PR DESCRIPTION
## 23.0.6 – 2026-06-02
### Changed
- Update dependencies
- Update translations

### Fixed
- fix(chat): Fix hotkeys handling for editing chat messages
  [#18188](https://github.com/nextcloud/spreed/pull/18188)
- fix(sipbridge): End dial-out calls if rejected by recipient
  [#18192](https://github.com/nextcloud/spreed/pull/18192)

---

## 24.0.0-rc.4 – 2026-06-02
### Changed
- Update dependencies
- Update translations

### Fixed
- fix(chat): Fix hotkeys handling for editing chat messages
  [#18189](https://github.com/nextcloud/spreed/pull/18189)
- fix(sipbridge): End dial-out calls if rejected by recipient
  [#18193](https://github.com/nextcloud/spreed/pull/18193)