### PR TITLE
chore(release): Changelog for v24.0.1,v23.0.7,v22.0.14

### DIFF
--- a/docs/changelogs/changelog-22.md
+++ b/docs/changelogs/changelog-22.md
@@ -5,6 +5,21 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 22.0.14 – 2026-06-26
+### Changed
+- Update dependencies
+- Update translations
+
+### Fixed
+- fix(call): Increase FPS to 30 in all levels and update video quality
+  [#18408](https://github.com/nextcloud/spreed/pull/18408)
+- fix(call): reconnect participants when media-permissions are re-granted
+  [#18439](https://github.com/nextcloud/spreed/pull/18439)
+- fix(call): stop virtual background effect when device checker is not in use
+  [#18295](https://github.com/nextcloud/spreed/pull/18295)
+- fix(recording): allow recording service to work on E2EE calls
+  [#18266](https://github.com/nextcloud/spreed/pull/18266)
+
 ## 22.0.13 – 2026-05-28
 ### Changed
 - Update dependencies

--- a/docs/changelogs/changelog-23.md
+++ b/docs/changelogs/changelog-23.md
@@ -5,6 +5,25 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 23.0.7 – 2026-06-26
+### Changed
+- Update dependencies
+- Update translations
+
+### Fixed
+- fix(call): Increase FPS to 30 in all levels and update video quality
+  [#18409](https://github.com/nextcloud/spreed/pull/18409)
+- fix(call): reconnect participants when media-permissions are re-granted
+  [#18440](https://github.com/nextcloud/spreed/pull/18440)
+- fix(settings): Allow to configure certificates expiration
+  [#18299](https://github.com/nextcloud/spreed/pull/18299)
+- fix(call): stop virtual background effect when device checker is not in use
+  [#18291](https://github.com/nextcloud/spreed/pull/18291)
+- fix(admin): restore admin setting for default group notifications
+  [#18280](https://github.com/nextcloud/spreed/pull/18280)
+- fix(recording): allow recording service to work on E2EE calls
+  [#18267](https://github.com/nextcloud/spreed/pull/18267)
+
 ## 23.0.6 – 2026-06-02
 ### Changed
 - Update dependencies

--- a/docs/changelogs/changelog-24.md
+++ b/docs/changelogs/changelog-24.md
@@ -5,6 +5,27 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 24.0.1 – 2026-06-26
+### Changed
+- Update dependencies
+- Update translations
+
+### Fixed
+- fix(call): Increase FPS to 30 in all levels and update video quality
+  [#18410](https://github.com/nextcloud/spreed/pull/18410)
+- fix(call): reconnect participants when media-permissions are re-granted
+  [#18441](https://github.com/nextcloud/spreed/pull/18441)
+- fix(session): restore access to password-protected rooms for email guests
+  [#18347](https://github.com/nextcloud/spreed/pull/18347)
+- fix(settings): Allow to configure certificates expiration
+  [#18300](https://github.com/nextcloud/spreed/pull/18300)
+- fix(call): stop virtual background effect when device checker is not in use
+  [#18292](https://github.com/nextcloud/spreed/pull/18292)
+- fix(admin): restore admin setting for default group notifications
+  [#18281](https://github.com/nextcloud/spreed/pull/18281)
+- fix(recording): allow recording service to work on E2EE calls
+  [#18268](https://github.com/nextcloud/spreed/pull/18268)
+
 ## 24.0.0 – 2026-06-08
 ### Added
 - Call from anywhere - Integration of calls into the avatar menu


### PR DESCRIPTION
## 22.0.14 – 2026-06-26
### Changed
- Update dependencies
- Update translations
### Fixed
- fix(call): Increase FPS to 30 in all levels and update video quality
  [#18408](https://github.com/nextcloud/spreed/pull/18408)
- fix(call): reconnect participants when media-permissions are re-granted
  [#18439](https://github.com/nextcloud/spreed/pull/18439)
- fix(call): stop virtual background effect when device checker is not in use
  [#18295](https://github.com/nextcloud/spreed/pull/18295)
- fix(recording): allow recording service to work on E2EE calls
  [#18266](https://github.com/nextcloud/spreed/pull/18266)
## 23.0.7 – 2026-06-26
### Changed
- Update dependencies
- Update translations
### Fixed
- fix(call): Increase FPS to 30 in all levels and update video quality
  [#18409](https://github.com/nextcloud/spreed/pull/18409)
- fix(call): reconnect participants when media-permissions are re-granted
  [#18440](https://github.com/nextcloud/spreed/pull/18440)
- fix(settings): Allow to configure certificates expiration
  [#18299](https://github.com/nextcloud/spreed/pull/18299)
- fix(call): stop virtual background effect when device checker is not in use
  [#18291](https://github.com/nextcloud/spreed/pull/18291)
- fix(admin): restore admin setting for default group notifications
  [#18280](https://github.com/nextcloud/spreed/pull/18280)
- fix(recording): allow recording service to work on E2EE calls
  [#18267](https://github.com/nextcloud/spreed/pull/18267)
## 24.0.1 – 2026-06-26
### Changed
- Update dependencies
- Update translations
### Fixed
- fix(call): Increase FPS to 30 in all levels and update video quality
  [#18410](https://github.com/nextcloud/spreed/pull/18410)
- fix(call): reconnect participants when media-permissions are re-granted
  [#18441](https://github.com/nextcloud/spreed/pull/18441)
- fix(session): restore access to password-protected rooms for email guests
  [#18347](https://github.com/nextcloud/spreed/pull/18347)
- fix(settings): Allow to configure certificates expiration
  [#18300](https://github.com/nextcloud/spreed/pull/18300)
- fix(call): stop virtual background effect when device checker is not in use
  [#18292](https://github.com/nextcloud/spreed/pull/18292)
- fix(admin): restore admin setting for default group notifications
  [#18281](https://github.com/nextcloud/spreed/pull/18281)
- fix(recording): allow recording service to work on E2EE calls
  [#18268](https://github.com/nextcloud/spreed/pull/18268)