### PR TITLE
feat: mark all tagged conversation 'read' at once

### DIFF
--- a/src/components/LeftSidebar/ConversationsList/ConversationTagHeader.vue
+++ b/src/components/LeftSidebar/ConversationsList/ConversationTagHeader.vue
@@ -14,11 +14,13 @@ import NcActionButton from '@nextcloud/vue/components/NcActionButton'
 import NcActionSeparator from '@nextcloud/vue/components/NcActionSeparator'
 import NcAppNavigationItem from '@nextcloud/vue/components/NcAppNavigationItem'
 import NcCounterBubble from '@nextcloud/vue/components/NcCounterBubble'
+import NcIconSvgWrapper from '@nextcloud/vue/components/NcIconSvgWrapper'
 import IconArrowDown from 'vue-material-design-icons/ArrowDown.vue'
 import IconArrowUp from 'vue-material-design-icons/ArrowUp.vue'
 import IconPencilOutline from 'vue-material-design-icons/PencilOutline.vue'
 import IconTrashCanOutline from 'vue-material-design-icons/TrashCanOutline.vue'
 import ConfirmDialog from '../../UIShared/ConfirmDialog.vue'
+import IconMarkChatRead from '../../../../img/material-icons/mark-chat-read.svg?raw'
 import { useConversationTagsStore } from '../../../stores/conversationTags.ts'
 
 export type TagHeaderItem = ConversationTag & {
@@ -85,6 +87,34 @@ async function handleDeleteTag() {
 		}
 	}
 }
+
+/**
+ * Clear last read message of a tag from all conversations
+ */
+async function handleMarkReadTag() {
+	const conversations = (vuexStore.getters.conversationsList as Conversation[]).filter((conversation) => {
+		if (!conversation.unreadMessages) {
+			return false
+		}
+
+		switch (props.item.type) {
+			case 'favorites': {
+				return conversation.isFavorite
+			}
+			case 'other': {
+				return !conversation.isFavorite && !conversation.tagIds?.length
+			}
+			case 'custom':
+			default: {
+				return conversation.tagIds?.includes(props.item.id)
+			}
+		}
+	})
+
+	for (const conversation of conversations) {
+		vuexStore.dispatch('clearLastReadMessage', { token: conversation.token })
+	}
+}
 </script>
 
 <template>
@@ -102,6 +132,15 @@ async function handleDeleteTag() {
 			<NcCounterBubble v-if="item.unreadCount > 0" :count="item.unreadCount" />
 		</template>
 		<template #actions>
+			<NcActionButton
+				v-if="item.unreadCount > 0"
+				closeAfterClick
+				@click="handleMarkReadTag">
+				<template #icon>
+					<NcIconSvgWrapper :svg="IconMarkChatRead" :size="20" />
+				</template>
+				{{ t('spreed', 'Mark as read') }}
+			</NcActionButton>
 			<template v-if="isCustomTag">
 				<NcActionButton closeAfterClick @click="handleRenameTag">
 					<template #icon>

--- a/src/components/LeftSidebar/ConversationsList/ConversationTagHeader.vue
+++ b/src/components/LeftSidebar/ConversationsList/ConversationTagHeader.vue
@@ -26,6 +26,8 @@ import { useConversationTagsStore } from '../../../stores/conversationTags.ts'
 export type TagHeaderItem = ConversationTag & {
 	_type: 'tag-header'
 	unreadCount: number
+	unreadMention: boolean
+	unreadMentionDirect: boolean
 	isFirst?: boolean
 	isLast?: boolean
 }
@@ -38,6 +40,15 @@ const vuexStore = useStore()
 const tagsStore = useConversationTagsStore()
 
 const isCustomTag = computed(() => props.item.type === 'custom')
+const counterType = computed(() => {
+	if (props.item.unreadMentionDirect) {
+		return 'highlighted'
+	} else if (props.item.unreadMention) {
+		return 'outlined'
+	} else {
+		return ''
+	}
+})
 
 /**
  * Assign a new name to the tag via dialog
@@ -129,7 +140,7 @@ async function handleMarkReadTag() {
 		<!-- Invisible child to trigger the collapse chevron -->
 		<li class="tag-header__spacer" />
 		<template #counter>
-			<NcCounterBubble v-if="item.unreadCount > 0" :count="item.unreadCount" />
+			<NcCounterBubble v-if="item.unreadCount > 0" :count="item.unreadCount" :type="counterType" />
 		</template>
 		<template #actions>
 			<NcActionButton

--- a/src/components/LeftSidebar/ConversationsList/ConversationsListVirtual.vue
+++ b/src/components/LeftSidebar/ConversationsList/ConversationsListVirtual.vue
@@ -12,7 +12,7 @@ import { computed } from 'vue'
 import LoadingPlaceholder from '../../UIShared/LoadingPlaceholder.vue'
 import ConversationItem from './ConversationItem.vue'
 import ConversationTagHeader from './ConversationTagHeader.vue'
-import { AVATAR } from '../../../constants.ts'
+import { AVATAR, CONVERSATION } from '../../../constants.ts'
 import { useConversationTagsStore } from '../../../stores/conversationTags.ts'
 
 export type VirtualListItem = (Conversation | TagHeaderItem) & { _key?: string }
@@ -54,20 +54,33 @@ const listItems = computed<VirtualListItem[]>(() => {
 		hasTagged: boolean
 		favorites: Conversation[]
 		favoritesUnreadCount: number
+		favoritesUnreadMention: boolean
+		favoritesUnreadMentionDirect: boolean
 		tagged: Record<string, Conversation[]>
 		taggedUnreadCount: Record<string, number>
+		taggedUnreadMention: Record<string, boolean>
+		taggedUnreadMentionDirect: Record<string, boolean>
 		other: Conversation[]
 		otherUnreadCount: number
+		otherUnreadMention: boolean
+		otherUnreadMentionDirect: boolean
 	}>((acc, conversation) => {
 		const unreadCount = conversation.unreadMessages || 0
+		const unreadMention = conversation.unreadMention
+		const unreadMentionDirect = conversation.unreadMentionDirect
+			|| (!!unreadCount && [CONVERSATION.TYPE.ONE_TO_ONE, CONVERSATION.TYPE.ONE_TO_ONE_FORMER].includes(conversation.type))
 		const isTagged = !!conversation.tagIds?.length
 
 		if (conversation.isFavorite) {
 			acc.favorites.push(conversation)
 			acc.favoritesUnreadCount += unreadCount
+			acc.favoritesUnreadMention ||= unreadMention
+			acc.favoritesUnreadMentionDirect ||= unreadMentionDirect
 		} else if (!isTagged) {
 			acc.other.push(conversation)
 			acc.otherUnreadCount += unreadCount
+			acc.otherUnreadMention ||= unreadMention
+			acc.otherUnreadMentionDirect ||= unreadMentionDirect
 		}
 
 		if (isTagged) {
@@ -80,16 +93,24 @@ const listItems = computed<VirtualListItem[]>(() => {
 			acc.tagged[tagId] ??= []
 			acc.tagged[tagId].push(conversation)
 			acc.taggedUnreadCount[tagId] = (acc.taggedUnreadCount[tagId] || 0) + unreadCount
+			acc.taggedUnreadMention[tagId] = acc.taggedUnreadMention[tagId] || unreadMention
+			acc.taggedUnreadMentionDirect[tagId] = acc.taggedUnreadMentionDirect[tagId] || unreadMentionDirect
 		}
 		return acc
 	}, {
 		hasTagged: false,
 		favorites: [],
 		favoritesUnreadCount: 0,
+		favoritesUnreadMention: false,
+		favoritesUnreadMentionDirect: false,
 		tagged: {},
 		taggedUnreadCount: {},
+		taggedUnreadMention: {},
+		taggedUnreadMentionDirect: {},
 		other: [],
 		otherUnreadCount: 0,
+		otherUnreadMention: false,
+		otherUnreadMentionDirect: false,
 	})
 
 	if (!groupedConversations.hasTagged) {
@@ -100,6 +121,8 @@ const listItems = computed<VirtualListItem[]>(() => {
 		tag: ConversationTag
 		conversations: Conversation[]
 		unreadCount: number
+		unreadMention: boolean
+		unreadMentionDirect: boolean
 	}>>((acc, tag) => {
 		const conversations = tag.type === 'favorites'
 			? groupedConversations.favorites
@@ -116,11 +139,23 @@ const listItems = computed<VirtualListItem[]>(() => {
 			: tag.type === 'other'
 				? groupedConversations.otherUnreadCount
 				: (groupedConversations.taggedUnreadCount[tag.id] ?? 0)
+		const unreadMention = tag.type === 'favorites'
+			? groupedConversations.favoritesUnreadMention
+			: tag.type === 'other'
+				? groupedConversations.otherUnreadMention
+				: (groupedConversations.taggedUnreadMention[tag.id] ?? false)
+		const unreadMentionDirect = tag.type === 'favorites'
+			? groupedConversations.favoritesUnreadMentionDirect
+			: tag.type === 'other'
+				? groupedConversations.otherUnreadMentionDirect
+				: (groupedConversations.taggedUnreadMentionDirect[tag.id] ?? false)
 
 		acc.push({
 			tag,
 			conversations,
 			unreadCount,
+			unreadMention,
+			unreadMentionDirect,
 		})
 		return acc
 	}, [])
@@ -130,6 +165,8 @@ const listItems = computed<VirtualListItem[]>(() => {
 			...section.tag,
 			_type: 'tag-header',
 			unreadCount: section.unreadCount,
+			unreadMention: section.unreadMention,
+			unreadMentionDirect: section.unreadMentionDirect,
 			isFirst: index === 0,
 			isLast: index === renderedSections.length - 1,
 		}


### PR DESCRIPTION
## ☑️ Resolves

* Fix #18372
	* Mirroring logic from ConversationItem (mark single as read)
* Fix unread counter highlight
	* Mirroring logic from ConversationItem
	* Make collapsed tags with mentions inside distinct

### AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
Screenshot before | <img width="217" height="109" alt="2026-07-08_17h42_02" src="https://github.com/user-attachments/assets/8e46273b-e0f2-456e-a49e-7c0a3e93bdca" />
<img width="115" height="113" alt="2026-07-08_18h15_05" src="https://github.com/user-attachments/assets/82770899-d19e-4f42-8d33-58efff2aac6b" /> | <img width="115" height="113" alt="2026-07-08_18h15_21" src="https://github.com/user-attachments/assets/e64ee279-ebb8-4cee-972e-b0fcc874c90d" />

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required