### PR TITLE
fix(admin): ensure to send string value to Provisioning API

### DIFF
--- a/src/components/AdminSettings/GeneralSettings.vue
+++ b/src/components/AdminSettings/GeneralSettings.vue
@@ -167,7 +167,7 @@ export default {
 		saveDefaultGroupNotification() {
 			this.loadingDefaultGroupNotification = true
 
-			OCP.AppConfig.setValue('spreed', 'default_group_notification', this.defaultGroupNotification.value, {
+			OCP.AppConfig.setValue('spreed', 'default_group_notification', String(this.defaultGroupNotification.value), {
 				success: () => {
 					this.loadingDefaultGroupNotification = false
 				},

--- a/src/components/AdminSettings/SIPBridge.vue
+++ b/src/components/AdminSettings/SIPBridge.vue
@@ -269,7 +269,7 @@ export default {
 				await OCP.AppConfig.setValue('spreed', 'sip_dialout', this.dialOutEnabled ? 'yes' : 'no')
 			}
 			if (this.currentSetup.dialOutAnonymous !== this.dialOutAnonymous) {
-				await OCP.AppConfig.setValue('spreed', 'sip_bridge_dialout_anonymous', this.dialOutAnonymous)
+				await OCP.AppConfig.setValue('spreed', 'sip_bridge_dialout_anonymous', String(this.dialOutAnonymous))
 			}
 			if (this.currentSetup.dialOutNumber !== this.dialOutNumber) {
 				await OCP.AppConfig.setValue('spreed', 'sip_bridge_dialout_number', this.dialOutNumber)

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -23,7 +23,7 @@ declare global {
 	interface Window {
 		OCP: {
 			AppConfig: {
-				setValue: (app: string, key: string, value: string | number | boolean, options?: { success?: () => void, error?: () => void }) => void
+				setValue: (app: string, key: string, value: string, options?: { success?: () => void, error?: () => void }) => Promise<void>
 			}
 			Accessibility: {
 				disableKeyboardShortcuts: () => boolean

--- a/src/types/core.ts
+++ b/src/types/core.ts
@@ -76,6 +76,8 @@ export type UpcomingEvent = componentsDav['schemas']['UpcomingEvent'] & {
 export type UpcomingEventsResponse = ApiResponse<operationsDav['upcoming_events-get-events']['responses'][200]['content']['application/json']>
 
 // Provisioning API
+export type AppConfigSetValueParams = Required<operationsProv['app_config-set-value']>['requestBody']['content']['application/json']
+export type AppConfigSetValueResponse = ApiResponse<operationsProv['app_config-set-value']['responses'][200]['content']['application/json']>
 export type UserPreferencesParams = Required<operationsProv['preferences-set-preference']>['requestBody']['content']['application/json']
 export type UserPreferencesResponse = ApiResponse<operationsProv['preferences-set-preference']['responses'][200]['content']['application/json']>
 


### PR DESCRIPTION
## ☑️ Resolves

* Fix #18260
* Server API was hardened to only accept string values, we've been out of sync a bit

### AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI

## 🖌️ UI Checklist

### 🚧 Tasks

- [ ] Upstream to server, that incorrect type passed? It's currently empty response with status 400

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required