### PR TITLE
fix(call): render special characters in another person name on an empty call view

### DIFF
--- a/src/components/CallView/shared/EmptyCallView.vue
+++ b/src/components/CallView/shared/EmptyCallView.vue
@@ -110,10 +110,6 @@ export default {
 					|| this.conversation.objectType === CONVERSATION.OBJECT_TYPE.PHONE_TEMPORARY)
 		},
 
-		conversationDisplayName() {
-			return this.conversation && this.conversation.displayName
-		},
-
 		canInviteOthers() {
 			return this.conversation && (
 				this.conversation.participantType === PARTICIPANT.TYPE.OWNER
@@ -143,7 +139,8 @@ export default {
 				return t('spreed', 'Calling …')
 			}
 			if (this.isOneToOneConversation) {
-				return t('spreed', 'Waiting for {user} to join the call', { user: this.conversationDisplayName })
+				// Rendered via Vue text interpolation - avoid double escaping to correctly render special characters
+				return t('spreed', 'Waiting for {user} to join the call', { user: this.conversation.displayName }, { escape: false })
 			}
 			return t('spreed', 'Waiting for others to join the call …')
 		},


### PR DESCRIPTION
## ☑️ Resolves

* Special characters `' " < >` are HTML-escaped twice: by l10n and vue on empty call
* Escaping is never needed when used with Vue's text interpolation

### AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="741" height="385" alt="image" src="https://github.com/user-attachments/assets/2278f7e5-444c-4311-b15d-bdbd35a52f80" /> | <img width="741" height="383" alt="image" src="https://github.com/user-attachments/assets/86225e03-89bb-4854-a1c6-7f9401d8f57e" />

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required