### PR TITLE
fix(webrtc): restore allow audio/video calls when permissions are re-granted

### DIFF
--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -1024,7 +1024,10 @@ export function initWebRtc(signaling, _callParticipantCollection, _localCallPart
 			// If permissions were revoked, disable media devices
 			webrtc.webrtc.disallowAudio()
 		} else if (!webrtc.webrtc.isAudioAllowed()) {
-			// If permissions were just granted and media was not previous allowed
+			// If permissions were just granted and media was not previously
+			// allowed, re-enable the media device so that MediaDevicesSource
+			// restarts the track and trigger force reconnection
+			webrtc.webrtc.allowAudio()
 			// Mute audio to avoid unintentional audio publishing
 			webrtc.webrtc.mute()
 		}
@@ -1032,6 +1035,8 @@ export function initWebRtc(signaling, _callParticipantCollection, _localCallPart
 		if (!hasPublishVideoPermissions) {
 			webrtc.webrtc.disallowVideo()
 		} else if (!webrtc.webrtc.isVideoAllowed()) {
+			webrtc.webrtc.allowVideo()
+			// Mute video to avoid unintentional audio publishing
 			webrtc.webrtc.pauseVideo()
 		}
 


### PR DESCRIPTION
## ☑️ Resolves

* Fix #18434
* Fix regression from #16517
  * allowAudio / allowVideo were required to trigger force reconnection.
  * without it, MediaDevicesSource._audioAllowed / _videoAllowed stays false, so the track was never restarted, no sender is added to the peer connection, and the forced reconnection is silently skipped.


### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required