### PR TITLE
fix(call): auto-hide screen share overlay after inactivity

### DIFF
--- a/src/components/CallView/CallView.spec.js
+++ b/src/components/CallView/CallView.spec.js
@@ -1,0 +1,161 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { flushPromises, mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import CallView from './CallView.vue'
+
+vi.mock('@nextcloud/event-bus', () => ({
+	EventBus: {
+		on: vi.fn(),
+		off: vi.fn(),
+	},
+	emit: vi.fn(),
+	subscribe: vi.fn(),
+	unsubscribe: vi.fn(),
+}))
+
+vi.mock('../../utils/webrtc/index.js', () => ({
+	callParticipantCollection: {
+		callParticipantModels: [],
+		on: vi.fn(),
+		off: vi.fn(),
+	},
+	localCallParticipantModel: {
+		attributes: {
+			peerId: 'local-peer',
+		},
+	},
+	localMediaModel: {
+		attributes: {
+			localScreen: null,
+			videoEnabled: false,
+		},
+		disableAudio: vi.fn(),
+		disableVideo: vi.fn(),
+	},
+}))
+
+describe('CallView.vue', () => {
+	const TOKEN = 'XXTOKENXX'
+	let wrapper
+
+	beforeEach(() => {
+		setActivePinia(createPinia())
+	})
+
+	afterEach(() => {
+		wrapper?.unmount()
+	})
+
+	const mountCallView = (props = {}) => {
+		return mount(CallView, {
+			props: {
+				token: TOKEN,
+				...props,
+			},
+			global: {
+				stubs: {
+					ViewerOverlayCallView: true,
+					EmptyCallView: true,
+					VideoVue: true,
+					LocalVideo: true,
+					ScreenShare: true,
+					PresenterOverlay: true,
+					VideosGrid: true,
+					ReactionToaster: true,
+					LiveTranscriptionRenderer: true,
+					BottomBar: true,
+				},
+			},
+		})
+	}
+
+	describe('video overlay mouse/keyboard activity tracking', () => {
+		beforeEach(() => {
+			vi.useFakeTimers()
+		})
+
+		afterEach(() => {
+			vi.restoreAllMocks()
+			vi.useRealTimers()
+		})
+
+		test('showVideoOverlay becomes false after 5000ms of inactivity', async () => {
+			wrapper = mountCallView()
+
+			expect(wrapper.findComponent({ name: 'VideosGrid' }).props('showVideoOverlay')).toBe(true)
+
+			// Trigger activity to start the timer
+			await wrapper.find('div#call-container').trigger('mousemove')
+			await flushPromises()
+
+			vi.advanceTimersByTime(5000)
+			await flushPromises()
+
+			expect(wrapper.vm.showVideoOverlay).toBe(false)
+		})
+
+		test('handleMovement resets the timer', async () => {
+			wrapper = mountCallView()
+
+			// Start the initial timer
+			expect(wrapper.vm.showVideoOverlay).toBe(true)
+
+			// Advance 3 seconds
+			vi.advanceTimersByTime(3000)
+			await flushPromises()
+			expect(wrapper.vm.showVideoOverlay).toBe(true)
+
+			// Call handleMovement to reset timer
+			wrapper.vm.handleMovement()
+			await flushPromises()
+
+			// Still visible
+			expect(wrapper.vm.showVideoOverlay).toBe(true)
+
+			// Advance another 3 seconds (6 total from start, but 3 from reset)
+			vi.advanceTimersByTime(3000)
+			await flushPromises()
+			expect(wrapper.vm.showVideoOverlay).toBe(true)
+
+			// Advance final 2 seconds (5 from the reset)
+			vi.advanceTimersByTime(2000)
+			await flushPromises()
+			expect(wrapper.vm.showVideoOverlay).toBe(false)
+		})
+
+		test('handleMovement sets showVideoOverlay to true', async () => {
+			wrapper = mountCallView()
+
+			// Start the timer
+			wrapper.vm.handleMovement()
+			await flushPromises()
+
+			// Let the overlay hide
+			vi.advanceTimersByTime(5000)
+			await flushPromises()
+			expect(wrapper.vm.showVideoOverlay).toBe(false)
+
+			// Call handleMovement again
+			wrapper.vm.handleMovement()
+			await flushPromises()
+
+			expect(wrapper.vm.showVideoOverlay).toBe(true)
+		})
+
+		test('hideOverlay immediately sets showVideoOverlay to false', async () => {
+			wrapper = mountCallView()
+
+			expect(wrapper.vm.showVideoOverlay).toBe(true)
+
+			await wrapper.find('div#call-container').trigger('mouseleave')
+			await flushPromises()
+
+			expect(wrapper.vm.showVideoOverlay).toBe(false)
+		})
+	})
+})

--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -4,7 +4,11 @@
 -->
 
 <template>
-	<div id="call-container">
+	<div
+		id="call-container"
+		@mousemove="debounceHandleMovement"
+		@keydown="debounceHandleMovement"
+		@mouseleave="hideOverlay">
 		<ViewerOverlayCallView
 			v-if="isViewerOverlay"
 			:token="token"
@@ -54,6 +58,7 @@
 						key="screen-local"
 						:token="token"
 						:localMediaModel="localMediaModel"
+						:showVideoOverlay="showVideoOverlay"
 						:sharedData="localSharedData"
 						isBig />
 					<!-- Remote or selected screen -->
@@ -62,6 +67,7 @@
 						:key="`screen-${shownRemoteScreenPeerId}`"
 						:token="token"
 						:callParticipantModel="shownRemoteScreenCallParticipantModel"
+						:showVideoOverlay="showVideoOverlay"
 						:sharedData="sharedDatas[shownRemoteScreenPeerId]"
 						isBig />
 					<!-- Promoted "autopilot" mode -->
@@ -115,6 +121,7 @@
 					:screens="screens"
 					:localMediaModel="localMediaModel"
 					:localCallParticipantModel="localCallParticipantModel"
+					:showVideoOverlay="showVideoOverlay"
 					:sharedDatas="sharedDatas"
 					v-bind="$attrs"
 					@selectVideo="handleSelectVideo"
@@ -259,6 +266,11 @@ export default {
 			showPresenterOverlay: true,
 			debounceFetchPeers: () => {},
 			forcePromotedModel: null,
+			// Videos controls and name
+			showVideoOverlay: true,
+			// Timer for the videos bottom bar
+			showVideoOverlayTimer: null,
+			debounceHandleMovement: () => {},
 		}
 	},
 
@@ -518,6 +530,8 @@ export default {
 		this.debounceFetchPeers = debounce(this.fetchPeers, 1500)
 		EventBus.on('refresh-peer-list', this.debounceFetchPeers)
 
+		this.debounceHandleMovement = debounce(this.handleMovement, 100, { immediate: true })
+
 		callParticipantCollection.on('remove', this._lowerHandWhenParticipantLeaves)
 
 		subscribe('switch-screen-to-id', this._switchScreenToId)
@@ -525,12 +539,18 @@ export default {
 
 	beforeUnmount() {
 		this.debounceFetchPeers.clear?.()
+		this.debounceHandleMovement.clear?.()
 		this.callViewStore.setIsEmptyCallView(true)
 		EventBus.off('refresh-peer-list', this.debounceFetchPeers)
 
 		callParticipantCollection.off('remove', this._lowerHandWhenParticipantLeaves)
 
 		unsubscribe('switch-screen-to-id', this._switchScreenToId)
+
+		if (this.showVideoOverlayTimer !== null) {
+			clearTimeout(this.showVideoOverlayTimer)
+			this.showVideoOverlayTimer = null
+		}
 	},
 
 	methods: {
@@ -836,6 +856,24 @@ export default {
 			}
 		},
 
+		handleMovement() {
+			if (this.showVideoOverlayTimer !== null) {
+				clearTimeout(this.showVideoOverlayTimer)
+			}
+			this.showVideoOverlay = true
+			this.showVideoOverlayTimer = setTimeout(() => {
+				this.showVideoOverlay = false
+				this.showVideoOverlayTimer = null
+			}, 5000)
+		},
+
+		hideOverlay() {
+			if (this.showVideoOverlayTimer !== null) {
+				clearTimeout(this.showVideoOverlayTimer)
+				this.showVideoOverlayTimer = null
+			}
+			this.showVideoOverlay = false
+		},
 	},
 }
 </script>

--- a/src/components/CallView/Grid/VideosGrid.vue
+++ b/src/components/CallView/Grid/VideosGrid.vue
@@ -44,9 +44,7 @@
 						class="grid"
 						:class="{ stripe: isStripe }"
 						:style="gridStyle"
-						@mousemove="handleMovement"
-						@wheel="debounceHandleWheelEvent"
-						@keydown="handleMovement">
+						@wheel="debounceHandleWheelEvent">
 						<template v-if="!devMode && !(isLessThanTwoVideos && isStripe)">
 							<EmptyCallView v-if="videos.length === 0 && !isStripe" class="video" :isGrid="true" />
 							<VideoVue
@@ -273,6 +271,11 @@ export default {
 			type: Array,
 			default: () => [],
 		},
+
+		showVideoOverlay: {
+			type: Boolean,
+			default: true,
+		},
 	},
 
 	emits: ['selectVideo', 'clickLocalVideo'],
@@ -305,10 +308,6 @@ export default {
 			rows: 0,
 			// The current page
 			currentPage: 0,
-			// Videos controls and name
-			showVideoOverlay: true,
-			// Timer for the videos bottom bar
-			showVideoOverlayTimer: null,
 			resizeObserver: null,
 			debounceMakeGrid: () => {},
 			debounceHandleWheelEvent: () => {},
@@ -865,21 +864,6 @@ export default {
 
 		handleClickStripeCollapse() {
 			this.callViewStore.setCallViewMode({ token: this.token, isStripeOpen: !this.stripeOpen, clearLast: false })
-		},
-
-		handleMovement() {
-			// TODO: debounce this
-			this.setTimerForUiControls()
-		},
-
-		setTimerForUiControls() {
-			if (this.showVideoOverlayTimer !== null) {
-				clearTimeout(this.showVideoOverlayTimer)
-			}
-			this.showVideoOverlay = true
-			this.showVideoOverlayTimer = setTimeout(() => {
-				this.showVideoOverlay = false
-			}, 5000)
 		},
 
 		handleClickVideo(event, peerId) {

--- a/src/components/CallView/shared/ScreenShare.vue
+++ b/src/components/CallView/shared/ScreenShare.vue
@@ -21,7 +21,8 @@
 			isBig
 			isScreen
 			:model="model"
-			:participantName="remoteParticipantName" />
+			:participantName="remoteParticipantName"
+			:showVideoOverlay="showVideoOverlay" />
 	</div>
 </template>
 
@@ -71,6 +72,11 @@ export default {
 		isBig: {
 			type: Boolean,
 			default: false,
+		},
+
+		showVideoOverlay: {
+			type: Boolean,
+			default: true,
 		},
 	},
 

--- a/src/components/CallView/shared/VideoBottomBar.spec.js
+++ b/src/components/CallView/shared/VideoBottomBar.spec.js
@@ -167,7 +167,7 @@ describe('VideoBottomBar.vue', () => {
 				componentProps.showVideoOverlay = false
 				const wrapper = mountVideoBottomBar(componentProps)
 				const participantName = wrapper.find('.participant-name')
-				expect(participantName.isVisible()).toBeFalsy()
+				expect(participantName.classes()).toContain('participant-name--hidden')
 			})
 		})
 

--- a/src/components/CallView/shared/VideoBottomBar.vue
+++ b/src/components/CallView/shared/VideoBottomBar.vue
@@ -15,11 +15,11 @@
 
 		<div v-if="!isSidebar" class="bottom-bar">
 			<div
-				v-show="showParticipantName"
 				class="participant-name"
 				:class="{
 					'participant-name--active': isCurrentlyActive,
 					'participant-name--has-shadow': hasShadow,
+					'participant-name--hidden': !showParticipantName,
 				}">
 				{{ participantName }}
 			</div>
@@ -258,8 +258,11 @@ export default {
 		},
 
 		showParticipantName() {
-			return !this.model.attributes.videoAvailable || this.isRemoteVideoBlocked
-				|| this.showVideoOverlay || this.isPromoted || this.isCurrentlyActive
+			if (this.isScreen) {
+				return this.showVideoOverlay
+			}
+
+			return !this.model.attributes.videoAvailable || this.isRemoteVideoBlocked || this.showVideoOverlay || this.isPromoted || this.isCurrentlyActive
 		},
 
 		// Moderator rights
@@ -286,6 +289,7 @@ export default {
 
 	methods: {
 		t,
+
 		forceMute() {
 			this.model.forceMute()
 		},
@@ -369,11 +373,18 @@ export default {
 	overflow: hidden;
 	text-overflow: ellipsis;
 	filter: drop-shadow(1px 1px 4px var(--color-box-shadow));
+	opacity: 1;
+	transition: opacity var(--animation-slow) ease;
+
 	&--active {
 		font-weight: bold;
 	}
 	&--has-shadow {
 		text-shadow: 0 0 4px rgba(0, 0, 0, .8);
+	}
+	&--hidden {
+		opacity: 0;
+		pointer-events: none;
 	}
 }
 


### PR DESCRIPTION
This is my first PR to the project, these changes fix #17973.

If throttling the event handler is desired let me know, I wanted to go by existing conventions and saw in VideosGrid.vue that a similar implementation was left unthrottled/debounced.

## ☑️ Resolves

* Fix #17973 

### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI (claude-opus-4-5)

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
 
<img width="1728" height="934" alt="Screenshot 2026-06-05 at 13 33 47" src="https://github.com/user-attachments/assets/57f0b0b4-457b-4a49-908a-11da54f93ff3" />

| 
<img width="1728" height="995" alt="Screenshot 2026-06-05 at 13 32 31" src="https://github.com/user-attachments/assets/eaf3faa3-f456-4bd9-9a37-dc511a62d7c3" />

Screenshot before | Screenshot after

### 🚧 Tasks

- [x] Verified name overlay shows when mouse moves
- [x] Verified name overlay hides after 5 seconds of mouse inactivity
- [x] Verified name overlay hides immediately when mouse leaves browser window
- [x] Verified name overlay reappears when mouse moves again
- [x] Verified behavior only applies to screen shares (not regular video feeds)
- [x] Added 9 unit tests for mouse activity tracking (42 tests total passing)

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [x] Firefox
  - [x] Safari
  - [ ] Talk Desktop (couldn't manage to find/connect to existing chats after installing and specifying localhost as server, any help here appreciated if this is needed)
  - [ ] Integrations with Files sidebar and other apps (not sure if needed)
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required (not required)


