### PR TITLE
fix(virtual-bg): stop effect when device checker is not in use

### DIFF
--- a/src/components/MediaSettings/MediaSettings.vue
+++ b/src/components/MediaSettings/MediaSettings.vue
@@ -658,6 +658,8 @@ export default {
 					this.clearVirtualBackground()
 				}
 			} else {
+				// Disable virtual background when closing
+				this.clearVirtualBackground()
 				this.unsubscribeFromDevices(PARTICIPANT.PERMISSIONS.MAX_DEFAULT)
 			}
 		},


### PR DESCRIPTION
## ☑️ Resolves

* While checking devices:
  * effect lives as long as dialog is opened (no parallel inference during call)

### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

Running the same pattern:
1. Camera off, blur off
2. Camera on, blur off
3. Camera on, blur on
4. Camera off, blur on (fix)

🏚️ Before | 🏡 After
-- | --
<img width="344" height="277" alt="image" src="https://github.com/user-attachments/assets/31d4beb4-79ba-46ba-8d6b-cae441154650" /> | <img width="348" height="276" alt="image" src="https://github.com/user-attachments/assets/5a84be7a-29c3-4eab-8160-0e1b4c88ed5a" />

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required