### PR TITLE
feat(sip): treat direct-dial-in and dial-out similarly

### DIFF
--- a/src/components/CallView/shared/EmptyCallView.vue
+++ b/src/components/CallView/shared/EmptyCallView.vue
@@ -36,6 +36,7 @@ import IconLink from 'vue-material-design-icons/Link.vue'
 import IconPhoneOutline from 'vue-material-design-icons/PhoneOutline.vue'
 import { useGetToken } from '../../../composables/useGetToken.ts'
 import { CONVERSATION, PARTICIPANT } from '../../../constants.ts'
+import { isConversationPhoneRoom } from '../../../utils/conversation.ts'
 import { copyConversationLinkToClipboard } from '../../../utils/handleUrl.ts'
 
 export default {
@@ -104,10 +105,7 @@ export default {
 		},
 
 		isPhoneConversation() {
-			return this.conversation
-				&& (this.conversation.objectType === CONVERSATION.OBJECT_TYPE.PHONE_LEGACY
-					|| this.conversation.objectType === CONVERSATION.OBJECT_TYPE.PHONE_PERSISTENT
-					|| this.conversation.objectType === CONVERSATION.OBJECT_TYPE.PHONE_TEMPORARY)
+			return this.conversation && isConversationPhoneRoom(this.conversation)
 		},
 
 		canInviteOthers() {

--- a/src/components/TopBar/CallButton.vue
+++ b/src/components/TopBar/CallButton.vue
@@ -129,6 +129,7 @@ import { useSoundsStore } from '../../stores/sounds.js'
 import { useTalkHashStore } from '../../stores/talkHash.js'
 import { useTokenStore } from '../../stores/token.ts'
 import { blockCalls, unsupportedWarning } from '../../utils/browserCheck.ts'
+import { isConversationPhoneRoom } from '../../utils/conversation.ts'
 import { messagePleaseReload } from '../../utils/talkDesktopUtils.ts'
 
 export default {
@@ -354,10 +355,7 @@ export default {
 		},
 
 		isPhoneRoom() {
-			return this.conversation.objectId === CONVERSATION.OBJECT_ID.PHONE_OUTGOING
-				&& (this.conversation.objectType === CONVERSATION.OBJECT_TYPE.PHONE_LEGACY
-					|| this.conversation.objectType === CONVERSATION.OBJECT_TYPE.PHONE_PERSISTENT
-					|| this.conversation.objectType === CONVERSATION.OBJECT_TYPE.PHONE_TEMPORARY)
+			return isConversationPhoneRoom(this.conversation)
 		},
 
 		isInLobby() {

--- a/src/composables/useJoinCall.ts
+++ b/src/composables/useJoinCall.ts
@@ -3,18 +3,19 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import type { Conversation, Participant } from '../types/index.ts'
+import type { Participant } from '../types/index.ts'
 
 import { showError } from '@nextcloud/dialogs'
 import { emit } from '@nextcloud/event-bus'
 import { t } from '@nextcloud/l10n'
 import { useStore } from 'vuex'
-import { ATTENDEE, CALL, CONVERSATION, PARTICIPANT } from '../constants.ts'
+import { ATTENDEE, CALL, PARTICIPANT } from '../constants.ts'
 import { callSIPDialOut } from '../services/callsService.ts'
 import { getTalkConfig } from '../services/CapabilitiesManager.ts'
 import { useActorStore } from '../stores/actor.ts'
 import { useSettingsStore } from '../stores/settings.ts'
 import { isAxiosErrorResponse } from '../types/guards.ts'
+import { isConversationPhoneRoom } from '../utils/conversation.ts'
 
 /**
  * Handler function to join a call and manage side effects
@@ -23,22 +24,6 @@ export function useJoinCall() {
 	const actorStore = useActorStore()
 	const settingsStore = useSettingsStore()
 	const vuexStore = useStore()
-
-	/**
-	 * Returns whether the conversation is a phone room (with a single SIP phone participant)
-	 *
-	 * @param conversation - conversation object
-	 * @param conversation.objectId - conversation objectId
-	 * @param conversation.objectType - conversation objectType
-	 */
-	function isConversationPhoneRoom({ objectId, objectType }: Conversation) {
-		return objectId === CONVERSATION.OBJECT_ID.PHONE_OUTGOING
-			&& [
-				CONVERSATION.OBJECT_TYPE.PHONE_LEGACY,
-				CONVERSATION.OBJECT_TYPE.PHONE_PERSISTENT,
-				CONVERSATION.OBJECT_TYPE.PHONE_TEMPORARY,
-			].includes(objectType)
-	}
 
 	/**
 	 * Tries to call the given SIP phone participant

--- a/src/store/participantsStore.js
+++ b/src/store/participantsStore.js
@@ -9,7 +9,7 @@ import { emit } from '@nextcloud/event-bus'
 import { t } from '@nextcloud/l10n'
 import Hex from 'crypto-js/enc-hex.js'
 import SHA1 from 'crypto-js/sha1.js'
-import { ATTENDEE, CONVERSATION, PARTICIPANT } from '../constants.ts'
+import { ATTENDEE, PARTICIPANT } from '../constants.ts'
 import { banActor } from '../services/banService.ts'
 import {
 	joinCall,
@@ -40,6 +40,7 @@ import pinia from '../stores/pinia.ts'
 import { useSessionStore } from '../stores/session.ts'
 import { useTokenStore } from '../stores/token.ts'
 import CancelableRequest from '../utils/CancelableRequest.ts'
+import { isConversationPhoneRoom } from '../utils/conversation.ts'
 import { convertToUnix } from '../utils/formattedTime.ts'
 import { messagePleaseTryToReload } from '../utils/talkDesktopUtils.ts'
 
@@ -1178,17 +1179,11 @@ const actions = {
 			}, 5000)
 		}
 
-		// Special handling for dial-out rooms, if a call was rejected
+		// Special handling for phone rooms, if a call was rejected
 		if (value.status === 'rejected') {
 			const conversation = context.rootGetters.conversation(tokenStore.token)
-			const isConversationPhoneRoom = [
-				CONVERSATION.OBJECT_TYPE.PHONE_LEGACY,
-				CONVERSATION.OBJECT_TYPE.PHONE_PERSISTENT,
-				CONVERSATION.OBJECT_TYPE.PHONE_TEMPORARY,
-			].includes(conversation.objectType)
-			&& conversation.objectId === CONVERSATION.OBJECT_ID.PHONE_OUTGOING
 
-			if (isConversationPhoneRoom) {
+			if (isConversationPhoneRoom(conversation)) {
 				const actorStore = useActorStore()
 				await context.dispatch('leaveCall', {
 					token: tokenStore.token,

--- a/src/utils/conversation.ts
+++ b/src/utils/conversation.ts
@@ -56,6 +56,25 @@ export function isEvent(conversation: Conversation): boolean {
 }
 
 /**
+ * Returns whether the conversation is a phone room (with a single SIP phone participant).
+ * Covers both dial-out and direct-dial-in rooms.
+ *
+ * @param conversation - conversation object
+ * @param conversation.objectId - conversation objectId
+ * @param conversation.objectType - conversation objectType
+ */
+export function isConversationPhoneRoom({ objectId, objectType }: Conversation) {
+	return [
+		CONVERSATION.OBJECT_ID.PHONE_OUTGOING,
+		CONVERSATION.OBJECT_ID.PHONE_INCOMING,
+	].includes(objectId) && [
+		CONVERSATION.OBJECT_TYPE.PHONE_LEGACY,
+		CONVERSATION.OBJECT_TYPE.PHONE_PERSISTENT,
+		CONVERSATION.OBJECT_TYPE.PHONE_TEMPORARY,
+	].includes(objectType)
+}
+
+/**
  * check if the conversation is archived
  *
  * @param conversation conversation object

--- a/src/views/MainView.vue
+++ b/src/views/MainView.vue
@@ -24,6 +24,7 @@ import { CALL, CONVERSATION } from '../constants.ts'
 import { getTalkConfig } from '../services/CapabilitiesManager.ts'
 import { useActorStore } from '../stores/actor.ts'
 import { useSettingsStore } from '../stores/settings.ts'
+import { isConversationPhoneRoom } from '../utils/conversation.ts'
 
 const props = defineProps<{
 	token: string
@@ -116,15 +117,9 @@ function handleDirectCall(routeToken: string) {
 		CALL.RECORDING.AUDIO,
 	].includes(conversation.callRecording)
 	|| conversation.recordingConsent === CALL.RECORDING_CONSENT.ENABLED
-	const isConversationPhoneRoom = [
-		CONVERSATION.OBJECT_TYPE.PHONE_LEGACY,
-		CONVERSATION.OBJECT_TYPE.PHONE_PERSISTENT,
-		CONVERSATION.OBJECT_TYPE.PHONE_TEMPORARY,
-	].includes(conversation.objectType)
-	&& conversation.objectId === CONVERSATION.OBJECT_ID.PHONE_OUTGOING
 
 	// Verify conditions for showing MediaSettings (required or user opted out)
-	if (showRecordingWarning || settingsStore.showMediaSettings || isConversationPhoneRoom) {
+	if (showRecordingWarning || settingsStore.showMediaSettings || isConversationPhoneRoom(conversation)) {
 		emit('talk:media-settings:show')
 		return
 	}


### PR DESCRIPTION
## ☑️ Resolves

* Fix #18122
* On top of #18567
	* `OBJECT_ID.PHONE_INCOMING` was not used before in client code
	* Now with saving callers as phone actors, this should work same way as dial-out rooms

### AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
Screenshot before | Screenshot after

### 🚧 Tasks

- [x] Was not tested on live instance

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required