### PR TITLE
fix(calls): Increase FPS to 30 in all levels and update video quality

### DIFF
--- a/docs/call-experience.md
+++ b/docs/call-experience.md
@@ -10,33 +10,39 @@ If a participant enabled their microphone and starts speaking the video quality 
 
 ### Number of video streams
 
-| Streams | Quality   |
-|---------|-----------|
-| < 4     | High      |
-| 4-7     | Medium    |
-| 8-10    | Low       |
-| 11-14   | Very low  |
-| > 14    | Thumbnail |
+| Streams | Quality        |
+|---------|----------------|
+| < 20    | High           |
+| 21-80   | Medium         |
+| 80-119  | Low / Very low |
+| > 120   | Thumbnail      |
 
 ### Number of audio streams
 
 | Streams | Quality   |
 |---------|-----------|
-| < 10    | High      |
-| 10-19   | Medium    |
-| 20-29   | Low       |
-| 30-39   | Very low  |
-| > 40    | Thumbnail |
+| < 40    | High      |
+| 40-79   | Medium    |
+| 80-119  | Low       |
+| 120-199 | Very low  |
+| > 200   | Thumbnail |
 
 ### Video qualities
 
-| Quality   | Max width | Ideal width | Max height | Ideal height | Max frames | Ideal frames |
-|-----------|-----------|-------------|------------|--------------|------------|--------------|
-| High      | -         | 720         | -          | 540          | -          | 30           |
-| Medium    | 640       | 560         | 480        | 420          | 24         | 24           |
-| Low       | 480       | 360         | 320        | 270          | 15         | 15           |
-| Very low  | 320       | -           | 240        | -            | 8          | -            |
-| Thumbnail | 320       | -           | 240        | -            | 1          | -            |
+Frames:
+- Max frames: 30
+- Ideal frames: 30
+- Min frames: 20
+
+| Quality   | Max width | Ideal width | Min width | Max height | Ideal height | Min height |
+|-----------|-----------|-------------|-----------|------------|--------------|------------|
+| High      | -         | -           | 1440      | -          | -            | 1080       |
+| Medium    | -         | -           | 720       | -          | -            | 540        |
+| Low       | 640       | 560         | 480       | 480        | 420          | 320        |
+| Very low  | 480       | 360         | 320       | 320        | 270          | 240        |
+| Thumbnail | 320       | -           | -         | 240        | -            | -          |
+
+*These values were last changes in Nextcloud Talk 24.0.1, 23.0.7 and 22.0.14*
 
 ## Judging the connection quality
 

--- a/src/utils/webrtc/SentVideoQualityThrottler.js
+++ b/src/utils/webrtc/SentVideoQualityThrottler.js
@@ -34,17 +34,17 @@ export default function SentVideoQualityThrottler(localMediaModel, callParticipa
 	this._speakingOrInGracePeriodAfterSpeaking = false
 
 	this._availableVideosThreshold = {}
-	this._availableVideosThreshold[QUALITY.THUMBNAIL] = 15
-	this._availableVideosThreshold[QUALITY.VERY_LOW] = 10
-	this._availableVideosThreshold[QUALITY.LOW] = 7
-	this._availableVideosThreshold[QUALITY.MEDIUM] = 4
+	this._availableVideosThreshold[QUALITY.THUMBNAIL] = 120
+	this._availableVideosThreshold[QUALITY.VERY_LOW] = 120
+	this._availableVideosThreshold[QUALITY.LOW] = 80
+	this._availableVideosThreshold[QUALITY.MEDIUM] = 20
 	// QUALITY.HIGH otherwise
 
 	this._availableAudiosThreshold = {}
-	this._availableAudiosThreshold[QUALITY.THUMBNAIL] = 40
-	this._availableAudiosThreshold[QUALITY.VERY_LOW] = 30
-	this._availableAudiosThreshold[QUALITY.LOW] = 20
-	this._availableAudiosThreshold[QUALITY.MEDIUM] = 10
+	this._availableAudiosThreshold[QUALITY.THUMBNAIL] = 200
+	this._availableAudiosThreshold[QUALITY.VERY_LOW] = 120
+	this._availableAudiosThreshold[QUALITY.LOW] = 80
+	this._availableAudiosThreshold[QUALITY.MEDIUM] = 40
 	// QUALITY.HIGH otherwise
 
 	this._handleLocalVideoAvailableChangeBound = this._handleLocalVideoAvailableChange.bind(this)

--- a/src/utils/webrtc/VideoConstrainer.js
+++ b/src/utils/webrtc/VideoConstrainer.js
@@ -169,12 +169,10 @@ VideoConstrainer.prototype = {
 		if (quality === QUALITY.HIGH) {
 			return {
 				width: {
-					ideal: 720,
-					min: 640,
+					min: 1440,
 				},
 				height: {
-					ideal: 540,
-					min: 480,
+					min: 1080,
 				},
 				frameRate: {
 					max: 30,
@@ -188,6 +186,23 @@ VideoConstrainer.prototype = {
 		if (quality === QUALITY.MEDIUM) {
 			return {
 				width: {
+					min: 720,
+				},
+				height: {
+					min: 540,
+				},
+				frameRate: {
+					max: 30,
+					ideal: 30,
+					min: 20,
+				},
+				resizeMode: 'none',
+			}
+		}
+
+		if (quality === QUALITY.LOW) {
+			return {
+				width: {
 					max: 640,
 					ideal: 560,
 					min: 480,
@@ -198,15 +213,15 @@ VideoConstrainer.prototype = {
 					min: 320,
 				},
 				frameRate: {
-					max: 24,
-					ideal: 24,
-					min: 15,
+					max: 30,
+					ideal: 30,
+					min: 20,
 				},
 				resizeMode: 'none',
 			}
 		}
 
-		if (quality === QUALITY.LOW) {
+		if (quality === QUALITY.VERY_LOW) {
 			return {
 				width: {
 					max: 480,
@@ -219,24 +234,9 @@ VideoConstrainer.prototype = {
 					min: 240,
 				},
 				frameRate: {
-					max: 15,
-					ideal: 15,
-					min: 8,
-				},
-				resizeMode: 'none',
-			}
-		}
-
-		if (quality === QUALITY.VERY_LOW) {
-			return {
-				width: {
-					max: 320,
-				},
-				height: {
-					max: 240,
-				},
-				frameRate: {
-					max: 8,
+					max: 30,
+					ideal: 30,
+					min: 20,
 				},
 				resizeMode: 'none',
 			}
@@ -250,7 +250,9 @@ VideoConstrainer.prototype = {
 				max: 240,
 			},
 			frameRate: {
-				max: 1,
+				max: 30,
+				ideal: 30,
+				min: 20,
 			},
 			resizeMode: 'none',
 		}


### PR DESCRIPTION
Since the videos on other "pages" are no longer rendered (compared to when we started these settings),
we can increase the video quality and quality selectors so that small group grid views still show proper video sizes

## ☑️ Resolves

* Fix #…

### AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [x] Firefox
  - [x] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
