### PR TITLE
fix: Circle getBasedOn can be null

### DIFF
--- a/lib/Listener/CircleMembershipListener.php
+++ b/lib/Listener/CircleMembershipListener.php
@@ -89,13 +89,17 @@ class CircleMembershipListener extends AMembershipListener {
 		// Get the base circle of the membership
 		$basedOnCircle = $newMember->getBasedOn();
 		// Get all (nested) memberships in the added $newMember as a flat list
-		$userMembers = $basedOnCircle->getInheritedMembers();
+		$userMembers = $basedOnCircle?->getInheritedMembers();
+
+		if ($userMembers === null) {
+			return;
+		}
 
 		$invitedBy = $circle->hasInitiator() ? $circle->getInitiator() : $newMember->getInvitedBy();
 		if ($invitedBy->getUserType() === Member::TYPE_USER && $invitedBy->getUserId() !== '') {
 			$this->session->set('talk-overwrite-actor-id', $invitedBy->getUserId());
 			$this->session->set('talk-overwrite-actor-displayname', $invitedBy->getDisplayName());
-		} elseif ($invitedBy->getUserType() === Member::TYPE_APP && $invitedBy->getBasedOn()->getSource() === Member::APP_OCC) {
+		} elseif ($invitedBy->getUserType() === Member::TYPE_APP && $invitedBy->getBasedOn()?->getSource() === Member::APP_OCC) {
 			$this->session->set('talk-overwrite-actor-cli', 'cli');
 		}
 


### PR DESCRIPTION
## 🛠️ API Checklist

* Ref https://github.com/nextcloud/circles/pull/2519

The methods `getBasedOn` can return `null`, although it the type was incorrectly specified. Therefore we need to handle this a bit more gracefully.
Not detected by psalm... I assume it's because the classes are undefined, as it is OCA.

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
