### PR TITLE
feat(call): keep call running while browsing other conversations (minimized call bar)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -5,8 +5,9 @@
 
 <template>
 	<NcContent
-		:class="{ 'icon-loading': loading, 'in-call': isInCall }"
+		:class="{ 'icon-loading': loading, 'in-call': isInCall, 'call-minimized': isCallMinimized }"
 		appName="talk">
+		<MinimizedCallBar v-if="isCallMinimized" class="app-call-bar" />
 		<LeftSidebar v-if="getUserId" ref="leftSidebar" />
 		<NcAppContent>
 			<router-view />
@@ -33,6 +34,7 @@ import { provide } from 'vue'
 import { START_LOCATION } from 'vue-router'
 import NcAppContent from '@nextcloud/vue/components/NcAppContent'
 import NcContent from '@nextcloud/vue/components/NcContent'
+import MinimizedCallBar from './components/CallView/MinimizedCallBar.vue'
 import ConversationSettingsDialog from './components/ConversationSettings/ConversationSettingsDialog.vue'
 import LeftSidebar from './components/LeftSidebar/LeftSidebar.vue'
 import MediaSettings from './components/MediaSettings/MediaSettings.vue'
@@ -50,7 +52,7 @@ import { useGetMessagesProvider } from './composables/useGetMessages.ts'
 import { useGetToken } from './composables/useGetToken.ts'
 import { useHashCheck } from './composables/useHashCheck.js'
 import { useInterceptNotifications } from './composables/useInterceptNotifications.ts'
-import { useIsInCall } from './composables/useIsInCall.js'
+import { useCallMinimized, useIsInCall } from './composables/useIsInCall.js'
 import { watchJoinedConversation } from './composables/useJoinedConversation.ts'
 import { useRecordingStatusSync } from './composables/useRecordingStatusSync.ts'
 import { useSessionIssueHandler } from './composables/useSessionIssueHandler.ts'
@@ -88,6 +90,7 @@ export default {
 		SettingsDialog,
 		ConversationSettingsDialog,
 		MediaSettings,
+		MinimizedCallBar,
 		PollManager,
 	},
 
@@ -107,6 +110,7 @@ export default {
 			token: useGetToken(),
 			tokenStore: useTokenStore(),
 			isInCall: useIsInCall(),
+			isCallMinimized: useCallMinimized(),
 			isLeavingAfterSessionIssue: useSessionIssueHandler(),
 			isMobile: useIsMobile(),
 			isNextcloudTalkHashDirty: useHashCheck(),
@@ -322,15 +326,38 @@ export default {
 				return
 			}
 
-			if (from.name === 'conversation' && from.params.token !== to.params.token) {
+			// Whether we are navigating away from the conversation that holds
+			// the active call. In that case we keep the call (and its signaling
+			// room) alive so it can be shown minimized, and open the target
+			// conversation as chat-only (no signaling join for it).
+			const keepCallAlive = from.name === 'conversation'
+				&& from.params.token !== to.params.token
+				&& this.callViewStore.activeCallToken === from.params.token
+				&& this.$store.getters.isInCall(from.params.token)
+
+			// Whether we are navigating back to the conversation that holds the
+			// active (minimized) call. Its session was never left, so we must
+			// NOT re-join it (that would trigger a "duplicate session" error).
+			const returningToActiveCall = to.name === 'conversation'
+				&& from.params.token !== to.params.token
+				&& this.callViewStore.activeCallToken === to.params.token
+				&& this.$store.getters.isInCall(to.params.token)
+
+			if (from.name === 'conversation' && from.params.token !== to.params.token && !keepCallAlive) {
 				// Await to properly close session / leave call before joining another one
 				await this.$store.dispatch('leaveConversation', { token: from.params.token })
 			}
 
-			/**
-			 * This runs whenever the new route is a conversation.
-			 */
-			if (to.name === 'conversation' && from.params.token !== to.params.token) {
+			if (returningToActiveCall) {
+				// Returning to the active call's conversation: its session was
+				// never left, so do not re-join. Restore the "joined" marker
+				// (a chat-only visit to another conversation moved it away) so
+				// the call controls are enabled again.
+				this.tokenStore.updateLastJoinedConversationToken(to.params.token)
+			} else if (to.name === 'conversation' && from.params.token !== to.params.token) {
+				/**
+				 * This runs whenever the new route is a conversation.
+				 */
 				// Fetch conversation object, if it's not known yet to the client
 				if (!this.$store.getters.conversation(to.params.token)) {
 					const result = await this.fetchSingleConversation(to.params.token)
@@ -340,7 +367,13 @@ export default {
 						return
 					}
 				}
-				this.$store.dispatch('joinConversation', { token: to.params.token })
+				// While a call is kept alive in another conversation, open the
+				// target as chat-only so we don't move the single signaling
+				// connection out of the call's room. Chat works over REST/poll.
+				// Awaited so the session is stable before next()/any follow-up
+				// joinCall reads the actor session id (otherwise a concurrent
+				// join can replace the session under a live call).
+				await this.$store.dispatch('joinConversation', { token: to.params.token, chatOnly: keepCallAlive })
 			}
 
 			next()
@@ -373,6 +406,10 @@ export default {
 			}
 			if (from.name === 'conversation' && to.name === 'conversation' && from.params.token === to.params.token) {
 				// Navigating within the same conversation
+				beforeRouteChangeListener(to, from, next)
+			} else if (this.canMinimizeCall(to, from)) {
+				// Navigating to another conversation while in a call: keep the
+				// call running and show it minimized instead of asking to leave.
 				beforeRouteChangeListener(to, from, next)
 			} else if (!this.warnLeaving || this.skipLeaveWarning || this.isVoiceRoom(from.params.token)) {
 				// Safe to navigate
@@ -421,6 +458,38 @@ export default {
 		isVoiceRoom(token) {
 			const conversation = this.$store.getters.conversation(token)
 			return Boolean(conversation?.attributes & CONVERSATION.ATTRIBUTE.VOICE_ROOM)
+		},
+
+		/**
+		 * Whether navigating from `from` to `to` should keep the active call
+		 * running (minimized) instead of prompting to leave it. True both when
+		 * leaving the active call's conversation to browse another one, and when
+		 * returning to the active call's conversation.
+		 *
+		 * @param {object} to target route
+		 * @param {object} from current route
+		 * @return {boolean}
+		 */
+		canMinimizeCall(to, from) {
+			const activeCallToken = this.callViewStore.activeCallToken
+			if (!activeCallToken
+				|| from.name !== 'conversation'
+				|| to.name !== 'conversation'
+				|| from.params.token === to.params.token) {
+				return false
+			}
+			// Leaving the active call's conversation to browse another one.
+			if (activeCallToken === from.params.token
+				&& this.$store.getters.isInCall(from.params.token)
+				&& !this.isVoiceRoom(from.params.token)) {
+				return true
+			}
+			// Returning to the active call's conversation from elsewhere.
+			if (activeCallToken === to.params.token
+				&& this.$store.getters.isInCall(to.params.token)) {
+				return true
+			}
+			return false
 		},
 
 		preventUnload(event) {
@@ -655,9 +724,25 @@ body#body-public {
 <style lang="scss" scoped>
 
 .content {
+	--call-bar-height: var(--default-clickable-area);
+
 	&.in-call {
 		:deep(.app-content) {
 			background-color: transparent;
+		}
+	}
+
+	// Minimized call bar: a full-width banner pinned just below the app header,
+	// pushing the navigation/content/sidebar columns down so it never overlaps
+	// existing UI (matches the "return to call" banner in Teams/Meet/Zoom).
+	&.call-minimized {
+		padding-block-start: var(--call-bar-height);
+
+		:deep(.app-call-bar) {
+			position: absolute;
+			inset-block-start: 0;
+			inset-inline: 0;
+			z-index: 1;
 		}
 	}
 

--- a/src/components/CallView/MinimizedCallBar.vue
+++ b/src/components/CallView/MinimizedCallBar.vue
@@ -1,0 +1,197 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<script setup lang="ts">
+import type { Conversation } from '../../types/index.ts'
+
+import { t } from '@nextcloud/l10n'
+import { computed } from 'vue'
+import { useRouter } from 'vue-router'
+import { useStore } from 'vuex'
+import NcButton from '@nextcloud/vue/components/NcButton'
+import IconArrowExpand from 'vue-material-design-icons/ArrowExpand.vue'
+import IconPhoneHangup from 'vue-material-design-icons/PhoneHangup.vue'
+import IconPhoneInTalk from 'vue-material-design-icons/PhoneInTalk.vue'
+import CallTime from '../TopBar/CallTime.vue'
+import LocalAudioControlButton from './shared/LocalAudioControlButton.vue'
+import { useActorStore } from '../../stores/actor.ts'
+import { useCallViewStore } from '../../stores/callView.ts'
+import { useTokenStore } from '../../stores/token.ts'
+import { localMediaModel } from '../../utils/webrtc/index.js'
+
+const router = useRouter()
+const store = useStore()
+const actorStore = useActorStore()
+const callViewStore = useCallViewStore()
+const tokenStore = useTokenStore()
+
+const token = computed<string>(() => callViewStore.activeCallToken)
+const conversation = computed<Conversation | undefined>(() => store.getters.conversation(token.value))
+
+/**
+ * Navigate back to the conversation the call is running in, which restores the
+ * full-size call view and dismisses this bar.
+ */
+function returnToCall() {
+	router.push({ name: 'conversation', params: { token: token.value } })
+}
+
+/**
+ * Leave the active call. The leaveCall store action clears the active call
+ * token, which dismisses this bar. The actor session is kept on the call's
+ * conversation while minimized, so participantIdentifier targets it correctly.
+ */
+async function leaveCall() {
+	const callToken = token.value
+	// The conversation currently being browsed was opened chat-only (no active
+	// session, so the global session stayed on the call). Remember it before
+	// leaving so we can give it a real session afterwards.
+	const openToken = tokenStore.token
+
+	callViewStore.setSelectedVideoPeerId(null)
+	await store.dispatch('leaveCall', {
+		token: callToken,
+		participantIdentifier: actorStore.participantIdentifier,
+		all: false,
+	})
+
+	// Now that the call is gone (leaveCall cleared the active call token), the
+	// central guard in joinConversation no longer forces chat-only, so this
+	// establishes a real session for the conversation we are viewing. Without
+	// it the actor session stays on the (now left) call and starting a call
+	// here would fail. Done here exactly once; cannot race the start-call flow
+	// (confirmLeaveMinimizedCall) as those are distinct user actions.
+	if (openToken && openToken !== callToken) {
+		await store.dispatch('joinConversation', { token: openToken })
+	}
+}
+</script>
+
+<template>
+	<div class="minimized-call-bar">
+		<button
+			class="minimized-call-bar__main"
+			:aria-label="t('spreed', 'Return to call')"
+			:title="t('spreed', 'Return to call')"
+			@click="returnToCall">
+			<IconPhoneInTalk :size="20" class="minimized-call-bar__icon" />
+			<span class="minimized-call-bar__label">
+				{{ t('spreed', 'Ongoing call in {name}', { name: conversation?.displayName ?? '' }) }}
+			</span>
+			<CallTime v-if="conversation" :start="conversation.callStartTime" class="minimized-call-bar__time" />
+		</button>
+
+		<div class="minimized-call-bar__controls">
+			<LocalAudioControlButton
+				v-if="conversation"
+				:token="token"
+				:conversation="conversation"
+				:model="localMediaModel"
+				variant="tertiary"
+				disableKeyboardShortcuts />
+			<NcButton
+				variant="tertiary"
+				@click="returnToCall">
+				<template #icon>
+					<IconArrowExpand :size="20" />
+				</template>
+				{{ t('spreed', 'Return to call') }}
+			</NcButton>
+			<NcButton
+				:aria-label="t('spreed', 'Leave call')"
+				:title="t('spreed', 'Leave call')"
+				variant="error"
+				@click="leaveCall">
+				<template #icon>
+					<IconPhoneHangup :size="20" />
+				</template>
+			</NcButton>
+		</div>
+	</div>
+</template>
+
+<style lang="scss" scoped>
+@use '../../assets/variables.scss' as *;
+
+// The bar uses the same dark "call chrome" as the rest of the call UI, so
+// white text/icons keep full contrast and the red leave button stands out
+// (matches the "return to call" banner pattern in Teams/Meet/Zoom).
+.minimized-call-bar {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: var(--default-grid-baseline);
+
+	width: 100%;
+	height: var(--call-bar-height);
+	padding-inline: var(--default-grid-baseline);
+
+	color: #ffffff;
+	background-color: $color-call-background;
+}
+
+.minimized-call-bar__main {
+	display: flex;
+	align-items: center;
+	gap: var(--default-grid-baseline);
+
+	min-width: 0;
+	height: var(--default-clickable-area);
+	padding-inline: var(--default-grid-baseline);
+	border: none;
+	border-radius: var(--border-radius-element);
+
+	color: inherit;
+	background-color: transparent;
+	cursor: pointer;
+
+	&:hover,
+	&:focus-visible {
+		background-color: rgba(255, 255, 255, 0.1);
+	}
+}
+
+.minimized-call-bar__icon {
+	flex: 0 0 auto;
+}
+
+.minimized-call-bar__label {
+	overflow: hidden;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+	font-weight: 600;
+}
+
+.minimized-call-bar__time {
+	flex: 0 0 auto;
+	opacity: 0.85;
+}
+
+.minimized-call-bar__controls {
+	display: flex;
+	align-items: center;
+	gap: calc(0.5 * var(--default-grid-baseline));
+	flex: 0 0 auto;
+
+	// White-on-dark for the reused tertiary control buttons (mute, return),
+	// with a translucent-white hover/focus consistent with the call chrome.
+	:deep(.button-vue--vue-tertiary),
+	:deep(.button-vue--tertiary) {
+		color: #ffffff;
+
+		&:hover,
+		&:focus-visible {
+			background-color: rgba(255, 255, 255, 0.1) !important;
+		}
+	}
+}
+
+// On mobile only the timer + controls fit; the long label collapses.
+@media (max-width: 768px) {
+	.minimized-call-bar__label {
+		display: none;
+	}
+}
+</style>

--- a/src/components/ChatView.vue
+++ b/src/components/ChatView.vue
@@ -10,6 +10,12 @@
 		@dragleave.prevent="handleDragLeave"
 		@drop.prevent="handleDropFiles">
 		<GuestWelcomeWindow v-if="showGuestWelcomeWindow" :token="token" />
+		<NcNoteCard
+			v-if="showLimitedUpdatesHint"
+			type="info"
+			class="chatView__call-hint">
+			{{ t('spreed', 'Live updates are limited while you are in a call. New messages may appear with a short delay.') }}
+		</NcNoteCard>
 		<div class="messages-list-dragover-wrapper">
 			<TransitionWrapper name="slide-up" mode="out-in">
 				<NcEmptyContent
@@ -68,6 +74,7 @@ import { provide } from 'vue'
 import NcButton from '@nextcloud/vue/components/NcButton'
 import NcEmptyContent from '@nextcloud/vue/components/NcEmptyContent'
 import NcIconSvgWrapper from '@nextcloud/vue/components/NcIconSvgWrapper'
+import NcNoteCard from '@nextcloud/vue/components/NcNoteCard'
 import IconAccountOutline from 'vue-material-design-icons/AccountOutline.vue'
 import IconAlertOctagonOutline from 'vue-material-design-icons/AlertOctagonOutline.vue'
 import IconChevronDoubleDown from 'vue-material-design-icons/ChevronDoubleDown.vue'
@@ -80,6 +87,7 @@ import TransitionWrapper from './UIShared/TransitionWrapper.vue'
 import IconFileUpload from '../../img/material-icons/file-upload.svg?raw'
 import { useGetThreadId } from '../composables/useGetThreadId.ts'
 import { useGetToken } from '../composables/useGetToken.ts'
+import { useCallMinimized } from '../composables/useIsInCall.js'
 import { CONVERSATION, PARTICIPANT } from '../constants.ts'
 import { getTalkConfig } from '../services/CapabilitiesManager.ts'
 import { EventBus } from '../services/EventBus.ts'
@@ -97,6 +105,7 @@ export default {
 		NcButton,
 		NcEmptyContent,
 		NcIconSvgWrapper,
+		NcNoteCard,
 		MessagesList,
 		NewMessage,
 		NewMessageUploadEditor,
@@ -126,6 +135,7 @@ export default {
 			IconFileUpload,
 			token: useGetToken(),
 			threadId: useGetThreadId(),
+			isCallMinimized: useCallMinimized(),
 			chatExtrasStore: useChatExtrasStore(),
 			actorStore: useActorStore(),
 			settingsStore: useSettingsStore(),
@@ -147,6 +157,17 @@ export default {
 
 		isGuestWithoutDisplayName() {
 			return this.isGuest && !this.actorStore.displayName
+		},
+
+		/**
+		 * Whether to warn that chat updates are poll-only because a call is
+		 * kept alive in another conversation. Not shown in the sidebar chat
+		 * (which belongs to the active call itself).
+		 *
+		 * @return {boolean}
+		 */
+		showLimitedUpdatesHint() {
+			return this.isCallMinimized && !this.isSidebar
 		},
 
 		canUploadFiles() {

--- a/src/components/NewMessage/NewMessage.vue
+++ b/src/components/NewMessage/NewMessage.vue
@@ -359,6 +359,7 @@ import NewMessageNewFileDialog from './NewMessageNewFileDialog.vue'
 import NewMessageTypingIndicator from './NewMessageTypingIndicator.vue'
 import { useChatMentions } from '../../composables/useChatMentions.ts'
 import { useGetThreadId } from '../../composables/useGetThreadId.ts'
+import { useCallMinimized } from '../../composables/useIsInCall.js'
 import { useTemporaryMessage } from '../../composables/useTemporaryMessage.ts'
 import { CONVERSATION, MESSAGE, PARTICIPANT, PRIVACY } from '../../constants.ts'
 import BrowserStorage from '../../services/BrowserStorage.js'
@@ -502,6 +503,7 @@ export default {
 			createTemporaryMessage,
 			convertToUnix,
 			isSidebar,
+			isCallMinimized: useCallMinimized(),
 		}
 	},
 
@@ -544,7 +546,7 @@ export default {
 		},
 
 		disabled() {
-			return this.isReadOnly || this.noChatPermission || !this.currentConversationIsJoined || this.isRecordingAudio
+			return this.isReadOnly || this.noChatPermission || !this.currentConversationChatAvailable || this.isRecordingAudio
 		},
 
 		scheduleMessageTime() {
@@ -571,7 +573,7 @@ export default {
 				return t('spreed', 'This conversation has been locked')
 			} else if (this.noChatPermission) {
 				return t('spreed', 'No permission to post messages in this conversation')
-			} else if (!this.currentConversationIsJoined) {
+			} else if (!this.currentConversationChatAvailable) {
 				return t('spreed', 'Joining conversation …')
 			} else if (this.silentChat) {
 				return t('spreed', 'Write a message without notification')
@@ -636,6 +638,18 @@ export default {
 
 		currentConversationIsJoined() {
 			return this.tokenStore.currentConversationIsJoined
+		},
+
+		/**
+		 * Whether chatting in this conversation is available. True when the
+		 * conversation is joined in the signaling server, OR when a call is kept
+		 * alive in another conversation and this one is browsed chat-only (no
+		 * signaling join). In the latter case the chat works over REST/polling.
+		 *
+		 * @return {boolean}
+		 */
+		currentConversationChatAvailable() {
+			return this.currentConversationIsJoined || this.isCallMinimized
 		},
 
 		currentUploadId() {
@@ -771,7 +785,7 @@ export default {
 	},
 
 	watch: {
-		currentConversationIsJoined() {
+		currentConversationChatAvailable() {
 			this.focusInput()
 		},
 

--- a/src/components/TopBar/CallButton.vue
+++ b/src/components/TopBar/CallButton.vue
@@ -116,7 +116,7 @@ import IconPhoneHangupOutline from 'vue-material-design-icons/PhoneHangupOutline
 import IconPhoneOffOutline from 'vue-material-design-icons/PhoneOffOutline.vue'
 import IconPhoneOutline from 'vue-material-design-icons/PhoneOutline.vue'
 import { useGetToken } from '../../composables/useGetToken.ts'
-import { useIsInCall } from '../../composables/useIsInCall.js'
+import { useCallMinimized, useIsInCall } from '../../composables/useIsInCall.js'
 import { useJoinCall } from '../../composables/useJoinCall.ts'
 import { ATTENDEE, CALL, CONVERSATION, PARTICIPANT } from '../../constants.ts'
 import { callSIPDialOut } from '../../services/callsService.ts'
@@ -207,12 +207,13 @@ export default {
 	},
 
 	setup() {
-		const { joinCall } = useJoinCall()
+		const { joinCall, confirmLeaveMinimizedCall } = useJoinCall()
 		return {
 			actorStore: useActorStore(),
 			tokenStore: useTokenStore(),
 			token: useGetToken(),
 			isInCall: useIsInCall(),
+			isCallMinimized: useCallMinimized(),
 			breakoutRoomsStore: useBreakoutRoomsStore(),
 			callViewStore: useCallViewStore(),
 			talkHashStore: useTalkHashStore(),
@@ -220,6 +221,7 @@ export default {
 			soundsStore: useSoundsStore(),
 			isMobile: useIsMobile(),
 			joinCall,
+			confirmLeaveMinimizedCall,
 		}
 	},
 
@@ -285,7 +287,7 @@ export default {
 				|| this.isInLobby
 				|| this.conversation.readOnly
 				|| this.isNextcloudTalkHashDirty
-				|| !this.tokenStore.currentConversationIsJoined
+				|| (!this.tokenStore.currentConversationIsJoined && !this.isCallMinimized)
 				|| blockCalls
 		},
 
@@ -432,7 +434,7 @@ export default {
 			this.loading = false
 		},
 
-		handleClick() {
+		async handleClick() {
 			if (this.hasExternalCallService) {
 				// Another service is in charge, trigger iframe rendering in MainView
 				this.handleExternalCall()
@@ -441,6 +443,13 @@ export default {
 
 			// Create audio objects as a result of a user interaction to allow playing sounds in Safari
 			this.soundsStore.initAudioObjects()
+
+			// If another call is kept alive (minimized), confirm leaving it and
+			// re-join this conversation before continuing the normal join flow
+			// (which may open MediaSettings). Cancelling keeps the other call.
+			if (!await this.confirmLeaveMinimizedCall(this.token)) {
+				return
+			}
 
 			if (this.isMediaSettings || this.isPhoneRoom) {
 				this.handleJoinCall()

--- a/src/composables/useActiveSession.js
+++ b/src/composables/useActiveSession.js
@@ -8,6 +8,7 @@ import { useStore } from 'vuex'
 import { SESSION } from '../constants.ts'
 import { hasTalkFeature } from '../services/CapabilitiesManager.ts'
 import { setSessionState } from '../services/participantsService.js'
+import { useCallViewStore } from '../stores/callView.ts'
 import { useTokenStore } from '../stores/token.ts'
 import { useDocumentVisibility } from './useDocumentVisibility.ts'
 import { useGetToken } from './useGetToken.ts'
@@ -27,6 +28,7 @@ export function useActiveSession() {
 	const store = useStore()
 	const token = useGetToken()
 	const tokenStore = useTokenStore()
+	const callViewStore = useCallViewStore()
 	// FIXME has no API support on federated conversations
 	const supportSessionState = computed(() => hasTalkFeature(token.value, 'session-state'))
 
@@ -81,8 +83,13 @@ export function useActiveSession() {
 			if (error?.response?.status === 404) {
 				// In case of 404 - participant did not have a session, block UI to join call
 				tokenStore.updateLastJoinedConversationToken('')
-				// Automatically try to join the conversation again
-				store.dispatch('joinConversation', { token: token.value })
+				// Automatically try to join the conversation again, unless a call
+				// is kept alive in another conversation: this one is intentionally
+				// chat-only and has no session, so re-joining would only churn
+				// (and the central guard would force it chat-only anyway).
+				if (!(callViewStore.activeCallToken && callViewStore.activeCallToken !== token.value)) {
+					store.dispatch('joinConversation', { token: token.value })
+				}
 			}
 		}
 	}
@@ -107,8 +114,13 @@ export function useActiveSession() {
 			if (error?.response?.status === 404) {
 				// In case of 404 - participant did not have a session, block UI to join call
 				tokenStore.updateLastJoinedConversationToken('')
-				// Automatically try to join the conversation again
-				store.dispatch('joinConversation', { token: token.value })
+				// Automatically try to join the conversation again, unless a call
+				// is kept alive in another conversation: this one is intentionally
+				// chat-only and has no session, so re-joining would only churn
+				// (and the central guard would force it chat-only anyway).
+				if (!(callViewStore.activeCallToken && callViewStore.activeCallToken !== token.value)) {
+					store.dispatch('joinConversation', { token: token.value })
+				}
 			}
 		}
 	}

--- a/src/composables/useIsInCall.js
+++ b/src/composables/useIsInCall.js
@@ -26,6 +26,16 @@ function useIsInCallComposable() {
 		if (callViewStore.forceCallView) {
 			return true
 		}
+		// When viewing the conversation that holds the active call, show the
+		// full call view even if the joined-conversation session marker points
+		// to another conversation we browsed to while the call was minimized.
+		// Guard against the empty token (no conversation open / no active call),
+		// otherwise '' === '' would short-circuit into isInCall('').
+		if (callViewStore.activeCallToken !== ''
+			&& callViewStore.activeCallToken === token.value
+			&& store.getters.isInCall(token.value)) {
+			return true
+		}
 		return joinedConversationToken.value === token.value && store.getters.isInCall(token.value)
 	})
 }
@@ -36,3 +46,31 @@ function useIsInCallComposable() {
  * @return {import('vue').ComputedRef<boolean>}
  */
 export const useIsInCall = createSharedComposable(useIsInCallComposable)
+
+/**
+ * Check whether the user is connected to a call of a conversation other than
+ * the one currently shown. In that case the call should be rendered as a
+ * minimized in-call bar so the user can browse other conversations while the
+ * call keeps running.
+ *
+ * @return {import('vue').ComputedRef<boolean>}
+ */
+function useCallMinimizedComposable() {
+	const store = useStore()
+	const callViewStore = useCallViewStore()
+	const token = useGetToken()
+
+	return computed(() => {
+		const activeCallToken = callViewStore.activeCallToken
+		return activeCallToken !== ''
+			&& activeCallToken !== token.value
+			&& store.getters.isInCall(activeCallToken)
+	})
+}
+
+/**
+ * Shared composable to check whether the active call should be shown minimized.
+ *
+ * @return {import('vue').ComputedRef<boolean>}
+ */
+export const useCallMinimized = createSharedComposable(useCallMinimizedComposable)

--- a/src/composables/useJoinCall.ts
+++ b/src/composables/useJoinCall.ts
@@ -8,11 +8,14 @@ import type { Conversation, Participant } from '../types/index.ts'
 import { showError } from '@nextcloud/dialogs'
 import { emit } from '@nextcloud/event-bus'
 import { t } from '@nextcloud/l10n'
+import { spawnDialog } from '@nextcloud/vue/functions/dialog'
 import { useStore } from 'vuex'
+import ConfirmDialog from '../components/UIShared/ConfirmDialog.vue'
 import { ATTENDEE, CALL, CONVERSATION, PARTICIPANT } from '../constants.ts'
 import { callSIPDialOut } from '../services/callsService.ts'
 import { getTalkConfig } from '../services/CapabilitiesManager.ts'
 import { useActorStore } from '../stores/actor.ts'
+import { useCallViewStore } from '../stores/callView.ts'
 import { useSettingsStore } from '../stores/settings.ts'
 import { isAxiosErrorResponse } from '../types/guards.ts'
 
@@ -22,7 +25,47 @@ import { isAxiosErrorResponse } from '../types/guards.ts'
 export function useJoinCall() {
 	const actorStore = useActorStore()
 	const settingsStore = useSettingsStore()
+	const callViewStore = useCallViewStore()
 	const vuexStore = useStore()
+
+	/**
+	 * If a call is kept alive (minimized) in another conversation, ask the user
+	 * to leave it before joining this one. A single signaling connection can
+	 * only be in one call at a time. Returns false if the user cancelled.
+	 *
+	 * @param token - conversation token the user wants to join a call in
+	 */
+	async function confirmLeaveMinimizedCall(token: string): Promise<boolean> {
+		const activeCallToken = callViewStore.activeCallToken
+		if (!activeCallToken || activeCallToken === token || !vuexStore.getters.isInCall(activeCallToken)) {
+			return true
+		}
+
+		const activeConversation = vuexStore.getters.conversation(activeCallToken)
+		const result = await spawnDialog(ConfirmDialog, {
+			name: t('spreed', 'Leave call'),
+			message: t('spreed', 'You are already in a call in {conversation}. Leave it and join the call here?', {
+				conversation: activeConversation?.displayName ?? '',
+			}),
+			buttons: [
+				{ label: t('spreed', 'Cancel'), variant: 'tertiary', callback: () => false },
+				{ label: t('spreed', 'Leave call & join'), variant: 'primary', callback: () => true },
+			],
+		})
+		if (result !== true) {
+			return false
+		}
+
+		// Leave the previous call, then re-join this conversation fully so the
+		// actor session / signaling move here before joining its call.
+		await vuexStore.dispatch('leaveCall', {
+			token: activeCallToken,
+			participantIdentifier: actorStore.participantIdentifier,
+			all: false,
+		})
+		await vuexStore.dispatch('joinConversation', { token })
+		return true
+	}
 
 	/**
 	 * Returns whether the conversation is a phone room (with a single SIP phone participant)
@@ -77,6 +120,13 @@ export function useJoinCall() {
 		shouldStartRecording = false,
 		directCall = false,
 	} = {}) {
+		// If another call is kept alive (minimized), confirm leaving it first.
+		// This also re-joins the target conversation so the actor session moves
+		// here before the guard below and before joining the call.
+		if (!await confirmLeaveMinimizedCall(token)) {
+			return
+		}
+
 		const conversation = vuexStore.getters.conversation(token)
 		if (!actorStore.participantIdentifier.sessionId || conversation.attendeeId !== actorStore.participantIdentifier.attendeeId) {
 			console.error('Trying to join call without having joined the conversation')
@@ -143,5 +193,6 @@ export function useJoinCall() {
 
 	return {
 		joinCall,
+		confirmLeaveMinimizedCall,
 	}
 }

--- a/src/store/participantsStore.js
+++ b/src/store/participantsStore.js
@@ -864,12 +864,15 @@ const actions = {
 			commit('updateParticipant', { token, attendeeId: attendee.attendeeId, updatedData })
 			const callViewStore = useCallViewStore()
 			callViewStore.handleJoinCall(getters.conversation(token))
+			// Remember the joined call so it survives navigation to other
+			// conversations and can be shown in the MinimizedCallBar.
+			callViewStore.setActiveCallToken(token)
 		} catch (e) {
 			console.error('Error while joining call: ', e)
 		}
 	},
 
-	async leaveCall({ commit, getters }, { token, participantIdentifier, all = false }) {
+	async leaveCall({ commit, dispatch, getters }, { token, participantIdentifier, all = false }) {
 		if (!participantIdentifier?.sessionId) {
 			console.error('Trying to leave call without sessionId')
 		}
@@ -904,6 +907,34 @@ const actions = {
 			sessionId: participantIdentifier.sessionId,
 			flags: PARTICIPANT.CALL_FLAG.DISCONNECTED,
 		})
+
+		// Forget the active call so the MinimizedCallBar is dismissed.
+		if (callViewStore.activeCallToken === token) {
+			callViewStore.clearActiveCallToken()
+		}
+
+		// Always drop the forced call view on leave. It is only set by the
+		// automatic call-switch flow and its single reset lives in an
+		// async, success-only callback; without this, a stuck forceCallView
+		// would keep useIsInCall returning true and the call view mounted
+		// after leaving (the "leave does nothing" symptom).
+		callViewStore.setForceCallView(false)
+
+		// When leaving a call that is not the conversation currently open (i.e.
+		// leaving from the minimized call bar while browsing another one), the
+		// left conversation's chat is no longer polled, so its "call_ended"
+		// system message never arrives to clear the "Call in progress"
+		// indicator. Refresh it from the server.
+		//
+		// NB: re-establishing the actor session for the currently open
+		// (chat-only) conversation is intentionally NOT done here. It is
+		// handled by the leave caller (MinimizedCallBar when hanging up while
+		// browsing, or confirmLeaveMinimizedCall when starting a call here),
+		// so the join happens exactly once and is awaited before any follow-up
+		// joinCall — doing it here as well races and drops the new call.
+		if (tokenStore.token && tokenStore.token !== token) {
+			dispatch('fetchConversation', { token })
+		}
 	},
 
 	/**
@@ -952,8 +983,42 @@ const actions = {
 	 * @param {object} context - unused.
 	 * @param {object} data - the wrapping object.
 	 * @param {string} data.token - conversation token.
+	 * @param data.chatOnly
 	 */
-	async joinConversation(context, { token }) {
+	async joinConversation(context, { token, chatOnly = false }) {
+		// Invariant: while a call is active in another conversation, NEVER create
+		// a second active session. Talk has a single active session per user, so
+		// a real join (POST participants/active + signaling.joinRoom) would move
+		// the signaling room off the call and the server would drop it after a
+		// few seconds (start->auto-leave loop). Force chat-only here so every
+		// caller (navigation, useActiveSession 404 handler, forceJoinConversation
+		// churn) is safe regardless of how it dispatched. A real join is only
+		// allowed again after leaveCall has cleared the active call token.
+		const callViewStore = useCallViewStore()
+		if (callViewStore.activeCallToken
+			&& callViewStore.activeCallToken !== token
+			&& context.getters.isInCall(callViewStore.activeCallToken)) {
+			chatOnly = true
+		}
+
+		// Chat-only mode: opened while a call is kept alive in another
+		// conversation. Do NOT create a second active session (which would
+		// conflict with the call's session and trigger a "duplicate session"
+		// error). The chat works over REST + polling, which only needs the
+		// conversation and its participants in the store, not an active session.
+		if (chatOnly) {
+			await context.dispatch('fetchConversation', { token })
+			await context.dispatch('fetchParticipants', { token })
+			// NB: we deliberately do NOT mark this conversation as "joined"
+			// (updateLastJoinedConversationToken) — that would falsely imply a
+			// signaling-room join and mislead consumers of currentConversationIsJoined
+			// (typing, WebRTC, presence). Chat input and the call button are
+			// instead enabled via the dedicated "chat available" / minimized-call
+			// state (see currentConversationChatAvailable in NewMessage/CallButton,
+			// derived from useCallMinimized). The chat works over REST + polling.
+			return
+		}
+
 		const forceJoin = SessionStorage.getItem('joined_conversation') === token
 		const actorStore = useActorStore()
 

--- a/src/store/participantsStore.spec.js
+++ b/src/store/participantsStore.spec.js
@@ -59,7 +59,13 @@ vi.mock('../services/conversationsService', () => ({
 }))
 vi.mock('../stores/callView', () => ({
 	useCallViewStore: vi.fn(() => ({
+		activeCallToken: '',
+		isLiveTranscriptionEnabled: false,
 		handleJoinCall: vi.fn(),
+		setActiveCallToken: vi.fn(),
+		clearActiveCallToken: vi.fn(),
+		setForceCallView: vi.fn(),
+		disableLiveTranscription: vi.fn(),
 	})),
 }))
 

--- a/src/stores/__tests__/callView.spec.js
+++ b/src/stores/__tests__/callView.spec.js
@@ -230,6 +230,14 @@ describe('callViewStore', () => {
 			expect(callViewStore.forceCallView).toBeTruthy()
 		})
 
+		it('sets and clears the active call token', () => {
+			expect(callViewStore.activeCallToken).toBe('')
+			callViewStore.setActiveCallToken(TOKEN)
+			expect(callViewStore.activeCallToken).toBe(TOKEN)
+			callViewStore.clearActiveCallToken()
+			expect(callViewStore.activeCallToken).toBe('')
+		})
+
 		it('sets value on isViewerOverlay', () => {
 			expect(callViewStore.isViewerOverlay).toBeFalsy()
 			callViewStore.setIsViewerOverlay(true)

--- a/src/stores/callView.ts
+++ b/src/stores/callView.ts
@@ -27,6 +27,7 @@ type State = {
 	callEndedTimeout: NodeJS.Timeout | number | undefined
 	isLiveTranscriptionEnabled: boolean
 	externalCallServiceUrl: string | null
+	activeCallToken: string
 }
 
 type CallViewModePayload = {
@@ -50,6 +51,10 @@ export const useCallViewStore = defineStore('callView', {
 		callEndedTimeout: undefined,
 		isLiveTranscriptionEnabled: false,
 		externalCallServiceUrl: null,
+		// Token of the call the user actually joined. Unlike the route token,
+		// this stays set while the user navigates to other conversations, so
+		// the call keeps running and can be shown in the MinimizedCallBar.
+		activeCallToken: '',
 	}),
 
 	getters: {
@@ -75,6 +80,20 @@ export const useCallViewStore = defineStore('callView', {
 
 		setSelectedVideoPeerId(value: string | null) {
 			this.selectedVideoPeerId = value
+		},
+
+		/**
+		 * Remembers which call the user is actually connected to, so the call
+		 * survives navigation to other conversations and can be minimized.
+		 *
+		 * @param token conversation token of the joined call
+		 */
+		setActiveCallToken(token: string) {
+			this.activeCallToken = token
+		},
+
+		clearActiveCallToken() {
+			this.activeCallToken = ''
 		},
 
 		handleJoinCall(conversation: Conversation) {


### PR DESCRIPTION
## ☑️ Resolves

* No existing issue — this PR stands on its own; the problem is described below.
* Related: nextcloud/talk-desktop#1292

Navigating to another conversation while in a call used to **end the call**, forcing users to leave the call to read or reply in other chats. This PR keeps the call running and shows it as a persistent **minimized in-call bar** while another conversation opens as chat-only — matching how Teams, Google Meet and Zoom keep a "return to call" banner while you browse.

<img width="1411" height="710" alt="Talk switch" src="https://github.com/user-attachments/assets/ccc9963a-b60c-4064-ba83-908811b5876b" />


### How it works

Talk shares a **single signaling connection** that can only be in one room at a time, and a **single active session per user**. So the browsed conversation is opened *without* joining its signaling room or creating a second active session:

- The call's conversation keeps the signaling room **and** the active session, so audio/video/screenshare keep flowing.
- The browsed conversation's chat works over **REST + polling** (`fetchConversation` + `fetchParticipants`, no `POST participants/active`). Sending, history, reactions and read markers all work; only typing/presence push is unavailable while the call runs — indicated by a subtle hint.
- Starting a call in another conversation while one is already running asks for **confirmation first** (leave the current call and join here).

The core invariant: **while a call is active, no code path may create a second active session** (a central guard in the `joinConversation` Vuex action forces chat-only for any other conversation; a real join only resumes after the call is left). This prevents the call's session from being superseded and dropped.


https://github.com/user-attachments/assets/9ba8c5a5-0162-44b4-89ec-df2e81c4818f



### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
Opening another chat during a call ends the call | The call keeps running as a dark in-call bar under the header; the other chat opens as chat-only

<!-- TODO: attach before/after screenshots (light + dark) and a short screencast of: start call → open another chat → return / hang up -->

### 🚧 Tasks

- [x] Keep the call running when navigating to another conversation (no `DELETE /call/{token}`, no `signaling.joinRoom` for the browsed room)
- [x] Persistent minimized in-call bar (conversation name, call timer, mute, return-to-call, leave); full-width top bar on mobile-web
- [x] Subtle hint in the browsed chat that live updates are poll-only during a call
- [x] Confirmation dialog before starting a second call (leave current call & join here)
- [x] Single-active-session invariant enforced centrally in `joinConversation`

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [x] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required

#### Notes for reviewers

- **Scope:** web + Talk Desktop (same bundle). Native Talk Android/iOS are separate repositories and out of scope.
- **Trade-off:** the browsed conversation's chat is poll-only while a call is minimized (no typing/presence push, ~0.5–1s latency). This is surfaced with an `NcNoteCard` hint and is the intended behavior given the single signaling connection.
- **No new server requirements:** purely client-side. No new endpoints or capabilities; the existing `session-state` capability and REST chat polling are reused. Minimum Nextcloud version is unchanged (NC 35 / Talk 25).
- **Bar styling:** reuses the existing `$color-call-background` call-chrome token with white-on-dark text (consistent with `CallTime`/`VideoBottomBar`).
- Design-team review on the in-call bar placement/styling would be welcome.

## 🛠️ API Checklist

No API changes — this is a frontend-only feature.

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed
