### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -337,12 +337,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "45bd50c0ac735c48588e702edf9ecd528f13dbc3"
+                "reference": "40842eb82f4972ef0fe465e9c03832275bb85533"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/45bd50c0ac735c48588e702edf9ecd528f13dbc3",
-                "reference": "45bd50c0ac735c48588e702edf9ecd528f13dbc3",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/40842eb82f4972ef0fe465e9c03832275bb85533",
+                "reference": "40842eb82f4972ef0fe465e9c03832275bb85533",
                 "shasum": ""
             },
             "require": {
@@ -379,7 +379,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2026-06-13T02:11:14+00:00"
+            "time": "2026-06-13T09:58:31+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency