### PR TITLE
fix(call): keep audio/video state choice from device picker when joining call

### DIFF
--- a/src/components/MediaSettings/MediaSettings.vue
+++ b/src/components/MediaSettings/MediaSettings.vue
@@ -665,13 +665,15 @@ export default {
 		},
 
 		audioInputId(audioInputId) {
-			if (this.tabContent === 'devices' && audioInputId && !this.audioOn) {
+			if (this.tabContent === 'devices' && audioInputId && !this.audioOn
+				&& !this.settingsStore.startWithoutMedia) {
 				this.toggleAudio()
 			}
 		},
 
 		videoInputId(videoInputId) {
-			if (this.tabContent === 'devices' && videoInputId && !this.videoOn) {
+			if (this.tabContent === 'devices' && videoInputId && !this.videoOn
+				&& !this.settingsStore.startWithoutMedia) {
 				this.toggleVideo()
 			}
 		},

--- a/src/composables/useJoinCall.ts
+++ b/src/composables/useJoinCall.ts
@@ -100,16 +100,13 @@ export function useJoinCall() {
 		emit('toggle-navigation', { open: false })
 
 		const options: Partial<Record<'audioOn' | 'videoOn', boolean>> = {}
-		if (settingsStore.startWithoutMedia) {
-			// Option: 'Turn camera and microphone off by default'
-			options.audioOn = false
+		if (!settingsStore.showMediaSettings || directCall) {
+			// Join calls with video off if device preview skipped or bypassed
 			options.videoOn = false
-		} else if (!settingsStore.showMediaSettings) {
-			// Join calls with video off if device preview skipped
-			options.videoOn = false
-		} else if (directCall) {
-			// Join direct calls with video off
-			options.videoOn = false
+			if (settingsStore.startWithoutMedia) {
+				// Option: 'Turn camera and microphone off by default'
+				options.audioOn = false
+			}
 		}
 
 		console.debug('Joining call')


### PR DESCRIPTION
## ☑️ Resolves

* Fix regression from #17498
	* with option 'Turn camera and microphone off by default' it forces both to be disabled on joining call
	* instead mediasettings choice should be kept
* Fix initial off/on state on first dialog open

### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
audio/video off | audio/video as selected

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
