### PR TITLE
fix(recording): Limit config key length for request-upload configs

### DIFF
--- a/lib/Service/RecordingService.php
+++ b/lib/Service/RecordingService.php
@@ -54,7 +54,7 @@ class RecordingService {
 	public const CONSENT_REQUIRED_OPTIONAL = 2;
 
 	public const APPCONFIG_PREFIX = 'recording/';
-	public const APPCONFIG_UPLOAD_PREFIX = 'recording-upload/';
+	public const APPCONFIG_UPLOAD_PREFIX = 'recupload/';
 
 	public const DEFAULT_ALLOWED_RECORDING_FORMATS = [
 		'audio/ogg' => ['ogg'],
@@ -315,7 +315,7 @@ class RecordingService {
 	}
 
 	private function getUploadShareConfigKey(Room $room, string $fileName): string {
-		return self::APPCONFIG_UPLOAD_PREFIX . $room->getToken() . '/' . basename($fileName);
+		return self::APPCONFIG_UPLOAD_PREFIX . $room->getToken() . '/' . sha1(basename($fileName));
 	}
 
 	/**

--- a/tests/php/Service/RecordingServiceTest.php
+++ b/tests/php/Service/RecordingServiceTest.php
@@ -246,7 +246,7 @@ class RecordingServiceTest extends TestCase {
 
 		$this->appConfig->expects($this->once())
 			->method('setAppValueString')
-			->with(RecordingService::APPCONFIG_UPLOAD_PREFIX . 'token123/recording.mp4', 'shareToken', true, true);
+			->with(RecordingService::APPCONFIG_UPLOAD_PREFIX . 'token123/' . sha1('recording.mp4'), 'shareToken', true, true);
 
 		// The active-recording marker is cleared once the upload share is created,
 		// so a new recording can start while this one is still being uploaded.
@@ -324,7 +324,7 @@ class RecordingServiceTest extends TestCase {
 		// Only the temporary upload share's tracking value is cleared here; the
 		// active-recording marker was already removed in requestUpload().
 		$this->appConfig->expects($this->once())->method('deleteAppValue')
-			->with(RecordingService::APPCONFIG_UPLOAD_PREFIX . 'token123/name.ogg');
+			->with(RecordingService::APPCONFIG_UPLOAD_PREFIX . 'token123/' . sha1('name.ogg'));
 
 		$this->notificationManager->expects($this->once())->method('notify');
 


### PR DESCRIPTION
## ☑️ Resolves

Upload with a long filename otherwise causes an error:
```xml
<?xml version="1.0"?>
<ocs>
<meta>
<status>failure</status>
<statuscode>400</statuscode>
<message></message>
</meta>
<data>
<error>Value (recording-upload/iip3ca8c/dbe5c5e0e279a4f73442062c41f3fc7f_1782454462.mp4) for key is too long (64)</error>
</data>
</ocs>
```

## 🛠️ API Checklist
### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
