### PR TITLE
fix(chat): download shared folder as .zip archive

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
@@ -178,17 +178,17 @@
 							<template #icon>
 								<IconFileOutline :size="20" />
 							</template>
-							{{ t('spreed', 'Go to file') }}
+							{{ isSharedFolder ? t('spreed', 'Go to folder') : t('spreed', 'Go to file') }}
 						</NcActionLink>
 						<NcActionLink
 							v-if="!hideDownloadOption"
 							:href="linkToFileDownload"
-							:download="messageFile.name"
+							:download="downloadFileName"
 							closeAfterClick>
 							<template #icon>
 								<NcIconSvgWrapper :svg="IconFileDownload" :size="20" />
 							</template>
-							{{ t('spreed', 'Download file') }}
+							{{ isSharedFolder ? t('spreed', 'Download folder') : t('spreed', 'Download file') }}
 						</NcActionLink>
 					</template>
 					<template v-if="isThreadStarterMessage">
@@ -465,7 +465,7 @@ import { useChatExtrasStore } from '../../../../../stores/chatExtras.ts'
 import { useIntegrationsStore } from '../../../../../stores/integrations.js'
 import { useReactionsStore } from '../../../../../stores/reactions.js'
 import { useSharedItemsStore } from '../../../../../stores/sharedItems.ts'
-import { generatePublicShareDownloadUrl, generateUserFileUrl } from '../../../../../utils/davUtils.ts'
+import { generatePublicShareDownloadUrl, generateUserFileUrl, generateUserFolderUrl } from '../../../../../utils/davUtils.ts'
 import { convertToUnix, formatDateTime, ONE_DAY_IN_MS } from '../../../../../utils/formattedTime.ts'
 import { getCustomDateOptions } from '../../../../../utils/getCustomDateOptions.ts'
 import { copyConversationLinkToClipboard } from '../../../../../utils/handleUrl.ts'
@@ -664,9 +664,19 @@ export default {
 			return this.message.messageParameters[firstFileKey]
 		},
 
+		isSharedFolder() {
+			return this.messageFile?.mimetype === 'httpd/unix-directory'
+		},
+
+		downloadFileName() {
+			return this.messageFile.name + (this.isSharedFolder ? '.zip' : '')
+		},
+
 		linkToFileDownload() {
 			return getCurrentUser()
-				? generateUserFileUrl(this.messageFile.path)
+				? (this.isSharedFolder
+						? generateUserFolderUrl(this.messageFile.path)
+						: generateUserFileUrl(this.messageFile.path))
 				: generatePublicShareDownloadUrl(this.messageFile.link)
 		},
 

--- a/src/utils/davUtils.ts
+++ b/src/utils/davUtils.ts
@@ -21,6 +21,23 @@ export function generateUserFileUrl(filepath: string, userid: string | undefined
 }
 
 /**
+ * Generate a WebDAV url to a user folder (to download as a ZIP archive).
+ * Mirrors Files app behaviour (appends trailing slash and `accept=zip` to the DAV URL).
+ *
+ * @param filepath - The path to the user's folder, e.g., Talk/Media
+ * @param userid - The user id, e.g., 'admin'. Defaults to the current user id
+ * @return The WebDAV URL to download the folder as ZIP, e.g., https://nextcloud.ltd/remote.php/dav/files/admin/Talk/Media/?accept=zip
+ */
+export function generateUserFolderUrl(filepath: string, userid: string | undefined = getCurrentUser()?.uid) {
+	const url = new URL(generateUserFileUrl(filepath, userid))
+	url.searchParams.append('accept', 'zip')
+	if (!url.pathname.endsWith('/')) {
+		url.pathname = `${url.pathname}/`
+	}
+	return url.href
+}
+
+/**
  * Generate a download link for a public share
  *
  * @param shareLink - The public share link, e.g., https://nextcloud.ltd/s/CBeNTiJz5JeT2CH/


### PR DESCRIPTION
## ☑️ Resolves

* Fix download of shared folders
* Method mirrored from Files app

### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

<img width="432" height="224" alt="image" src="https://github.com/user-attachments/assets/e5c1c96f-1f3f-4f56-b5a5-7ea66fac488e" />
<img width="633" height="277" alt="image" src="https://github.com/user-attachments/assets/ac14a769-5b5c-4fa9-b28b-e083cc441a58" />

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required