### PR TITLE
fix(performance): drop blur in call view (temporarily)

### DIFF
--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -4,7 +4,7 @@
 -->
 
 <template>
-	<div id="call-container" :class="callContainerClass">
+	<div id="call-container">
 		<ViewerOverlayCallView
 			v-if="isViewerOverlay"
 			:token="token"
@@ -171,20 +171,17 @@ import VideoBottomBar from './shared/VideoBottomBar.vue'
 import VideoVue from './shared/VideoVue.vue'
 import ViewerOverlayCallView from './shared/ViewerOverlayCallView.vue'
 import { SIMULCAST } from '../../constants.ts'
-import BrowserStorage from '../../services/BrowserStorage.js'
 import { fetchPeers } from '../../services/callsService.ts'
 import { getTalkConfig } from '../../services/CapabilitiesManager.ts'
 import { EventBus } from '../../services/EventBus.ts'
 import { useCallViewStore } from '../../stores/callView.ts'
 import { useSettingsStore } from '../../stores/settings.ts'
-import { satisfyVersion } from '../../utils/satisfyVersion.ts'
 import { callParticipantCollection, localCallParticipantModel, localMediaModel } from '../../utils/webrtc/index.js'
 import RemoteVideoBlocker from '../../utils/webrtc/RemoteVideoBlocker.js'
 import { placeholderImage, placeholderModel, placeholderName, placeholderSharedData } from './Grid/gridPlaceholders.ts'
 import { useWakeLock } from './useWakeLock.ts'
 
 const serverVersion = loadState('core', 'config', {}).version ?? '29.0.0.0'
-const serverSupportsBackgroundBlurred = satisfyVersion(serverVersion, '29.0.4.0')
 
 export default {
 	name: 'CallView',
@@ -238,16 +235,12 @@ export default {
 			localMediaModel.disableVideo()
 		}
 
-		// Fallback ref for versions before v29.0.4
-		const isBackgroundBlurred = ref(BrowserStorage.getItem('background-blurred') !== 'false')
-
 		return {
 			localMediaModel,
 			localCallParticipantModel,
 			callParticipantCollection,
 			devMode,
 			callViewStore: useCallViewStore(),
-			isBackgroundBlurred,
 		}
 	},
 
@@ -426,17 +419,6 @@ export default {
 			return getTalkConfig(this.token, 'call', 'supported-reactions')
 		},
 
-		/**
-		 * Fallback style for versions before v29.0.4
-		 */
-		callContainerClass() {
-			if (serverSupportsBackgroundBlurred) {
-				return
-			}
-
-			return this.isBackgroundBlurred ? 'call-container__blurred' : 'call-container__non-blurred'
-		},
-
 		isLiveTranscriptionEnabled() {
 			return this.callViewStore.isLiveTranscriptionEnabled
 		},
@@ -539,7 +521,6 @@ export default {
 		callParticipantCollection.on('remove', this._lowerHandWhenParticipantLeaves)
 
 		subscribe('switch-screen-to-id', this._switchScreenToId)
-		subscribe('set-background-blurred', this.setBackgroundBlurred)
 	},
 
 	beforeUnmount() {
@@ -550,7 +531,6 @@ export default {
 		callParticipantCollection.off('remove', this._lowerHandWhenParticipantLeaves)
 
 		unsubscribe('switch-screen-to-id', this._switchScreenToId)
-		unsubscribe('set-background-blurred', this.setBackgroundBlurred)
 	},
 
 	methods: {
@@ -839,15 +819,6 @@ export default {
 			}
 		},
 
-		/**
-		 * Fallback method for versions before v29.0.4
-		 *
-		 * @param {boolean} value whether background should be blurred
-		 */
-		setBackgroundBlurred(value) {
-			this.isBackgroundBlurred = value
-		},
-
 		isModelWithVideo(callParticipantModel) {
 			if (!callParticipantModel) {
 				return false
@@ -876,21 +847,12 @@ export default {
 	width: 100%;
 	height: 100%;
 	background-color: $color-call-background;
-	// Default value has changed since v29.0.4: 'blur(25px)' => 'none'
-	backdrop-filter: var(--filter-background-blur);
 	--grid-gap: calc(var(--default-grid-baseline) * 2);
 	--top-bar-height: 51px;
 	--wrapper-padding: calc(var(--default-grid-baseline) * 2.5);
 	--bottom-bar-height: calc(var(--default-clickable-area) + var(--wrapper-padding) * 2);
 	// For sidebar integrations: show container in a 16/9 proportion (+ top/bottom bar) based on the sidebar width
 	--sidebar-container-height: calc(56.25% + var(--top-bar-height) + var(--bottom-bar-height));
-
-	&.call-container__blurred {
-		backdrop-filter: blur(25px);
-	}
-	&.call-container__non-blurred {
-		backdrop-filter: none;
-	}
 }
 
 #videos {


### PR DESCRIPTION
## ☑️ Resolves

* I couldn't reproduce flickering easily but whenever it happens, disabling blur always fixes it + there is no need to keep it as it renders gray-ish color combination, it is better off without it. 
* Dropped support for >v29 (I am not sure we are doing backward compatibility to +5 earlier versions)

### AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
Screenshot before | Screenshot after

<!-- ☀️ Light theme | 🌑 Dark Theme -->

### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required

---