### PR TITLE
fix(matterbridge): Always allow Talk usage for the matterbridge bot user

### DIFF
--- a/lib/Config.php
+++ b/lib/Config.php
@@ -265,6 +265,10 @@ class Config {
 	}
 
 	public function isDisabledForUser(IUser $user): bool {
+		if ($user->getUID() === MatterbridgeManager::BRIDGE_BOT_USERID) {
+			return false;
+		}
+
 		$allowedGroups = $this->getAllowedTalkGroupIds();
 		if (empty($allowedGroups)) {
 			return false;


### PR DESCRIPTION
## ☑️ Resolves

* Fix #18262 

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
