### PR TITLE
fix(external-calls): Create conversations as System instead of guest

### DIFF
--- a/lib/Chat/Parser/SystemMessage.php
+++ b/lib/Chat/Parser/SystemMessage.php
@@ -347,7 +347,16 @@ class SystemMessage implements IEventListener {
 		} elseif ($message === 'user_added') {
 			$parsedParameters['user'] = $this->getUser($parameters['user']);
 			$parsedMessage = $this->l->t('{actor} added {user}');
-			if ($parsedParameters['user']['id'] === $parsedParameters['actor']['id']) {
+			$systemIsActor = $parsedParameters['actor']['type'] === 'guest'
+				&& 'guest/' . Attendee::ACTOR_ID_SYSTEM === $parsedParameters['actor']['id'];
+
+			if ($systemIsActor) {
+				if ($this->isCurrentParticipantChangedUser($currentActorType, $currentActorId, $parsedParameters['user'])) {
+					$parsedMessage = $this->l->t('System added you');
+				} else {
+					$parsedMessage = $this->l->t('System added {user}');
+				}
+			} elseif ($parsedParameters['user']['id'] === $parsedParameters['actor']['id']) {
 				if ($currentUserIsActor) {
 					$parsedMessage = $this->l->t('You joined the conversation');
 				} else {

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -579,15 +579,34 @@ class RoomController extends AEnvironmentAwareOCSController {
 	}
 
 	/**
-	 * Authenticate an external call service request via the
-	 * `x-nextcloud-talk-external-service` header.
+	 * Check if the current request is coming from the configured external call
+	 * service.
+	 *
+	 * The `x-nextcloud-talk-external-service` variant is deprecated and going
+	 * to be removed with the next update
+	 *
+	 * @param string $owner User ID the external call service wants to act as
+	 * @return bool True if the request is from the external call service and valid
 	 */
-	private function validateExternalCallServiceRequest(string $providedSecret): bool {
+	private function validateExternalCallServiceRequest(string $owner, string $legacySecret = ''): bool {
 		if (!$this->talkConfig->isExternalCallServiceConfigured()) {
 			return false;
 		}
 
-		return hash_equals($this->talkConfig->getExternalCallServiceSharedSecret(), $providedSecret);
+		$secret = $this->talkConfig->getExternalCallServiceSharedSecret();
+
+		$random = $this->request->getHeader('x-nextcloud-talk-external-service-random');
+		$checksum = $this->request->getHeader('x-nextcloud-talk-external-service-checksum');
+		if ($random !== '' || $checksum !== '') {
+			try {
+				return $this->checksumVerificationService->validateRequest($random, $checksum, $secret, $owner);
+			} catch (UnauthorizedException) {
+				return false;
+			}
+		}
+
+		// Deprecated: raw shared secret comparison, kept for a transition phase.
+		return $legacySecret !== '' && hash_equals($secret, $legacySecret);
 	}
 
 	/**
@@ -629,10 +648,10 @@ class RoomController extends AEnvironmentAwareOCSController {
 	 * or `$participants` parameter is supported.
 	 *
 	 * The endpoint can also be used unauthenticated by an external call service
-	 * by sending the configured shared secret in the
-	 * `x-nextcloud-talk-external-service` header. In that case the `$owner`
-	 * parameter is required and will be used as the actor and conversation
-	 * owner.
+	 * by signing the request with the configured shared secret via the
+	 * `x-nextcloud-talk-external-service-random` and
+	 * `x-nextcloud-talk-external-service-checksum` headers (SHA256-HMAC of the
+	 * random seed and the `$owner` user ID).
 	 *
 	 * @param int $roomType Type of the room
 	 * @psalm-param Room::TYPE_* $roomType
@@ -665,7 +684,7 @@ class RoomController extends AEnvironmentAwareOCSController {
 	 * @param ?non-empty-string $avatarColor Background color of the avatar (Only considered when an emoji was provided) (only available with `conversation-creation-all` capability)
 	 * @param array<string, list<string>> $participants List of participants to add grouped by type (only available with `conversation-creation-all` capability)
 	 * @psalm-param TalkInvitationList $participants
-	 * @param string $owner User ID that will be used as actor and made owner of the conversation. Required when the request is authenticated via the `x-nextcloud-talk-external-service` header, otherwise ignored.
+	 * @param string $owner User ID that will be used as actor and made owner of the conversation. Required when the request is authenticated via the `x-nextcloud-talk-external-service-random` and `x-nextcloud-talk-external-service-checksum` headers, otherwise ignored.
 	 * @param ?string $preset Identifier of the preset that was used (only available with `conversation-preset` capability)
 	 * @return DataResponse<Http::STATUS_OK|Http::STATUS_CREATED, TalkRoom, array{}>|DataResponse<Http::STATUS_ACCEPTED, TalkRoomWithInvalidInvitations, array{}>|DataResponse<Http::STATUS_BAD_REQUEST|Http::STATUS_FORBIDDEN|Http::STATUS_NOT_FOUND, array{error: 'avatar'|'description'|'invite'|'listable'|'lobby'|'lobby-timer'|'mention-permissions'|'message-expiration'|'name'|'object'|'object-id'|'object-type'|'owner'|'password'|'permissions'|'preset'|'read-only'|'recording-consent'|'sip-enabled'|'type', message?: string}, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: 'auth'}, array{}>
 	 *
@@ -679,7 +698,8 @@ class RoomController extends AEnvironmentAwareOCSController {
 	 */
 	#[PublicPage]
 	#[BruteForceProtection(action: 'talkExternalCallServiceSecret')]
-	#[RequestHeader(name: 'x-nextcloud-talk-external-service', description: 'Shared secret used by the external call service to authenticate when creating a conversation on behalf of a user', indirect: true)]
+	#[RequestHeader(name: 'x-nextcloud-talk-external-service-random', description: 'Random seed (at least 32 bytes) used together with the owner user ID to generate the SHA256-HMAC request checksum', indirect: true)]
+	#[RequestHeader(name: 'x-nextcloud-talk-external-service-checksum', description: 'SHA256-HMAC checksum over the concatenation of the random seed and the owner user ID, signed with the shared external call service secret, to verify authenticity from the external call service', indirect: true)]
 	#[ApiRoute(verb: 'POST', url: '/api/{apiVersion}/room', requirements: [
 		'apiVersion' => '(v4)',
 	])]
@@ -707,16 +727,19 @@ class RoomController extends AEnvironmentAwareOCSController {
 		string $owner = '',
 		?string $preset = null,
 	): DataResponse {
-		$externalServiceHeader = $this->request->getHeader('x-nextcloud-talk-external-service');
-		if ($externalServiceHeader !== '') {
-			if (!$this->validateExternalCallServiceRequest($externalServiceHeader)) {
+		$externalServiceRandom = $this->request->getHeader('x-nextcloud-talk-external-service-random');
+		$externalServiceChecksum = $this->request->getHeader('x-nextcloud-talk-external-service-checksum');
+		// FIXME Remove in next update
+		$externalServiceLegacySecret = $this->request->getHeader('x-nextcloud-talk-external-service');
+		if ($externalServiceRandom !== '' || $externalServiceChecksum !== '' || $externalServiceLegacySecret !== '') {
+			if ($owner === '') {
+				return new DataResponse(['error' => 'owner'], Http::STATUS_BAD_REQUEST);
+			}
+
+			if (!$this->validateExternalCallServiceRequest($owner, $externalServiceLegacySecret)) {
 				$response = new DataResponse(['error' => 'auth'], Http::STATUS_UNAUTHORIZED);
 				$response->throttle(['action' => 'talkExternalCallServiceSecret']);
 				return $response;
-			}
-
-			if ($owner === '') {
-				return new DataResponse(['error' => 'owner'], Http::STATUS_BAD_REQUEST);
 			}
 
 			$actorUserId = $owner;

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -579,34 +579,22 @@ class RoomController extends AEnvironmentAwareOCSController {
 	}
 
 	/**
-	 * Check if the current request is coming from the configured external call
-	 * service.
-	 *
-	 * The `x-nextcloud-talk-external-service` variant is deprecated and going
-	 * to be removed with the next update
+	 * Check if the current request is coming from the configured external call service
 	 *
 	 * @param string $owner User ID the external call service wants to act as
 	 * @return bool True if the request is from the external call service and valid
 	 */
-	private function validateExternalCallServiceRequest(string $owner, string $legacySecret = ''): bool {
-		if (!$this->talkConfig->isExternalCallServiceConfigured()) {
+	private function validateExternalCallServiceRequest(string $owner, string $random, string $checksum): bool {
+		if ($owner === '' || !$this->talkConfig->isExternalCallServiceConfigured()) {
 			return false;
 		}
 
 		$secret = $this->talkConfig->getExternalCallServiceSharedSecret();
-
-		$random = $this->request->getHeader('x-nextcloud-talk-external-service-random');
-		$checksum = $this->request->getHeader('x-nextcloud-talk-external-service-checksum');
-		if ($random !== '' || $checksum !== '') {
-			try {
-				return $this->checksumVerificationService->validateRequest($random, $checksum, $secret, $owner);
-			} catch (UnauthorizedException) {
-				return false;
-			}
+		try {
+			return $this->checksumVerificationService->validateRequest($random, $checksum, $secret, $owner);
+		} catch (UnauthorizedException) {
+			return false;
 		}
-
-		// Deprecated: raw shared secret comparison, kept for a transition phase.
-		return $legacySecret !== '' && hash_equals($secret, $legacySecret);
 	}
 
 	/**
@@ -729,14 +717,12 @@ class RoomController extends AEnvironmentAwareOCSController {
 	): DataResponse {
 		$externalServiceRandom = $this->request->getHeader('x-nextcloud-talk-external-service-random');
 		$externalServiceChecksum = $this->request->getHeader('x-nextcloud-talk-external-service-checksum');
-		// FIXME Remove in next update
-		$externalServiceLegacySecret = $this->request->getHeader('x-nextcloud-talk-external-service');
-		if ($externalServiceRandom !== '' || $externalServiceChecksum !== '' || $externalServiceLegacySecret !== '') {
+		if ($externalServiceRandom !== '' || $externalServiceChecksum !== '') {
 			if ($owner === '') {
 				return new DataResponse(['error' => 'owner'], Http::STATUS_BAD_REQUEST);
 			}
 
-			if (!$this->validateExternalCallServiceRequest($owner, $externalServiceLegacySecret)) {
+			if (!$this->validateExternalCallServiceRequest($owner, $externalServiceRandom, $externalServiceChecksum)) {
 				$response = new DataResponse(['error' => 'auth'], Http::STATUS_UNAUTHORIZED);
 				$response->throttle(['action' => 'talkExternalCallServiceSecret']);
 				return $response;

--- a/lib/Service/RoomService.php
+++ b/lib/Service/RoomService.php
@@ -64,6 +64,7 @@ use OCP\EventDispatcher\IEventDispatcher;
 use OCP\HintException;
 use OCP\IDBConnection;
 use OCP\IL10N;
+use OCP\ISession;
 use OCP\IUser;
 use OCP\IUserManager;
 use OCP\Log\Audit\CriticalActionPerformedEvent;
@@ -92,6 +93,7 @@ class RoomService {
 		private readonly IL10N $l10n,
 		private readonly IManager $calendarManager,
 		private readonly IUserManager $userManager,
+		private readonly ISession $session,
 	) {
 	}
 
@@ -216,6 +218,11 @@ class RoomService {
 		if (($objectType !== '' && $objectId === '')
 			|| ($objectType === '' && $objectId !== '')) {
 			throw new CreationException(CreationException::REASON_OBJECT);
+		}
+
+		if ($objectType === Room::OBJECT_TYPE_EXTERNAL_CALL) {
+			$this->session->set('talk-overwrite-actor-type', Attendee::ACTOR_GUESTS);
+			$this->session->set('talk-overwrite-actor-id', Attendee::ACTOR_ID_SYSTEM);
 		}
 
 		if ($type === Room::TYPE_PUBLIC && $password === '' && $this->config->isPasswordEnforced()) {

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -18703,7 +18703,7 @@
             "post": {
                 "operationId": "room-create-room",
                 "summary": "Create a room with a user, a group or a circle",
-                "description": "With the `conversation-creation-all` capability a lot of new options where introduced. Before that only `$roomType`, `$roomName`, `$objectType` and `$objectId` were supported all the time, and `$password` with the `conversation-creation-password` capability In case the `$roomType` is {@see Room::TYPE_ONE_TO_ONE} only the `$invite` or `$participants` parameter is supported.\nThe endpoint can also be used unauthenticated by an external call service by sending the configured shared secret in the `x-nextcloud-talk-external-service` header. In that case the `$owner` parameter is required and will be used as the actor and conversation owner.",
+                "description": "With the `conversation-creation-all` capability a lot of new options where introduced. Before that only `$roomType`, `$roomName`, `$objectType` and `$objectId` were supported all the time, and `$password` with the `conversation-creation-password` capability In case the `$roomType` is {@see Room::TYPE_ONE_TO_ONE} only the `$invite` or `$participants` parameter is supported.\nThe endpoint can also be used unauthenticated by an external call service by signing the request with the configured shared secret via the `x-nextcloud-talk-external-service-random` and `x-nextcloud-talk-external-service-checksum` headers (SHA256-HMAC of the random seed and the `$owner` user ID).",
                 "tags": [
                     "room"
                 ],
@@ -18865,7 +18865,7 @@
                                     "owner": {
                                         "type": "string",
                                         "default": "",
-                                        "description": "User ID that will be used as actor and made owner of the conversation. Required when the request is authenticated via the `x-nextcloud-talk-external-service` header, otherwise ignored."
+                                        "description": "User ID that will be used as actor and made owner of the conversation. Required when the request is authenticated via the `x-nextcloud-talk-external-service-random` and `x-nextcloud-talk-external-service-checksum` headers, otherwise ignored."
                                     },
                                     "preset": {
                                         "type": "string",
@@ -18892,9 +18892,17 @@
                         }
                     },
                     {
-                        "name": "x-nextcloud-talk-external-service",
+                        "name": "x-nextcloud-talk-external-service-random",
                         "in": "header",
-                        "description": "Shared secret used by the external call service to authenticate when creating a conversation on behalf of a user",
+                        "description": "Random seed (at least 32 bytes) used together with the owner user ID to generate the SHA256-HMAC request checksum",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "x-nextcloud-talk-external-service-checksum",
+                        "in": "header",
+                        "description": "SHA256-HMAC checksum over the concatenation of the random seed and the owner user ID, signed with the shared external call service secret, to verify authenticity from the external call service",
                         "schema": {
                             "type": "string"
                         }

--- a/openapi.json
+++ b/openapi.json
@@ -18591,7 +18591,7 @@
             "post": {
                 "operationId": "room-create-room",
                 "summary": "Create a room with a user, a group or a circle",
-                "description": "With the `conversation-creation-all` capability a lot of new options where introduced. Before that only `$roomType`, `$roomName`, `$objectType` and `$objectId` were supported all the time, and `$password` with the `conversation-creation-password` capability In case the `$roomType` is {@see Room::TYPE_ONE_TO_ONE} only the `$invite` or `$participants` parameter is supported.\nThe endpoint can also be used unauthenticated by an external call service by sending the configured shared secret in the `x-nextcloud-talk-external-service` header. In that case the `$owner` parameter is required and will be used as the actor and conversation owner.",
+                "description": "With the `conversation-creation-all` capability a lot of new options where introduced. Before that only `$roomType`, `$roomName`, `$objectType` and `$objectId` were supported all the time, and `$password` with the `conversation-creation-password` capability In case the `$roomType` is {@see Room::TYPE_ONE_TO_ONE} only the `$invite` or `$participants` parameter is supported.\nThe endpoint can also be used unauthenticated by an external call service by signing the request with the configured shared secret via the `x-nextcloud-talk-external-service-random` and `x-nextcloud-talk-external-service-checksum` headers (SHA256-HMAC of the random seed and the `$owner` user ID).",
                 "tags": [
                     "room"
                 ],
@@ -18753,7 +18753,7 @@
                                     "owner": {
                                         "type": "string",
                                         "default": "",
-                                        "description": "User ID that will be used as actor and made owner of the conversation. Required when the request is authenticated via the `x-nextcloud-talk-external-service` header, otherwise ignored."
+                                        "description": "User ID that will be used as actor and made owner of the conversation. Required when the request is authenticated via the `x-nextcloud-talk-external-service-random` and `x-nextcloud-talk-external-service-checksum` headers, otherwise ignored."
                                     },
                                     "preset": {
                                         "type": "string",
@@ -18780,9 +18780,17 @@
                         }
                     },
                     {
-                        "name": "x-nextcloud-talk-external-service",
+                        "name": "x-nextcloud-talk-external-service-random",
                         "in": "header",
-                        "description": "Shared secret used by the external call service to authenticate when creating a conversation on behalf of a user",
+                        "description": "Random seed (at least 32 bytes) used together with the owner user ID to generate the SHA256-HMAC request checksum",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "x-nextcloud-talk-external-service-checksum",
+                        "in": "header",
+                        "description": "SHA256-HMAC checksum over the concatenation of the random seed and the owner user ID, signed with the shared external call service secret, to verify authenticity from the external call service",
                         "schema": {
                             "type": "string"
                         }

--- a/src/types/openapi/openapi-full.ts
+++ b/src/types/openapi/openapi-full.ts
@@ -1237,7 +1237,7 @@ export type paths = {
         /**
          * Create a room with a user, a group or a circle
          * @description With the `conversation-creation-all` capability a lot of new options where introduced. Before that only `$roomType`, `$roomName`, `$objectType` and `$objectId` were supported all the time, and `$password` with the `conversation-creation-password` capability In case the `$roomType` is {@see Room::TYPE_ONE_TO_ONE} only the `$invite` or `$participants` parameter is supported.
-         *     The endpoint can also be used unauthenticated by an external call service by sending the configured shared secret in the `x-nextcloud-talk-external-service` header. In that case the `$owner` parameter is required and will be used as the actor and conversation owner.
+         *     The endpoint can also be used unauthenticated by an external call service by signing the request with the configured shared secret via the `x-nextcloud-talk-external-service-random` and `x-nextcloud-talk-external-service-checksum` headers (SHA256-HMAC of the random seed and the `$owner` user ID).
          */
         post: operations["room-create-room"];
         delete?: never;
@@ -10353,8 +10353,10 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
-                /** @description Shared secret used by the external call service to authenticate when creating a conversation on behalf of a user */
-                "x-nextcloud-talk-external-service"?: string;
+                /** @description Random seed (at least 32 bytes) used together with the owner user ID to generate the SHA256-HMAC request checksum */
+                "x-nextcloud-talk-external-service-random"?: string;
+                /** @description SHA256-HMAC checksum over the concatenation of the random seed and the owner user ID, signed with the shared external call service secret, to verify authenticity from the external call service */
+                "x-nextcloud-talk-external-service-checksum"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -10477,7 +10479,7 @@ export interface operations {
                      */
                     participants?: components["schemas"]["InvitationList"];
                     /**
-                     * @description User ID that will be used as actor and made owner of the conversation. Required when the request is authenticated via the `x-nextcloud-talk-external-service` header, otherwise ignored.
+                     * @description User ID that will be used as actor and made owner of the conversation. Required when the request is authenticated via the `x-nextcloud-talk-external-service-random` and `x-nextcloud-talk-external-service-checksum` headers, otherwise ignored.
                      * @default
                      */
                     owner?: string;

--- a/src/types/openapi/openapi.ts
+++ b/src/types/openapi/openapi.ts
@@ -1237,7 +1237,7 @@ export type paths = {
         /**
          * Create a room with a user, a group or a circle
          * @description With the `conversation-creation-all` capability a lot of new options where introduced. Before that only `$roomType`, `$roomName`, `$objectType` and `$objectId` were supported all the time, and `$password` with the `conversation-creation-password` capability In case the `$roomType` is {@see Room::TYPE_ONE_TO_ONE} only the `$invite` or `$participants` parameter is supported.
-         *     The endpoint can also be used unauthenticated by an external call service by sending the configured shared secret in the `x-nextcloud-talk-external-service` header. In that case the `$owner` parameter is required and will be used as the actor and conversation owner.
+         *     The endpoint can also be used unauthenticated by an external call service by signing the request with the configured shared secret via the `x-nextcloud-talk-external-service-random` and `x-nextcloud-talk-external-service-checksum` headers (SHA256-HMAC of the random seed and the `$owner` user ID).
          */
         post: operations["room-create-room"];
         delete?: never;
@@ -9758,8 +9758,10 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
-                /** @description Shared secret used by the external call service to authenticate when creating a conversation on behalf of a user */
-                "x-nextcloud-talk-external-service"?: string;
+                /** @description Random seed (at least 32 bytes) used together with the owner user ID to generate the SHA256-HMAC request checksum */
+                "x-nextcloud-talk-external-service-random"?: string;
+                /** @description SHA256-HMAC checksum over the concatenation of the random seed and the owner user ID, signed with the shared external call service secret, to verify authenticity from the external call service */
+                "x-nextcloud-talk-external-service-checksum"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
@@ -9882,7 +9884,7 @@ export interface operations {
                      */
                     participants?: components["schemas"]["InvitationList"];
                     /**
-                     * @description User ID that will be used as actor and made owner of the conversation. Required when the request is authenticated via the `x-nextcloud-talk-external-service` header, otherwise ignored.
+                     * @description User ID that will be used as actor and made owner of the conversation. Required when the request is authenticated via the `x-nextcloud-talk-external-service-random` and `x-nextcloud-talk-external-service-checksum` headers, otherwise ignored.
                      * @default
                      */
                     owner?: string;

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -1185,6 +1185,15 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 
 	#[Then('/^external call service creates room "([^"]*)" with secret "([^"]*)" with (\d+) \((v4)\)$/')]
 	public function externalCallServiceCreatesRoom(string $identifier, string $secret, int $statusCode, string $apiVersion, ?TableNode $formData = null): void {
+		$this->externalCallServiceCreatesRoomInternal($identifier, $secret, false, $statusCode, $apiVersion, $formData);
+	}
+
+	#[Then('/^external call service creates room "([^"]*)" with legacy secret "([^"]*)" with (\d+) \((v4)\)$/')]
+	public function externalCallServiceCreatesRoomWithLegacySecret(string $identifier, string $secret, int $statusCode, string $apiVersion, ?TableNode $formData = null): void {
+		$this->externalCallServiceCreatesRoomInternal($identifier, $secret, true, $statusCode, $apiVersion, $formData);
+	}
+
+	private function externalCallServiceCreatesRoomInternal(string $identifier, string $secret, bool $legacy, int $statusCode, string $apiVersion, ?TableNode $formData = null): void {
 		$body = $formData ? $formData->getRowsHash() : [];
 		if (isset($body['roomName']) && $body['roomName'] === 'IDENTIFIER') {
 			$body['roomName'] = $identifier;
@@ -1195,9 +1204,18 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 
 		$headers = [];
 		if ($secret !== '') {
-			$headers = [
-				'x-nextcloud-talk-external-service' => $secret,
-			];
+			if ($legacy) {
+				$headers = [
+					'x-nextcloud-talk-external-service' => $secret,
+				];
+			} else {
+				$random = bin2hex(random_bytes(32));
+				$checksum = hash_hmac('sha256', $random . ($body['owner'] ?? ''), $secret);
+				$headers = [
+					'x-nextcloud-talk-external-service-random' => $random,
+					'x-nextcloud-talk-external-service-checksum' => $checksum,
+				];
+			}
 		}
 
 		$this->setCurrentUser('');

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -1185,15 +1185,6 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 
 	#[Then('/^external call service creates room "([^"]*)" with secret "([^"]*)" with (\d+) \((v4)\)$/')]
 	public function externalCallServiceCreatesRoom(string $identifier, string $secret, int $statusCode, string $apiVersion, ?TableNode $formData = null): void {
-		$this->externalCallServiceCreatesRoomInternal($identifier, $secret, false, $statusCode, $apiVersion, $formData);
-	}
-
-	#[Then('/^external call service creates room "([^"]*)" with legacy secret "([^"]*)" with (\d+) \((v4)\)$/')]
-	public function externalCallServiceCreatesRoomWithLegacySecret(string $identifier, string $secret, int $statusCode, string $apiVersion, ?TableNode $formData = null): void {
-		$this->externalCallServiceCreatesRoomInternal($identifier, $secret, true, $statusCode, $apiVersion, $formData);
-	}
-
-	private function externalCallServiceCreatesRoomInternal(string $identifier, string $secret, bool $legacy, int $statusCode, string $apiVersion, ?TableNode $formData = null): void {
 		$body = $formData ? $formData->getRowsHash() : [];
 		if (isset($body['roomName']) && $body['roomName'] === 'IDENTIFIER') {
 			$body['roomName'] = $identifier;
@@ -1204,18 +1195,12 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 
 		$headers = [];
 		if ($secret !== '') {
-			if ($legacy) {
-				$headers = [
-					'x-nextcloud-talk-external-service' => $secret,
-				];
-			} else {
-				$random = bin2hex(random_bytes(32));
-				$checksum = hash_hmac('sha256', $random . ($body['owner'] ?? ''), $secret);
-				$headers = [
-					'x-nextcloud-talk-external-service-random' => $random,
-					'x-nextcloud-talk-external-service-checksum' => $checksum,
-				];
-			}
+			$random = bin2hex(random_bytes(32));
+			$checksum = hash_hmac('sha256', $random . ($body['owner'] ?? ''), $secret);
+			$headers = [
+				'x-nextcloud-talk-external-service-random' => $random,
+				'x-nextcloud-talk-external-service-checksum' => $checksum,
+			];
 		}
 
 		$this->setCurrentUser('');

--- a/tests/integration/features/conversation-1/create-external-service.feature
+++ b/tests/integration/features/conversation-1/create-external-service.feature
@@ -17,6 +17,10 @@ Feature: conversation-1/create-external-service
     Then user "participant1" is participant of the following rooms (v4)
       | id   | name | type | participantType | objectType    | objectId                             |
       | room | room | 3    | 1               | external_call | d4e5f6a7-b8c9-0123-defa-123456789012 |
+    Then user "participant1" sees the following system messages in room "room" with 200 (v1)
+      | room | actorType     | actorId | systemMessage        | message                         | silent | messageParameters |
+      | room | guests        | system  | user_added           | System added you                | !ISSET | {"actor":{"type":"guest","id":"guest\/system","name":"System","mention-id":"guest\/system"},"user":{"type":"user","id":"participant1","name":"participant1-displayname","mention-id":"participant1"}} |
+      | room | guests        | system  | conversation_created | System created the conversation | !ISSET | {"actor":{"type":"guest","id":"guest\/system","name":"System","mention-id":"guest\/system"}} |
     And user "participant1" gets external call url for room "room" with 200 (v4)
       | url | https://example.tld/webapp3/m/210987654321-afed-3210-9c8b-7a6f5e4d |
 

--- a/tests/integration/features/conversation-1/create-external-service.feature
+++ b/tests/integration/features/conversation-1/create-external-service.feature
@@ -24,31 +24,6 @@ Feature: conversation-1/create-external-service
     And user "participant1" gets external call url for room "room" with 200 (v4)
       | url | https://example.tld/webapp3/m/210987654321-afed-3210-9c8b-7a6f5e4d |
 
-  Scenario: External call service creates a room using the deprecated raw secret header during the transition phase
-    Given the following "spreed" app config is set
-      | external_call_service_shared_secret | aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa |
-      | external_call_service_auth_user | nextcloud |
-      | external_call_service_iframe_field | targetUrl |
-    Given external call server is started
-    When external call service creates room "room" with legacy secret "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" with 201 (v4)
-      | roomType | 3 |
-      | roomName | room |
-      | owner | participant1 |
-      | objectType | external_call |
-      | objectId | d4e5f6a7-b8c9-0123-defa-123456789012 |
-    Then user "participant1" is participant of the following rooms (v4)
-      | id   | name | type | participantType | objectType    | objectId                             |
-      | room | room | 3    | 1               | external_call | d4e5f6a7-b8c9-0123-defa-123456789012 |
-
-  Scenario: External call service with wrong legacy secret is rejected
-    Given the following "spreed" app config is set
-      | external_call_service               | https://external-service.example.org/ |
-      | external_call_service_shared_secret | aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa |
-    When external call service creates room "room" with legacy secret "bbbbbbbbbb" with 401 (v4)
-      | roomType | 3 |
-      | roomName | room |
-      | owner | participant1 |
-
   Scenario: Unauthenticated user without external service header is rejected
     Given the following "spreed" app config is set
       | external_call_service               | https://external-service.example.org/ |

--- a/tests/integration/features/conversation-1/create-external-service.feature
+++ b/tests/integration/features/conversation-1/create-external-service.feature
@@ -24,6 +24,31 @@ Feature: conversation-1/create-external-service
     And user "participant1" gets external call url for room "room" with 200 (v4)
       | url | https://example.tld/webapp3/m/210987654321-afed-3210-9c8b-7a6f5e4d |
 
+  Scenario: External call service creates a room using the deprecated raw secret header during the transition phase
+    Given the following "spreed" app config is set
+      | external_call_service_shared_secret | aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa |
+      | external_call_service_auth_user | nextcloud |
+      | external_call_service_iframe_field | targetUrl |
+    Given external call server is started
+    When external call service creates room "room" with legacy secret "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" with 201 (v4)
+      | roomType | 3 |
+      | roomName | room |
+      | owner | participant1 |
+      | objectType | external_call |
+      | objectId | d4e5f6a7-b8c9-0123-defa-123456789012 |
+    Then user "participant1" is participant of the following rooms (v4)
+      | id   | name | type | participantType | objectType    | objectId                             |
+      | room | room | 3    | 1               | external_call | d4e5f6a7-b8c9-0123-defa-123456789012 |
+
+  Scenario: External call service with wrong legacy secret is rejected
+    Given the following "spreed" app config is set
+      | external_call_service               | https://external-service.example.org/ |
+      | external_call_service_shared_secret | aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa |
+    When external call service creates room "room" with legacy secret "bbbbbbbbbb" with 401 (v4)
+      | roomType | 3 |
+      | roomName | room |
+      | owner | participant1 |
+
   Scenario: Unauthenticated user without external service header is rejected
     Given the following "spreed" app config is set
       | external_call_service               | https://external-service.example.org/ |

--- a/tests/php/Service/RoomServiceTest.php
+++ b/tests/php/Service/RoomServiceTest.php
@@ -29,6 +29,7 @@ use OCP\Calendar\IManager;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IDBConnection;
 use OCP\IL10N;
+use OCP\ISession;
 use OCP\IUser;
 use OCP\IUserManager;
 use OCP\Security\IHasher;
@@ -53,6 +54,7 @@ class RoomServiceTest extends TestCase {
 	protected IL10N&MockObject $l10n;
 	protected IManager $calendarManager;
 	protected IUserManager&MockObject $userManager;
+	protected ISession&MockObject $session;
 	protected EmojiService $emojiService;
 	protected ?RoomService $service = null;
 
@@ -71,6 +73,7 @@ class RoomServiceTest extends TestCase {
 		$this->emojiService = Server::get(EmojiService::class);
 		$this->calendarManager = $this->createMock(IManager::class);
 		$this->userManager = $this->createMock(IUserManager::class);
+		$this->session = $this->createMock(ISession::class);
 		$this->service = new RoomService(
 			$this->manager,
 			$this->participantService,
@@ -85,6 +88,7 @@ class RoomServiceTest extends TestCase {
 			$this->l10n,
 			$this->calendarManager,
 			$this->userManager,
+			$this->session,
 		);
 	}
 
@@ -279,7 +283,7 @@ class RoomServiceTest extends TestCase {
 		}
 
 		if ($password !== '') {
-			$this->hasher->expects(self::once())
+			$this->hasher->expects($this->once())
 				->method('hash')
 				->willReturn($password);
 		}
@@ -376,6 +380,7 @@ class RoomServiceTest extends TestCase {
 			$this->l10n,
 			$this->calendarManager,
 			$this->userManager,
+			$this->session,
 		);
 
 		$room = new Room(


### PR DESCRIPTION
## 🛠️ API Checklist

Test failure before:
```diff
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
     0 => Array (
         'room' => 'room'
         'actorType' => 'guests'
-        'actorId' => 'system'
+        'actorId' => 'failed-to-get-session'
         'systemMessage' => 'user_added'
-        'message' => 'You added {user}'
+        'message' => '{actor} added you'
         'silent' => '!ISSET'
-        'messageParameters' => '{"actor":{"type":"guest","id":"guest\/system","name":"System","mention-id":"guest\/system"},"user":{"type":"user","id":"participant1","name":"participant1-displayname","mention-id":"participant1"}}'
+        'messageParameters' => '{"actor":{"type":"guest","id":"guest\/failed-to-get-session","name":"Guest","mention-id":"guest\/failed-to-get-session"},"user":{"type":"user","id":"participant1","name":"participant1-displayname","mention-id":"participant1"}}'
     )
     1 => Array (
         'room' => 'room'
         'actorType' => 'guests'
-        'actorId' => 'system'
+        'actorId' => 'failed-to-get-session'
         'systemMessage' => 'conversation_created'
-        'message' => 'You created the conversation'
+        'message' => '{actor} created the conversation'
         'silent' => '!ISSET'
-        'messageParameters' => '{"actor":{"type":"guest","id":"guest\/system","name":"System","mention-id":"guest\/system"}}'
+        'messageParameters' => '{"actor":{"type":"guest","id":"guest\/failed-to-get-session","name":"Guest","mention-id":"guest\/failed-to-get-session"}}'
     )
 )
```

<img width="478" height="156" alt="grafik" src="https://github.com/user-attachments/assets/3ab0a482-7e5a-43e3-8fa1-dcaaf9f2ff02" />


### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
