### PR TITLE
feat(bots): allow bots to fetch their own enabled features

### DIFF
--- a/docs/bots.md
+++ b/docs/bots.md
@@ -417,15 +417,15 @@ Bots can also remove their previous reaction from a message. The same signature/
 
 🆕 Added in Talk 25.
 
-Bots can check which [features](constants.md#bot-features) an administrator enabled for them, without requiring administrator credentials. The same signature/verification method is applied. Since `GET` requests have no request body, the signature is computed over the random seed alone (`hash_hmac('sha256', $random, $secret)`); the conversation to look the bot up in is taken from the URL. Signing empty content also keeps the signature out of the value space of the `message` and `reaction` endpoints, which reject empty content before authenticating, so a captured features request cannot be replayed against them.
+Bots can check which [features](constants.md#bot-features) an administrator enabled for them, without requiring administrator credentials. The same signature/verification method is applied. The conversation token is sent in the request body and the signature is computed over the random seed and that token (`hash_hmac('sha256', $random . $token, $secret)`); the token identifies the conversation to look the bot up in. Keeping the token in the signed body binds the request to the conversation, so the signature headers on their own cannot be replayed.
 
 !!! note
 
     A bot that is set up in a conversation can authenticate against this endpoint even when all of its features were disabled (`features` = `0`), as the feature flags only control which actions and invocations are enabled. To fully cut off a bot, change its state to disabled or remove it from the conversation.
 
 * Required capability: `bot-features-api`
-* Method: `GET`
-* Endpoint: `/bot/{token}/features`
+* Method: `POST`
+* Endpoint: `/bot/ask-features`
 * Header:
 
 | Name                             | Description                                                     |
@@ -433,6 +433,12 @@ Bots can check which [features](constants.md#bot-features) an administrator enab
 | `X-Nextcloud-Talk-Bot-Random`    | The random value used when signing the request                  |
 | `X-Nextcloud-Talk-Bot-Signature` | The signature to validate the request comes from an enabled bot |
 | `OCS-APIRequest`                 | Needs to be set to `true` to access the ocs/vX.php endpoint     |
+
+* Data:
+
+| field   | type   | Description                                          |
+|---------|--------|------------------------------------------------------|
+| `token` | string | Token of the conversation the bot is set up in       |
 
 * Response:
     - Status code:
@@ -471,4 +477,4 @@ When installing the bot specify `nextcloudapp://$APPID` as the bot URL, together
 - Due to a bug the `object.name` was set to an empty string for messages with attachments. This was fixed to be `'message'` as for normal messages without any attachments.
 
 ### Nextcloud 35 / Talk 25
-- Added `GET /ocs/v2.php/apps/spreed/bot/{token}/features` endpoint which allows bots to fetch their own enabled features using their shared secret (required capability: `bot-features-api`)
+- Added `POST /ocs/v2.php/apps/spreed/bot/ask-features` endpoint which allows bots to fetch their own enabled features using their shared secret (required capability: `bot-features-api`)

--- a/docs/bots.md
+++ b/docs/bots.md
@@ -471,4 +471,4 @@ When installing the bot specify `nextcloudapp://$APPID` as the bot URL, together
 - Due to a bug the `object.name` was set to an empty string for messages with attachments. This was fixed to be `'message'` as for normal messages without any attachments.
 
 ### Nextcloud 35 / Talk 25
-- Added `GET /bot/{token}/features` endpoint which allows bots to fetch their own enabled features using their shared secret (required capability: `bot-features-api`)
+- Added `GET /ocs/v2.php/apps/spreed/bot/{token}/features` endpoint which allows bots to fetch their own enabled features using their shared secret (required capability: `bot-features-api`)

--- a/docs/bots.md
+++ b/docs/bots.md
@@ -413,6 +413,40 @@ Bots can also remove their previous reaction from a message. The same signature/
         + `404 Not Found` When the conversation or message could not be found
         + `429 Too Many Requests` When `401 Unauthenticated` was triggered too often
 
+## Get enabled features
+
+🆕 Added in Talk 25.
+
+Bots can check which [features](constants.md#bot-features) an administrator enabled for them, without requiring administrator credentials. The same signature/verification method is applied. Since `GET` requests have no request body, the signature is computed over the random seed alone (`hash_hmac('sha256', $random, $secret)`); the conversation to look the bot up in is taken from the URL. Signing empty content also keeps the signature out of the value space of the `message` and `reaction` endpoints, which reject empty content before authenticating, so a captured features request cannot be replayed against them.
+
+!!! note
+
+    A bot that is set up in a conversation can authenticate against this endpoint even when all of its features were disabled (`features` = `0`), as the feature flags only control which actions and invocations are enabled. To fully cut off a bot, change its state to disabled or remove it from the conversation.
+
+* Required capability: `bot-features-api`
+* Method: `GET`
+* Endpoint: `/bot/{token}/features`
+* Header:
+
+| Name                             | Description                                                     |
+|----------------------------------|-----------------------------------------------------------------|
+| `X-Nextcloud-Talk-Bot-Random`    | The random value used when signing the request                  |
+| `X-Nextcloud-Talk-Bot-Signature` | The signature to validate the request comes from an enabled bot |
+| `OCS-APIRequest`                 | Needs to be set to `true` to access the ocs/vX.php endpoint     |
+
+* Response:
+    - Status code:
+        + `200 OK` When the features were returned successfully
+        + `400 Bad Request` When the signature headers were missing or malformed
+        + `401 Unauthenticated` When the bot could not be verified for the conversation
+        + `429 Too Many Requests` When `401 Unauthenticated` was triggered too often
+
+    - Data:
+
+| field      | type | Description                                                                      |
+|------------|------|----------------------------------------------------------------------------------|
+| `features` | int  | Feature flags enabled for the bot, see [Bot features](constants.md#bot-features) |
+
 ## Nextcloud apps as a bot
 
 🆕 Added in Talk 21.
@@ -435,3 +469,6 @@ When installing the bot specify `nextcloudapp://$APPID` as the bot URL, together
 
 ### Nextcloud 33 / Talk 23 - February 2026
 - Due to a bug the `object.name` was set to an empty string for messages with attachments. This was fixed to be `'message'` as for normal messages without any attachments.
+
+### Nextcloud 35 / Talk 25
+- Added `GET /bot/{token}/features` endpoint which allows bots to fetch their own enabled features using their shared secret (required capability: `bot-features-api`)

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -232,3 +232,4 @@
 * `preserve-conversation` - Whether the owner can preserve a conversation
 * `recording-chunked-upload` (local) - Whether the recording backend can request a temporary upload share to upload large recordings via chunked public WebDAV before finishing with the store endpoint
 * `config => call => external-call-service` (local) - The target URL for an external call service if one is configured
+* `bot-features-api` - Whether bots can fetch their own enabled features using their shared secret

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -232,4 +232,4 @@
 * `preserve-conversation` - Whether the owner can preserve a conversation
 * `recording-chunked-upload` (local) - Whether the recording backend can request a temporary upload share to upload large recordings via chunked public WebDAV before finishing with the store endpoint
 * `config => call => external-call-service` (local) - The target URL for an external call service if one is configured
-* `bot-features-api` - Whether bots can fetch their own enabled features using their shared secret
+* `bot-features-api` (local) - Whether bots can fetch their own enabled features using their shared secret

--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -171,6 +171,7 @@ class Capabilities implements IPublicCapability {
 		'conversation-presets',
 		'conversation-tags',
 		'recording-chunked-upload',
+		'bot-features-api',
 	];
 
 	public const LOCAL_CONFIGS = [

--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -135,6 +135,7 @@ class Capabilities implements IPublicCapability {
 		'private-reply',
 		'conversation-tags',
 		'preserve-conversation',
+		'bot-features-api',
 	];
 
 	public const CONDITIONAL_FEATURES = [

--- a/lib/Controller/BotController.php
+++ b/lib/Controller/BotController.php
@@ -51,6 +51,7 @@ use Psr\Log\LoggerInterface;
 
 /**
  * @psalm-import-type TalkBot from ResponseDefinitions
+ * @psalm-import-type TalkBotFeatures from ResponseDefinitions
  * @psalm-import-type TalkBotWithDetails from ResponseDefinitions
  */
 class BotController extends AEnvironmentAwareOCSController {
@@ -77,10 +78,11 @@ class BotController extends AEnvironmentAwareOCSController {
 	/**
 	 * @param string $token
 	 * @param string $message
+	 * @param int $requiredFeature Feature the bot needs to have enabled, Bot::FEATURE_NONE to skip the check
 	 * @return Bot
 	 * @throws \InvalidArgumentException When the request could not be linked with a bot
 	 */
-	protected function getBotFromHeaders(string $token, string $message, string $random, string $checksum): Bot {
+	protected function getBotFromHeaders(string $token, string $message, string $random, string $checksum, int $requiredFeature = Bot::FEATURE_RESPONSE): Bot {
 		if (empty($random) || strlen($random) < 32) {
 			$this->logger->error('Invalid Random received from bot response');
 			throw new \InvalidArgumentException('Invalid Random received from bot response', Http::STATUS_BAD_REQUEST);
@@ -90,7 +92,7 @@ class BotController extends AEnvironmentAwareOCSController {
 			throw new \InvalidArgumentException('Invalid Signature received from bot response', Http::STATUS_BAD_REQUEST);
 		}
 
-		$bots = $this->botService->getBotsForToken($token, Bot::FEATURE_RESPONSE);
+		$bots = $this->botService->getBotsForToken($token, $requiredFeature === Bot::FEATURE_NONE ? null : $requiredFeature);
 		foreach ($bots as $botAttempt) {
 			try {
 				$this->checksumVerificationService->validateRequest(
@@ -100,11 +102,6 @@ class BotController extends AEnvironmentAwareOCSController {
 					$message
 				);
 
-				if (!($botAttempt->getBotServer()->getFeatures() & Bot::FEATURE_RESPONSE)) {
-					$this->logger->debug('Not accepting response from bot ID ' . $botAttempt->getBotServer()->getId() . ' because the feature is disabled for it');
-					throw new \InvalidArgumentException('Feature not enabled for bot', Http::STATUS_BAD_REQUEST);
-				}
-
 				return $botAttempt;
 			} catch (UnauthorizedException) {
 			}
@@ -112,6 +109,32 @@ class BotController extends AEnvironmentAwareOCSController {
 
 		$this->logger->debug('No valid Bot entry found');
 		throw new \InvalidArgumentException('No valid Bot entry found', Http::STATUS_UNAUTHORIZED);
+	}
+
+	/**
+	 * Authenticate the requesting bot via the signature headers or build the
+	 * error response, throttled on failed authentication
+	 *
+	 * @param string $token
+	 * @param string $message
+	 * @param int $requiredFeature Feature the bot needs to have enabled, Bot::FEATURE_NONE to skip the check
+	 * @return Bot|DataResponse<Http::STATUS_BAD_REQUEST|Http::STATUS_UNAUTHORIZED, null, array{}>
+	 */
+	protected function getBotOrErrorResponse(string $token, string $message, int $requiredFeature = Bot::FEATURE_RESPONSE): Bot|DataResponse {
+		$random = $this->request->getHeader('x-nextcloud-talk-bot-random');
+		$checksum = $this->request->getHeader('x-nextcloud-talk-bot-signature');
+
+		try {
+			return $this->getBotFromHeaders($token, $message, $random, $checksum, $requiredFeature);
+		} catch (\InvalidArgumentException $e) {
+			/** @var Http::STATUS_BAD_REQUEST|Http::STATUS_UNAUTHORIZED $status */
+			$status = $e->getCode();
+			$response = new DataResponse(null, $status);
+			if ($status === Http::STATUS_UNAUTHORIZED) {
+				$response->throttle(['action' => 'bot']);
+			}
+			return $response;
+		}
 	}
 
 	/**
@@ -137,8 +160,8 @@ class BotController extends AEnvironmentAwareOCSController {
 	#[BruteForceProtection(action: 'bot')]
 	#[OpenAPI(scope: 'bots')]
 	#[PublicPage]
-	#[RequestHeader(name: 'x-nextcloud-talk-bot-random', description: 'Random seed (at least 32 bytes) used together with the message to generate the SHA256-HMAC request signature')]
-	#[RequestHeader(name: 'x-nextcloud-talk-bot-signature', description: 'SHA256-HMAC signature over the concatenation of the random seed and the message, signed with the shared bot secret, to verify authenticity')]
+	#[RequestHeader(name: 'x-nextcloud-talk-bot-random', description: 'Random seed (at least 32 bytes) used together with the message to generate the SHA256-HMAC request signature', indirect: true)]
+	#[RequestHeader(name: 'x-nextcloud-talk-bot-signature', description: 'SHA256-HMAC signature over the concatenation of the random seed and the message, signed with the shared bot secret, to verify authenticity', indirect: true)]
 	#[ApiRoute(verb: 'POST', url: '/api/{apiVersion}/bot/{token}/message', requirements: [
 		'apiVersion' => '(v1)',
 		'token' => '[a-z0-9]{4,30}',
@@ -148,19 +171,9 @@ class BotController extends AEnvironmentAwareOCSController {
 			return new DataResponse(null, Http::STATUS_BAD_REQUEST);
 		}
 
-		$random = $this->request->getHeader('x-nextcloud-talk-bot-random');
-		$checksum = $this->request->getHeader('x-nextcloud-talk-bot-signature');
-
-		try {
-			$bot = $this->getBotFromHeaders($token, $message, $random, $checksum);
-		} catch (\InvalidArgumentException $e) {
-			/** @var Http::STATUS_BAD_REQUEST|Http::STATUS_UNAUTHORIZED $status */
-			$status = $e->getCode();
-			$response = new DataResponse(null, $status);
-			if ($e->getCode() === Http::STATUS_UNAUTHORIZED) {
-				$response->throttle(['action' => 'bot']);
-			}
-			return $response;
+		$bot = $this->getBotOrErrorResponse($token, $message);
+		if ($bot instanceof DataResponse) {
+			return $bot;
 		}
 
 		$room = $this->manager->getRoomByToken($token);
@@ -232,27 +245,21 @@ class BotController extends AEnvironmentAwareOCSController {
 	#[BruteForceProtection(action: 'bot')]
 	#[OpenAPI(scope: 'bots')]
 	#[PublicPage]
-	#[RequestHeader(name: 'x-nextcloud-talk-bot-random', description: 'Random seed (at least 32 bytes) used together with the reaction to generate the SHA256-HMAC request signature')]
-	#[RequestHeader(name: 'x-nextcloud-talk-bot-signature', description: 'SHA256-HMAC signature over the concatenation of the random seed and the reaction, signed with the shared bot secret, to verify authenticity')]
+	#[RequestHeader(name: 'x-nextcloud-talk-bot-random', description: 'Random seed (at least 32 bytes) used together with the reaction to generate the SHA256-HMAC request signature', indirect: true)]
+	#[RequestHeader(name: 'x-nextcloud-talk-bot-signature', description: 'SHA256-HMAC signature over the concatenation of the random seed and the reaction, signed with the shared bot secret, to verify authenticity', indirect: true)]
 	#[ApiRoute(verb: 'POST', url: '/api/{apiVersion}/bot/{token}/reaction/{messageId}', requirements: [
 		'apiVersion' => '(v1)',
 		'token' => '[a-z0-9]{4,30}',
 		'messageId' => '[0-9]+',
 	])]
 	public function react(string $token, int $messageId, string $reaction): DataResponse {
-		$random = $this->request->getHeader('x-nextcloud-talk-bot-random');
-		$checksum = $this->request->getHeader('x-nextcloud-talk-bot-signature');
+		if ($reaction === '') {
+			return new DataResponse(null, Http::STATUS_BAD_REQUEST);
+		}
 
-		try {
-			$bot = $this->getBotFromHeaders($token, $reaction, $random, $checksum);
-		} catch (\InvalidArgumentException $e) {
-			/** @var Http::STATUS_BAD_REQUEST|Http::STATUS_UNAUTHORIZED $status */
-			$status = $e->getCode();
-			$response = new DataResponse(null, $status);
-			if ($e->getCode() === Http::STATUS_UNAUTHORIZED) {
-				$response->throttle(['action' => 'bot']);
-			}
-			return $response;
+		$bot = $this->getBotOrErrorResponse($token, $reaction);
+		if ($bot instanceof DataResponse) {
+			return $bot;
 		}
 
 		$room = $this->manager->getRoomByToken($token);
@@ -296,27 +303,21 @@ class BotController extends AEnvironmentAwareOCSController {
 	#[BruteForceProtection(action: 'bot')]
 	#[OpenAPI(scope: 'bots')]
 	#[PublicPage]
-	#[RequestHeader(name: 'x-nextcloud-talk-bot-random', description: 'Random seed (at least 32 bytes) used together with the reaction to generate the SHA256-HMAC request signature')]
-	#[RequestHeader(name: 'x-nextcloud-talk-bot-signature', description: 'SHA256-HMAC signature over the concatenation of the random seed and the reaction, signed with the shared bot secret, to verify authenticity')]
+	#[RequestHeader(name: 'x-nextcloud-talk-bot-random', description: 'Random seed (at least 32 bytes) used together with the reaction to generate the SHA256-HMAC request signature', indirect: true)]
+	#[RequestHeader(name: 'x-nextcloud-talk-bot-signature', description: 'SHA256-HMAC signature over the concatenation of the random seed and the reaction, signed with the shared bot secret, to verify authenticity', indirect: true)]
 	#[ApiRoute(verb: 'DELETE', url: '/api/{apiVersion}/bot/{token}/reaction/{messageId}', requirements: [
 		'apiVersion' => '(v1)',
 		'token' => '[a-z0-9]{4,30}',
 		'messageId' => '[0-9]+',
 	])]
 	public function deleteReaction(string $token, int $messageId, string $reaction): DataResponse {
-		$random = $this->request->getHeader('x-nextcloud-talk-bot-random');
-		$checksum = $this->request->getHeader('x-nextcloud-talk-bot-signature');
+		if ($reaction === '') {
+			return new DataResponse(null, Http::STATUS_BAD_REQUEST);
+		}
 
-		try {
-			$bot = $this->getBotFromHeaders($token, $reaction, $random, $checksum);
-		} catch (\InvalidArgumentException $e) {
-			/** @var Http::STATUS_BAD_REQUEST|Http::STATUS_UNAUTHORIZED $status */
-			$status = $e->getCode();
-			$response = new DataResponse(null, $status);
-			if ($e->getCode() === Http::STATUS_UNAUTHORIZED) {
-				$response->throttle(['action' => 'bot']);
-			}
-			return $response;
+		$bot = $this->getBotOrErrorResponse($token, $reaction);
+		if ($bot instanceof DataResponse) {
+			return $bot;
 		}
 
 		$room = $this->manager->getRoomByToken($token);
@@ -340,6 +341,44 @@ class BotController extends AEnvironmentAwareOCSController {
 		}
 
 		return new DataResponse(null, Http::STATUS_OK);
+	}
+
+	/**
+	 * Get the features that are enabled for the requesting bot
+	 *
+	 * Allows bots to check which features an administrator has enabled for
+	 * them, without requiring administrator credentials. The request is
+	 * signed with the shared bot secret like all other bot requests. As GET
+	 * requests have no body, the signature is computed over the random seed
+	 * alone (the conversation to look the bot up in is taken from the URL).
+	 * This also keeps the signature out of the value space of the message and
+	 * reaction endpoints, which reject empty content before authenticating.
+	 *
+	 * @param string $token Conversation token
+	 * @return DataResponse<Http::STATUS_OK, TalkBotFeatures, array{}>|DataResponse<Http::STATUS_BAD_REQUEST|Http::STATUS_UNAUTHORIZED, null, array{}>
+	 *
+	 * 200: Bot features returned
+	 * 400: Missing or malformed signature headers
+	 * 401: Bot could not be verified for the conversation
+	 */
+	#[BruteForceProtection(action: 'bot')]
+	#[OpenAPI(scope: 'bots')]
+	#[PublicPage]
+	#[RequestHeader(name: 'x-nextcloud-talk-bot-random', description: 'Random seed (at least 32 bytes) used to generate the SHA256-HMAC request signature', indirect: true)]
+	#[RequestHeader(name: 'x-nextcloud-talk-bot-signature', description: 'SHA256-HMAC signature over the random seed, signed with the shared bot secret, to verify authenticity', indirect: true)]
+	#[ApiRoute(verb: 'GET', url: '/api/{apiVersion}/bot/{token}/features', requirements: [
+		'apiVersion' => '(v1)',
+		'token' => '[a-z0-9]{4,30}',
+	])]
+	public function getBotFeatures(string $token): DataResponse {
+		$bot = $this->getBotOrErrorResponse($token, '', Bot::FEATURE_NONE);
+		if ($bot instanceof DataResponse) {
+			return $bot;
+		}
+
+		return new DataResponse([
+			'features' => $bot->getBotServer()->getFeatures(),
+		]);
 	}
 
 	/**

--- a/lib/Controller/BotController.php
+++ b/lib/Controller/BotController.php
@@ -354,6 +354,8 @@ class BotController extends AEnvironmentAwareOCSController {
 	 * This also keeps the signature out of the value space of the message and
 	 * reaction endpoints, which reject empty content before authenticating.
 	 *
+	 * Required capability: `bot-features-api`
+	 *
 	 * @param string $token Conversation token
 	 * @return DataResponse<Http::STATUS_OK, TalkBotFeatures, array{}>|DataResponse<Http::STATUS_BAD_REQUEST|Http::STATUS_UNAUTHORIZED, null, array{}>
 	 *

--- a/lib/Controller/BotController.php
+++ b/lib/Controller/BotController.php
@@ -348,11 +348,11 @@ class BotController extends AEnvironmentAwareOCSController {
 	 *
 	 * Allows bots to check which features an administrator has enabled for
 	 * them, without requiring administrator credentials. The request is
-	 * signed with the shared bot secret like all other bot requests. As GET
-	 * requests have no body, the signature is computed over the random seed
-	 * alone (the conversation to look the bot up in is taken from the URL).
-	 * This also keeps the signature out of the value space of the message and
-	 * reaction endpoints, which reject empty content before authenticating.
+	 * signed with the shared bot secret like all other bot requests: the
+	 * signature is computed over the random seed and the conversation token
+	 * sent in the request body, which is used to look the bot up. Keeping the
+	 * token in the signed body binds the request to the conversation, so the
+	 * signature headers on their own cannot be replayed.
 	 *
 	 * Required capability: `bot-features-api`
 	 *
@@ -366,14 +366,13 @@ class BotController extends AEnvironmentAwareOCSController {
 	#[BruteForceProtection(action: 'bot')]
 	#[OpenAPI(scope: 'bots')]
 	#[PublicPage]
-	#[RequestHeader(name: 'x-nextcloud-talk-bot-random', description: 'Random seed (at least 32 bytes) used to generate the SHA256-HMAC request signature', indirect: true)]
-	#[RequestHeader(name: 'x-nextcloud-talk-bot-signature', description: 'SHA256-HMAC signature over the random seed, signed with the shared bot secret, to verify authenticity', indirect: true)]
-	#[ApiRoute(verb: 'GET', url: '/api/{apiVersion}/bot/{token}/features', requirements: [
+	#[RequestHeader(name: 'x-nextcloud-talk-bot-random', description: 'Random seed (at least 32 bytes) used together with the conversation token to generate the SHA256-HMAC request signature', indirect: true)]
+	#[RequestHeader(name: 'x-nextcloud-talk-bot-signature', description: 'SHA256-HMAC signature over the concatenation of the random seed and the conversation token, signed with the shared bot secret, to verify authenticity', indirect: true)]
+	#[ApiRoute(verb: 'POST', url: '/api/{apiVersion}/bot/ask-features', requirements: [
 		'apiVersion' => '(v1)',
-		'token' => '[a-z0-9]{4,30}',
 	])]
 	public function getBotFeatures(string $token): DataResponse {
-		$bot = $this->getBotOrErrorResponse($token, '', Bot::FEATURE_NONE);
+		$bot = $this->getBotOrErrorResponse($token, $token, Bot::FEATURE_NONE);
 		if ($bot instanceof DataResponse) {
 			return $bot;
 		}

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -57,6 +57,11 @@ namespace OCA\Talk;
  *     state: int,
  * }
  *
+ * @psalm-type TalkBotFeatures = array{
+ *     // Feature flags enabled for the bot (see [constants list](https://nextcloud-talk.readthedocs.io/en/latest/constants#bot-features))
+ *     features: int,
+ * }
+ *
  * @psalm-type TalkBotWithDetails = TalkBot&array{
  *     // Number of consecutive errors
  *     error_count: int,

--- a/openapi-bots.json
+++ b/openapi-bots.json
@@ -1232,7 +1232,7 @@
             "get": {
                 "operationId": "bot-get-bot-features",
                 "summary": "Get the features that are enabled for the requesting bot",
-                "description": "Allows bots to check which features an administrator has enabled for them, without requiring administrator credentials. The request is signed with the shared bot secret like all other bot requests. As GET requests have no body, the signature is computed over the random seed alone (the conversation to look the bot up in is taken from the URL). This also keeps the signature out of the value space of the message and reaction endpoints, which reject empty content before authenticating.",
+                "description": "Allows bots to check which features an administrator has enabled for them, without requiring administrator credentials. The request is signed with the shared bot secret like all other bot requests. As GET requests have no body, the signature is computed over the random seed alone (the conversation to look the bot up in is taken from the URL). This also keeps the signature out of the value space of the message and reaction endpoints, which reject empty content before authenticating.\nRequired capability: `bot-features-api`",
                 "tags": [
                     "bot"
                 ],

--- a/openapi-bots.json
+++ b/openapi-bots.json
@@ -1228,11 +1228,11 @@
                 }
             }
         },
-        "/ocs/v2.php/apps/spreed/api/{apiVersion}/bot/{token}/features": {
-            "get": {
+        "/ocs/v2.php/apps/spreed/api/{apiVersion}/bot/ask-features": {
+            "post": {
                 "operationId": "bot-get-bot-features",
                 "summary": "Get the features that are enabled for the requesting bot",
-                "description": "Allows bots to check which features an administrator has enabled for them, without requiring administrator credentials. The request is signed with the shared bot secret like all other bot requests. As GET requests have no body, the signature is computed over the random seed alone (the conversation to look the bot up in is taken from the URL). This also keeps the signature out of the value space of the message and reaction endpoints, which reject empty content before authenticating.\nRequired capability: `bot-features-api`",
+                "description": "Allows bots to check which features an administrator has enabled for them, without requiring administrator credentials. The request is signed with the shared bot secret like all other bot requests: the signature is computed over the random seed and the conversation token sent in the request body, which is used to look the bot up. Keeping the token in the signed body binds the request to the conversation, so the signature headers on their own cannot be replayed.\nRequired capability: `bot-features-api`",
                 "tags": [
                     "bot"
                 ],
@@ -1245,6 +1245,25 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "token"
+                                ],
+                                "properties": {
+                                    "token": {
+                                        "type": "string",
+                                        "description": "Conversation token"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
                     {
                         "name": "apiVersion",
@@ -1259,19 +1278,9 @@
                         }
                     },
                     {
-                        "name": "token",
-                        "in": "path",
-                        "description": "Conversation token",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "pattern": "^[a-z0-9]{4,30}$"
-                        }
-                    },
-                    {
                         "name": "x-nextcloud-talk-bot-random",
                         "in": "header",
-                        "description": "Random seed (at least 32 bytes) used to generate the SHA256-HMAC request signature",
+                        "description": "Random seed (at least 32 bytes) used together with the conversation token to generate the SHA256-HMAC request signature",
                         "schema": {
                             "type": "string"
                         }
@@ -1279,7 +1288,7 @@
                     {
                         "name": "x-nextcloud-talk-bot-signature",
                         "in": "header",
-                        "description": "SHA256-HMAC signature over the random seed, signed with the shared bot secret, to verify authenticity",
+                        "description": "SHA256-HMAC signature over the concatenation of the random seed and the conversation token, signed with the shared bot secret, to verify authenticity",
                         "schema": {
                             "type": "string"
                         }

--- a/openapi-bots.json
+++ b/openapi-bots.json
@@ -20,6 +20,19 @@
             }
         },
         "schemas": {
+            "BotFeatures": {
+                "type": "object",
+                "required": [
+                    "features"
+                ],
+                "properties": {
+                    "features": {
+                        "type": "integer",
+                        "format": "int64",
+                        "description": "Feature flags enabled for the bot (see [constants list](https://nextcloud-talk.readthedocs.io/en/latest/constants#bot-features))"
+                    }
+                }
+            },
             "Capabilities": {
                 "type": "object",
                 "required": [
@@ -1184,6 +1197,167 @@
                     },
                     "401": {
                         "description": "Reacting is not allowed",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "nullable": true
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/apps/spreed/api/{apiVersion}/bot/{token}/features": {
+            "get": {
+                "operationId": "bot-get-bot-features",
+                "summary": "Get the features that are enabled for the requesting bot",
+                "description": "Allows bots to check which features an administrator has enabled for them, without requiring administrator credentials. The request is signed with the shared bot secret like all other bot requests. As GET requests have no body, the signature is computed over the random seed alone (the conversation to look the bot up in is taken from the URL). This also keeps the signature out of the value space of the message and reaction endpoints, which reject empty content before authenticating.",
+                "tags": [
+                    "bot"
+                ],
+                "security": [
+                    {},
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v1"
+                            ],
+                            "default": "v1"
+                        }
+                    },
+                    {
+                        "name": "token",
+                        "in": "path",
+                        "description": "Conversation token",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^[a-z0-9]{4,30}$"
+                        }
+                    },
+                    {
+                        "name": "x-nextcloud-talk-bot-random",
+                        "in": "header",
+                        "description": "Random seed (at least 32 bytes) used to generate the SHA256-HMAC request signature",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "x-nextcloud-talk-bot-signature",
+                        "in": "header",
+                        "description": "SHA256-HMAC signature over the random seed, signed with the shared bot secret, to verify authenticity",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Bot features returned",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "$ref": "#/components/schemas/BotFeatures"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Missing or malformed signature headers",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "nullable": true
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Bot could not be verified for the conversation",
                         "content": {
                             "application/json": {
                                 "schema": {

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -31179,11 +31179,11 @@
                 }
             }
         },
-        "/ocs/v2.php/apps/spreed/api/{apiVersion}/bot/{token}/features": {
-            "get": {
+        "/ocs/v2.php/apps/spreed/api/{apiVersion}/bot/ask-features": {
+            "post": {
                 "operationId": "bot-get-bot-features",
                 "summary": "Get the features that are enabled for the requesting bot",
-                "description": "Allows bots to check which features an administrator has enabled for them, without requiring administrator credentials. The request is signed with the shared bot secret like all other bot requests. As GET requests have no body, the signature is computed over the random seed alone (the conversation to look the bot up in is taken from the URL). This also keeps the signature out of the value space of the message and reaction endpoints, which reject empty content before authenticating.\nRequired capability: `bot-features-api`",
+                "description": "Allows bots to check which features an administrator has enabled for them, without requiring administrator credentials. The request is signed with the shared bot secret like all other bot requests: the signature is computed over the random seed and the conversation token sent in the request body, which is used to look the bot up. Keeping the token in the signed body binds the request to the conversation, so the signature headers on their own cannot be replayed.\nRequired capability: `bot-features-api`",
                 "tags": [
                     "bot"
                 ],
@@ -31196,6 +31196,25 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "token"
+                                ],
+                                "properties": {
+                                    "token": {
+                                        "type": "string",
+                                        "description": "Conversation token"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
                     {
                         "name": "apiVersion",
@@ -31210,19 +31229,9 @@
                         }
                     },
                     {
-                        "name": "token",
-                        "in": "path",
-                        "description": "Conversation token",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "pattern": "^[a-z0-9]{4,30}$"
-                        }
-                    },
-                    {
                         "name": "x-nextcloud-talk-bot-random",
                         "in": "header",
-                        "description": "Random seed (at least 32 bytes) used to generate the SHA256-HMAC request signature",
+                        "description": "Random seed (at least 32 bytes) used together with the conversation token to generate the SHA256-HMAC request signature",
                         "schema": {
                             "type": "string"
                         }
@@ -31230,7 +31239,7 @@
                     {
                         "name": "x-nextcloud-talk-bot-signature",
                         "in": "header",
-                        "description": "SHA256-HMAC signature over the random seed, signed with the shared bot secret, to verify authenticity",
+                        "description": "SHA256-HMAC signature over the concatenation of the random seed and the conversation token, signed with the shared bot secret, to verify authenticity",
                         "schema": {
                             "type": "string"
                         }

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -169,6 +169,19 @@
                     }
                 }
             },
+            "BotFeatures": {
+                "type": "object",
+                "required": [
+                    "features"
+                ],
+                "properties": {
+                    "features": {
+                        "type": "integer",
+                        "format": "int64",
+                        "description": "Feature flags enabled for the bot (see [constants list](https://nextcloud-talk.readthedocs.io/en/latest/constants#bot-features))"
+                    }
+                }
+            },
             "BotWithDetails": {
                 "allOf": [
                     {
@@ -31135,6 +31148,167 @@
                     },
                     "401": {
                         "description": "Reacting is not allowed",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "nullable": true
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/apps/spreed/api/{apiVersion}/bot/{token}/features": {
+            "get": {
+                "operationId": "bot-get-bot-features",
+                "summary": "Get the features that are enabled for the requesting bot",
+                "description": "Allows bots to check which features an administrator has enabled for them, without requiring administrator credentials. The request is signed with the shared bot secret like all other bot requests. As GET requests have no body, the signature is computed over the random seed alone (the conversation to look the bot up in is taken from the URL). This also keeps the signature out of the value space of the message and reaction endpoints, which reject empty content before authenticating.",
+                "tags": [
+                    "bot"
+                ],
+                "security": [
+                    {},
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v1"
+                            ],
+                            "default": "v1"
+                        }
+                    },
+                    {
+                        "name": "token",
+                        "in": "path",
+                        "description": "Conversation token",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^[a-z0-9]{4,30}$"
+                        }
+                    },
+                    {
+                        "name": "x-nextcloud-talk-bot-random",
+                        "in": "header",
+                        "description": "Random seed (at least 32 bytes) used to generate the SHA256-HMAC request signature",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "x-nextcloud-talk-bot-signature",
+                        "in": "header",
+                        "description": "SHA256-HMAC signature over the random seed, signed with the shared bot secret, to verify authenticity",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Bot features returned",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "$ref": "#/components/schemas/BotFeatures"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Missing or malformed signature headers",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "nullable": true
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Bot could not be verified for the conversation",
                         "content": {
                             "application/json": {
                                 "schema": {

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -31183,7 +31183,7 @@
             "get": {
                 "operationId": "bot-get-bot-features",
                 "summary": "Get the features that are enabled for the requesting bot",
-                "description": "Allows bots to check which features an administrator has enabled for them, without requiring administrator credentials. The request is signed with the shared bot secret like all other bot requests. As GET requests have no body, the signature is computed over the random seed alone (the conversation to look the bot up in is taken from the URL). This also keeps the signature out of the value space of the message and reaction endpoints, which reject empty content before authenticating.",
+                "description": "Allows bots to check which features an administrator has enabled for them, without requiring administrator credentials. The request is signed with the shared bot secret like all other bot requests. As GET requests have no body, the signature is computed over the random seed alone (the conversation to look the bot up in is taken from the URL). This also keeps the signature out of the value space of the message and reaction endpoints, which reject empty content before authenticating.\nRequired capability: `bot-features-api`",
                 "tags": [
                     "bot"
                 ],

--- a/src/types/openapi/openapi-bots.ts
+++ b/src/types/openapi/openapi-bots.ts
@@ -42,10 +42,37 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
+    "/ocs/v2.php/apps/spreed/api/{apiVersion}/bot/{token}/features": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get the features that are enabled for the requesting bot
+         * @description Allows bots to check which features an administrator has enabled for them, without requiring administrator credentials. The request is signed with the shared bot secret like all other bot requests. As GET requests have no body, the signature is computed over the random seed alone (the conversation to look the bot up in is taken from the URL). This also keeps the signature out of the value space of the message and reaction endpoints, which reject empty content before authenticating.
+         */
+        get: operations["bot-get-bot-features"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 };
 export type webhooks = Record<string, never>;
 export type components = {
     schemas: {
+        BotFeatures: {
+            /**
+             * Format: int64
+             * @description Feature flags enabled for the bot (see [constants list](https://nextcloud-talk.readthedocs.io/en/latest/constants#bot-features))
+             */
+            features: number;
+        };
         Capabilities: {
             /** @description List of features available on the server */
             features: string[];
@@ -561,6 +588,70 @@ export interface operations {
             };
             /** @description Reaction not found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: unknown;
+                        };
+                    };
+                };
+            };
+        };
+    };
+    "bot-get-bot-features": {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Random seed (at least 32 bytes) used to generate the SHA256-HMAC request signature */
+                "x-nextcloud-talk-bot-random"?: string;
+                /** @description SHA256-HMAC signature over the random seed, signed with the shared bot secret, to verify authenticity */
+                "x-nextcloud-talk-bot-signature"?: string;
+                /** @description Required to be true for the API request to pass */
+                "OCS-APIRequest": boolean;
+            };
+            path: {
+                apiVersion: "v1";
+                /** @description Conversation token */
+                token: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Bot features returned */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: components["schemas"]["BotFeatures"];
+                        };
+                    };
+                };
+            };
+            /** @description Missing or malformed signature headers */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: unknown;
+                        };
+                    };
+                };
+            };
+            /** @description Bot could not be verified for the conversation */
+            401: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/src/types/openapi/openapi-bots.ts
+++ b/src/types/openapi/openapi-bots.ts
@@ -52,6 +52,7 @@ export type paths = {
         /**
          * Get the features that are enabled for the requesting bot
          * @description Allows bots to check which features an administrator has enabled for them, without requiring administrator credentials. The request is signed with the shared bot secret like all other bot requests. As GET requests have no body, the signature is computed over the random seed alone (the conversation to look the bot up in is taken from the URL). This also keeps the signature out of the value space of the message and reaction endpoints, which reject empty content before authenticating.
+         *     Required capability: `bot-features-api`
          */
         get: operations["bot-get-bot-features"];
         put?: never;

--- a/src/types/openapi/openapi-bots.ts
+++ b/src/types/openapi/openapi-bots.ts
@@ -42,21 +42,21 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
-    "/ocs/v2.php/apps/spreed/api/{apiVersion}/bot/{token}/features": {
+    "/ocs/v2.php/apps/spreed/api/{apiVersion}/bot/ask-features": {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
+        get?: never;
+        put?: never;
         /**
          * Get the features that are enabled for the requesting bot
-         * @description Allows bots to check which features an administrator has enabled for them, without requiring administrator credentials. The request is signed with the shared bot secret like all other bot requests. As GET requests have no body, the signature is computed over the random seed alone (the conversation to look the bot up in is taken from the URL). This also keeps the signature out of the value space of the message and reaction endpoints, which reject empty content before authenticating.
+         * @description Allows bots to check which features an administrator has enabled for them, without requiring administrator credentials. The request is signed with the shared bot secret like all other bot requests: the signature is computed over the random seed and the conversation token sent in the request body, which is used to look the bot up. Keeping the token in the signed body binds the request to the conversation, so the signature headers on their own cannot be replayed.
          *     Required capability: `bot-features-api`
          */
-        get: operations["bot-get-bot-features"];
-        put?: never;
-        post?: never;
+        post: operations["bot-get-bot-features"];
         delete?: never;
         options?: never;
         head?: never;
@@ -607,21 +607,26 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
-                /** @description Random seed (at least 32 bytes) used to generate the SHA256-HMAC request signature */
+                /** @description Random seed (at least 32 bytes) used together with the conversation token to generate the SHA256-HMAC request signature */
                 "x-nextcloud-talk-bot-random"?: string;
-                /** @description SHA256-HMAC signature over the random seed, signed with the shared bot secret, to verify authenticity */
+                /** @description SHA256-HMAC signature over the concatenation of the random seed and the conversation token, signed with the shared bot secret, to verify authenticity */
                 "x-nextcloud-talk-bot-signature"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
             path: {
                 apiVersion: "v1";
-                /** @description Conversation token */
-                token: string;
             };
             cookie?: never;
         };
-        requestBody?: never;
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @description Conversation token */
+                    token: string;
+                };
+            };
+        };
         responses: {
             /** @description Bot features returned */
             200: {

--- a/src/types/openapi/openapi-full.ts
+++ b/src/types/openapi/openapi-full.ts
@@ -2274,6 +2274,7 @@ export type paths = {
         /**
          * Get the features that are enabled for the requesting bot
          * @description Allows bots to check which features an administrator has enabled for them, without requiring administrator credentials. The request is signed with the shared bot secret like all other bot requests. As GET requests have no body, the signature is computed over the random seed alone (the conversation to look the bot up in is taken from the URL). This also keeps the signature out of the value space of the message and reaction endpoints, which reject empty content before authenticating.
+         *     Required capability: `bot-features-api`
          */
         get: operations["bot-get-bot-features"];
         put?: never;

--- a/src/types/openapi/openapi-full.ts
+++ b/src/types/openapi/openapi-full.ts
@@ -2264,6 +2264,26 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
+    "/ocs/v2.php/apps/spreed/api/{apiVersion}/bot/{token}/features": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get the features that are enabled for the requesting bot
+         * @description Allows bots to check which features an administrator has enabled for them, without requiring administrator credentials. The request is signed with the shared bot secret like all other bot requests. As GET requests have no body, the signature is computed over the random seed alone (the conversation to look the bot up in is taken from the URL). This also keeps the signature out of the value space of the message and reaction endpoints, which reject empty content before authenticating.
+         */
+        get: operations["bot-get-bot-features"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/ocs/v2.php/apps/spreed/api/{apiVersion}/bot/admin": {
         parameters: {
             query?: never;
@@ -2702,6 +2722,13 @@ export type components = {
              * @description One of the [Bot states](https://nextcloud-talk.readthedocs.io/en/latest/constants#bot-states)
              */
             state: number;
+        };
+        BotFeatures: {
+            /**
+             * Format: int64
+             * @description Feature flags enabled for the bot (see [constants list](https://nextcloud-talk.readthedocs.io/en/latest/constants#bot-features))
+             */
+            features: number;
         };
         BotWithDetails: components["schemas"]["Bot"] & {
             /**
@@ -15346,6 +15373,70 @@ export interface operations {
             };
             /** @description Reaction not found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: unknown;
+                        };
+                    };
+                };
+            };
+        };
+    };
+    "bot-get-bot-features": {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Random seed (at least 32 bytes) used to generate the SHA256-HMAC request signature */
+                "x-nextcloud-talk-bot-random"?: string;
+                /** @description SHA256-HMAC signature over the random seed, signed with the shared bot secret, to verify authenticity */
+                "x-nextcloud-talk-bot-signature"?: string;
+                /** @description Required to be true for the API request to pass */
+                "OCS-APIRequest": boolean;
+            };
+            path: {
+                apiVersion: "v1";
+                /** @description Conversation token */
+                token: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Bot features returned */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: components["schemas"]["BotFeatures"];
+                        };
+                    };
+                };
+            };
+            /** @description Missing or malformed signature headers */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: unknown;
+                        };
+                    };
+                };
+            };
+            /** @description Bot could not be verified for the conversation */
+            401: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/src/types/openapi/openapi-full.ts
+++ b/src/types/openapi/openapi-full.ts
@@ -2264,21 +2264,21 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
-    "/ocs/v2.php/apps/spreed/api/{apiVersion}/bot/{token}/features": {
+    "/ocs/v2.php/apps/spreed/api/{apiVersion}/bot/ask-features": {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
+        get?: never;
+        put?: never;
         /**
          * Get the features that are enabled for the requesting bot
-         * @description Allows bots to check which features an administrator has enabled for them, without requiring administrator credentials. The request is signed with the shared bot secret like all other bot requests. As GET requests have no body, the signature is computed over the random seed alone (the conversation to look the bot up in is taken from the URL). This also keeps the signature out of the value space of the message and reaction endpoints, which reject empty content before authenticating.
+         * @description Allows bots to check which features an administrator has enabled for them, without requiring administrator credentials. The request is signed with the shared bot secret like all other bot requests: the signature is computed over the random seed and the conversation token sent in the request body, which is used to look the bot up. Keeping the token in the signed body binds the request to the conversation, so the signature headers on their own cannot be replayed.
          *     Required capability: `bot-features-api`
          */
-        get: operations["bot-get-bot-features"];
-        put?: never;
-        post?: never;
+        post: operations["bot-get-bot-features"];
         delete?: never;
         options?: never;
         head?: never;
@@ -15392,21 +15392,26 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
-                /** @description Random seed (at least 32 bytes) used to generate the SHA256-HMAC request signature */
+                /** @description Random seed (at least 32 bytes) used together with the conversation token to generate the SHA256-HMAC request signature */
                 "x-nextcloud-talk-bot-random"?: string;
-                /** @description SHA256-HMAC signature over the random seed, signed with the shared bot secret, to verify authenticity */
+                /** @description SHA256-HMAC signature over the concatenation of the random seed and the conversation token, signed with the shared bot secret, to verify authenticity */
                 "x-nextcloud-talk-bot-signature"?: string;
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
             };
             path: {
                 apiVersion: "v1";
-                /** @description Conversation token */
-                token: string;
             };
             cookie?: never;
         };
-        requestBody?: never;
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @description Conversation token */
+                    token: string;
+                };
+            };
+        };
         responses: {
             /** @description Bot features returned */
             200: {

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -5062,11 +5062,13 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 	public function botRetrievesFeatures(string $botName, string $identifier, string $secret, int $status, string $apiVersion, ?TableNode $body = null): void {
 		$currentUser = $this->setCurrentUser('');
 
+		$token = self::$identifierToToken[$identifier];
 		$this->sendBotSignedRequest(
-			'GET',
-			'/apps/spreed/api/' . $apiVersion . '/bot/' . self::$identifierToToken[$identifier] . '/features',
+			'POST',
+			'/apps/spreed/api/' . $apiVersion . '/bot/ask-features',
 			$secret,
-			''
+			$token,
+			['token' => $token]
 		);
 		$this->assertStatusCode($this->response, $status);
 

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -5014,6 +5014,17 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 		$this->theCommandWasSuccessful();
 	}
 
+	/**
+	 * Sends a request signed with the shared bot secret like a bot server would
+	 */
+	private function sendBotSignedRequest(string $verb, string $url, string $secret, string $toSign, TableNode|array|null $body = null): void {
+		$random = bin2hex(random_bytes(32));
+		$this->sendRequest($verb, $url, $body, [
+			'X-Nextcloud-Talk-Bot-Random' => $random,
+			'X-Nextcloud-Talk-Bot-Signature' => hash_hmac('sha256', $random . $toSign, $secret),
+		]);
+	}
+
 	#[Then('/^Bot "([^"]*)" (sends|removes) a (message|reaction) for room "([^"]*)" with (\d+)(?: \((v1)\))?$/')]
 	public function botSendsRequest(string $botName, string $sends, string $action, string $identifier, int $status, string $apiVersion, TableNode $body): void {
 		$currentUser = $this->setCurrentUser('');
@@ -5035,20 +5046,38 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 			$toSign = $data['reaction'];
 		}
 
-		$random = bin2hex(random_bytes(32));
-		$hash = hash_hmac('sha256', $random . $toSign, $secret);
-		$headers = [
-			'X-Nextcloud-Talk-Bot-Random' => $random,
-			'X-Nextcloud-Talk-Bot-Signature' => $hash,
-		];
-
-		$this->sendRequest(
+		$this->sendBotSignedRequest(
 			$sends === 'sends' ? 'POST' : 'DELETE',
 			'/apps/spreed/api/' . $apiVersion . '/bot/' . self::$identifierToToken[$identifier] . $url,
-			$data,
-			$headers
+			$secret,
+			$toSign,
+			$data
 		);
 		$this->assertStatusCode($this->response, $status);
+
+		$this->setCurrentUser($currentUser);
+	}
+
+	#[Then('/^Bot "([^"]*)" retrieves its features for room "([^"]*)" with (\d+)(?: \((v1)\))?$/')]
+	public function botRetrievesFeatures(string $botName, string $identifier, int $status, string $apiVersion, TableNode $body): void {
+		$currentUser = $this->setCurrentUser('');
+
+		$data = $body->getRowsHash();
+		$secret = $data['secret'];
+		$token = self::$identifierToToken[$identifier];
+
+		$this->sendBotSignedRequest(
+			'GET',
+			'/apps/spreed/api/' . $apiVersion . '/bot/' . $token . '/features',
+			$secret,
+			''
+		);
+		$this->assertStatusCode($this->response, $status);
+
+		if ($status === 200 && isset($data['features'])) {
+			$response = $this->getDataFromResponse($this->response);
+			Assert::assertSame((int)$data['features'], $response['features']);
+		}
 
 		$this->setCurrentUser($currentUser);
 	}

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -5058,25 +5058,22 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 		$this->setCurrentUser($currentUser);
 	}
 
-	#[Then('/^Bot "([^"]*)" retrieves its features for room "([^"]*)" with (\d+)(?: \((v1)\))?$/')]
-	public function botRetrievesFeatures(string $botName, string $identifier, int $status, string $apiVersion, TableNode $body): void {
+	#[Then('/^Bot "([^"]*)" retrieves its features for room "([^"]*)" using secret "([^"]*)" with (\d+)(?: \((v1)\))?$/')]
+	public function botRetrievesFeatures(string $botName, string $identifier, string $secret, int $status, string $apiVersion, ?TableNode $body = null): void {
 		$currentUser = $this->setCurrentUser('');
-
-		$data = $body->getRowsHash();
-		$secret = $data['secret'];
-		$token = self::$identifierToToken[$identifier];
 
 		$this->sendBotSignedRequest(
 			'GET',
-			'/apps/spreed/api/' . $apiVersion . '/bot/' . $token . '/features',
+			'/apps/spreed/api/' . $apiVersion . '/bot/' . self::$identifierToToken[$identifier] . '/features',
 			$secret,
 			''
 		);
 		$this->assertStatusCode($this->response, $status);
 
-		if ($status === 200 && isset($data['features'])) {
+		if ($body instanceof TableNode) {
+			$expected = $body->getRowsHash();
 			$response = $this->getDataFromResponse($this->response);
-			Assert::assertSame((int)$data['features'], $response['features']);
+			Assert::assertSame((int)$expected['features'], $response['features']);
 		}
 
 		$this->setCurrentUser($currentUser);

--- a/tests/integration/features/chat-2/bots.feature
+++ b/tests/integration/features/chat-2/bots.feature
@@ -424,30 +424,25 @@ Feature: chat-2/bots
       | roomName | room1 |
 
     # Not set up for the conversation yet
-    When Bot "Bot" retrieves its features for room "room1" with 401 (v1)
-      | secret | Secret1234567890123456789012345678901234567890 |
+    When Bot "Bot" retrieves its features for room "room1" using secret "Secret1234567890123456789012345678901234567890" with 401 (v1)
 
     Given invoking occ with "talk:bot:setup BOT(Bot) ROOM(room1)"
     And the command was successful
-    Then Bot "Bot" retrieves its features for room "room1" with 200 (v1)
-      | secret   | Secret1234567890123456789012345678901234567890 |
-      | features | 3                                              |
+    Then Bot "Bot" retrieves its features for room "room1" using secret "Secret1234567890123456789012345678901234567890" with 200 (v1)
+      | features | 3 |
 
     When set state enabled for bot "Bot" via OCC
       | feature |
       | webhook |
-    Then Bot "Bot" retrieves its features for room "room1" with 200 (v1)
-      | secret   | Secret1234567890123456789012345678901234567890 |
-      | features | 1                                              |
+    Then Bot "Bot" retrieves its features for room "room1" using secret "Secret1234567890123456789012345678901234567890" with 200 (v1)
+      | features | 1 |
 
     # Bots can authenticate even when all features are disabled
     When set state enabled for bot "Bot" via OCC
       | feature |
       | none    |
-    Then Bot "Bot" retrieves its features for room "room1" with 200 (v1)
-      | secret   | Secret1234567890123456789012345678901234567890 |
-      | features | 0                                              |
+    Then Bot "Bot" retrieves its features for room "room1" using secret "Secret1234567890123456789012345678901234567890" with 200 (v1)
+      | features | 0 |
 
     # Wrong secret is rejected
-    When Bot "Bot" retrieves its features for room "room1" with 401 (v1)
-      | secret | WrongSecret4567890123456789012345678901234567890 |
+    When Bot "Bot" retrieves its features for room "room1" using secret "WrongSecret4567890123456789012345678901234567890" with 401 (v1)

--- a/tests/integration/features/chat-2/bots.feature
+++ b/tests/integration/features/chat-2/bots.feature
@@ -414,3 +414,40 @@ Feature: chat-2/bots
     And the command output contains the text "Secret:"
     When invoking occ with "talk:bot:create --secret Secret1234567890123456789012345678901234567890 Bot"
     Then the command was successful
+
+  Scenario: Bot fetches its own enabled features
+    Given invoking occ with "talk:bot:install Bot Secret1234567890123456789012345678901234567890 https://localhost/bot1"
+    And the command was successful
+    And read bot ids from OCC
+    And user "participant1" creates room "room1" (v4)
+      | roomType | 2 |
+      | roomName | room1 |
+
+    # Not set up for the conversation yet
+    When Bot "Bot" retrieves its features for room "room1" with 401 (v1)
+      | secret | Secret1234567890123456789012345678901234567890 |
+
+    Given invoking occ with "talk:bot:setup BOT(Bot) ROOM(room1)"
+    And the command was successful
+    Then Bot "Bot" retrieves its features for room "room1" with 200 (v1)
+      | secret   | Secret1234567890123456789012345678901234567890 |
+      | features | 3                                              |
+
+    When set state enabled for bot "Bot" via OCC
+      | feature |
+      | webhook |
+    Then Bot "Bot" retrieves its features for room "room1" with 200 (v1)
+      | secret   | Secret1234567890123456789012345678901234567890 |
+      | features | 1                                              |
+
+    # Bots can authenticate even when all features are disabled
+    When set state enabled for bot "Bot" via OCC
+      | feature |
+      | none    |
+    Then Bot "Bot" retrieves its features for room "room1" with 200 (v1)
+      | secret   | Secret1234567890123456789012345678901234567890 |
+      | features | 0                                              |
+
+    # Wrong secret is rejected
+    When Bot "Bot" retrieves its features for room "room1" with 401 (v1)
+      | secret | WrongSecret4567890123456789012345678901234567890 |


### PR DESCRIPTION
## ☑️ Resolves

* Fix #18523

### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

## 🛠️ Description

Adds `GET /bot/{token}/features` so a bot can check which features an administrator enabled for it, authenticated with its own shared secret instead of admin credentials.

**Why polling instead of "try and report the error":** a disabled feature is indistinguishable from a broken secret from the bot's side — `getBotsForToken()` filters by feature *before* the checksum trial, so a response-disabled bot gets the same `401` as one with a wrong secret. Webhook delivery can't be probed at all; it just silently never happens. My concrete case: a bot that offers reaction-based interactions (e.g. approve/deny via ✅/❌) needs to know up front whether the reaction feature is enabled, rather than degrading mid-conversation.

**Design:** the endpoint reuses the existing `X-Nextcloud-Talk-Bot-Random` / `X-Nextcloud-Talk-Bot-Signature` HMAC scheme. Since `GET` has no body, the signature is computed over the random seed alone — modeled after the recording-settings endpoint in `SignalingController`, which signs random-only for the same reason (the SIP bridge variant signs random+token, but the conversation is already bound via the URL token in the bot lookup). Signing empty content also gives domain separation: the message and reaction endpoints reject empty content **before** authenticating (the reaction endpoints now enforce this explicitly), so a captured features-request signature cannot be replayed to post a message or reaction.

The bot lookup accepts any *enabled* bot of the conversation regardless of feature flags (`Bot::FEATURE_NONE` skips the filter) — the flags describe what a bot may do, not whether it may authenticate; a state-disabled bot still gets `401`. Along the way the unreachable feature re-check inside the checksum loop was removed and the duplicated header/throttle handling was extracted into a shared `getBotOrErrorResponse()` helper.

## 🛠️ API Checklist

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed

---

Signed-off-by: Lance <Gero3977@gmail.com>
Assisted-by: Claude-Code:claude-fable-5
