### PR TITLE
fix(sharing): Allow sharing with read-write again

### DIFF
--- a/lib/Config.php
+++ b/lib/Config.php
@@ -11,6 +11,7 @@ namespace OCA\Talk;
 use OCA\Talk\AppInfo\Application;
 use OCA\Talk\Events\BeforeTurnServersGetEvent;
 use OCA\Talk\Model\Attendee;
+use OCA\Talk\Service\ConversationFolderService;
 use OCA\Talk\Service\RecordingService;
 use OCA\Talk\Settings\UserPreference;
 use OCA\Talk\Vendor\Firebase\JWT\JWT;
@@ -327,14 +328,16 @@ class Config {
 	 *
 	 * Format: "<displayPrefix>-<uid>" where the prefix length is capped so that
 	 * the total segment length stays under 64 characters on all filesystems.
+	 * A trailing ` (u)` indicates that the share allows updates
+	 *
 	 * If the uid is 63+ characters, the prefix is omitted.
 	 */
-	public function getConversationSubfolderName(string $userId): string {
+	public function getConversationSubfolderName(string $userId, bool $allowUpdate): string {
 		if (!$this->isConversationSubfoldersEnabled()) {
 			throw new \LogicException('getConversationSubfolderName called while conversation subfolders are disabled');
 		}
 		$displayName = $this->userManager->getDisplayName($userId) ?? '';
-		return $this->buildConversationSubfolderName($userId, $displayName);
+		return $this->buildConversationSubfolderName($userId, $displayName, $allowUpdate);
 	}
 
 	/**
@@ -342,7 +345,10 @@ class Config {
 	 * Use this when the caller already holds the IUser object (e.g. the current
 	 * user from IUserSession) to avoid an extra IUserManager::get() lookup.
 	 */
-	public function buildConversationSubfolderName(string $userId, string $displayName): string {
+	public function buildConversationSubfolderName(string $userId, string $displayName, bool $allowUpdate): string {
+		if ($allowUpdate) {
+			$userId .= ConversationFolderService::UPDATABLE_SUFFIX;
+		}
 		$prefixLen = min(16, max(0, 63 - strlen($userId)));
 		if ($prefixLen > 0) {
 			$prefix = $this->sanitizeDisplayName($displayName, $prefixLen);

--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -2424,6 +2424,7 @@ class ChatController extends AEnvironmentAwareOCSController {
 	 *    into the shared subfolder, resolves any conflicts, and posts the message.
 	 *
 	 * @param list<string> $fileNames Desired filenames to probe
+	 * @param bool $allowUpdate Allow recipients to modify shared files
 	 * @return DataResponse<Http::STATUS_OK, array{folder: string, renames: list<array<string, string>>}, array{}>|DataResponse<Http::STATUS_INTERNAL_SERVER_ERROR|Http::STATUS_INSUFFICIENT_STORAGE|Http::STATUS_NOT_IMPLEMENTED, array{error: string}, array{}>
 	 *
 	 * 200: Draft folder path and rename map returned
@@ -2440,7 +2441,7 @@ class ChatController extends AEnvironmentAwareOCSController {
 		'apiVersion' => '(v1)',
 		'token' => '[a-z0-9]{4,30}',
 	])]
-	public function probeAttachmentFolder(array $fileNames = []): DataResponse {
+	public function probeAttachmentFolder(array $fileNames = [], bool $allowUpdate = false): DataResponse {
 		/** @var string $uid — non-null, guaranteed by RequireLoggedInParticipant */
 		$uid = $this->userId;
 
@@ -2450,7 +2451,7 @@ class ChatController extends AEnvironmentAwareOCSController {
 		}
 
 		try {
-			$subfolder = $this->conversationFolderService->getOrCreateSubfolder($uid, $this->room);
+			$subfolder = $this->conversationFolderService->getOrCreateSubfolder($uid, $this->room, $allowUpdate);
 			$draftFolder = $this->conversationFolderService->getOrCreateDraftFolder($subfolder);
 		} catch (NotEnoughSpaceException) {
 			return new DataResponse(['error' => $this->l->t('Storage quota exceeded')], Http::STATUS_INSUFFICIENT_STORAGE);
@@ -2486,6 +2487,7 @@ class ChatController extends AEnvironmentAwareOCSController {
 	 * @param string $talkMetaData JSON-encoded metadata (caption, messageType, silent, …)
 	 * @param string $fileName Desired final file name; the service resolves conflicts
 	 *                         by appending " (1)", " (2)", … if already taken
+	 * @param bool $allowUpdate Allow recipients to modify shared files
 	 * @return DataResponse<Http::STATUS_OK, array{renames: list<array<string, string>>}, array{}>|DataResponse<Http::STATUS_NOT_FOUND|Http::STATUS_UNPROCESSABLE_ENTITY|Http::STATUS_INTERNAL_SERVER_ERROR|Http::STATUS_INSUFFICIENT_STORAGE|Http::STATUS_BAD_REQUEST|Http::STATUS_NOT_IMPLEMENTED, array{error: string}, array{}>
 	 *
 	 * 200: File moved from Draft and posted as chat message
@@ -2505,7 +2507,7 @@ class ChatController extends AEnvironmentAwareOCSController {
 		'apiVersion' => '(v1)',
 		'token' => '[a-z0-9]{4,30}',
 	])]
-	public function postAttachmentToRoom(string $filePath, string $referenceId, string $talkMetaData = '', string $fileName = ''): DataResponse {
+	public function postAttachmentToRoom(string $filePath, string $referenceId, string $talkMetaData = '', string $fileName = '', bool $allowUpdate = false): DataResponse {
 		if (!$this->talkConfig->isConversationSubfoldersEnabled()) {
 			return new DataResponse(['error' => $this->l->t('Conversation subfolders are disabled')], Http::STATUS_NOT_IMPLEMENTED);
 		}
@@ -2516,7 +2518,7 @@ class ChatController extends AEnvironmentAwareOCSController {
 		// Ensure the user's conversation subfolder exists and is shared with
 		// the room.  The service creates the full folder hierarchy if missing.
 		try {
-			$subfolder = $this->conversationFolderService->getOrCreateSubfolder($uid, $this->room);
+			$subfolder = $this->conversationFolderService->getOrCreateSubfolder($uid, $this->room, $allowUpdate);
 			$draftFolder = $this->conversationFolderService->getOrCreateDraftFolder($subfolder);
 		} catch (NotEnoughSpaceException) {
 			return new DataResponse(['error' => $this->l->t('Storage quota exceeded')], Http::STATUS_INSUFFICIENT_STORAGE);

--- a/lib/Service/ConversationFolderService.php
+++ b/lib/Service/ConversationFolderService.php
@@ -32,6 +32,8 @@ use Psr\Log\LoggerInterface;
  * room members can access files uploaded there.
  */
 class ConversationFolderService {
+	public const UPDATABLE_SUFFIX = ' (u)';
+
 	public function __construct(
 		private readonly TalkConfig $talkConfig,
 		private readonly IRootFolder $rootFolder,
@@ -67,7 +69,7 @@ class ConversationFolderService {
 	 * @throws \RuntimeException if a path component exists but is not a folder
 	 * @throws \OCP\Files\NotPermittedException if a folder cannot be created
 	 */
-	public function getOrCreateSubfolder(string $userId, Room $room): Folder {
+	public function getOrCreateSubfolder(string $userId, Room $room, bool $allowUpdate): Folder {
 		$userFolder = $this->rootFolder->getUserFolder($userId);
 
 		$freeSpace = $userFolder->getFreeSpace();
@@ -100,7 +102,7 @@ class ConversationFolderService {
 		}
 
 		// Get or create user subfolder (e.g. Talk/Room Name-token/Alice-alice/)
-		$subfolderName = $this->talkConfig->getConversationSubfolderName($userId);
+		$subfolderName = $this->talkConfig->getConversationSubfolderName($userId, $allowUpdate);
 		try {
 			$subfolder = $convFolder->get($subfolderName);
 			if (!$subfolder instanceof Folder) {
@@ -110,7 +112,7 @@ class ConversationFolderService {
 			$subfolder = $convFolder->newFolder($subfolderName);
 		}
 
-		$this->ensureSubfolderShared($subfolder, $userId, $room->getToken());
+		$this->ensureSubfolderShared($subfolder, $userId, $room->getToken(), $allowUpdate);
 
 		return $subfolder;
 	}
@@ -282,14 +284,19 @@ class ConversationFolderService {
 	 * Uses an optimistic create-and-catch approach so it works correctly even
 	 * when the folder is already shared with many rooms (no limit on the check).
 	 */
-	private function ensureSubfolderShared(Folder $folder, string $userId, string $token): void {
+	private function ensureSubfolderShared(Folder $folder, string $userId, string $token, bool $allowUpdate): void {
+		$permissions = Constants::PERMISSION_READ;
+		if ($allowUpdate) {
+			$permissions |= Constants::PERMISSION_UPDATE;
+		}
+
 		$share = $this->shareManager->newShare();
 		$share->setNode($folder)
 			->setShareType(IShare::TYPE_ROOM)
 			->setSharedBy($userId)
 			->setShareOwner($userId)
 			->setSharedWith($token)
-			->setPermissions(Constants::PERMISSION_READ)
+			->setPermissions($permissions)
 			->setMailSend(false);
 
 		try {

--- a/lib/Share/Listener.php
+++ b/lib/Share/Listener.php
@@ -13,6 +13,7 @@ use OCA\Talk\Config;
 use OCA\Talk\Events\RoomDeletedEvent;
 use OCA\Talk\Exceptions\RoomNotFoundException;
 use OCA\Talk\Manager;
+use OCA\Talk\Service\ConversationFolderService;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Share\Events\BeforeShareCreatedEvent;
@@ -71,7 +72,8 @@ class Listener implements IEventListener {
 				$potentialConversationFolder = $segments[0];
 				$potentialUserFolder = $segments[1] ?? '';
 				if (str_ends_with($potentialConversationFolder, '-' . $share->getSharedWith())
-					&& str_ends_with($potentialUserFolder, '-' . $share->getShareOwner())) {
+					&& (str_ends_with($potentialUserFolder, '-' . $share->getShareOwner())
+						|| str_ends_with($potentialUserFolder, '-' . $share->getShareOwner() . ConversationFolderService::UPDATABLE_SUFFIX))) {
 					$relativePath = $candidate;
 				}
 			}

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -12244,6 +12244,11 @@
                                         "items": {
                                             "type": "string"
                                         }
+                                    },
+                                    "allowUpdate": {
+                                        "type": "boolean",
+                                        "default": false,
+                                        "description": "Allow recipients to modify shared files"
                                     }
                                 }
                             }
@@ -12521,6 +12526,11 @@
                                         "type": "string",
                                         "default": "",
                                         "description": "Desired final file name; the service resolves conflicts by appending \" (1)\", \" (2)\", … if already taken"
+                                    },
+                                    "allowUpdate": {
+                                        "type": "boolean",
+                                        "default": false,
+                                        "description": "Allow recipients to modify shared files"
                                     }
                                 }
                             }

--- a/openapi.json
+++ b/openapi.json
@@ -12132,6 +12132,11 @@
                                         "items": {
                                             "type": "string"
                                         }
+                                    },
+                                    "allowUpdate": {
+                                        "type": "boolean",
+                                        "default": false,
+                                        "description": "Allow recipients to modify shared files"
                                     }
                                 }
                             }
@@ -12409,6 +12414,11 @@
                                         "type": "string",
                                         "default": "",
                                         "description": "Desired final file name; the service resolves conflicts by appending \" (1)\", \" (2)\", … if already taken"
+                                    },
+                                    "allowUpdate": {
+                                        "type": "boolean",
+                                        "default": false,
+                                        "description": "Allow recipients to modify shared files"
                                     }
                                 }
                             }

--- a/src/types/openapi/openapi-full.ts
+++ b/src/types/openapi/openapi-full.ts
@@ -7760,6 +7760,11 @@ export interface operations {
                      * @default []
                      */
                     fileNames?: string[];
+                    /**
+                     * @description Allow recipients to modify shared files
+                     * @default false
+                     */
+                    allowUpdate?: boolean;
                 };
             };
         };
@@ -7877,6 +7882,11 @@ export interface operations {
                      * @default
                      */
                     fileName?: string;
+                    /**
+                     * @description Allow recipients to modify shared files
+                     * @default false
+                     */
+                    allowUpdate?: boolean;
                 };
             };
         };

--- a/src/types/openapi/openapi.ts
+++ b/src/types/openapi/openapi.ts
@@ -7165,6 +7165,11 @@ export interface operations {
                      * @default []
                      */
                     fileNames?: string[];
+                    /**
+                     * @description Allow recipients to modify shared files
+                     * @default false
+                     */
+                    allowUpdate?: boolean;
                 };
             };
         };
@@ -7282,6 +7287,11 @@ export interface operations {
                      * @default
                      */
                     fileName?: string;
+                    /**
+                     * @description Allow recipients to modify shared files
+                     * @default false
+                     */
+                    allowUpdate?: boolean;
                 };
             };
         };

--- a/tests/integration/features/bootstrap/SharingContext.php
+++ b/tests/integration/features/bootstrap/SharingContext.php
@@ -56,8 +56,8 @@ class SharingContext implements Context {
 		$this->theHTTPStatusCodeShouldBe(201);
 	}
 
-	#[Given('/^user "([^"]*)" uploads file "([^"]*)" with content "([^"]*)" to conversation folder for room "([^"]*)" with name "([^"]*)"$/')]
-	public function userUploadsFileToConversationFolder(string $user, string $filename, string $content, string $room, string $displayName): void {
+	#[Given('/^user "([^"]*)" uploads (updatable |)file "([^"]*)" with content "([^"]*)" to conversation folder for room "([^"]*)" with name "([^"]*)"$/')]
+	public function userUploadsFileToConversationFolder(string $user, string $updatable, string $filename, string $content, string $room, string $displayName): void {
 		$this->currentUser = $user;
 
 		// $displayName is no longer needed: the probe endpoint creates the folder
@@ -66,20 +66,24 @@ class SharingContext implements Context {
 		// match without rewriting every scenario.
 		unset($displayName);
 
+		$allowUpdate = trim($updatable) === 'updatable';
+
 		$token = FeatureContext::getTokenForIdentifier($room);
-		$draftPath = $this->ensureDraftFolderViaProbe($user, $token);
+		$draftPath = $this->ensureDraftFolderViaProbe($user, $token, $allowUpdate);
 
 		$this->sendingToDav('PUT', "/$user/$draftPath/$filename", null, $content);
 		$this->theHTTPStatusCodeShouldBe(201);
 	}
 
-	#[When('/^user "([^"]*)" posts file "([^"]*)" from conversation folder of room "([^"]*)" with name "([^"]*)" with (\d+) \(v1\)$/')]
-	public function userPostsFileFromConversationFolder(string $user, string $filename, string $room, string $displayName, int $statusCode, ?TableNode $body = null): void {
+	#[When('/^user "([^"]*)" posts (updatable |)file "([^"]*)" from conversation folder of room "([^"]*)" with name "([^"]*)" with (\d+) \(v1\)$/')]
+	public function userPostsFileFromConversationFolder(string $user, string $updatable, string $filename, string $room, string $displayName, int $statusCode, ?TableNode $body = null): void {
 		$this->currentUser = $user;
 		unset($displayName); // see userUploadsFileToConversationFolder
 
+		$allowUpdate = trim($updatable) === 'updatable';
+
 		$token = FeatureContext::getTokenForIdentifier($room);
-		$draftPath = $this->ensureDraftFolderViaProbe($user, $token);
+		$draftPath = $this->ensureDraftFolderViaProbe($user, $token, $allowUpdate);
 		$filePath = $draftPath . '/' . $filename;
 
 		$talkMetaData = [];
@@ -94,7 +98,7 @@ class SharingContext implements Context {
 			}
 		}
 
-		$this->sendingToTalkAttachmentEndpoint($token, $filePath, $talkMetaData);
+		$this->sendingToTalkAttachmentEndpoint($token, $filePath, $talkMetaData, allowUpdate: $allowUpdate);
 		$this->theHTTPStatusCodeShouldBe($statusCode);
 	}
 
@@ -111,13 +115,14 @@ class SharingContext implements Context {
 	 * Post a file that was uploaded under a temporary name, passing the desired
 	 * final name via `fileName` so the backend renames it with conflict resolution.
 	 */
-	#[When('/^user "([^"]*)" posts temp file "([^"]*)" with name "([^"]*)" from conversation folder of room "([^"]*)" with name "([^"]*)" with (\d+) \(v1\)$/')]
-	public function userPostsTempFileWithDesiredName(string $user, string $tempFileName, string $desiredName, string $room, string $displayName, int $statusCode): void {
+	#[When('/^user "([^"]*)" posts (updatable |)temp file "([^"]*)" with name "([^"]*)" from conversation folder of room "([^"]*)" with name "([^"]*)" with (\d+) \(v1\)$/')]
+	public function userPostsTempFileWithDesiredName(string $user, string $updatable, string $tempFileName, string $desiredName, string $room, string $displayName, int $statusCode): void {
 		$this->currentUser = $user;
 		unset($displayName); // see userUploadsFileToConversationFolder
+		$allowUpdate = trim($updatable) === 'updatable';
 
 		$token = FeatureContext::getTokenForIdentifier($room);
-		$draftPath = $this->ensureDraftFolderViaProbe($user, $token);
+		$draftPath = $this->ensureDraftFolderViaProbe($user, $token, $allowUpdate);
 		$filePath = $draftPath . '/' . $tempFileName;
 		$this->sendingToTalkAttachmentEndpoint($token, $filePath, [], $desiredName);
 		$this->theHTTPStatusCodeShouldBe($statusCode);
@@ -127,12 +132,14 @@ class SharingContext implements Context {
 	 * Call the probe endpoint for a room and store the response.
 	 * $fileNames is a comma-separated list of desired filenames.
 	 */
-	#[When('/^user "([^"]*)" probes attachment folder for room "([^"]*)" with files "([^"]*)" with (\d+) \(v1\)$/')]
-	public function userProbesAttachmentFolder(string $user, string $room, string $fileNamesCsv, int $statusCode, ?TableNode $tableNode = null): void {
+	#[When('/^user "([^"]*)" probes attachment folder for room "([^"]*)" with (updatable |)files "([^"]*)" with (\d+) \(v1\)$/')]
+	public function userProbesAttachmentFolder(string $user, string $room, string $updatable, string $fileNamesCsv, int $statusCode, ?TableNode $tableNode = null): void {
 		$this->currentUser = $user;
 		$token = FeatureContext::getTokenForIdentifier($room);
+		$allowUpdate = trim($updatable) === 'updatable';
+
 		$fileNames = array_map('trim', explode(',', $fileNamesCsv));
-		$this->sendingToTalkAttachmentFolderProbe($token, $fileNames);
+		$this->sendingToTalkAttachmentFolderProbe($token, $fileNames, $allowUpdate);
 		$this->theHTTPStatusCodeShouldBe($statusCode);
 
 		if ($statusCode === 200 && $tableNode !== null) {
@@ -1015,7 +1022,7 @@ class SharingContext implements Context {
 	 * client should upload into. Result is cached per (user, token) so repeated
 	 * uploads in the same scenario don't issue redundant probes.
 	 */
-	private function ensureDraftFolderViaProbe(string $user, string $token): string {
+	private function ensureDraftFolderViaProbe(string $user, string $token, bool $allowUpdate): string {
 		$cacheKey = $user . '|' . $token;
 		if (isset($this->draftFolderByUserToken[$cacheKey])) {
 			return $this->draftFolderByUserToken[$cacheKey];
@@ -1023,7 +1030,7 @@ class SharingContext implements Context {
 
 		$previousUser = $this->currentUser;
 		$this->currentUser = $user;
-		$this->sendingToTalkAttachmentFolderProbe($token, []);
+		$this->sendingToTalkAttachmentFolderProbe($token, [], $allowUpdate);
 		$this->currentUser = $previousUser;
 
 		\PHPUnit\Framework\Assert::assertSame(
@@ -1049,10 +1056,12 @@ class SharingContext implements Context {
 	 *
 	 * @param list<string> $fileNames
 	 */
-	private function sendingToTalkAttachmentFolderProbe(string $token, array $fileNames): void {
+	private function sendingToTalkAttachmentFolderProbe(string $token, array $fileNames, bool $allowUpdate): void {
 		$fullUrl = $this->baseUrl . 'ocs/v2.php/apps/spreed/api/v1/chat/' . $token . '/attachment/folder?format=json';
 		$client = new Client();
-		$formParams = [];
+		$formParams = [
+			'allowUpdate' => $allowUpdate,
+		];
 		foreach ($fileNames as $i => $name) {
 			$formParams['fileNames[' . $i . ']'] = $name;
 		}
@@ -1073,7 +1082,7 @@ class SharingContext implements Context {
 	/**
 	 * POST to the Talk attachment endpoint (OCS v2).
 	 */
-	private function sendingToTalkAttachmentEndpoint(string $token, string $filePath, array $talkMetaData, string $fileName = ''): void {
+	private function sendingToTalkAttachmentEndpoint(string $token, string $filePath, array $talkMetaData, string $fileName = '', bool $allowUpdate = false): void {
 		$fullUrl = $this->baseUrl . 'ocs/v2.php/apps/spreed/api/v1/chat/' . $token . '/attachment?format=json';
 		$client = new Client();
 		$options = [
@@ -1084,6 +1093,7 @@ class SharingContext implements Context {
 				'fileName' => $fileName,
 				'referenceId' => '',
 				'talkMetaData' => !empty($talkMetaData) ? json_encode($talkMetaData) : '',
+				'allowUpdate' => $allowUpdate,
 			],
 		];
 		try {

--- a/tests/integration/features/sharing-1/conversation-folder.feature
+++ b/tests/integration/features/sharing-1/conversation-folder.feature
@@ -31,6 +31,32 @@ Feature: sharing-1/conversation-folder
       | item_type         | folder                   |
       | permissions       | 1                        |
       | path              | REGEXP /^\/Talk\/.+\/participant1-dis-participant1$/ |
+    When user "participant1" uploads updatable file "writable.txt" with content "Update!" to conversation folder for room "group room" with name "Group room"
+    And user "participant1" posts updatable file "writable.txt" from conversation folder of room "group room" with name "Group room" with 200 (v1)
+    And user "participant1" gets all shares
+    And share 0 is returned with
+      | uid_owner         | participant1             |
+      | displayname_owner | participant1-displayname |
+      | item_type         | folder                   |
+      | permissions       | 1                        |
+      | file_target       | REGEXP /^\/\{TALK_PLACEHOLDER\}\/.+\/participant1-dis-participant1$/ |
+    And share 1 is returned with
+      | uid_owner         | participant1             |
+      | displayname_owner | participant1-displayname |
+      | item_type         | folder                   |
+      | permissions       | 3                        |
+      | file_target       | REGEXP /^\/\{TALK_PLACEHOLDER\}\/.+\/participant1-dis-participant1 \(u\)$/ |
+    And user "participant2" gets all received shares
+    And share 0 is returned with
+      | uid_owner         | participant1             |
+      | item_type         | folder                   |
+      | permissions       | 1                        |
+      | path              | REGEXP /^\/Talk\/.+\/participant1-dis-participant1$/ |
+    And share 1 is returned with
+      | uid_owner         | participant1             |
+      | item_type         | folder                   |
+      | permissions       | 3                        |
+      | path              | REGEXP /^\/Talk\/.+\/participant1-dis-participant1 \(u\)$/ |
 
   Scenario: Upload file to conversation folder and post as attachment to public room
     Given user "participant1" creates room "public room" (v4)

--- a/tests/php/Service/ConversationFolderServiceTest.php
+++ b/tests/php/Service/ConversationFolderServiceTest.php
@@ -94,7 +94,7 @@ class ConversationFolderServiceTest extends TestCase {
 		$this->rootFolder->method('getUserFolder')->with($userId)->willReturn($userFolder);
 
 		$this->expectException(NotEnoughSpaceException::class);
-		$this->service->getOrCreateSubfolder($userId, $room);
+		$this->service->getOrCreateSubfolder($userId, $room, false);
 	}
 
 	public function testGetOrCreateSubfolderProceedsWithUnlimitedQuota(): void {
@@ -117,7 +117,7 @@ class ConversationFolderServiceTest extends TestCase {
 		$this->shareManager->method('newShare')->willReturn($this->makeShareMock());
 
 		// No exception expected
-		$result = $this->service->getOrCreateSubfolder($userId, $room);
+		$result = $this->service->getOrCreateSubfolder($userId, $room, false);
 		$this->assertSame($subfolder, $result);
 	}
 
@@ -140,7 +140,7 @@ class ConversationFolderServiceTest extends TestCase {
 		$convFolder->method('get')->willReturn($subfolder);
 		$this->shareManager->method('newShare')->willReturn($this->makeShareMock());
 
-		$result = $this->service->getOrCreateSubfolder($userId, $room);
+		$result = $this->service->getOrCreateSubfolder($userId, $room, false);
 		$this->assertSame($subfolder, $result);
 	}
 
@@ -163,7 +163,7 @@ class ConversationFolderServiceTest extends TestCase {
 		$convFolder->method('get')->willReturn($subfolder);
 		$this->shareManager->method('newShare')->willReturn($this->makeShareMock());
 
-		$result = $this->service->getOrCreateSubfolder($userId, $room);
+		$result = $this->service->getOrCreateSubfolder($userId, $room, false);
 		$this->assertSame($subfolder, $result);
 	}
 
@@ -192,7 +192,7 @@ class ConversationFolderServiceTest extends TestCase {
 		$this->shareManager->method('newShare')->willReturn($this->makeShareMock());
 		$this->shareManager->expects($this->once())->method('createShare');
 
-		$result = $this->service->getOrCreateSubfolder($userId, $room);
+		$result = $this->service->getOrCreateSubfolder($userId, $room, false);
 		$this->assertSame($subfolder, $result);
 	}
 
@@ -220,7 +220,7 @@ class ConversationFolderServiceTest extends TestCase {
 
 		$this->shareManager->method('newShare')->willReturn($this->makeShareMock());
 
-		$result = $this->service->getOrCreateSubfolder($userId, $room);
+		$result = $this->service->getOrCreateSubfolder($userId, $room, false);
 		$this->assertSame($subfolder, $result);
 	}
 
@@ -248,7 +248,7 @@ class ConversationFolderServiceTest extends TestCase {
 
 		$this->shareManager->method('newShare')->willReturn($this->makeShareMock());
 
-		$result = $this->service->getOrCreateSubfolder($userId, $room);
+		$result = $this->service->getOrCreateSubfolder($userId, $room, false);
 		$this->assertSame($subfolder, $result);
 	}
 
@@ -275,7 +275,7 @@ class ConversationFolderServiceTest extends TestCase {
 
 		$this->shareManager->method('newShare')->willReturn($this->makeShareMock());
 
-		$result = $this->service->getOrCreateSubfolder($userId, $room);
+		$result = $this->service->getOrCreateSubfolder($userId, $room, false);
 		$this->assertSame($subfolder, $result);
 	}
 
@@ -298,7 +298,7 @@ class ConversationFolderServiceTest extends TestCase {
 		$userFolder->method('get')->with('Talk')->willReturn($fileNode);
 
 		$this->expectException(\RuntimeException::class);
-		$this->service->getOrCreateSubfolder($userId, $room);
+		$this->service->getOrCreateSubfolder($userId, $room, false);
 	}
 
 	public function testGetOrCreateSubfolderThrowsWhenConvFolderIsFile(): void {
@@ -318,7 +318,7 @@ class ConversationFolderServiceTest extends TestCase {
 		$attachmentNode->method('get')->willReturn($fileNode);
 
 		$this->expectException(\RuntimeException::class);
-		$this->service->getOrCreateSubfolder($userId, $room);
+		$this->service->getOrCreateSubfolder($userId, $room, false);
 	}
 
 	public function testGetOrCreateSubfolderThrowsWhenUserSubfolderIsFile(): void {
@@ -340,7 +340,7 @@ class ConversationFolderServiceTest extends TestCase {
 		$convFolder->method('get')->willReturn($fileNode);
 
 		$this->expectException(\RuntimeException::class);
-		$this->service->getOrCreateSubfolder($userId, $room);
+		$this->service->getOrCreateSubfolder($userId, $room, false);
 	}
 
 	// -------------------------------------------------------------------------
@@ -371,7 +371,7 @@ class ConversationFolderServiceTest extends TestCase {
 			->willThrowException(new GenericShareException('Already shared', 'Already shared', 403));
 
 		// No exception expected
-		$result = $this->service->getOrCreateSubfolder($userId, $room);
+		$result = $this->service->getOrCreateSubfolder($userId, $room, false);
 		$this->assertSame($subfolder, $result);
 	}
 
@@ -404,7 +404,7 @@ class ConversationFolderServiceTest extends TestCase {
 		$this->expectException(\RuntimeException::class);
 		$this->expectExceptionMessage('Unexpected DB error');
 
-		$this->service->getOrCreateSubfolder($userId, $room);
+		$this->service->getOrCreateSubfolder($userId, $room, false);
 	}
 
 	public function testGetOrCreateSubfolderRethrowsNonDuplicateGenericShareException(): void {
@@ -433,7 +433,7 @@ class ConversationFolderServiceTest extends TestCase {
 		$this->expectException(GenericShareException::class);
 		$this->expectExceptionMessage('Room not found');
 
-		$this->service->getOrCreateSubfolder($userId, $room);
+		$this->service->getOrCreateSubfolder($userId, $room, false);
 	}
 
 	// -------------------------------------------------------------------------
@@ -469,7 +469,7 @@ class ConversationFolderServiceTest extends TestCase {
 		$newShare->expects($this->once())->method('setPermissions')->with(Constants::PERMISSION_READ)->willReturnSelf();
 		$newShare->expects($this->once())->method('setMailSend')->with(false)->willReturnSelf();
 
-		$this->service->getOrCreateSubfolder($userId, $room);
+		$this->service->getOrCreateSubfolder($userId, $room, false);
 	}
 
 	// -------------------------------------------------------------------------


### PR DESCRIPTION
## ☑️ Resolves

* Fix #…

Tested with:
```diff
diff --git a/src/services/filesSharingServices.ts b/src/services/filesSharingServices.ts
index 756644149a..d6fc9866c3 100644
--- a/src/services/filesSharingServices.ts
+++ b/src/services/filesSharingServices.ts
@@ -77,7 +77,7 @@ async function createNewFile({ filePath, templatePath, templateType }: createFil
  *         and a rename simulation for the requested file names.
  */
 async function probeAttachmentFolder({ token, fileNames }: { token: string } & ProbeAttachmentFolderParams): ProbeAttachmentFolderResponse {
-       return axios.post(generateOcsUrl('apps/spreed/api/v1/chat/{token}/attachment/folder', { token }), { fileNames })
+       return axios.post(generateOcsUrl('apps/spreed/api/v1/chat/{token}/attachment/folder', { token }), { fileNames, allowUpdate: true })
 }
 
 /**
@@ -106,6 +106,7 @@ async function postAttachment({ token, filePath, fileName, referenceId, talkMeta
                fileName,
                referenceId,
                talkMetaData,
+               allowUpdate: true,
        })
 }
 
```

## 🛠️ API Checklist
### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
