### PR TITLE
fix: introduce UI toggle to allow/disallow updating

### DIFF
--- a/src/components/NewMessage/NewMessageUploadEditor.vue
+++ b/src/components/NewMessage/NewMessageUploadEditor.vue
@@ -58,6 +58,14 @@
 					:name="voiceMessageName"
 					:localUrl="voiceMessageLocalURL" />
 			</template>
+
+			<NcCheckboxRadioSwitch
+				v-if="!isVoiceMessage && supportConversationSubfolders"
+				v-model="allowUpdate"
+				type="switch">
+				{{ t('spreed', 'Allow editing of uploaded files') }}
+			</NcCheckboxRadioSwitch>
+
 			<div v-if="!supportMediaCaption" class="upload-editor__actions">
 				<NcButton variant="tertiary" @click="handleDismiss">
 					{{ t('spreed', 'Dismiss') }}
@@ -86,6 +94,7 @@
 import { t } from '@nextcloud/l10n'
 import { ref, useId } from 'vue'
 import NcButton from '@nextcloud/vue/components/NcButton'
+import NcCheckboxRadioSwitch from '@nextcloud/vue/components/NcCheckboxRadioSwitch'
 import NcModal from '@nextcloud/vue/components/NcModal'
 import IconPlus from 'vue-material-design-icons/Plus.vue'
 import AudioPlayer from '../MessagesList/MessagesGroup/Message/MessagePart/AudioPlayer.vue'
@@ -95,7 +104,7 @@ import NewMessage from './NewMessage.vue'
 import { useGetThreadId } from '../../composables/useGetThreadId.ts'
 import { useGetToken } from '../../composables/useGetToken.ts'
 import { MESSAGE } from '../../constants.ts'
-import { hasTalkFeature } from '../../services/CapabilitiesManager.ts'
+import { getTalkConfig, hasTalkFeature } from '../../services/CapabilitiesManager.ts'
 import { useUploadStore } from '../../stores/upload.ts'
 
 export default {
@@ -107,12 +116,14 @@ export default {
 		IconPlus,
 		AudioPlayer,
 		NcButton,
+		NcCheckboxRadioSwitch,
 		NewMessage,
 		TransitionWrapper,
 	},
 
 	setup() {
 		const isDraggingOver = ref(false)
+		const allowUpdate = ref(false)
 		const dialogMaskId = `new-message-upload-${useId()}`
 		const dialogHeaderId = `new-message-upload-header-${useId()}`
 		const modalContainerId = '#' + dialogMaskId
@@ -120,6 +131,7 @@ export default {
 		return {
 			modalContainerId,
 			isDraggingOver,
+			allowUpdate,
 			dialogMaskId,
 			dialogHeaderId,
 			token: useGetToken(),
@@ -131,6 +143,10 @@ export default {
 	computed: {
 		supportMediaCaption() {
 			return hasTalkFeature(this.token, 'media-caption')
+		},
+
+		supportConversationSubfolders() {
+			return getTalkConfig(this.token, 'attachments', 'conversation-subfolders') === true
 		},
 
 		currentUploadId() {
@@ -183,6 +199,9 @@ export default {
 				} else {
 					this.$refs.submitButton.$el.focus()
 				}
+			} else {
+				// Reset user's choice at closing
+				this.allowUpdate = false
 			}
 		},
 	},
@@ -200,6 +219,7 @@ export default {
 				uploadId: this.currentUploadId,
 				caption: null,
 				options: null,
+				allowUpdate: this.supportConversationSubfolders ? this.allowUpdate : undefined,
 			})
 		},
 
@@ -216,6 +236,7 @@ export default {
 						silent: temporaryMessage.silent,
 						parent: temporaryMessage.parent,
 					},
+					allowUpdate: this.supportConversationSubfolders ? this.allowUpdate : undefined,
 				})
 			} else {
 				this.uploadStore.discardUpload(this.currentUploadId)

--- a/src/services/filesSharingServices.ts
+++ b/src/services/filesSharingServices.ts
@@ -73,11 +73,12 @@ async function createNewFile({ filePath, templatePath, templateType }: createFil
  * @param payload.fileNames Desired file names — used only for server-side
  *        rename-on-conflict probing; the authoritative final names are
  *        returned by {@link postAttachment}.
+ * @param payload.allowUpdate Whether to grant update permissions
  * @return Draft folder path (relative to user home root, no leading slash)
  *         and a rename simulation for the requested file names.
  */
-async function probeAttachmentFolder({ token, fileNames }: { token: string } & ProbeAttachmentFolderParams): ProbeAttachmentFolderResponse {
-	return axios.post(generateOcsUrl('apps/spreed/api/v1/chat/{token}/attachment/folder', { token }), { fileNames })
+async function probeAttachmentFolder({ token, fileNames, allowUpdate }: { token: string } & ProbeAttachmentFolderParams): ProbeAttachmentFolderResponse {
+	return axios.post(generateOcsUrl('apps/spreed/api/v1/chat/{token}/attachment/folder', { token }), { fileNames, allowUpdate })
 }
 
 /**
@@ -96,16 +97,18 @@ async function probeAttachmentFolder({ token, fileNames }: { token: string } & P
  * @param payload.fileName Desired final file name (for rename-on-conflict)
  * @param payload.referenceId Client reference ID for the chat message
  * @param payload.talkMetaData JSON-encoded metadata (caption, messageType, silent, …)
+ * @param payload.allowUpdate Whether to grant update permissions
  * @return An array of `{ originalName: finalName }` entries — one per posted
  *         file.  When the backend had to rename due to a conflict the two
  *         names differ; otherwise they are identical.
  */
-async function postAttachment({ token, filePath, fileName, referenceId, talkMetaData }: { token: string } & PostAttachmentFolderParams): PostAttachmentFolderResponse {
+async function postAttachment({ token, filePath, fileName, referenceId, talkMetaData, allowUpdate }: { token: string } & PostAttachmentFolderParams): PostAttachmentFolderResponse {
 	return axios.post(generateOcsUrl('apps/spreed/api/v1/chat/{token}/attachment', { token }), {
 		filePath,
 		fileName,
 		referenceId,
 		talkMetaData,
+		allowUpdate,
 	})
 }
 

--- a/src/stores/upload.ts
+++ b/src/stores/upload.ts
@@ -44,6 +44,7 @@ type UploadsState = {
 	[uploadId: string]: {
 		token: string
 		draftFolderPath?: string | null
+		allowUpdate?: boolean
 		files: {
 			[index: string]: UploadFile
 		}
@@ -55,6 +56,7 @@ type UploadFilesPayload = {
 	uploadId: string
 	caption?: string
 	options: Pick<ChatMessage, | 'threadId' | 'threadTitle' | 'silent' | 'parent'> | null
+	allowUpdate?: boolean
 }
 
 type PerformSharePayload = {
@@ -66,6 +68,7 @@ type PerformSharePayload = {
 	referenceId?: string
 	talkMetaData?: string
 	fileName?: string
+	allowUpdate?: boolean
 }
 
 export const useUploadStore = defineStore('upload', () => {
@@ -363,8 +366,9 @@ export const useUploadStore = defineStore('upload', () => {
 	 * @param payload.uploadId unique identifier
 	 * @param payload.caption The text caption to the media
 	 * @param payload.options The share options
+	 * @param payload.allowUpdate Whether to grant update permissions
 	 */
-	async function uploadFiles({ token, uploadId, caption, options }: UploadFilesPayload) {
+	async function uploadFiles({ token, uploadId, caption, options, allowUpdate }: UploadFilesPayload) {
 		if (currentUploadId.value === uploadId) {
 			currentUploadId.value = undefined
 		}
@@ -397,8 +401,9 @@ export const useUploadStore = defineStore('upload', () => {
 			const fileNames = initialisedUploads
 				.map(([, uploadedFile]) => uploadedFile.file.newName || uploadedFile.file.name)
 			try {
-				const response = await probeAttachmentFolder({ token, fileNames })
+				const response = await probeAttachmentFolder({ token, fileNames, allowUpdate })
 				uploads[uploadId].draftFolderPath = response.data.ocs.data.folder
+				uploads[uploadId].allowUpdate = allowUpdate
 
 				// Update temporary messages with predicted rename-on-conflict
 				// names so the user sees the expected final name while uploading.
@@ -434,7 +439,7 @@ export const useUploadStore = defineStore('upload', () => {
 
 		await processUpload({ token, uploadId })
 
-		await shareFiles({ token, uploadId, lastIndex, caption, options })
+		await shareFiles({ token, uploadId, lastIndex, caption, options, allowUpdate })
 
 		EventBus.emit('upload-finished')
 	}
@@ -578,8 +583,9 @@ export const useUploadStore = defineStore('upload', () => {
 	 * @param payload.lastIndex The index of last uploaded file
 	 * @param payload.caption The text caption to the media
 	 * @param payload.options The share options
+	 * @param payload.allowUpdate Whether to grant update permissions
 	 */
-	async function shareFiles({ token, uploadId, lastIndex, caption, options }: UploadFilesPayload & { lastIndex: string }) {
+	async function shareFiles({ token, uploadId, lastIndex, caption, options, allowUpdate }: UploadFilesPayload & { lastIndex: string }) {
 		const shares = getShareableFiles(uploadId)
 		for await (const share of shares) {
 			if (!share) {
@@ -601,7 +607,7 @@ export const useUploadStore = defineStore('upload', () => {
 			uploads[uploadId].files[index].talkMetaData = talkMetaData
 
 			const fileName = shareableFile.file.newName || shareableFile.file.name
-			await performShare({ token, path: shareableFile.sharePath!, index, uploadId, id, referenceId, talkMetaData, fileName })
+			await performShare({ token, path: shareableFile.sharePath!, index, uploadId, id, referenceId, talkMetaData, fileName, allowUpdate })
 		}
 	}
 
@@ -623,8 +629,9 @@ export const useUploadStore = defineStore('upload', () => {
 	 * @param [payload.talkMetaData] The metadata JSON-encoded object
 	 * @param [payload.fileName] Original file name — when present together
 	 *        with a stored draftFolderPath, the attachment endpoint is used
+	 * @param payload.allowUpdate Whether to grant update permissions
 	 */
-	async function performShare({ token, path, index, uploadId, id, referenceId, talkMetaData, fileName }: PerformSharePayload) {
+	async function performShare({ token, path, index, uploadId, id, referenceId, talkMetaData, fileName, allowUpdate }: PerformSharePayload) {
 		try {
 			if (!uploadId || !index) {
 				throw new Error('Missing uploadId or index for sharing file')
@@ -635,7 +642,7 @@ export const useUploadStore = defineStore('upload', () => {
 			if (draftFolderPath && fileName) {
 				// Draft-folder flow: post via the Talk attachment endpoint
 				const filePath = path.replace(/^\//, '')
-				await postAttachment({ token, filePath, fileName, referenceId: referenceId!, talkMetaData: talkMetaData! })
+				await postAttachment({ token, filePath, fileName, referenceId: referenceId!, talkMetaData: talkMetaData!, allowUpdate })
 			} else {
 				await shareFileApi({ path, shareWith: token, referenceId, talkMetaData })
 			}
@@ -711,6 +718,8 @@ export const useUploadStore = defineStore('upload', () => {
 		const failedShares = getUploadsArray(uploadId)
 			.filter(([, file]) => file.status === 'sharing')
 
+		// User was not asked again via dialog, so keep the initial choice
+		const allowUpdate = uploads[uploadId].allowUpdate
 		for (const [index, shareableFile] of failedShares) {
 			// Reset status so markFileAsSharing (called inside performShare) can proceed
 			uploads[uploadId].files[index].status = 'successUpload'
@@ -719,7 +728,7 @@ export const useUploadStore = defineStore('upload', () => {
 			const talkMetaData = shareableFile.talkMetaData || '{}'
 			const fileName = shareableFile.file.newName || shareableFile.file.name
 
-			await performShare({ token, path: shareableFile.sharePath!, index, uploadId, id, referenceId, talkMetaData, fileName })
+			await performShare({ token, path: shareableFile.sharePath!, index, uploadId, id, referenceId, talkMetaData, fileName, allowUpdate })
 		}
 	}
 


### PR DESCRIPTION
## ☑️ Resolves

* Frontend on top of #18485

### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
Screenshot before | <img width="555" height="305" alt="2026-07-03_16h39_07" src="https://github.com/user-attachments/assets/d3749911-74de-48a6-82b4-da0370106d2d" />

### 🚧 Tasks

- [ ] Default is 'off'?

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required[skip ci]

Signed-off-by: Maksim Sukharev <antreesy.web@gmail.com>