### PR TITLE
feat: read last-common-read number from chat-relay messages

### DIFF
--- a/src/composables/useGetMessages.ts
+++ b/src/composables/useGetMessages.ts
@@ -664,17 +664,18 @@ export function useGetMessagesProvider() {
 	/**
 	 * Chat relay sends one message at a time, we update our stores directly
 	 *
-	 * @param payload
-	 * @param payload.token
-	 * @param payload.message
+	 * @param payload - signaling event payload
+	 * @param payload.token - conversation token, where event was sent
+	 * @param payload.message - chat message from the event
+	 * @param [payload.lastCommonReadMessage] - optional last common read marker
 	 */
-	function addMessageFromChatRelay(payload: { token: string, message: ChatMessage }) {
+	function addMessageFromChatRelay(payload: { token: string, message: ChatMessage, lastCommonReadMessage?: number }) {
 		if (!chatRelaySupported) {
 			// chat relay is not supported, ignore the message
 			return
 		}
 
-		const { token, message } = payload
+		const { token, message, lastCommonReadMessage } = payload
 		if (token !== currentToken.value) {
 			// Guard: Message is for another conversation
 			// e.g., user switched conversation while messages were in-flight
@@ -714,6 +715,11 @@ export function useGetMessagesProvider() {
 
 		chatStore.processChatBlocks(token, [message], { mergeBy: chatStore.getLastKnownId(token) })
 		store.dispatch('processMessage', { token, message, fromRealtime: true })
+		if (lastCommonReadMessage !== undefined) {
+			// do not compare with conversation.lastCommonReadMessage
+			// value from signaling is actual, but not incremental (can be lesser or equal 0)
+			store.dispatch('updateLastCommonReadMessage', { token, lastCommonReadMessage })
+		}
 	}
 
 	provide(GET_MESSAGES_CONTEXT_KEY, {

--- a/src/services/EventBus.ts
+++ b/src/services/EventBus.ts
@@ -21,7 +21,7 @@ import mitt from 'mitt'
 export type Events = {
 	[key: EventType]: unknown
 	'audio-player-ended': number
-	'signaling-message-received': { token: string, message: ChatMessage }
+	'signaling-message-received': { token: string, message: ChatMessage, lastCommonReadMessage?: number }
 	'conversations-received': { singleConversation?: Conversation, fromBrowserStorage?: boolean }
 	'session-conflict-confirmation': string
 	'deleted-session-detected': void

--- a/src/utils/signaling.js
+++ b/src/utils/signaling.js
@@ -1437,7 +1437,8 @@ Signaling.Standalone.prototype.processRoomMessageEvent = function(token, data) {
 	switch (data.type) {
 		case 'chat':
 			if ('comment' in data.chat) {
-				EventBus.emit('signaling-message-received', { token, message: { ...data.chat.comment, token } })
+				const { lastCommonRead: lastCommonReadMessage, ...comment } = data.chat.comment
+				EventBus.emit('signaling-message-received', { token, message: { ...comment, token }, lastCommonReadMessage })
 			} else {
 				// TOREMOVE after HPB next release
 				EventBus.emit('should-refresh-chat-messages')


### PR DESCRIPTION
## ☑️ Resolves

* Follow-up to #18433

### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
Screenshot before | <img width="309" height="102" alt="image" src="https://github.com/user-attachments/assets/753d2edb-3b4c-4398-9fc4-ad25647ae640" />


### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
