### PR TITLE
fix: Use system actor for SAML provisioned users added to existing groups

### DIFF
--- a/lib/Chat/SystemMessage/Listener.php
+++ b/lib/Chat/SystemMessage/Listener.php
@@ -554,8 +554,16 @@ class Listener implements IEventListener {
 				$actorId = $this->session->get('talk-overwrite-actor-id');
 			} else {
 				$actorType = Attendee::ACTOR_GUESTS;
-				$sessionId = $this->talkSession->getSessionForRoom($room->getToken());
-				$actorId = $sessionId ? sha1($sessionId) : 'failed-to-get-session';
+
+				// We might reach this point when a new user is provisioned via SAML and added
+				// to already existing groups. Check if the corresponding session value exists
+				// and use the system actor in this case.
+				if ($this->session->get('user_saml.Idp') !== null) {
+					$actorId = Attendee::ACTOR_ID_SYSTEM;
+				} else {
+					$sessionId = $this->talkSession->getSessionForRoom($room->getToken());
+					$actorId = $sessionId ? sha1($sessionId) : 'failed-to-get-session';
+				}
 			}
 		}
 


### PR DESCRIPTION
## 🛠️ API Checklist

* Have SAML configured that also maps groups
* Add a SAML group to a talk conversation
* Login through SAML with a new user that is part of the SAML group before

**Before** 
<img width="308" height="41" alt="SCR-20260701-qobl" src="https://github.com/user-attachments/assets/9342cafc-4bd6-428a-b2d1-8291b828ecfa" />

**After this PR**
<img width="311" height="44" alt="SCR-20260701-qnvn" src="https://github.com/user-attachments/assets/4dbe268a-1c06-4bcc-a7fc-833a29859fa3" />

**After this PR combined with https://github.com/nextcloud/spreed/pull/18512** 
<img width="279" height="41" alt="SCR-20260701-qowz" src="https://github.com/user-attachments/assets/586916eb-f563-469b-805e-199865cfef78" />

Ref of the attribute: https://github.com/nextcloud/user_saml/blob/54436b20d0e4bc916f242ecdbe988a9a3404f626/lib/Model/SessionData.php#L14

Ref stacktrace:
<img width="1673" height="842" alt="SCR-20260527-sqes" src="https://github.com/user-attachments/assets/7ac96ef3-c067-4af3-8d04-1cecbb796afd" />

I did not find any existing tests around the session handling with `talk-overwrite-actor-id` for example, so not fully sure if we should add one here.

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
