### PR TITLE
fix: Force grid layout in recording mode

### DIFF
--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -220,6 +220,7 @@
 * `config => call => play-sounds` (local) - Whether the user has sounds enabled for calls (falls back to admin default for guests)
 * `config => call => grid-limit` (local) - Suggested gird size for all participants
 * `config => call => grid-limit-enforced` (local) - Whether the limit is hard enforced for all participants
+* `config => call => recording-layout` (local) - Recording layout style, either `grid` or `speaker` (defaults to `speaker`)
 * `config => feature-hints => current` (local) - The current feature hint count that should be sent to the app config to hide all current feature hints
 * `config => feature-hints => hidden` (local) - Number of the last hint the administration has hidden via the app config
 * `config => conversations => sort-order` (local) - User selected sort order for conversations (`activity` or `alphabetical`)

--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -184,6 +184,7 @@ class Capabilities implements IPublicCapability {
 			'play-sounds',
 			'grid-limit',
 			'grid-limit-enforced',
+			'recording-layout',
 		],
 		'chat' => [
 			'read-privacy',
@@ -286,6 +287,7 @@ class Capabilities implements IPublicCapability {
 					'play-sounds' => $this->talkConfig->getPlaySoundsForUser($user),
 					'grid-limit' => $this->talkConfig->getGridVideosLimit(),
 					'grid-limit-enforced' => $this->talkConfig->getGridVideosLimitEnforced(),
+					'recording-layout' => $this->talkConfig->getRecordingLayout(),
 				],
 				'chat' => [
 					'max-length' => ChatManager::MAX_CHAT_LENGTH,

--- a/lib/Config.php
+++ b/lib/Config.php
@@ -255,6 +255,11 @@ class Config {
 		);
 	}
 
+	public function getRecordingLayout(): string {
+		$value = $this->config->getAppValue('spreed', 'recording_layout', 'speaker');
+		return in_array($value, ['grid', 'speaker'], true) ? $value : 'speaker';
+	}
+
 	public function getLiveTranscriptionTargetLanguageId(?string $userId = null): string {
 		return $this->config->getUserValue(
 			$userId,

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -806,6 +806,8 @@ namespace OCA\Talk;
  *             grid-limit: int,
  *             // Whether the grid limit is enforced by the server
  *             grid-limit-enforced: bool,
+ *             // Recording layout ('grid' or 'speaker')
+ *             recording-layout: string,
  *         },
  *         chat: array{
  *             // Maximum length of a chat message

--- a/openapi-administration.json
+++ b/openapi-administration.json
@@ -183,7 +183,8 @@
                                     "live-transcription-target-language-id",
                                     "play-sounds",
                                     "grid-limit",
-                                    "grid-limit-enforced"
+                                    "grid-limit-enforced",
+                                    "recording-layout"
                                 ],
                                 "properties": {
                                     "enabled": {
@@ -285,6 +286,10 @@
                                     "grid-limit-enforced": {
                                         "type": "boolean",
                                         "description": "Whether the grid limit is enforced by the server"
+                                    },
+                                    "recording-layout": {
+                                        "type": "string",
+                                        "description": "Recording layout ('grid' or 'speaker')"
                                     }
                                 }
                             },

--- a/openapi-backend-recording.json
+++ b/openapi-backend-recording.json
@@ -106,7 +106,8 @@
                                     "live-transcription-target-language-id",
                                     "play-sounds",
                                     "grid-limit",
-                                    "grid-limit-enforced"
+                                    "grid-limit-enforced",
+                                    "recording-layout"
                                 ],
                                 "properties": {
                                     "enabled": {
@@ -208,6 +209,10 @@
                                     "grid-limit-enforced": {
                                         "type": "boolean",
                                         "description": "Whether the grid limit is enforced by the server"
+                                    },
+                                    "recording-layout": {
+                                        "type": "string",
+                                        "description": "Recording layout ('grid' or 'speaker')"
                                     }
                                 }
                             },

--- a/openapi-backend-signaling.json
+++ b/openapi-backend-signaling.json
@@ -106,7 +106,8 @@
                                     "live-transcription-target-language-id",
                                     "play-sounds",
                                     "grid-limit",
-                                    "grid-limit-enforced"
+                                    "grid-limit-enforced",
+                                    "recording-layout"
                                 ],
                                 "properties": {
                                     "enabled": {
@@ -208,6 +209,10 @@
                                     "grid-limit-enforced": {
                                         "type": "boolean",
                                         "description": "Whether the grid limit is enforced by the server"
+                                    },
+                                    "recording-layout": {
+                                        "type": "string",
+                                        "description": "Recording layout ('grid' or 'speaker')"
                                     }
                                 }
                             },

--- a/openapi-backend-sipbridge.json
+++ b/openapi-backend-sipbridge.json
@@ -157,7 +157,8 @@
                                     "live-transcription-target-language-id",
                                     "play-sounds",
                                     "grid-limit",
-                                    "grid-limit-enforced"
+                                    "grid-limit-enforced",
+                                    "recording-layout"
                                 ],
                                 "properties": {
                                     "enabled": {
@@ -259,6 +260,10 @@
                                     "grid-limit-enforced": {
                                         "type": "boolean",
                                         "description": "Whether the grid limit is enforced by the server"
+                                    },
+                                    "recording-layout": {
+                                        "type": "string",
+                                        "description": "Recording layout ('grid' or 'speaker')"
                                     }
                                 }
                             },

--- a/openapi-bots.json
+++ b/openapi-bots.json
@@ -106,7 +106,8 @@
                                     "live-transcription-target-language-id",
                                     "play-sounds",
                                     "grid-limit",
-                                    "grid-limit-enforced"
+                                    "grid-limit-enforced",
+                                    "recording-layout"
                                 ],
                                 "properties": {
                                     "enabled": {
@@ -208,6 +209,10 @@
                                     "grid-limit-enforced": {
                                         "type": "boolean",
                                         "description": "Whether the grid limit is enforced by the server"
+                                    },
+                                    "recording-layout": {
+                                        "type": "string",
+                                        "description": "Recording layout ('grid' or 'speaker')"
                                     }
                                 }
                             },

--- a/openapi-federation.json
+++ b/openapi-federation.json
@@ -157,7 +157,8 @@
                                     "live-transcription-target-language-id",
                                     "play-sounds",
                                     "grid-limit",
-                                    "grid-limit-enforced"
+                                    "grid-limit-enforced",
+                                    "recording-layout"
                                 ],
                                 "properties": {
                                     "enabled": {
@@ -259,6 +260,10 @@
                                     "grid-limit-enforced": {
                                         "type": "boolean",
                                         "description": "Whether the grid limit is enforced by the server"
+                                    },
+                                    "recording-layout": {
+                                        "type": "string",
+                                        "description": "Recording layout ('grid' or 'speaker')"
                                     }
                                 }
                             },

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -340,7 +340,8 @@
                                     "live-transcription-target-language-id",
                                     "play-sounds",
                                     "grid-limit",
-                                    "grid-limit-enforced"
+                                    "grid-limit-enforced",
+                                    "recording-layout"
                                 ],
                                 "properties": {
                                     "enabled": {
@@ -442,6 +443,10 @@
                                     "grid-limit-enforced": {
                                         "type": "boolean",
                                         "description": "Whether the grid limit is enforced by the server"
+                                    },
+                                    "recording-layout": {
+                                        "type": "string",
+                                        "description": "Recording layout ('grid' or 'speaker')"
                                     }
                                 }
                             },

--- a/openapi.json
+++ b/openapi.json
@@ -293,7 +293,8 @@
                                     "live-transcription-target-language-id",
                                     "play-sounds",
                                     "grid-limit",
-                                    "grid-limit-enforced"
+                                    "grid-limit-enforced",
+                                    "recording-layout"
                                 ],
                                 "properties": {
                                     "enabled": {
@@ -395,6 +396,10 @@
                                     "grid-limit-enforced": {
                                         "type": "boolean",
                                         "description": "Whether the grid limit is enforced by the server"
+                                    },
+                                    "recording-layout": {
+                                        "type": "string",
+                                        "description": "Recording layout ('grid' or 'speaker')"
                                     }
                                 }
                             },

--- a/src/RecordingApp.vue
+++ b/src/RecordingApp.vue
@@ -8,7 +8,9 @@ import { onBeforeMount } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import CallView from './components/CallView/CallView.vue'
 import { useGetToken } from './composables/useGetToken.ts'
+import { getTalkConfig } from './services/CapabilitiesManager.ts'
 import SessionStorage from './services/SessionStorage.js'
+import { useCallViewStore } from './stores/callView.ts'
 import { useSoundsStore } from './stores/sounds.js'
 import { useTokenStore } from './stores/token.ts'
 import { signalingKill } from './utils/webrtc/index.js'
@@ -19,12 +21,15 @@ const route = useRoute()
 const soundsStore = useSoundsStore()
 const token = useGetToken()
 const tokenStore = useTokenStore()
+const callViewStore = useCallViewStore()
 
 onBeforeMount(async () => {
 	await router.isReady()
 	if (route.name === 'recording') {
 		tokenStore.updateToken(route.params.token as string)
 		await soundsStore.setShouldPlaySounds(false)
+		const isGridLayout = getTalkConfig(token.value, 'call', 'recording-layout') === 'grid'
+		callViewStore.setCallViewMode({ token: token.value, isGrid: isGridLayout, isStripeOpen: false })
 	}
 
 	// This should not be strictly needed, as the recording server is

--- a/src/__mocks__/capabilities.ts
+++ b/src/__mocks__/capabilities.ts
@@ -168,6 +168,7 @@ export const mockedCapabilities: Capabilities = {
 				'play-sounds': true,
 				'grid-limit': 0,
 				'grid-limit-enforced': false,
+				'recording-layout': 'speaker',
 			},
 			chat: {
 				'max-length': 32000,

--- a/src/__mocks__/capabilities.ts
+++ b/src/__mocks__/capabilities.ts
@@ -230,6 +230,7 @@ export const mockedCapabilities: Capabilities = {
 				'can-upload-background',
 				'start-without-media',
 				'blur-virtual-background',
+				'recording-layout',
 			],
 			chat: [
 				'read-privacy',

--- a/src/components/CallView/Grid/VideosGrid.vue
+++ b/src/components/CallView/Grid/VideosGrid.vue
@@ -457,9 +457,13 @@ export default {
 
 		// Number of grid slots at any given moment
 		// The local video always takes one slot if the grid view is not shown
-		// as a stripe.
+		// as a stripe. In recording mode the local video is not shown, so all
+		// slots are available for remote participants.
 		slots() {
-			return this.isStripe ? this.rows * this.columns : this.rows * this.columns - 1
+			if (this.isStripe || this.isRecording) {
+				return this.rows * this.columns
+			}
+			return this.rows * this.columns - 1
 		},
 
 		// Grid pages at any given moment
@@ -776,7 +780,7 @@ export default {
 
 			let currentColumns = this.columns
 			let currentRows = this.rows
-			let currentSlots = this.isStripe ? currentColumns * currentRows : currentColumns * currentRows - 1
+			let currentSlots = this.isStripe || this.isRecording ? currentColumns * currentRows : currentColumns * currentRows - 1
 
 			// Run this code only if we don't have an 'overflow' of videos. If the
 			// videos are populating the grid, there's no point in shrinking it.
@@ -809,7 +813,7 @@ export default {
 						currentColumns--
 					}
 
-					currentSlots = this.isStripe ? currentColumns * currentRows : currentColumns * currentRows - 1
+					currentSlots = this.isStripe || this.isRecording ? currentColumns * currentRows : currentColumns * currentRows - 1
 
 					// Check that there are still enough slots available
 					if (numberOfVideos > currentSlots) {
@@ -822,7 +826,7 @@ export default {
 						currentRows--
 					}
 
-					currentSlots = this.isStripe ? currentColumns * currentRows : currentColumns * currentRows - 1
+					currentSlots = this.isStripe || this.isRecording ? currentColumns * currentRows : currentColumns * currentRows - 1
 
 					// Check that there are still enough slots available
 					if (numberOfVideos > currentSlots) {

--- a/src/types/openapi/openapi-administration.ts
+++ b/src/types/openapi/openapi-administration.ts
@@ -296,6 +296,8 @@ export type components = {
                     "grid-limit": number;
                     /** @description Whether the grid limit is enforced by the server */
                     "grid-limit-enforced": boolean;
+                    /** @description Recording layout ('grid' or 'speaker') */
+                    "recording-layout": string;
                 };
                 chat: {
                     /**

--- a/src/types/openapi/openapi-backend-recording.ts
+++ b/src/types/openapi/openapi-backend-recording.ts
@@ -110,6 +110,8 @@ export type components = {
                     "grid-limit": number;
                     /** @description Whether the grid limit is enforced by the server */
                     "grid-limit-enforced": boolean;
+                    /** @description Recording layout ('grid' or 'speaker') */
+                    "recording-layout": string;
                 };
                 chat: {
                     /**

--- a/src/types/openapi/openapi-backend-signaling.ts
+++ b/src/types/openapi/openapi-backend-signaling.ts
@@ -96,6 +96,8 @@ export type components = {
                     "grid-limit": number;
                     /** @description Whether the grid limit is enforced by the server */
                     "grid-limit-enforced": boolean;
+                    /** @description Recording layout ('grid' or 'speaker') */
+                    "recording-layout": string;
                 };
                 chat: {
                     /**

--- a/src/types/openapi/openapi-backend-sipbridge.ts
+++ b/src/types/openapi/openapi-backend-sipbridge.ts
@@ -221,6 +221,8 @@ export type components = {
                     "grid-limit": number;
                     /** @description Whether the grid limit is enforced by the server */
                     "grid-limit-enforced": boolean;
+                    /** @description Recording layout ('grid' or 'speaker') */
+                    "recording-layout": string;
                 };
                 chat: {
                     /**

--- a/src/types/openapi/openapi-bots.ts
+++ b/src/types/openapi/openapi-bots.ts
@@ -114,6 +114,8 @@ export type components = {
                     "grid-limit": number;
                     /** @description Whether the grid limit is enforced by the server */
                     "grid-limit-enforced": boolean;
+                    /** @description Recording layout ('grid' or 'speaker') */
+                    "recording-layout": string;
                 };
                 chat: {
                     /**

--- a/src/types/openapi/openapi-federation.ts
+++ b/src/types/openapi/openapi-federation.ts
@@ -232,6 +232,8 @@ export type components = {
                     "grid-limit": number;
                     /** @description Whether the grid limit is enforced by the server */
                     "grid-limit-enforced": boolean;
+                    /** @description Recording layout ('grid' or 'speaker') */
+                    "recording-layout": string;
                 };
                 chat: {
                     /**

--- a/src/types/openapi/openapi-full.ts
+++ b/src/types/openapi/openapi-full.ts
@@ -2751,6 +2751,8 @@ export type components = {
                     "grid-limit": number;
                     /** @description Whether the grid limit is enforced by the server */
                     "grid-limit-enforced": boolean;
+                    /** @description Recording layout ('grid' or 'speaker') */
+                    "recording-layout": string;
                 };
                 chat: {
                     /**

--- a/src/types/openapi/openapi.ts
+++ b/src/types/openapi/openapi.ts
@@ -2217,6 +2217,8 @@ export type components = {
                     "grid-limit": number;
                     /** @description Whether the grid limit is enforced by the server */
                     "grid-limit-enforced": boolean;
+                    /** @description Recording layout ('grid' or 'speaker') */
+                    "recording-layout": string;
                 };
                 chat: {
                     /**

--- a/tests/php/CapabilitiesTest.php
+++ b/tests/php/CapabilitiesTest.php
@@ -187,6 +187,7 @@ class CapabilitiesTest extends TestCase {
 						'play-sounds' => false,
 						'grid-limit' => 0,
 						'grid-limit-enforced' => false,
+						'recording-layout' => 'speaker',
 						'predefined-backgrounds' => [
 							'1_office.jpg',
 							'2_home.jpg',
@@ -414,6 +415,7 @@ class CapabilitiesTest extends TestCase {
 						'play-sounds' => false,
 						'grid-limit' => 0,
 						'grid-limit-enforced' => false,
+						'recording-layout' => 'speaker',
 						'predefined-backgrounds' => [
 							'1_office.jpg',
 							'2_home.jpg',

--- a/tests/php/CapabilitiesTest.php
+++ b/tests/php/CapabilitiesTest.php
@@ -132,6 +132,10 @@ class CapabilitiesTest extends TestCase {
 			->with(null)
 			->willReturn('');
 
+		$this->talkConfig->expects($this->any())
+			->method('getRecordingLayout')
+			->willReturn('speaker');
+
 		$this->serverConfig->expects($this->any())
 			->method('getAppValue')
 			->willReturnMap([
@@ -337,6 +341,10 @@ class CapabilitiesTest extends TestCase {
 		$this->talkConfig->expects($this->any())
 			->method('getDefaultPermissions')
 			->willReturn(502);
+
+		$this->talkConfig->expects($this->any())
+			->method('getRecordingLayout')
+			->willReturn('speaker');
 
 		$user->method('getQuota')
 			->willReturn($quota);


### PR DESCRIPTION
## Problem

When recording a Talk call, the recording browser session uses promoted/speaker view by default. This means only the active speaker is shown prominently, with other participants in a thin stripe at the bottom. For recorded videos that will be published (e.g., podcasts, social media), a grid layout showing all participants equally is far more useful.

Issue #10060 requested a configurable grid mode for the recording backend, but was closed as "not planned" and redirected to #8768 (Recording UI customization), which remains in the backlog with no timeline.

## Current workaround

The maintainer suggested modifying `Participant.py` on the recording server to run `store.commit("isGrid", true)`. However, this hack has known problems:
- The grid still shows a placeholder/empty slot for the recording participant itself
- The slot math (`slots()` and `shrinkGrid()`) subtracts one slot for the local video, which is hidden in recording mode, causing poor layout with empty areas
- The `grid-wrapper` height does not fill the recording viewport properly

## Proposed fix

Instead of modifying the recording server, fix the recording frontend (`RecordingApp.vue` → `CallView.vue` → `VideosGrid.vue`) to properly support grid mode during recording:

1. **`CallView.vue`**: When `isRecording` is true, force `isGrid` to true so the recording always uses grid layout instead of promoted view.

2. **`VideosGrid.vue`**:
   - `slots()`: When recording, count all slots (do not subtract 1 for local video, since local video is hidden in recording mode).
   - `shrinkGrid()`: Use the same full slot count in recording mode so grid sizing does not leave empty space.

These changes only affect the recording view and do not change behavior for regular call participants.

## Testing

Tested on a production Nextcloud Talk setup with a dedicated recording VPS. The recording layout correctly:
- Shows all participants in an adaptive grid instead of promoted speaker-only view
- Adapts from 1 to 2+ participants during an active recording
- Fills the recording viewport without empty bottom gaps

## Related issues

- Fixes #10060
- Related to #8768