### PR TITLE
fix(chat): file share links are broken after reacting/replying

### DIFF
--- a/src/composables/useGetMessages.ts
+++ b/src/composables/useGetMessages.ts
@@ -701,7 +701,8 @@ export function useGetMessagesProvider() {
 		}
 
 		// FIXME Patch for file uploads: messageParameters['file']['path'] and messageParameters['file']['link'] do not match server request
-		if (isFileShareMessage(message)) {
+		// Additionally check messages and system messages with parent
+		if (isFileShareMessage(message) || (message.parent && 'messageParameters' in message.parent && isFileShareMessage(message.parent))) {
 			tryPollNewMessages()
 			return
 		}

--- a/src/composables/useGetMessages.ts
+++ b/src/composables/useGetMessages.ts
@@ -27,7 +27,7 @@ import { useChatExtrasStore } from '../stores/chatExtras.ts'
 import { useGuestNameStore } from '../stores/guestName.ts'
 import { isAxiosErrorResponse } from '../types/guards.ts'
 import { debugTimer } from '../utils/debugTimer.ts'
-import { tryLocalizeSystemMessage } from '../utils/message.ts'
+import { isFileShareMessage, tryLocalizeSystemMessage } from '../utils/message.ts'
 import { useGetThreadId } from './useGetThreadId.ts'
 import { useGetToken } from './useGetToken.ts'
 
@@ -701,13 +701,13 @@ export function useGetMessagesProvider() {
 		}
 
 		// FIXME Patch for file uploads: messageParameters['file']['path'] and messageParameters['file']['link'] do not match server request
-		if (Object.keys(message.messageParameters ?? {}).some((key) => key.startsWith('file'))) {
+		if (isFileShareMessage(message)) {
 			tryPollNewMessages()
 			return
 		}
 
 		// Patch for federated conversations: disable unsupported file shares
-		if (conversation?.remoteServer && Object.keys(message.messageParameters ?? {}).some((key) => key.startsWith('file'))
+		if (conversation?.remoteServer && isFileShareMessage(message)
 			&& [MESSAGE.TYPE.COMMENT, MESSAGE.TYPE.VOICE_MESSAGE, MESSAGE.TYPE.RECORD_VIDEO, MESSAGE.TYPE.RECORD_AUDIO].includes(message.messageType)) {
 			message.message = '*' + t('spreed', 'File shares are currently not supported in federated conversations') + '*'
 			delete message.messageParameters.file

--- a/src/utils/message.ts
+++ b/src/utils/message.ts
@@ -167,6 +167,15 @@ function selfIsUser(message: ChatMessage, selfActorId: string, selfActorType: st
 }
 
 /**
+ * Returns whether the given message shares a file (has a rich object parameter with a key starting with 'file').
+ *
+ * @param message Chat message (or a parent message)
+ */
+export function isFileShareMessage(message: ChatMessage): boolean {
+	return Object.keys(message.messageParameters ?? {}).some((key) => key.startsWith('file'))
+}
+
+/**
  * Returns whether the given system message should be hidden in the UI
  *
  * @param message Chat message


### PR DESCRIPTION
## ☑️ Resolves

* Fix inability to open a file in a viewer after it is shared in chat
  * We had a guard for chat-relay already, that does the HTTP request to get correct per-user details
  * But message.parent avoided that guard - so any reaction, edit, reply would break a link

### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="597" height="199" alt="2026-07-07_19h50_30" src="https://github.com/user-attachments/assets/2159c51b-8c82-4cae-8421-46a1f70fcfd0" /> | <img width="595" height="218" alt="2026-07-07_19h51_27" src="https://github.com/user-attachments/assets/3ce8ca5b-28a9-4fd6-9884-2c7fe0adf82e" />

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required