### PR TITLE
fix: Accept insecure certificates in Talkbuchet

### DIFF
--- a/docs/Talkbuchet-cli.py
+++ b/docs/Talkbuchet-cli.py
@@ -295,6 +295,9 @@ class SeleniumHelper:
         """
 
         options = webdriver.ChromeOptions()
+
+        options.set_capability('acceptInsecureCerts', True)
+
         options.set_capability("goog:loggingPrefs", { 'browser': 'ALL' })
         options.add_argument('--use-fake-device-for-media-stream')
         options.add_argument('--use-fake-ui-for-media-stream')
@@ -340,6 +343,8 @@ class SeleniumHelper:
         """
 
         options = webdriver.FirefoxOptions()
+
+        options.set_capability('acceptInsecureCerts', True)
 
         # "webSocketUrl" is needed for BiDi; this should be set already by
         # default, but just in case.


### PR DESCRIPTION
Insecure certificates are accepted so Talkbuchet can be used also against development systems that may not have valid certificates. I assumed that it was already the case since long ago, but turns out it was only in my hard drive :facepalm:

It is expected that Talkbuchet will be used only in controlled environments, so the insecure certificates are simply accepted, without adding an optional toggle to enable or disable the feature.
