### PR TITLE
fix(call): make optimistic update of UI in large conversations

### DIFF
--- a/src/store/participantsStore.js
+++ b/src/store/participantsStore.js
@@ -15,7 +15,7 @@ import {
 	joinCall,
 	leaveCall,
 } from '../services/callsService.ts'
-import { hasTalkFeature, setRemoteCapabilities } from '../services/CapabilitiesManager.ts'
+import { getTalkConfig, hasTalkFeature, setRemoteCapabilities } from '../services/CapabilitiesManager.ts'
 import { EventBus } from '../services/EventBus.ts'
 import {
 	demoteFromModerator,
@@ -792,6 +792,13 @@ const actions = {
 		let connectingTimeout = null
 		commit('joiningCall', { token, sessionId, flags })
 
+		// FIXME currently participant that starts the call can experience delays
+		// to receive a response from POST 'apps/spreed/api/v4/call/{token}' in large calls,
+		// so should render call UI optimistically based on the signaling message
+		const isCallStarter = !getters.conversation(token)?.hasCall
+		const isStandaloneSignaling = getTalkConfig(token, 'signaling', 'mode') !== 'internal'
+		let hasJoinedCallOptimistically = false
+
 		const handleJoinCall = ([token, flags]) => {
 			commit('setInCall', { token, sessionId, flags })
 			commit('finishedJoiningCall', { token, sessionId })
@@ -824,9 +831,22 @@ const actions = {
 		const handleParticipantsListReceived = (payload, key) => {
 			const participant = payload[0].find((p) => p[key] === sessionId)
 			if (participant && participant.inCall !== PARTICIPANT.CALL_FLAG.DISCONNECTED) {
+				const flags = participant.inCall
 				if (state.joiningCall[token]?.[sessionId]) {
 					isParticipantsListReceived = true
-					commit('connecting', { token, sessionId, flags })
+					// If both conditions match the call starter expectations, update UI optimistically
+					if (isStandaloneSignaling && isCallStarter) {
+						hasJoinedCallOptimistically = true
+						handleJoinCall([token, flags])
+
+						// Restore the failure listener in case server request goes rogue to rollback
+						EventBus.once('signaling-join-call-failed', handleJoinCallFailed)
+						// Show call UI
+						const callViewStore = useCallViewStore()
+						callViewStore.handleJoinCall(getters.conversation(token))
+					} else {
+						commit('connecting', { token, sessionId, flags })
+					}
 					return
 				}
 				finishConnecting()
@@ -862,6 +882,13 @@ const actions = {
 				inCall: actualFlags,
 			}
 			commit('updateParticipant', { token, attendeeId: attendee.attendeeId, updatedData })
+			if (hasJoinedCallOptimistically) {
+				// Request confirmed: set actual call flags and drop failure listener
+				commit('setInCall', { token, sessionId, flags: actualFlags })
+				EventBus.off('signaling-join-call-failed', handleJoinCallFailed)
+				return
+			}
+
 			const callViewStore = useCallViewStore()
 			callViewStore.handleJoinCall(getters.conversation(token))
 		} catch (e) {

--- a/src/store/participantsStore.spec.js
+++ b/src/store/participantsStore.spec.js
@@ -10,11 +10,12 @@ import { cloneDeep } from 'es-toolkit'
 import { createPinia, setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { createStore } from 'vuex'
-import { PARTICIPANT } from '../constants.ts'
+import { PARTICIPANT, SIGNALING } from '../constants.ts'
 import {
 	joinCall,
 	leaveCall,
 } from '../services/callsService.ts'
+import { getTalkConfig } from '../services/CapabilitiesManager.ts'
 import { fetchConversation } from '../services/conversationsService.ts'
 import { EventBus } from '../services/EventBus.ts'
 import {
@@ -67,6 +68,13 @@ vi.mock('@nextcloud/event-bus', () => ({
 	emit: vi.fn(),
 	subscribe: vi.fn(),
 }))
+vi.mock('../services/CapabilitiesManager.ts', async (importOriginal) => {
+	const actual = await importOriginal()
+	return {
+		...actual,
+		getTalkConfig: vi.fn(actual.getTalkConfig),
+	}
+})
 
 vi.spyOn(EventBus, 'emit')
 
@@ -789,6 +797,109 @@ describe('participantsStore', () => {
 				expect(store.getters.getParticipantRaisedHand(['session-id-1', 'session-id-2', 'session-id-3']))
 					.toStrictEqual({ state: true, timestamp: 1 })
 			})
+		})
+	})
+
+	describe('optimistic call join (external signaling)', () => {
+		const actualFlags = PARTICIPANT.CALL_FLAG.WITH_AUDIO
+		const flags = PARTICIPANT.CALL_FLAG.WITH_AUDIO | PARTICIPANT.CALL_FLAG.WITH_VIDEO
+		let resolveJoinCall = null
+
+		const usersChangedPayload = [{
+			attendeeId: 1,
+			nextcloudSessionId: 'session-id-1',
+			inCall: actualFlags,
+			participantType: PARTICIPANT.TYPE.USER,
+		}]
+
+		beforeEach(() => {
+			// No ongoing call yet, so the current participant is the call starter
+			testStoreConfig.getters.conversation = () => vi.fn().mockReturnValue({
+				token: TOKEN,
+				type: 3,
+				hasCall: false,
+			})
+			store = createStore(testStoreConfig)
+			store.dispatch('addParticipant', {
+				token: TOKEN,
+				participant: {
+					attendeeId: 1,
+					sessionId: 'session-id-1',
+					participantType: PARTICIPANT.TYPE.USER,
+					inCall: PARTICIPANT.CALL_FLAG.DISCONNECTED,
+				},
+			})
+			// Delay the "join call" request so the signaling message arrives first
+			joinCall.mockImplementation(() => new Promise((resolve) => {
+				resolveJoinCall = resolve
+			}))
+			leaveCall.mockResolvedValue()
+		})
+
+		afterEach(() => {
+			// Settle any still-pending request and restore a resolving default so
+			// the deferred implementation does not leak into later tests
+			resolveJoinCall?.(actualFlags)
+			joinCall.mockResolvedValue(actualFlags)
+		})
+
+		const dispatchJoinCall = () => {
+			// Use external signaling for this join request
+			getTalkConfig.mockReturnValueOnce(SIGNALING.MODE.EXTERNAL)
+			return store.dispatch('joinCall', {
+				token: TOKEN,
+				participantIdentifier: {
+					attendeeId: 1,
+					sessionId: 'session-id-1',
+				},
+				flags,
+				silent: false,
+				recordingConsent: false,
+			})
+		}
+
+		test('call starter joins optimistically before the request returns', async () => {
+			// Act: request is pending
+			const promise = dispatchJoinCall()
+			expect(store.getters.isJoiningCall(TOKEN)).toBe(true)
+			expect(store.getters.isInCall(TOKEN)).toBe(false)
+
+			// Act: signaling reports us in the call before the request resolves
+			EventBus.emit('signaling-users-changed', [usersChangedPayload])
+
+			// Assert: UI switched to "in call" optimistically
+			expect(store.getters.isInCall(TOKEN)).toBe(true)
+			expect(store.getters.isConnecting(TOKEN)).toBe(false)
+			expect(store.getters.isJoiningCall(TOKEN)).toBe(false)
+
+			// Act: the delayed request finally returns
+			resolveJoinCall(actualFlags)
+			await promise
+
+			// Assert: still in the call, flags reconciled with the actual ones
+			expect(store.getters.isInCall(TOKEN)).toBe(true)
+			expect(store.getters.participantsList(TOKEN)).toStrictEqual([{
+				attendeeId: 1,
+				sessionId: 'session-id-1',
+				inCall: actualFlags,
+				participantType: PARTICIPANT.TYPE.USER,
+			}])
+		})
+
+		test('optimistic join is rolled back when the request fails', () => {
+			// Act: request is pending, then optimistic join from signaling
+			dispatchJoinCall()
+			EventBus.emit('signaling-users-changed', [usersChangedPayload])
+			expect(store.getters.isInCall(TOKEN)).toBe(true)
+
+			// Act: the delayed request ultimately fails
+			EventBus.emit('signaling-join-call-failed', [TOKEN, 'error reason'])
+
+			// Assert: optimistic join rolled back
+			expect(store.getters.isInCall(TOKEN)).toBe(false)
+			expect(store.getters.isConnecting(TOKEN)).toBe(false)
+			expect(store.getters.isJoiningCall(TOKEN)).toBe(false)
+			expect(store.getters.connectionFailed(TOKEN)).toBe('error reason')
 		})
 	})
 


### PR DESCRIPTION
## ☑️ Resolves

* Fix call starter not being in the call, despite other people joining
* currently participant that starts the call can experience delays to receive a response from POST 'apps/spreed/api/v4/call/{token}' in large calls, so should render call UI optimistically based on the signaling message

### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
Screenshot before | Screenshot after
<img width="1418" height="622" alt="2026-07-07_16h45_26" src="https://github.com/user-attachments/assets/4a649431-35f0-4d26-b313-b363e9464de8" /> | <img width="1357" height="515" alt="2026-07-07_19h39_04" src="https://github.com/user-attachments/assets/af7b5f27-2904-423e-9540-14eb4dacd278" />

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required