### PR TITLE
fix(ThreadItem): adjust colors of the active element

### DIFF
--- a/src/components/RightSidebar/Threads/ThreadItem.vue
+++ b/src/components/RightSidebar/Threads/ThreadItem.vue
@@ -239,8 +239,7 @@ function handleActionsMenuOpen(open: boolean) {
 	}
 
 	&.list-item__wrapper--active .thread__details-replies {
-		color: var(--color-primary-element-text);
-		background-color: transparent;
+		background-color: var(--color-primary-element-light-hover);
 	}
 }
 </style>


### PR DESCRIPTION
## ☑️ Resolves

* Fix colors after new style scheme for 34

### AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="199" height="114" alt="image" src="https://github.com/user-attachments/assets/fcf4909e-4c7c-4f9b-b1a3-d57dcd419d6d" /> | <img width="203" height="104" alt="2026-06-03_10h01_05" src="https://github.com/user-attachments/assets/24eb4c5b-cf96-4ee1-8d4d-fbda7a57da91" />
<img width="200" height="108" alt="image" src="https://github.com/user-attachments/assets/c75b7957-aedf-4325-a362-e342058ce3ce" /> | <img width="199" height="105" alt="2026-06-03_10h01_18" src="https://github.com/user-attachments/assets/09fdb8c8-c77e-4372-a158-4dfee02bfb86" />

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required