### PR TITLE
fix(chat): translate deleted message coming from chat-relay

### DIFF
--- a/src/composables/useGetMessages.ts
+++ b/src/composables/useGetMessages.ts
@@ -27,7 +27,7 @@ import { useChatExtrasStore } from '../stores/chatExtras.ts'
 import { useGuestNameStore } from '../stores/guestName.ts'
 import { isAxiosErrorResponse } from '../types/guards.ts'
 import { debugTimer } from '../utils/debugTimer.ts'
-import { isFileShareMessage, tryLocalizeSystemMessage } from '../utils/message.ts'
+import { isFileShareMessage, tryLocalizeDeletedMessage, tryLocalizeSystemMessage } from '../utils/message.ts'
 import { useGetThreadId } from './useGetThreadId.ts'
 import { useGetToken } from './useGetToken.ts'
 
@@ -694,6 +694,17 @@ export function useGetMessagesProvider() {
 		if (message.systemMessage !== '' && conversation) {
 			try {
 				message.message = tryLocalizeSystemMessage(message, conversation)
+			} catch (exception) {
+				tryPollNewMessages()
+				return
+			}
+		}
+
+		// Attempt to localize deleted messages
+		if (message.systemMessage === MESSAGE.SYSTEM_TYPE.MESSAGE_DELETED && conversation
+			&& 'parent' in message && message.parent && 'message' in message.parent) {
+			try {
+				message.parent.message = tryLocalizeDeletedMessage(message.parent, conversation)
 			} catch (exception) {
 				tryPollNewMessages()
 				return

--- a/src/utils/message.ts
+++ b/src/utils/message.ts
@@ -143,6 +143,16 @@ function selfMentionType(actorType: string) {
 }
 
 /**
+ * Returns whether the actor is message author
+ *
+ * @param message Chat message
+ */
+function authorIsActor(message: ChatMessage) {
+	return selfMentionId(message.actorId, message.actorType) === message.messageParameters.actor.id
+		&& selfMentionType(message.actorType) === message.messageParameters.actor.type
+}
+
+/**
  * Returns whether the actor is current user (You)
  *
  * @param message Chat message
@@ -193,11 +203,11 @@ export function isHiddenSystemMessage(message: ChatMessage): boolean {
 }
 
 /**
- * Returns whether the given system message should be hidden in the UI
+ * Returns localized system message
  *
  * @param message Chat message
  * @param conversation Current conversation
- * @return whether the message is hidden in the UI
+ * @return localized string
  */
 export function tryLocalizeSystemMessage(message: ChatMessage, conversation: Conversation): string {
 	if (SYSTEM_MESSAGE_TYPE_UNTRANSLATED.includes(message.systemMessage)) {
@@ -310,5 +320,22 @@ export function tryLocalizeSystemMessage(message: ChatMessage, conversation: Con
 			// Don't localize non-supported relayed system messages, do polling
 			throw new Error()
 		}
+	}
+}
+
+/**
+ * Returns localized deleted message
+ *
+ * @param message Deleted chat message
+ * @param conversation Current conversation
+ * @return localized string
+ */
+export function tryLocalizeDeletedMessage(message: ChatMessage, conversation: Conversation): string {
+	if (selfIsActor(message, conversation.actorId, conversation.actorType)) {
+		return t('spreed', 'Message deleted by you')
+	} else if (authorIsActor(message)) {
+		return t('spreed', 'Message deleted by author')
+	} else {
+		return t('spreed', 'Message deleted by {actor}')
 	}
 }


### PR DESCRIPTION
## ☑️ Resolves

* Fix #18590

### AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI

### Note for testing
- When you delete a message, there's a race condition between 'raw' chat-relay and DELETE HTTP response (localized by server) - flickers in Before, fixed After

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After / Server response
-- | --
<img width="326" height="133" alt="2026-07-09_10h31_35" src="https://github.com/user-attachments/assets/21698893-7631-4164-b190-e8af4b3f724e" /> | <img width="329" height="135" alt="2026-07-09_10h30_03" src="https://github.com/user-attachments/assets/a45e14f9-fd38-44d8-a1c0-df9cb8414356" />

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required