### PR TITLE
fix(signaling): rejoin with a fresh session on 'no_such_room' rejection

### DIFF
--- a/src/utils/signaling.js
+++ b/src/utils/signaling.js
@@ -820,6 +820,9 @@ Signaling.Standalone.prototype.connect = function() {
 					case 'token_expired':
 						this.processErrorTokenExpired()
 						break
+					case 'no_such_room':
+						console.error('An error occurred getting the room for user')
+						break
 					default:
 						console.error('Ignore unknown error: %s', JSON.stringify(data.error))
 						this._trigger('error', [data.error])
@@ -1284,6 +1287,13 @@ Signaling.Standalone.prototype.joinCall = function(token, flags, silent, recordi
 
 Signaling.Standalone.prototype.joinResponseReceived = function(data, token) {
 	console.debug('Joined', data, token)
+
+	if (data.type === 'error' && data.error.code === 'no_such_room') {
+		this.processErrorNoSuchRoom()
+		return
+	}
+
+	this._rejoinRoomAfterInvalidSession = null
 	this.signalingRoomJoined = token
 	if (this.pendingJoinCall && token === this.pendingJoinCall.token) {
 		const pendingJoinCallResolve = this.pendingJoinCall.resolve
@@ -1543,6 +1553,34 @@ Signaling.Standalone.prototype.processRoomParticipantsEvent = function(data) {
 			console.error('Unknown room participant event', data)
 			break
 	}
+}
+
+Signaling.Standalone.prototype.processErrorNoSuchRoom = function() {
+	// 'no_such_room' is a generic rejection of a room join:
+	// - the room might be gone;
+	// - the user might no longer be a participant (banned/removed);
+	// - the client was offline and then WS reconnects to the room with a stale PHP session id).
+	//
+	// Re-establish a fresh session as a best effort; if the room/participant is
+	// actually gone, the rejoin below fails and surfaces the proper error.
+	const token = this.currentRoomToken
+	if (!token) {
+		return
+	}
+
+	if (this._rejoinRoomAfterInvalidSession === token) {
+		// prevent re-join loop
+		console.error('Rejoining room with a new session failed, giving up', token)
+		return
+	}
+
+	console.debug('Room join was rejected, attempting to rejoin with a new session', token)
+	this._rejoinRoomAfterInvalidSession = token
+	this.resumeId = null
+	this.signalingRoomJoined = null
+	store.dispatch('joinConversation', { token }).catch((error) => {
+		console.error('Failed to rejoin conversation with a new session', token, error)
+	})
 }
 
 Signaling.Standalone.prototype.processErrorTokenExpired = function() {

--- a/src/utils/signaling.js
+++ b/src/utils/signaling.js
@@ -911,6 +911,7 @@ Signaling.Standalone.prototype.forceReconnect = function(newSession, flags) {
 
 		rejoinConversation(this.currentRoomToken)
 			.then((response) => {
+				// FIXME use _trigger() -> EventBus to emit payload instead of direct store usage
 				store.commit('setInCall', {
 					token: this.currentRoomToken,
 					sessionId: this.nextcloudSessionId,
@@ -919,7 +920,9 @@ Signaling.Standalone.prototype.forceReconnect = function(newSession, flags) {
 
 				this.nextcloudSessionId = response.data.ocs.data.sessionId
 
+				// FIXME use _trigger() -> EventBus to emit payload instead of direct store usage
 				actorStore.setCurrentParticipant(response.data.ocs.data)
+				// FIXME use _trigger() -> EventBus to emit payload instead of direct store usage
 				store.commit('setInCall', {
 					token: this.currentRoomToken,
 					sessionId: this.nextcloudSessionId,
@@ -1361,6 +1364,7 @@ Signaling.Standalone.prototype.processEvent = function(data) {
 
 Signaling.Standalone.prototype.processDialOutEvent = function(data) {
 	if (data.dialout.callid) {
+		// FIXME use _trigger() -> EventBus to emit payload instead of direct store usage
 		store.dispatch('processDialOutAnswer', { callid: data.dialout.callid })
 	} else if (data.dialout.error) {
 		console.debug(data.dialout.error)
@@ -1371,6 +1375,7 @@ Signaling.Standalone.prototype.processTransientEvent = function(data) {
 	switch (data.transient.type) {
 		case 'set':
 			if (data.transient.key.startsWith('callstatus_')) {
+				// FIXME use _trigger() -> EventBus to emit payload instead of direct store usage
 				store.dispatch('processTransientCallStatus', { value: data.transient.value })
 			}
 			break
@@ -1379,6 +1384,7 @@ Signaling.Standalone.prototype.processTransientEvent = function(data) {
 			break
 		case 'initial':
 			if (data.transient.data) {
+				// FIXME use _trigger() -> EventBus to emit payload instead of direct store usage
 				store.dispatch('addPhonesStates', { phoneStates: data.transient.data })
 			}
 			break
@@ -1578,6 +1584,7 @@ Signaling.Standalone.prototype.processErrorNoSuchRoom = function() {
 	this._rejoinRoomAfterInvalidSession = token
 	this.resumeId = null
 	this.signalingRoomJoined = null
+	// FIXME use _trigger() -> EventBus to emit payload instead of direct store usage
 	store.dispatch('joinConversation', { token }).catch((error) => {
 		console.error('Failed to rejoin conversation with a new session', token, error)
 	})


### PR DESCRIPTION
## ☑️ Resolves

* Ref (and partial fix) for #9382
	* When client reconnect to HPB after a network change, both HPB and PHP sessions might be expired
	* HPB opens a new websocket gracefully, but nothing triggers PHP session to be established again
	* HPB then rejects the room join with a "no_such_room" error.
	* Handle by dispatching server request to join conversation similar to useActiveSession.js logic
	* track `_rejoinRoomAfterInvalidSession` for loop reconnect prevention, reset on successful join

Reproduction steps:
* Join room as userA and userB
* Put userA to offline (Devtools > Network or on a hardware level)
* Wait for ~3 minutes, then re-join room as userB
* This should trigger expiring of userA session (removed from DB oc_talk_sessions, HPB sends users left)
* Put userA back online

Results without this PR:
* PHP session no longer exists, joining call failed, no signaling messages received for the room (e.g. typing indicator)

Results with this PR:
* Brief interruption to reconnect, error toast indicating
* PHP session renewed, joining call works, signaling messages work

### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
	- Assisted-by: ClaudeCode:claude-opus-4-8

### Tasks:
* [Not reproduced] If PHP session still alive, but HPB refreshed, it might open a new room session? E.g. call can be joined, but userA won't see userB


## 🖌️ UI Checklist

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required