### PR TITLE
fix(recording): support long room tokens for uploads

### DIFF
--- a/lib/Service/RecordingService.php
+++ b/lib/Service/RecordingService.php
@@ -55,7 +55,7 @@ class RecordingService {
 
 	public const APPCONFIG_PREFIX = 'recording/';
 	public const APPCONFIG_UPLOAD_PREFIX = 'recupload/';
-	private const APPCONFIG_KEY_MAX_LENGTH = 64;
+	public const APPCONFIG_KEY_MAX_LENGTH = 64;
 
 	public const DEFAULT_ALLOWED_RECORDING_FORMATS = [
 		'audio/ogg' => ['ogg'],

--- a/lib/Service/RecordingService.php
+++ b/lib/Service/RecordingService.php
@@ -55,6 +55,7 @@ class RecordingService {
 
 	public const APPCONFIG_PREFIX = 'recording/';
 	public const APPCONFIG_UPLOAD_PREFIX = 'recupload/';
+	private const APPCONFIG_KEY_MAX_LENGTH = 64;
 
 	public const DEFAULT_ALLOWED_RECORDING_FORMATS = [
 		'audio/ogg' => ['ogg'],
@@ -315,7 +316,10 @@ class RecordingService {
 	}
 
 	private function getUploadShareConfigKey(Room $room, string $fileName): string {
-		return self::APPCONFIG_UPLOAD_PREFIX . $room->getToken() . '/' . sha1(basename($fileName));
+		$prefix = self::APPCONFIG_UPLOAD_PREFIX . $room->getToken() . '/';
+		$fileNameHashLength = self::APPCONFIG_KEY_MAX_LENGTH - strlen($prefix);
+
+		return $prefix . substr(sha1(basename($fileName)), 0, $fileNameHashLength);
 	}
 
 	/**

--- a/tests/php/Service/RecordingServiceTest.php
+++ b/tests/php/Service/RecordingServiceTest.php
@@ -219,15 +219,23 @@ class RecordingServiceTest extends TestCase {
 		$this->timeFactory->method('getDateTime')->willReturnCallback(fn () => new \DateTime());
 	}
 
-	public function testRequestUpload(): void {
+	public static function dataRequestUpload(): array {
+		return [
+			['token123', sha1('recording.mp4')],
+			[str_repeat('a', 30), substr(sha1('recording.mp4'), 0, 23)],
+		];
+	}
+
+	#[DataProvider('dataRequestUpload')]
+	public function testRequestUpload(string $roomToken, string $fileNameHash): void {
 		$owner = 'user1';
-		$room = $this->createRoom();
+		$room = $this->createRoom($roomToken);
 		$participant = $this->createParticipant($room, $owner);
 		$this->participantService->method('getParticipant')
 			->with($room, $owner)
 			->willReturn($participant);
 
-		$recordingFolder = $this->mockRecordingFolder($owner, 'token123');
+		$recordingFolder = $this->mockRecordingFolder($owner, $roomToken);
 
 		$this->shareManager->method('shareApiAllowLinks')->willReturn(true);
 		$this->shareManager->method('shareApiLinkAllowPublicUpload')->willReturn(true);
@@ -246,13 +254,13 @@ class RecordingServiceTest extends TestCase {
 
 		$this->appConfig->expects($this->once())
 			->method('setAppValueString')
-			->with(RecordingService::APPCONFIG_UPLOAD_PREFIX . 'token123/' . sha1('recording.mp4'), 'shareToken', true, true);
+			->with(RecordingService::APPCONFIG_UPLOAD_PREFIX . $roomToken . '/' . $fileNameHash, 'shareToken', true, true);
 
 		// The active-recording marker is cleared once the upload share is created,
 		// so a new recording can start while this one is still being uploaded.
 		$this->appConfig->expects($this->once())
 			->method('deleteAppValue')
-			->with(RecordingService::APPCONFIG_PREFIX . 'token123');
+			->with(RecordingService::APPCONFIG_PREFIX . $roomToken);
 
 		$result = $this->recordingService->requestUpload($room, $owner, 'recording.mp4');
 


### PR DESCRIPTION
## ☑️ Resolves

- Fix #18458

### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

I used AI assistance to help draft and refine the code changes and regression tests in this pull request. I reviewed the final diff, verified the boundary behavior around the app-config key length, and rewrote this PR description myself.

## 🛠️ API Checklist

### 🚧 Tasks

- [x] Keep recording upload app-config keys within Nextcloud's 64-character limit for long room tokens
- [x] Preserve the existing full SHA-1 hash for normal short-token cases
- [x] Add regression coverage for both boundary cases

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed