### PR TITLE
chore(chat): Drop OC_Util usage and use setupManager instead

### DIFF
--- a/lib/Chat/Parser/SystemMessage.php
+++ b/lib/Chat/Parser/SystemMessage.php
@@ -32,6 +32,7 @@ use OCP\Federation\ICloudIdManager;
 use OCP\Files\FileInfo;
 use OCP\Files\InvalidPathException;
 use OCP\Files\IRootFolder;
+use OCP\Files\ISetupManager;
 use OCP\Files\Node;
 use OCP\Files\NotFoundException;
 use OCP\FilesMetadata\Exceptions\FilesMetadataNotFoundException;
@@ -77,6 +78,7 @@ class SystemMessage implements IEventListener {
 		private readonly RoomShareProvider $shareProvider,
 		private readonly PhotoCache $photoCache,
 		private readonly IRootFolder $rootFolder,
+		private readonly ISetupManager $setupManager,
 		private readonly ICloudIdManager $cloudIdManager,
 		private readonly IURLGenerator $url,
 		private readonly FilesMetadataCache $metadataCache,
@@ -983,13 +985,12 @@ class SystemMessage implements IEventListener {
 
 				$node = $userFolder->getFirstNodeById($share->getNodeId());
 				if (!$node instanceof Node) {
+					$user = $this->userManager->getExistingUser($participant->getAttendee()->getActorId());
 					// FIXME This should be much more sensible, e.g.
 					// 1. Only be executed on "Waiting for new messages"
 					// 2. Once per request
-					/** @psalm-suppress UndefinedClass */
-					\OC_Util::tearDownFS();
-					/** @psalm-suppress UndefinedClass */
-					\OC_Util::setupFS($participant->getAttendee()->getActorId());
+					$this->setupManager->tearDown();
+					$this->setupManager->setupForUser($user);
 					$userNodes = $userFolder->getById($share->getNodeId());
 
 					if (empty($userNodes)) {

--- a/tests/php/Chat/Parser/SystemMessageTest.php
+++ b/tests/php/Chat/Parser/SystemMessageTest.php
@@ -29,6 +29,7 @@ use OCP\Federation\ICloudIdManager;
 use OCP\Files\Folder;
 use OCP\Files\InvalidPathException;
 use OCP\Files\IRootFolder;
+use OCP\Files\ISetupManager;
 use OCP\Files\Node;
 use OCP\Files\NotFoundException;
 use OCP\IGroup;
@@ -54,6 +55,7 @@ class SystemMessageTest extends TestCase {
 	protected RoomShareProvider&MockObject $shareProvider;
 	protected PhotoCache&MockObject $photoCache;
 	protected IRootFolder&MockObject $rootFolder;
+	protected ISetupManager&MockObject $setupManager;
 	protected IURLGenerator&MockObject $url;
 	protected ICloudIdManager&MockObject $cloudIdManager;
 	protected FilesMetadataCache&MockObject $filesMetadataCache;
@@ -72,6 +74,7 @@ class SystemMessageTest extends TestCase {
 		$this->shareProvider = $this->createMock(RoomShareProvider::class);
 		$this->photoCache = $this->createMock(PhotoCache::class);
 		$this->rootFolder = $this->createMock(IRootFolder::class);
+		$this->setupManager = $this->createMock(ISetupManager::class);
 		$this->url = $this->createMock(IURLGenerator::class);
 		$this->cloudIdManager = $this->createMock(ICloudIdManager::class);
 		$this->filesMetadataCache = $this->createMock(FilesMetadataCache::class);
@@ -103,6 +106,7 @@ class SystemMessageTest extends TestCase {
 					$this->shareProvider,
 					$this->photoCache,
 					$this->rootFolder,
+					$this->setupManager,
 					$this->cloudIdManager,
 					$this->url,
 					$this->filesMetadataCache,
@@ -123,6 +127,7 @@ class SystemMessageTest extends TestCase {
 			$this->shareProvider,
 			$this->photoCache,
 			$this->rootFolder,
+			$this->setupManager,
 			$this->cloudIdManager,
 			$this->url,
 			$this->filesMetadataCache,


### PR DESCRIPTION
## ☑️ Resolves

* Ref #18305 

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
