### PR TITLE
fix: Wrong id in reaction_revoked chat relay message

### DIFF
--- a/lib/Chat/ReactionManager.php
+++ b/lib/Chat/ReactionManager.php
@@ -123,7 +123,7 @@ class ReactionManager {
 		$comment->setVerb(ChatManager::VERB_REACTION_DELETED);
 		$this->commentsManager->save($comment);
 
-		$this->chatManager->addSystemMessage(
+		$revokedComment = $this->chatManager->addSystemMessage(
 			$chat,
 			null,
 			$actorType,
@@ -136,7 +136,7 @@ class ReactionManager {
 			true
 		);
 
-		$event = new ReactionRemovedEvent($chat, $parentComment, $actorType, $actorId, $actorDisplayName, $reaction, $comment);
+		$event = new ReactionRemovedEvent($chat, $parentComment, $actorType, $actorId, $actorDisplayName, $reaction, $revokedComment);
 		$this->dispatcher->dispatchTyped($event);
 
 		return $comment;


### PR DESCRIPTION
## 🛠️ API Checklist

How to reproduce:
* Send a message and react to it
* Now revoke the reaction
* Check the signaling messages that you received
* -> Both messages (`reaction_added` and `reaction_revoked`) have the same ID


### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not possible
- [ ] 📘 API documentation in `docs/` has been updated or is not required
- [ ] 🔖 Capability is added or not needed 
