### PR TITLE
fix: exclude local video slot reservation for recording layout

### DIFF
--- a/src/components/CallView/Grid/VideosGrid.vue
+++ b/src/components/CallView/Grid/VideosGrid.vue
@@ -452,14 +452,19 @@ export default {
 			}
 		},
 
+		// The local video always takes one slot if the grid view is not shown as a stripe.
+		// In recording mode the local video is not shown, so all slots are available.
+		noLocalVideoReserve() {
+			return this.isStripe || this.isRecording
+		},
+
 		// Number of grid slots (videos per page) at any given moment, clamped to
-		// `videosCap` (`0` means no cap). The local video always takes one slot if
-		// the grid view is not shown as a stripe.
+		// `videosCap` (`0` means no cap).
 		// The cap is primarily enforced by shrinking the grid layout (see
 		// `makeGrid`/`shrinkGrid`); this clamp keeps the "videos per page" math
 		// consistent even before the layout has been recomputed.
 		slots() {
-			const slots = this.isStripe ? this.rows * this.columns : this.rows * this.columns - 1
+			const slots = this.noLocalVideoReserve ? this.rows * this.columns : this.rows * this.columns - 1
 			return this.videosCap ? Math.min(this.videosCap, slots) : slots
 		},
 
@@ -771,7 +776,7 @@ export default {
 
 			let currentColumns = this.columns
 			let currentRows = this.rows
-			let currentSlots = this.isStripe ? currentColumns * currentRows : currentColumns * currentRows - 1
+			let currentSlots = this.noLocalVideoReserve ? currentColumns * currentRows : currentColumns * currentRows - 1
 
 			// Run this code only if we don't have an 'overflow' of videos. If the
 			// videos are populating the grid, there's no point in shrinking it.
@@ -804,7 +809,7 @@ export default {
 						currentColumns--
 					}
 
-					currentSlots = this.isStripe ? currentColumns * currentRows : currentColumns * currentRows - 1
+					currentSlots = this.noLocalVideoReserve ? currentColumns * currentRows : currentColumns * currentRows - 1
 
 					// Check that there are still enough slots available
 					if (numberOfVideos > currentSlots) {
@@ -817,7 +822,7 @@ export default {
 						currentRows--
 					}
 
-					currentSlots = this.isStripe ? currentColumns * currentRows : currentColumns * currentRows - 1
+					currentSlots = this.noLocalVideoReserve ? currentColumns * currentRows : currentColumns * currentRows - 1
 
 					// Check that there are still enough slots available
 					if (numberOfVideos > currentSlots) {


### PR DESCRIPTION
## ☑️ Resolves

* Extracted from #18208
* Can serve as a pre-requisite for:
  * RecordingApp.vue - in future might use the grid layout, but without local video (subscriber-only) VideosGrid.vue should use full slot count. #10060
  * LocalVideo.vue - user option to hide self from the screen #5351

### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

- Tested with older PR that includes excluded server changes

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [x] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required