### PR TITLE
fix(encryption): load wasm module on demand

### DIFF
--- a/src/utils/e2ee/encryption.js
+++ b/src/utils/e2ee/encryption.js
@@ -39,7 +39,7 @@ class Encryption {
 	/**
 	 * Check if the current browser supports encryption.
 	 *
-	 * @return {boolean} Returns true if supported and throws an error otherwise.
+	 * @return {Promise<boolean>} Returns true if supported and throws an error otherwise.
 	 * @async
 	 */
 	static async isSupported() {

--- a/src/utils/signaling.js
+++ b/src/utils/signaling.js
@@ -1003,7 +1003,7 @@ Signaling.Standalone.prototype._getBackendUrl = function(baseURL = undefined) {
 	return generateOcsUrl('apps/spreed/api/v3/signaling/backend', {}, { baseURL })
 }
 
-Signaling.Standalone.prototype.sendHello = function() {
+Signaling.Standalone.prototype.sendHello = async function() {
 	if (this.resumeId) {
 		console.debug('Trying to resume session', this.sessionId)
 		const msg = {
@@ -1027,33 +1027,36 @@ Signaling.Standalone.prototype.sendHello = function() {
 		helloVersion = '1.0'
 	}
 	const features = ['chat-relay']
-	Encryption.isSupported()
-		.then(() => {
-			features.push('encryption')
-		})
-		.catch(() => {
-			// Ignore any errors.
-		})
-		.finally(() => {
-			const msg = {
-				type: 'hello',
-				hello: {
-					version: helloVersion,
-					auth: {
-						url,
-						params: this.settings.helloAuthParams[helloVersion],
-					},
-				},
+
+	try {
+		if (Encryption.isEnabled()) {
+			const isSupported = await Encryption.isSupported()
+			if (isSupported) {
+				features.push('encryption')
 			}
-			if (features.length > 0) {
-				msg.hello.features = features
-			}
-			if (this.settings.helloAuthParams.internal) {
-				msg.hello.auth.type = 'internal'
-				msg.hello.auth.params = this.settings.helloAuthParams.internal
-			}
-			this.doSend(msg, this.helloResponseReceived.bind(this))
-		})
+		}
+	} catch (error) {
+		// Ignore any errors.
+	}
+
+	const msg = {
+		type: 'hello',
+		hello: {
+			version: helloVersion,
+			auth: {
+				url,
+				params: this.settings.helloAuthParams[helloVersion],
+			},
+		},
+	}
+	if (features.length > 0) {
+		msg.hello.features = features
+	}
+	if (this.settings.helloAuthParams.internal) {
+		msg.hello.auth.type = 'internal'
+		msg.hello.auth.params = this.settings.helloAuthParams.internal
+	}
+	this.doSend(msg, this.helloResponseReceived.bind(this))
 }
 
 Signaling.Standalone.prototype.helloResponseReceived = function(data) {


### PR DESCRIPTION
## ☑️ Resolves

* Follow-up to #14005
- Encryption.isSupported() have a side effect of initializing Olm module
- Should be pre-checked if needed by Encryption.isEnabled()
- Already done in src/utils/webrtc/index.js, but not in src/utils/signaling.js
- Migrated to async syntax

### AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
olm.wasm always loaded | skipped

### 🚧 Tasks

- [ ] @fancycode unless there is a reason to include `features.push('encryption')` from client side?

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required