### PR TITLE
fix(dashboard): start meeting on enter key

### DIFF
--- a/src/components/Dashboard/TalkDashboard.vue
+++ b/src/components/Dashboard/TalkDashboard.vue
@@ -221,6 +221,7 @@ function scrollEventCards({ direction }: { direction: 'backward' | 'forward' }) 
 						<NcInputField
 							id="room-name"
 							v-model="conversationName"
+							@keyup.enter="startMeeting"
 							:placeholder="t('spreed', 'Meeting')" />
 						<NcButton
 							variant="primary"


### PR DESCRIPTION
## ☑️ Resolves

* Fix #17817

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required

