### PR TITLE
fix: remove dangling listeners in cleanup operations

### DIFF
--- a/src/FloatingCallOverlay.vue
+++ b/src/FloatingCallOverlay.vue
@@ -94,6 +94,7 @@ onBeforeUnmount(() => {
 	EventBus.off('signaling-participant-list-changed', fetchCurrentConversation)
 	fetchCurrentConversationIntervalId = undefined
 	window.removeEventListener('beforeunload', preventUnload)
+	window.removeEventListener('unload', syncLeaveConversation)
 	syncLeaveConversation()
 })
 

--- a/src/utils/webrtc/models/CallParticipantModel.js
+++ b/src/utils/webrtc/models/CallParticipantModel.js
@@ -101,6 +101,7 @@ CallParticipantModel.prototype = {
 		this._webRtc.off('channelMessage', this._handleChannelMessageBound)
 		this._webRtc.off('raisedHand', this._handleRaisedHandBound)
 		this._webRtc.off('reaction', this._handleReactionBound)
+		this._webRtc.off('transcript', this._handleTranscriptBound)
 	},
 
 	get(key) {


### PR DESCRIPTION
## ☑️ Resolves

* Better clean up resources on:
  * floating call unmount (can theoretically stack)
  * participant model transcript (webrtc itself persists, so can also stack)

### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

## 🖌️ UI Checklist

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required