### PR TITLE
fix(recording): Support sensitive config for recording data

### DIFF
--- a/lib/Config.php
+++ b/lib/Config.php
@@ -182,25 +182,13 @@ class Config {
 	}
 
 	public function getRecordingServers(): array {
-		$config = $this->config->getAppValue('spreed', 'recording_servers');
-		$recording = json_decode($config, true);
-
-		if (!is_array($recording) || !isset($recording['servers'])) {
-			return [];
-		}
-
-		return $recording['servers'];
+		$recording = $this->appConfig->getAppValueArray('recording_servers');
+		return $recording['servers'] ?? [];
 	}
 
 	public function getRecordingSecret(): string {
-		$config = $this->config->getAppValue('spreed', 'recording_servers');
-		$recording = json_decode($config, true);
-
-		if (!is_array($recording)) {
-			return '';
-		}
-
-		return $recording['secret'];
+		$recording = $this->appConfig->getAppValueArray('recording_servers');
+		return $recording['secret'] ?? '';
 	}
 
 	public function isRecordingEnabled(): bool {

--- a/tests/php/Recording/BackendNotifierTest.php
+++ b/tests/php/Recording/BackendNotifierTest.php
@@ -76,19 +76,23 @@ class BackendNotifierTest extends TestCase {
 		$config = \OCP\Server::get(IConfig::class);
 		$this->recordingSecret = 'the-recording-secret';
 		$this->baseUrl = 'https://localhost/recording';
-		$config->setAppValue('spreed', 'recording_servers', json_encode([
-			'secret' => $this->recordingSecret,
-			'servers' => [
-				[
-					'server' => $this->baseUrl,
-				],
-			],
-		]));
 
 		$this->secureRandom = \OCP\Server::get(ISecureRandom::class);
 		$this->urlGenerator = $this->createMock(IURLGenerator::class);
 
 		$appConfig = $this->createMock(IAppConfig::class);
+		$appConfig->expects($this->any())
+			->method('getAppValueArray')
+			->with('recording_servers')
+			->willReturn([
+				'secret' => $this->recordingSecret,
+				'servers' => [
+					[
+						'server' => $this->baseUrl,
+					],
+				],
+			]);
+
 		$userConfig = $this->createMock(IUserConfig::class);
 		$groupManager = $this->createMock(IGroupManager::class);
 		$userManager = $this->createMock(IUserManager::class);


### PR DESCRIPTION
Use:
```
occ config:app:set spreed recording_servers --value '{"secret":"abc"}' --sensitive
```
and try to use the recording afterwards or load the data in the admin UI

Before | After
---|---
<img width="701" height="226" alt="Bildschirmfoto vom 2026-06-26 13-24-26" src="https://github.com/user-attachments/assets/e9b0d3f5-f613-4cad-ab50-4ccc55e3338d" /> | <img width="701" height="226" alt="Bildschirmfoto vom 2026-06-26 13-24-15" src="https://github.com/user-attachments/assets/2005295f-f9e8-44d7-8215-f51521095003" />


### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
