### PR TITLE
fix(session): skip tab-ID verification for password-protected rooms

### DIFF
--- a/lib/TalkSession.php
+++ b/lib/TalkSession.php
@@ -87,15 +87,15 @@ class TalkSession {
 	}
 
 	public function getPasswordForRoom(string $token): ?string {
-		return $this->getValue('spreed-password', $token);
+		return $this->getValue('spreed-password', $token, false);
 	}
 
 	public function setPasswordForRoom(string $token, string $password): void {
-		$this->setValue('spreed-password', $token, $password);
+		$this->setValue('spreed-password', $token, $password, false);
 	}
 
 	public function removePasswordForRoom(string $token): void {
-		$this->removeValue('spreed-password', $token);
+		$this->removeValue('spreed-password', $token, false);
 	}
 
 	protected function getValues(string $key): array {

--- a/tests/php/TalkSessionTest.php
+++ b/tests/php/TalkSessionTest.php
@@ -123,4 +123,59 @@ class TalkSessionTest extends TestCase {
 			->with('spreed-password', $expected);
 		$this->talkSession->removePasswordForRoom('t1');
 	}
+
+	/**
+	 * The password is stored during the HTML page request (no x-nextcloud-talk-session-tab-id
+	 * header) and read back during a subsequent API call (which carries the header via the
+	 * axios interceptor set up in init.js). The methods must ignore the tab-ID so that the
+	 * two contexts share the same session key.
+	 */
+	public function testGetPasswordForRoomIgnoresTabId(): void {
+		$this->request->method('getHeader')
+			->with(TalkSession::HEADER_TAB_ID)
+			->willReturn(str_repeat('a', 64));
+
+		// Password was stored without a tab-ID suffix (page-request context)
+		$this->session->expects($this->once())
+			->method('get')
+			->with('spreed-password')
+			->willReturn(json_encode(['t1' => 'secret']));
+
+		// Must resolve to the value even though a tab-ID header is now present
+		$this->assertSame('secret', $this->talkSession->getPasswordForRoom('t1'));
+	}
+
+	public function testSetPasswordForRoomIgnoresTabId(): void {
+		$this->request->method('getHeader')
+			->with(TalkSession::HEADER_TAB_ID)
+			->willReturn(str_repeat('a', 64));
+
+		$this->session->expects($this->once())
+			->method('get')
+			->with('spreed-password')
+			->willReturn(null);
+		// Key must be the bare token, not 't1$<tabId>'
+		$this->session->expects($this->once())
+			->method('set')
+			->with('spreed-password', json_encode(['t1' => 'secret']));
+
+		$this->talkSession->setPasswordForRoom('t1', 'secret');
+	}
+
+	public function testRemovePasswordForRoomIgnoresTabId(): void {
+		$this->request->method('getHeader')
+			->with(TalkSession::HEADER_TAB_ID)
+			->willReturn(str_repeat('a', 64));
+
+		$this->session->expects($this->once())
+			->method('get')
+			->with('spreed-password')
+			->willReturn(json_encode(['t1' => 'secret', 't2' => 'other']));
+		// 't1' must be removed by bare key, not 't1$<tabId>'
+		$this->session->expects($this->once())
+			->method('set')
+			->with('spreed-password', json_encode(['t2' => 'other']));
+
+		$this->talkSession->removePasswordForRoom('t1');
+	}
 }


### PR DESCRIPTION
## ☑️ Resolves

* Fix #18345

### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

---

<!--
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
░░░███████░░░█████████░░█████░
░░███░░░███░░░███░░░███░░███░░
░░█████████░░░████████░░░███░░
░░███░░░███░░░███░░░░░░░░███░░
░█████░█████░█████░░░░░░█████░
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching frontend/UI code
-->

## 🛠️ API Checklist

### 🚧 Tasks

- [ ] Validate change

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
