### PR TITLE
feat: promote "search messages in current chat" feature

### DIFF
--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -538,6 +538,11 @@ export default {
 		},
 
 		handleUpdateActive(active) {
+			if (active === 'search') {
+				// 'search' is not a real tab: route it to the search content state
+				this.handleUpdateState('search')
+				return
+			}
 			this.activeTab = active
 		},
 

--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -538,12 +538,17 @@ export default {
 		},
 
 		handleUpdateActive(active) {
-			if (active === 'search') {
-				// 'search' is not a real tab: route it to the search content state
-				this.handleUpdateState('search')
-				return
+			switch (active) {
+				case 'search-messages':
+					this.handleUpdateState('search')
+					break
+				case 'threads':
+					this.handleUpdateState('threads')
+					break
+				default:
+					this.contentState = 'default'
+					this.activeTab = active
 			}
-			this.activeTab = active
 		},
 
 		handleUpdateMode(mode) {
@@ -554,13 +559,19 @@ export default {
 		},
 
 		handleUpdateState(value) {
+			if (value === this.contentState) {
+				return
+			}
+			// Remember the tab to return to, but only when leaving the default state,
+			// so re-entering search / threads does not make them their own previous tab
+			if (this.contentState === 'default') {
+				this.previousActiveTab = this.activeTab
+			}
 			this.contentState = value
 			// FIXME upstream: NcAppSidebar should emit update:active
 			if (value === 'search') {
-				this.previousActiveTab = this.activeTab
 				this.activeTab = 'search-messages'
 			} else if (value === 'threads') {
-				this.previousActiveTab = this.activeTab
 				this.activeTab = 'threads'
 			} else {
 				this.activeTab = this.previousActiveTab
@@ -583,7 +594,7 @@ export default {
 			if (message) {
 				this.unreadNotificationHandle = showMessage(message, {
 					onClick: () => {
-						this.activeTab = 'chat'
+						this.handleUpdateActive('chat')
 						this.sidebarStore.showSidebar()
 					},
 				})

--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -554,12 +554,17 @@ export default {
 		},
 
 		handleUpdateActive(active) {
-			if (active === 'search') {
-				// 'search' is not a real tab: route it to the search content state
-				this.handleUpdateState('search')
-				return
+			switch (active) {
+				case 'search-messages':
+					this.handleUpdateState('search')
+					break
+				case 'threads':
+					this.handleUpdateState('threads')
+					break
+				default:
+					this.contentState = 'default'
+					this.activeTab = active
 			}
-			this.activeTab = active
 		},
 
 		handleUpdateMode(mode) {
@@ -570,13 +575,19 @@ export default {
 		},
 
 		handleUpdateState(value) {
+			if (value === this.contentState) {
+				return
+			}
+			// Remember the tab to return to, but only when leaving the default state,
+			// so re-entering search / threads does not make them their own previous tab
+			if (this.contentState === 'default') {
+				this.previousActiveTab = this.activeTab
+			}
 			this.contentState = value
 			// FIXME upstream: NcAppSidebar should emit update:active
 			if (value === 'search') {
-				this.previousActiveTab = this.activeTab
 				this.activeTab = 'search-messages'
 			} else if (value === 'threads') {
-				this.previousActiveTab = this.activeTab
 				this.activeTab = 'threads'
 			} else {
 				this.activeTab = this.previousActiveTab
@@ -599,7 +610,7 @@ export default {
 			if (message) {
 				this.unreadNotificationHandle = showMessage(message, {
 					onClick: () => {
-						this.activeTab = 'chat'
+						this.handleUpdateActive('chat')
 						this.sidebarStore.showSidebar()
 					},
 				})

--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -554,6 +554,11 @@ export default {
 		},
 
 		handleUpdateActive(active) {
+			if (active === 'search') {
+				// 'search' is not a real tab: route it to the search content state
+				this.handleUpdateState('search')
+				return
+			}
 			this.activeTab = active
 		},
 

--- a/src/components/RightSidebar/RightSidebarContent.vue
+++ b/src/components/RightSidebar/RightSidebarContent.vue
@@ -24,7 +24,6 @@ import IconAccountOutline from 'vue-material-design-icons/AccountOutline.vue'
 import IconArrowLeft from 'vue-material-design-icons/ArrowLeft.vue'
 import IconClockOutline from 'vue-material-design-icons/ClockOutline.vue'
 import IconDeleteClockOutline from 'vue-material-design-icons/DeleteClockOutline.vue'
-import IconMagnify from 'vue-material-design-icons/Magnify.vue'
 import IconOfficeBuildingOutline from 'vue-material-design-icons/OfficeBuildingOutline.vue'
 import CalendarEventSmall from '../UIShared/CalendarEventSmall.vue'
 import LocalTime from '../UIShared/LocalTime.vue'
@@ -232,8 +231,8 @@ function handleHeaderClick() {
 		class="content"
 		:class="{ ['content--' + mode]: state === 'default' }">
 		<template v-if="state === 'default'">
-			<div v-if="isUser" class="content__actions">
-				<NcActions v-if="profileActions.length" forceMenu>
+			<div v-if="isUser && profileActions.length" class="content__actions">
+				<NcActions forceMenu>
 					<NcActionLink
 						v-for="action in profileActions"
 						:key="action.id"
@@ -244,15 +243,6 @@ function handleHeaderClick() {
 						{{ action.title }}
 					</NcActionLink>
 				</NcActions>
-				<NcButton
-					variant="tertiary"
-					:title="t('spreed', 'Search messages')"
-					:aria-label="t('spreed', 'Search messages')"
-					@click="emit('update:state', 'search')">
-					<template #icon>
-						<IconMagnify :size="20" />
-					</template>
-				</NcButton>
 			</div>
 
 			<div class="content__scroller animated">
@@ -273,7 +263,7 @@ function handleHeaderClick() {
 				<!-- User / conversation profile information -->
 				<div class="content__header animated">
 					<NcAppSidebarHeader
-						class="content__name content__name--has-actions"
+						class="content__name"
 						:class="{ 'content__name--has-profile-actions': profileActions.length }"
 						:name="sidebarTitle"
 						:title="sidebarTitle"
@@ -504,12 +494,8 @@ function handleHeaderClick() {
 			text-overflow: ellipsis;
 			cursor: pointer;
 
-			&--has-actions {
-				padding-inline-end: calc(var(--actions-offset) + var(--app-sidebar-close-button-offset));
-			}
-
 			&--has-profile-actions {
-				padding-inline-end: calc(2 * var(--actions-offset) + var(--app-sidebar-close-button-offset));
+				padding-inline-end: calc(var(--actions-offset) + var(--app-sidebar-close-button-offset));
 			}
 		}
 

--- a/src/components/RightSidebar/RightSidebarContent.vue
+++ b/src/components/RightSidebar/RightSidebarContent.vue
@@ -24,7 +24,6 @@ import IconAccountOutline from 'vue-material-design-icons/AccountOutline.vue'
 import IconArrowLeft from 'vue-material-design-icons/ArrowLeft.vue'
 import IconClockOutline from 'vue-material-design-icons/ClockOutline.vue'
 import IconDeleteClockOutline from 'vue-material-design-icons/DeleteClockOutline.vue'
-import IconMagnify from 'vue-material-design-icons/Magnify.vue'
 import IconOfficeBuildingOutline from 'vue-material-design-icons/OfficeBuildingOutline.vue'
 import CalendarEventSmall from '../UIShared/CalendarEventSmall.vue'
 import LocalTime from '../UIShared/LocalTime.vue'
@@ -230,8 +229,8 @@ function handleHeaderClick() {
 		class="content"
 		:class="{ ['content--' + mode]: state === 'default' }">
 		<template v-if="state === 'default'">
-			<div v-if="isUser" class="content__actions">
-				<NcActions v-if="profileActions.length" forceMenu>
+			<div v-if="isUser && profileActions.length" class="content__actions">
+				<NcActions forceMenu>
 					<NcActionLink
 						v-for="action in profileActions"
 						:key="action.id"
@@ -242,15 +241,6 @@ function handleHeaderClick() {
 						{{ action.title }}
 					</NcActionLink>
 				</NcActions>
-				<NcButton
-					variant="tertiary"
-					:title="t('spreed', 'Search messages')"
-					:aria-label="t('spreed', 'Search messages')"
-					@click="emit('update:state', 'search')">
-					<template #icon>
-						<IconMagnify :size="20" />
-					</template>
-				</NcButton>
 			</div>
 
 			<div class="content__scroller animated">
@@ -271,7 +261,7 @@ function handleHeaderClick() {
 				<!-- User / conversation profile information -->
 				<div class="content__header animated">
 					<NcAppSidebarHeader
-						class="content__name content__name--has-actions"
+						class="content__name"
 						:class="{ 'content__name--has-profile-actions': profileActions.length }"
 						:name="sidebarTitle"
 						:title="sidebarTitle"
@@ -502,12 +492,8 @@ function handleHeaderClick() {
 			text-overflow: ellipsis;
 			cursor: pointer;
 
-			&--has-actions {
-				padding-inline-end: calc(var(--actions-offset) + var(--app-sidebar-close-button-offset));
-			}
-
 			&--has-profile-actions {
-				padding-inline-end: calc(2 * var(--actions-offset) + var(--app-sidebar-close-button-offset));
+				padding-inline-end: calc(var(--actions-offset) + var(--app-sidebar-close-button-offset));
 			}
 		}
 

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -127,6 +127,18 @@
 			<!-- Upcoming meetings -->
 			<CalendarEventsDialog v-if="showCalendarEvents" :token="token" />
 
+			<!-- Search messages button -->
+			<NcButton
+				v-if="!isInCall && !isSidebar && getUserId"
+				:title="t('spreed', 'Search messages')"
+				:aria-label="t('spreed', 'Search messages')"
+				variant="tertiary"
+				@click="openSidebar('search')">
+				<template #icon>
+					<IconMagnify :size="20" />
+				</template>
+			</NcButton>
+
 			<CallButton v-if="!isInCall" shrinkOnMobile />
 
 			<!-- TopBar menu -->
@@ -156,6 +168,7 @@ import IconAccountMultiplePlusOutline from 'vue-material-design-icons/AccountMul
 import IconArrowLeft from 'vue-material-design-icons/ArrowLeft.vue'
 import IconChevronRight from 'vue-material-design-icons/ChevronRight.vue'
 import IconClockOutline from 'vue-material-design-icons/ClockOutline.vue'
+import IconMagnify from 'vue-material-design-icons/Magnify.vue'
 import BreakoutRoomsEditor from '../BreakoutRoomsEditor/BreakoutRoomsEditor.vue'
 import CalendarEventsDialog from '../CalendarEventsDialog.vue'
 import ConversationIcon from '../ConversationIcon.vue'
@@ -201,6 +214,7 @@ export default {
 		IconArrowLeft,
 		IconChevronRight,
 		IconClockOutline,
+		IconMagnify,
 	},
 
 	props: {

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -140,12 +140,25 @@
 					class="top-bar__calendar-events"
 					:token="token" />
 
+				<!-- Search messages button -->
+				<NcButton
+					v-if="!isSidebar && actorStore.isLoggedIn && !isSmallMobile"
+					:title="t('spreed', 'Search messages')"
+					:aria-label="t('spreed', 'Search messages')"
+					variant="tertiary"
+					@click="openSidebar('search-messages')">
+					<template #icon>
+						<IconMagnify :size="20" />
+					</template>
+				</NcButton>
+
 				<CallButton v-if="!isInCall" shrinkOnMobile />
 
 				<!-- TopBar menu -->
 				<TopBarMenu
 					v-if="!isSidebar"
 					:token="token"
+					:showSearchAction="isSmallMobile"
 					@openBreakoutRoomsEditor="showBreakoutRoomsEditor = true" />
 			</div>
 
@@ -161,7 +174,7 @@
 <script>
 import { emit } from '@nextcloud/event-bus'
 import { n, t } from '@nextcloud/l10n'
-import { useIsMobile } from '@nextcloud/vue/composables/useIsMobile'
+import { useIsMobile, useIsSmallMobile } from '@nextcloud/vue/composables/useIsMobile'
 import { usernameToColor } from '@nextcloud/vue/functions/usernameToColor'
 import NcButton from '@nextcloud/vue/components/NcButton'
 import NcPopover from '@nextcloud/vue/components/NcPopover'
@@ -171,6 +184,7 @@ import IconAccountMultiplePlusOutline from 'vue-material-design-icons/AccountMul
 import IconArrowLeft from 'vue-material-design-icons/ArrowLeft.vue'
 import IconChevronRight from 'vue-material-design-icons/ChevronRight.vue'
 import IconClockOutline from 'vue-material-design-icons/ClockOutline.vue'
+import IconMagnify from 'vue-material-design-icons/Magnify.vue'
 import IconShieldLockOutline from 'vue-material-design-icons/ShieldLockOutline.vue'
 import BreakoutRoomsEditor from '../BreakoutRoomsEditor/BreakoutRoomsEditor.vue'
 import CalendarEventsDialog from '../CalendarEventsDialog.vue'
@@ -218,6 +232,7 @@ export default {
 		IconArrowLeft,
 		IconChevronRight,
 		IconClockOutline,
+		IconMagnify,
 		IconShieldLockOutline,
 	},
 
@@ -248,6 +263,7 @@ export default {
 			threadId: useGetThreadId(),
 			token: useGetToken(),
 			isMobile: useIsMobile(),
+			isSmallMobile: useIsSmallMobile(),
 		}
 	},
 

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -129,11 +129,11 @@
 
 			<!-- Search messages button -->
 			<NcButton
-				v-if="!isInCall && !isSidebar && getUserId"
+				v-if="!isSidebar && getUserId"
 				:title="t('spreed', 'Search messages')"
 				:aria-label="t('spreed', 'Search messages')"
 				variant="tertiary"
-				@click="openSidebar('search')">
+				@click="openSidebar('search-messages')">
 				<template #icon>
 					<IconMagnify :size="20" />
 				</template>

--- a/src/components/TopBar/TopBarMenu.vue
+++ b/src/components/TopBar/TopBarMenu.vue
@@ -123,7 +123,7 @@
 		<NcActionButton
 			v-if="actorStore.isLoggedIn"
 			variant="tertiary"
-			@click="sidebarStore.showSidebar({ activeTab: 'search' })">
+			@click="sidebarStore.showSidebar({ activeTab: 'search-messages' })">
 			<template #icon>
 				<IconMagnify :size="20" />
 			</template>

--- a/src/components/TopBar/TopBarMenu.vue
+++ b/src/components/TopBar/TopBarMenu.vue
@@ -119,9 +119,9 @@
 			{{ t('spreed', 'Download attendance list') }}
 		</NcActionLink>
 
-		<!-- Search messages button -->
+		<!-- Search messages button, only when not already shown next to CallButton -->
 		<NcActionButton
-			v-if="actorStore.isLoggedIn"
+			v-if="actorStore.isLoggedIn && showSearchAction"
 			variant="tertiary"
 			@click="sidebarStore.showSidebar({ activeTab: 'search-messages' })">
 			<template #icon>
@@ -223,6 +223,15 @@ export default {
 		token: {
 			type: String,
 			required: true,
+		},
+
+		/**
+		 * Whether the search messages action should be shown in this menu.
+		 * False when a dedicated search button is already shown next to CallButton.
+		 */
+		showSearchAction: {
+			type: Boolean,
+			default: false,
 		},
 	},
 

--- a/src/components/TopBar/TopBarMenu.vue
+++ b/src/components/TopBar/TopBarMenu.vue
@@ -118,6 +118,18 @@
 			</template>
 			{{ t('spreed', 'Download attendance list') }}
 		</NcActionLink>
+
+		<!-- Search messages button -->
+		<NcActionButton
+			v-if="actorStore.isLoggedIn"
+			variant="tertiary"
+			@click="sidebarStore.showSidebar({ activeTab: 'search' })">
+			<template #icon>
+				<IconMagnify :size="20" />
+			</template>
+			{{ t('spreed', 'Search messages') }}
+		</NcActionButton>
+
 		<!-- Fullscreen -->
 		<NcActionButton
 			v-if="!isInCall"
@@ -159,6 +171,7 @@ import IconDotsHorizontal from 'vue-material-design-icons/DotsHorizontal.vue'
 import IconFileOutline from 'vue-material-design-icons/FileOutline.vue'
 import IconFullscreen from 'vue-material-design-icons/Fullscreen.vue'
 import IconFullscreenExit from 'vue-material-design-icons/FullscreenExit.vue'
+import IconMagnify from 'vue-material-design-icons/Magnify.vue'
 import IconStop from 'vue-material-design-icons/Stop.vue'
 import IconVideoOutline from 'vue-material-design-icons/VideoOutline.vue'
 import IconFileDownload from '../../../img/material-icons/file-download.svg?raw'
@@ -175,6 +188,8 @@ import {
 	hasTalkFeature,
 	showTalkFeatureHint,
 } from '../../services/CapabilitiesManager.ts'
+import { useActorStore } from '../../stores/actor.ts'
+import { useSidebarStore } from '../../stores/sidebar.ts'
 import { isChannelConversation, isClassifiedConversation } from '../../utils/conversation.ts'
 import { generateAbsoluteUrl } from '../../utils/handleUrl.ts'
 import { callParticipantCollection } from '../../utils/webrtc/index.js'
@@ -196,6 +211,7 @@ export default {
 		IconFileOutline,
 		IconFullscreen,
 		IconFullscreenExit,
+		IconMagnify,
 		IconStop,
 		IconVideoOutline,
 	},
@@ -213,6 +229,9 @@ export default {
 	emits: ['openBreakoutRoomsEditor'],
 
 	setup(props) {
+		const actorStore = useActorStore()
+		const sidebarStore = useSidebarStore()
+
 		return {
 			IconFileDownload,
 			IconMicrophoneOffOutline,
@@ -220,6 +239,8 @@ export default {
 			isFullscreen: useDocumentFullscreen(),
 			isInCall: useIsInCall(),
 			toggleFullscreen,
+			actorStore,
+			sidebarStore,
 		}
 	},
 

--- a/src/components/UIShared/SearchBox.vue
+++ b/src/components/UIShared/SearchBox.vue
@@ -127,10 +127,11 @@ export default {
 		},
 
 		/**
-		 * Focuses the input
+		 * Focuses the input. `preventScroll` is on to avoid scrolling
+		 * hidden containers (e.g. sidebar) into view and aborting animations.
 		 */
 		focus() {
-			this.$refs.searchConversations.focus()
+			this.$refs.searchConversations.focus({ preventScroll: true })
 		},
 
 		getTrailingButton() {

--- a/src/components/UIShared/SearchBox.vue
+++ b/src/components/UIShared/SearchBox.vue
@@ -128,10 +128,11 @@ export default {
 		},
 
 		/**
-		 * Focuses the input
+		 * Focuses the input. `preventScroll` is on to avoid scrolling
+		 * hidden containers (e.g. sidebar) into view and aborting animations.
 		 */
 		focus() {
-			this.$refs.searchConversations.focus()
+			this.$refs.searchConversations.focus({ preventScroll: true })
 		},
 
 		getTrailingButton() {


### PR DESCRIPTION
## ☑️ Resolves

The in-conversation message search is hard to find: the only way to reach it is through the right sidebar. This adds a search button to the conversation top bar that opens it directly.

While wiring the button I noticed `showSidebar({ activeTab: 'search' })` landed on the participants tab, since `'search'` is a content state and not a tab id. `RightSidebar.handleUpdateActive` now forwards `'search'` to `handleUpdateState('search')`.

The first version of this PR also bound Ctrl+F, removed after @Antreesy pointed out it is already taken by the conversation search in the left navigation.

### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

Developed with Claude Code (claude-opus-4-8), commit carries the `Assisted-by` trailer. Reviewed and verified on a local Nextcloud 34 + Talk stable34 instance.

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="429" height="94" alt="2026-07-28_17h32_25" src="https://github.com/user-attachments/assets/c9ea8ad5-0cc0-4049-a7f1-c322b5a7be63" /> | <img width="443" height="89" alt="2026-07-28_17h16_47" src="https://github.com/user-attachments/assets/cc3b74c9-657a-41bc-9a7d-58213660a636" />
<img width="424" height="95" alt="2026-07-28_17h32_35" src="https://github.com/user-attachments/assets/8429fa22-7786-49e4-900f-c72bd634dabe" /> | <img width="444" height="89" alt="2026-07-28_17h16_55" src="https://github.com/user-attachments/assets/a777b32d-1016-4255-bb4d-4fd6cdb18f6b" />
<img width="337" height="91" alt="2026-07-28_17h32_52" src="https://github.com/user-attachments/assets/5b63c88f-811b-4fb9-b727-80563b5804dc" /> | <img width="348" height="90" alt="2026-07-28_17h33_29" src="https://github.com/user-attachments/assets/b8fe3445-c108-4505-b8db-9496ce2caf22" />

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
- [ ] 🏗️ Changes to database schema — no
- [ ] 🔖 New/changed API endpoints — no