### PR TITLE
fix(shared-items): validate entries before storing

### DIFF
--- a/src/stores/__tests__/sharedItems.spec.js
+++ b/src/stores/__tests__/sharedItems.spec.js
@@ -23,6 +23,15 @@ vi.mock('vuex', () => ({
 	})),
 }))
 
+function requiresObject(type) {
+	return [
+		SHARED_ITEM.TYPES.LOCATION,
+		SHARED_ITEM.TYPES.DECK_CARD,
+		SHARED_ITEM.TYPES.POLL,
+		SHARED_ITEM.TYPES.OTHER,
+	].includes(type)
+}
+
 describe('sharedItemsStore', () => {
 	const token = 'TOKEN'
 	let sharedItemsStore
@@ -35,8 +44,10 @@ describe('sharedItemsStore', () => {
 		setActivePinia(createPinia())
 		sharedItemsStore = useSharedItemsStore()
 		sharedItemsOrder.forEach((type, index) => {
-			payloadOverview[type] = [{ id: 100 + index, message: type }]
-			result[type] = { [100 + index]: { id: 100 + index, message: type } }
+			const message = { id: 100 + index, message: type, messageParameters: {} }
+			message.messageParameters = requiresObject(type) ? { object: {} } : { file: {} }
+			payloadOverview[type] = [message]
+			result[type] = { [100 + index]: message }
 		})
 	})
 

--- a/src/stores/sharedItems.ts
+++ b/src/stores/sharedItems.ts
@@ -20,9 +20,9 @@ import {
 	unpinMessage,
 } from '../services/messagesService.ts'
 import { getSharedItems, getSharedItemsOverview } from '../services/sharedItemsService.ts'
-import { getItemTypeFromMessage } from '../utils/getItemTypeFromMessage.ts'
+import { getItemTypeFromMessage, isValidSharedItem } from '../utils/getItemTypeFromMessage.ts'
 
-type SharedItemType = keyof SharedItemsOverview
+type SharedItemType = typeof SHARED_ITEM.TYPES[keyof typeof SHARED_ITEM.TYPES] | (string & {})
 
 type SharedItemsPoolType = Record<string, {
 	[K: string]: Record<number, SharedItems[keyof SharedItems]>
@@ -78,7 +78,9 @@ export const useSharedItemsStore = defineStore('sharedItems', () => {
 			if (Object.keys(data[type]).length) {
 				checkForExistence(token, type)
 				for (const message of data[type]) {
-					sharedItemsPool[token][type][message.id] = message
+					if (isValidSharedItem(type, message)) {
+						sharedItemsPool[token][type][message.id] = message
+					}
 				}
 			}
 		}
@@ -96,7 +98,9 @@ export const useSharedItemsStore = defineStore('sharedItems', () => {
 	function addSharedItemFromMessage(token: string, message: ChatMessage, type?: SharedItemType) {
 		const itemType = type ?? getItemTypeFromMessage(message)
 		checkForExistence(token, itemType)
-		sharedItemsPool[token][itemType][message.id] = message
+		if (isValidSharedItem(itemType, message)) {
+			sharedItemsPool[token][itemType][message.id] = message
+		}
 	}
 
 	/**
@@ -135,7 +139,9 @@ export const useSharedItemsStore = defineStore('sharedItems', () => {
 		checkForExistence(token, type)
 
 		messages.forEach((message) => {
-			sharedItemsPool[token][type][message.id] = message
+			if (isValidSharedItem(type, message)) {
+				sharedItemsPool[token][type][message.id] = message
+			}
 		})
 	}
 

--- a/src/utils/getItemTypeFromMessage.ts
+++ b/src/utils/getItemTypeFromMessage.ts
@@ -1,9 +1,10 @@
-import type { ChatMessage } from '../types/index.ts'
-
 /**
  * SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+
+import type { ChatMessage, PinnedChatMessage } from '../types/index.ts'
+
 import { MESSAGE, SHARED_ITEM } from '../constants.ts'
 
 /**
@@ -38,4 +39,43 @@ export function getItemTypeFromMessage(message: ChatMessage): string {
 	} else {
 		return SHARED_ITEM.TYPES.OTHER
 	}
+}
+
+/**
+ * Validates whether a shared item has the required messageParameters for its type.
+ * Only valid items should be stored and rendered.
+ *
+ * @param type shared item type
+ * @param message message to validate
+ * @return true if the message has valid messageParameters for its type
+ */
+export function isValidSharedItem(type: string, message: ChatMessage | PinnedChatMessage): boolean {
+	// Pinned messages have a different structure
+	if (type === SHARED_ITEM.TYPES.PINNED) {
+		return true
+	}
+
+	// Items that require messageParameters.object
+	if ([
+		SHARED_ITEM.TYPES.LOCATION,
+		SHARED_ITEM.TYPES.DECK_CARD,
+		SHARED_ITEM.TYPES.POLL,
+		SHARED_ITEM.TYPES.OTHER,
+	].includes(type)) {
+		return !!(message.messageParameters?.object)
+	}
+
+	// Items that require messageParameters.file
+	if ([
+		SHARED_ITEM.TYPES.FILE,
+		SHARED_ITEM.TYPES.AUDIO,
+		SHARED_ITEM.TYPES.MEDIA,
+		SHARED_ITEM.TYPES.RECORDING,
+		SHARED_ITEM.TYPES.VOICE,
+	].includes(type)) {
+		return !!(message.messageParameters?.file)
+	}
+
+	// At least one truthy property should be present
+	return !!(message.messageParameters?.object) || !!(message.messageParameters?.file)
 }


### PR DESCRIPTION
## ☑️ Resolves

* FIx #18030
* Fix #18200
- filter out malformed shared items that are missing required messageParameters properties (object or file).
- this prevents runtime errors when rendering shared items in the UI.

### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
Runtime errors in console, failed render, failed Viewer for valid media | Malformed shares skipped

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required