### PR TITLE
feat: Add last-common-read to chat relay

### DIFF
--- a/lib/Signaling/Listener.php
+++ b/lib/Signaling/Listener.php
@@ -530,6 +530,7 @@ class Listener implements IEventListener {
 			$thread = null;
 		}
 		$data['chat']['comment'] = $message->toArray('json', $thread);
+		$data['chat']['comment']['lastCommonRead'] = $this->participantService->getLastCommonReadChatMessage($room);
 
 		$parent = $event->getParent();
 		if ($parent !== null) {
@@ -593,6 +594,7 @@ class Listener implements IEventListener {
 		}
 
 		$data['chat']['comment'] = $message->toArray('json', $thread);
+		$data['chat']['comment']['lastCommonRead'] = $this->participantService->getLastCommonReadChatMessage($room);
 
 		if ($messageType === 'call_started') {
 			$metaData = $comment->getMetaData() ?? [];
@@ -701,6 +703,7 @@ class Listener implements IEventListener {
 			'markdown' => false ,
 			'expirationTimestamp' => $message->getExpirationDateTime()?->getTimestamp() ?? 0,
 			'threadId' => $threadId,
+			'lastCommonRead' => $this->participantService->getLastCommonReadChatMessage($room),
 		];
 
 		$data['chat']['comment']['parent'] = $message->toArray('json', $thread);

--- a/tests/php/Signaling/ListenerTest.php
+++ b/tests/php/Signaling/ListenerTest.php
@@ -290,7 +290,9 @@ class ListenerTest extends TestCase {
 		$comment->method('getId')->willReturn(1);
 		$message = $this->createConfiguredMock(Message::class, [
 			'getVisibility' => true,
-			'toArray' => [],
+			'toArray' => [
+				'id' => 123,
+			],
 			'getMessageId' => 123,
 		]);
 		$l10n = $this->createStub(IL10N::class);
@@ -317,7 +319,10 @@ class ListenerTest extends TestCase {
 				'type' => 'chat',
 				'chat' => [
 					'refresh' => true,
-					'comment' => [],
+					'comment' => [
+						'id' => 123,
+						'lastCommonRead' => 0,
+					],
 				],
 			]);
 
@@ -333,7 +338,9 @@ class ListenerTest extends TestCase {
 		$comment->method('getId')->willReturn(1);
 		$message = $this->createConfiguredMock(Message::class, [
 			'getVisibility' => true,
-			'toArray' => [],
+			'toArray' => [
+				'id' => 123,
+			],
 			'getMessageId' => 123,
 		]);
 
@@ -365,7 +372,10 @@ class ListenerTest extends TestCase {
 				'type' => 'chat',
 				'chat' => [
 					'refresh' => true,
-					'comment' => [],
+					'comment' => [
+						'id' => 123,
+						'lastCommonRead' => 0,
+					],
 				],
 			]);
 


### PR DESCRIPTION
## 🛠️ API Checklist

When using chat relay, we are not updating the readmarker (that is the received lastCommonRead, we _do_ update our own readmarker). So the only way to do it while staying in a conversation is to wait for the next api request, which will include that.
We cannot add a property on the level of `comment`, the signaling controller does not allow that (since it also allows sending multiple chat messages in one signaling messages).

Downsides here are:
* We do an additional query
* We always send the data, even if the participant has set the read marker to private (which is currently suppressed on api level)

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
