### PR TITLE
fix: migrate speaking state to Pinia

### DIFF
--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -182,6 +182,7 @@ import { fetchPeers } from '../../services/callsService.ts'
 import { getTalkConfig } from '../../services/CapabilitiesManager.ts'
 import { EventBus } from '../../services/EventBus.ts'
 import { useCallViewStore } from '../../stores/callView.ts'
+import { useParticipantActivityStore } from '../../stores/participantActivity.ts'
 import { useSettingsStore } from '../../stores/settings.ts'
 import { callParticipantCollection, localCallParticipantModel, localMediaModel } from '../../utils/webrtc/index.js'
 import RemoteVideoBlocker from '../../utils/webrtc/RemoteVideoBlocker.js'
@@ -242,12 +243,15 @@ export default {
 			localMediaModel.disableVideo()
 		}
 
+		const participantActivityStore = useParticipantActivityStore()
+
 		return {
 			localMediaModel,
 			localCallParticipantModel,
 			callParticipantCollection,
 			devMode,
 			callViewStore: useCallViewStore(),
+			participantActivityStore,
 		}
 	},
 
@@ -679,15 +683,14 @@ export default {
 				}
 			}
 
-			// update in callViewStore
-			this.$store.dispatch('setParticipantHandRaised', {
+			this.participantActivityStore.setParticipantHandRaised({
 				sessionId: callParticipantModel.attributes.nextcloudSessionId,
 				raisedHand,
 			})
 		},
 
 		_lowerHandWhenParticipantLeaves(callParticipantCollection, callParticipantModel) {
-			this.$store.dispatch('setParticipantHandRaised', {
+			this.participantActivityStore.setParticipantHandRaised({
 				sessionId: callParticipantModel.attributes.nextcloudSessionId,
 				raisedHand: false,
 			})

--- a/src/components/NewMessage/NewMessageTypingIndicator.vue
+++ b/src/components/NewMessage/NewMessageTypingIndicator.vue
@@ -33,7 +33,7 @@ import AvatarWrapper from '../AvatarWrapper/AvatarWrapper.vue'
 import { AVATAR } from '../../constants.ts'
 import { useActorStore } from '../../stores/actor.ts'
 import { useGuestNameStore } from '../../stores/guestName.ts'
-import { useSignalingStateStore } from '../../stores/signalingState.ts'
+import { useParticipantActivityStore } from '../../stores/participantActivity.ts'
 
 export default {
 	name: 'NewMessageTypingIndicator',
@@ -51,11 +51,11 @@ export default {
 
 	setup() {
 		const guestNameStore = useGuestNameStore()
-		const signalingStateStore = useSignalingStateStore()
+		const participantActivityStore = useParticipantActivityStore()
 		return {
 			AVATAR,
 			guestNameStore,
-			signalingStateStore,
+			participantActivityStore,
 			actorStore: useActorStore(),
 		}
 	},
@@ -66,7 +66,7 @@ export default {
 		},
 
 		externalTypingSignals() {
-			return this.signalingStateStore.externalTypingSignals(this.token)
+			return this.participantActivityStore.externalTypingSignals(this.token)
 		},
 
 		/**

--- a/src/components/RightSidebar/Participants/Participant.spec.js
+++ b/src/components/RightSidebar/Participants/Participant.spec.js
@@ -21,6 +21,7 @@ import router from '../../../__mocks__/router.js'
 import { ATTENDEE, PARTICIPANT, WEBINAR } from '../../../constants.ts'
 import storeConfig from '../../../store/storeConfig.js'
 import { useActorStore } from '../../../stores/actor.ts'
+import { useParticipantActivityStore } from '../../../stores/participantActivity.ts'
 import { useTokenStore } from '../../../stores/token.ts'
 import { findNcActionButton, findNcActionText, findNcButton } from '../../../test-helpers.js'
 
@@ -269,7 +270,6 @@ describe('ParticipantItem.vue', () => {
 	})
 
 	describe('call icons', () => {
-		let getParticipantRaisedHandMock
 		const components = [IconVideoOutline, IconPhoneDialOutline, IconMicrophoneOutline, IconHandBackLeft]
 
 		/**
@@ -288,20 +288,10 @@ describe('ParticipantItem.vue', () => {
 			}
 		}
 
-		beforeEach(() => {
-			getParticipantRaisedHandMock = vi.fn().mockReturnValue({ state: false })
-
-			testStoreConfig = cloneDeep(storeConfig)
-			testStoreConfig.modules.participantsStore.getters.getParticipantRaisedHand = () => getParticipantRaisedHandMock
-			store = createStore(testStoreConfig)
-		})
-
 		test('does not renders call icon and hand raised icon when disconnected', () => {
+			// isHandRaised returns false immediately when DISCONNECTED, so raised hand state is irrelevant
 			participant.inCall = PARTICIPANT.CALL_FLAG.DISCONNECTED
-			getParticipantRaisedHandMock = vi.fn().mockReturnValue({ state: true })
-
 			checkStateIconsRendered(participant, null)
-			expect(getParticipantRaisedHandMock).not.toHaveBeenCalled()
 		})
 		test('renders video call icon', async () => {
 			participant.inCall = PARTICIPANT.CALL_FLAG.WITH_VIDEO
@@ -317,10 +307,11 @@ describe('ParticipantItem.vue', () => {
 		})
 		test('renders hand raised icon', async () => {
 			participant.inCall = PARTICIPANT.CALL_FLAG.WITH_VIDEO
-			getParticipantRaisedHandMock = vi.fn().mockReturnValue({ state: true })
-
-			checkStateIconsRendered(participant, IconHandBackLeft)
-			expect(getParticipantRaisedHandMock).toHaveBeenCalledWith(['session-id-alice'])
+			const wrapper = mountParticipant(participant)
+			// Store is initialized inside component setup — safe to use now
+			useParticipantActivityStore().setParticipantHandRaised({ sessionId: 'session-id-alice', raisedHand: { state: true, timestamp: Date.now() } })
+			await flushPromises()
+			expect(wrapper.findComponent(IconHandBackLeft).exists()).toBeTruthy()
 		})
 		test('renders video call icon when joined with multiple', async () => {
 			participant.inCall = PARTICIPANT.CALL_FLAG.WITH_VIDEO | PARTICIPANT.CALL_FLAG.WITH_PHONE

--- a/src/components/RightSidebar/Participants/ParticipantItem.vue
+++ b/src/components/RightSidebar/Participants/ParticipantItem.vue
@@ -385,6 +385,7 @@ import {
 } from '../../../services/callsService.ts'
 import { hasTalkFeature } from '../../../services/CapabilitiesManager.ts'
 import { useActorStore } from '../../../stores/actor.ts'
+import { useParticipantActivityStore } from '../../../stores/participantActivity.ts'
 import { formattedTime } from '../../../utils/formattedTime.ts'
 import { getDisplayNameWithFallback } from '../../../utils/getDisplayName.ts'
 import { readableNumber } from '../../../utils/readableNumber.ts'
@@ -446,11 +447,14 @@ export default {
 	},
 
 	setup() {
+		const participantActivityStore = useParticipantActivityStore()
+
 		return {
 			IconMicrophoneOffOutline,
 			isInCall: useIsInCall(),
 			actorStore: useActorStore(),
 			token: useGetToken(),
+			participantActivityStore,
 		}
 	},
 
@@ -620,11 +624,11 @@ export default {
 		},
 
 		participantSpeakingInformation() {
-			return this.$store.getters.getParticipantSpeakingInformation(this.attendeeId)
+			return this.participantActivityStore.getParticipantSpeakingInformation(this.attendeeId)
 		},
 
 		isParticipantSpeaking() {
-			return this.participantSpeakingInformation?.speaking
+			return this.participantSpeakingInformation?.isSpeaking
 		},
 
 		attendeePin() {

--- a/src/components/RightSidebar/Participants/ParticipantItem.vue
+++ b/src/components/RightSidebar/Participants/ParticipantItem.vue
@@ -597,7 +597,7 @@ export default {
 				return false
 			}
 
-			const raisedState = this.$store.getters.getParticipantRaisedHand(this.participant.sessionIds)
+			const raisedState = this.participantActivityStore.getParticipantRaisedHand(this.participant.sessionIds)
 			return raisedState.state
 		},
 

--- a/src/components/TopBar/ReactionMenu.vue
+++ b/src/components/TopBar/ReactionMenu.vue
@@ -22,6 +22,7 @@ import { CONVERSATION, PARTICIPANT } from '../../constants.ts'
 import { getTalkConfig } from '../../services/CapabilitiesManager.ts'
 import { useActorStore } from '../../stores/actor.ts'
 import { useBreakoutRoomsStore } from '../../stores/breakoutRooms.ts'
+import { useParticipantActivityStore } from '../../stores/participantActivity.ts'
 
 const props = defineProps<{
 	/* The conversation token */
@@ -34,6 +35,7 @@ const props = defineProps<{
 
 const actorStore = useActorStore()
 const breakoutRoomsStore = useBreakoutRoomsStore()
+const participantActivityStore = useParticipantActivityStore()
 const vuexStore = useStore()
 
 const AUTO_LOWER_HAND_THRESHOLD = 3_000
@@ -108,14 +110,14 @@ function sendReaction(reaction: string) {
 function toggleHandRaised() {
 	const newState = !isHandRaised.value
 	props.localMediaModel.toggleHandRaised(newState)
-	vuexStore.dispatch('setParticipantHandRaised', {
-		sessionId: actorStore.sessionId,
+	participantActivityStore.setParticipantHandRaised({
+		sessionId: actorStore.sessionId!,
 		raisedHand: props.localMediaModel.attributes.raisedHand,
 	})
 
 	// Handle breakout room assistance requests
 	if (userIsInBreakoutRoomAndInCall.value && !canModerate.value) {
-		const hasRaisedHands = Object.keys(vuexStore.getters.participantRaisedHandList)
+		const hasRaisedHands = Object.keys(participantActivityStore.raisedHands)
 			.filter((sessionId) => sessionId !== actorStore.sessionId)
 			.length !== 0
 

--- a/src/composables/useSortParticipants.js
+++ b/src/composables/useSortParticipants.js
@@ -7,6 +7,7 @@
 import { computed } from 'vue'
 import { useStore } from 'vuex'
 import { ATTENDEE, PARTICIPANT } from '../constants.ts'
+import { useParticipantActivityStore } from '../stores/participantActivity.ts'
 import { isDoNotDisturb } from '../utils/userStatus.ts'
 import { useGetToken } from './useGetToken.ts'
 
@@ -17,6 +18,7 @@ const MODERATOR_TYPES = [PARTICIPANT.TYPE.OWNER, PARTICIPANT.TYPE.MODERATOR, PAR
  */
 export function useSortParticipants() {
 	const store = useStore()
+	const participantActivityStore = useParticipantActivityStore()
 	const token = useGetToken()
 
 	const selfIsModerator = computed(() => {
@@ -100,8 +102,8 @@ export function useSortParticipants() {
 			return p1inCall ? -1 : 1
 		}
 
-		const p1HandRaised = store.getters.getParticipantRaisedHand(participant1.sessionIds)
-		const p2HandRaised = store.getters.getParticipantRaisedHand(participant2.sessionIds)
+		const p1HandRaised = participantActivityStore.getParticipantRaisedHand(participant1.sessionIds)
+		const p2HandRaised = participantActivityStore.getParticipantRaisedHand(participant2.sessionIds)
 		if (p1HandRaised.state !== p2HandRaised.state) {
 			return p1HandRaised.state ? -1 : 1
 		}

--- a/src/store/participantsStore.js
+++ b/src/store/participantsStore.js
@@ -82,8 +82,6 @@ function state() {
 		},
 		connectionFailed: {
 		},
-		speaking: {
-		},
 		// TODO: moved from callViewStore, separate to callExtras (with typing + speaking)
 		participantRaisedHands: {
 		},
@@ -95,7 +93,6 @@ function state() {
 		 * when quickly switching to a new conversation.
 		 */
 		cancelFetchParticipants: null,
-		speakingInterval: null,
 	}
 }
 
@@ -126,17 +123,6 @@ const getters = {
 			return Object.values(state.attendees[token])
 		}
 		return []
-	},
-
-	/**
-	 * Gets the speaking information for the participant.
-	 *
-	 * @param {object} state - the state object.
-	 * param {number} attendeeId - attendee's ID for the participant in conversation.
-	 * @return {object|undefined}
-	 */
-	getParticipantSpeakingInformation: (state) => (attendeeId) => {
-		return state.speaking[attendeeId]
 	},
 
 	participantRaisedHandList: (state) => {
@@ -338,84 +324,6 @@ const mutations = {
 			if (!Object.keys(state.connecting[token]).length) {
 				delete state.connecting[token]
 			}
-		}
-	},
-
-	/**
-	 * Sets the speaking status of a participant in a conversation / call.
-	 *
-	 * Note that "updateParticipant" should not be called to add a "speaking"
-	 * property to an existing participant, as the participant would be reset
-	 * when the participants are purged whenever they are fetched again.
-	 * Similarly, "addParticipant" can not be called either to add a participant
-	 * if it was not fetched yet but the call model reported it as being
-	 * speaking, as the attendeeId would be unknown.
-	 *
-	 * @param {object} state - current store state.
-	 * @param {object} data - the wrapping object.
-	 * @param {string} data.attendeeId - the attendee ID of the participant in conversation.
-	 * @param {boolean} data.speaking - whether the participant is speaking or not
-	 */
-	setSpeaking(state, { attendeeId, speaking }) {
-		// create a dummy object for current call
-		if (!state.speaking[attendeeId]) {
-			state.speaking[attendeeId] = { speaking, lastTimestamp: Date.now(), totalCountedTime: 0 }
-		}
-		state.speaking[attendeeId].speaking = speaking
-	},
-
-	/**
-	 * Tracks the interval id to update speaking information for a current call.
-	 *
-	 * @param {object} state - current store state.
-	 * @param {number} interval - interval id.
-	 */
-	setSpeakingInterval(state, interval) {
-		state.speakingInterval = interval
-	},
-
-	/**
-	 * Update speaking information for a participant.
-	 *
-	 * @param {object} state - current store state.
-	 * @param {object} data - the wrapping object.
-	 * @param {string} data.attendeeId - the attendee ID of the participant in conversation.
-	 * @param {boolean} data.speaking - whether the participant is speaking or not
-	 */
-	updateTimeSpeaking(state, { attendeeId, speaking }) {
-		if (!state.speaking[attendeeId]) {
-			return
-		}
-
-		const currentTimestamp = Date.now()
-		const currentSpeakingState = state.speaking[attendeeId].speaking
-
-		if (!currentSpeakingState && !speaking) {
-			// false -> false, no updates
-			return
-		}
-
-		if (currentSpeakingState) {
-			// true -> false / true -> true, participant is still speaking or finished to speak, update total time
-			state.speaking[attendeeId].totalCountedTime += (currentTimestamp - state.speaking[attendeeId].lastTimestamp)
-		}
-
-		// false -> true / true -> false / true -> true, update timestamp of last check / signal
-		state.speaking[attendeeId].lastTimestamp = currentTimestamp
-	},
-
-	/**
-	 * Purge the speaking information for recent call when local participant leaves call
-	 * (including cases when the call ends for everyone).
-	 *
-	 * @param {object} state - current store state.
-	 */
-	purgeSpeakingStore(state) {
-		state.speaking = {}
-
-		if (state.speakingInterval) {
-			clearInterval(state.speakingInterval)
-			state.speakingInterval = null
 		}
 	},
 
@@ -1131,35 +1039,6 @@ const actions = {
 			attendeePermissions: permissions,
 		}
 		context.commit('updateParticipant', { token, attendeeId, updatedData })
-	},
-
-	setSpeaking(context, { attendeeId, speaking }) {
-		// We should update time before speaking state, to be able to check previous state
-		context.commit('updateTimeSpeaking', { attendeeId, speaking })
-		context.commit('setSpeaking', { attendeeId, speaking })
-
-		if (!context.state.speakingInterval && speaking) {
-			const interval = setInterval(() => {
-				context.dispatch('updateIntervalTimeSpeaking')
-			}, 1000)
-			context.commit('setSpeakingInterval', interval)
-		}
-	},
-
-	updateIntervalTimeSpeaking(context) {
-		if (!context.state.speaking || !context.state.speakingInterval) {
-			return
-		}
-
-		for (const attendeeId in context.state.speaking) {
-			if (context.state.speaking[attendeeId].speaking) {
-				context.commit('updateTimeSpeaking', { attendeeId, speaking: true })
-			}
-		}
-	},
-
-	purgeSpeakingStore(context) {
-		context.commit('purgeSpeakingStore')
 	},
 
 	setParticipantHandRaised(context, { sessionId, raisedHand }) {

--- a/src/store/participantsStore.js
+++ b/src/store/participantsStore.js
@@ -36,6 +36,7 @@ import { talkBroadcastChannel } from '../services/talkBroadcastChannel.js'
 import { useActorStore } from '../stores/actor.ts'
 import { useCallViewStore } from '../stores/callView.ts'
 import { useGuestNameStore } from '../stores/guestName.ts'
+import { useParticipantActivityStore } from '../stores/participantActivity.ts'
 import pinia from '../stores/pinia.ts'
 import { useSessionStore } from '../stores/session.ts'
 import { useTokenStore } from '../stores/token.ts'
@@ -82,9 +83,6 @@ function state() {
 		},
 		connectionFailed: {
 		},
-		// TODO: moved from callViewStore, separate to callExtras (with typing + speaking)
-		participantRaisedHands: {
-		},
 		initialised: {
 		},
 		/**
@@ -125,19 +123,6 @@ const getters = {
 		return []
 	},
 
-	participantRaisedHandList: (state) => {
-		return state.participantRaisedHands
-	},
-	getParticipantRaisedHand: (state) => (sessionIds) => {
-		for (let i = 0; i < sessionIds.length; i++) {
-			if (state.participantRaisedHands[sessionIds[i]]) {
-				// note: only the raised states are stored, so no need to confirm
-				return state.participantRaisedHands[sessionIds[i]]
-			}
-		}
-
-		return { state: false, timestamp: null }
-	},
 	/**
 	 * Replaces the legacy getParticipant getter. Returns a callback function in which you can
 	 * pass in the token and attendeeId as arguments to get the participant object.
@@ -325,21 +310,6 @@ const mutations = {
 				delete state.connecting[token]
 			}
 		}
-	},
-
-	setParticipantHandRaised(state, { sessionId, raisedHand }) {
-		if (!sessionId) {
-			throw new Error('Missing or empty sessionId argument in call to setParticipantHandRaised')
-		}
-		if (raisedHand && raisedHand.state) {
-			state.participantRaisedHands[sessionId] = raisedHand
-		} else {
-			delete state.participantRaisedHands[sessionId]
-		}
-	},
-
-	clearParticipantHandRaised(state) {
-		state.participantRaisedHands = {}
 	},
 
 	/**
@@ -833,7 +803,7 @@ const actions = {
 		commit('updateParticipant', { token, attendeeId: attendee.attendeeId, updatedData })
 
 		// clear raised hands as they were specific to the call
-		commit('clearParticipantHandRaised')
+		useParticipantActivityStore().purgeRaisedHandsState()
 
 		commit('setInCall', {
 			token,
@@ -1039,10 +1009,6 @@ const actions = {
 			attendeePermissions: permissions,
 		}
 		context.commit('updateParticipant', { token, attendeeId, updatedData })
-	},
-
-	setParticipantHandRaised(context, { sessionId, raisedHand }) {
-		context.commit('setParticipantHandRaised', { sessionId, raisedHand })
 	},
 
 	processDialOutAnswer(context, { callid }) {

--- a/src/store/participantsStore.spec.js
+++ b/src/store/participantsStore.spec.js
@@ -712,6 +712,8 @@ describe('participantsStore', () => {
 		})
 
 		test('leaves call', async () => {
+			vi.spyOn(participantActivityStore, 'purgeRaisedHandsState')
+
 			// Act
 			await store.dispatch('leaveCall', {
 				token: TOKEN,
@@ -733,73 +735,7 @@ describe('participantsStore', () => {
 					participantType: PARTICIPANT.TYPE.USER,
 				},
 			])
-		})
-
-		describe('raised hand', () => {
-			test('get whether participants raised hands with single session id', () => {
-				participantActivityStore.setParticipantHandRaised({
-					sessionId: 'session-id-1',
-					raisedHand: { state: true, timestamp: 1 },
-				})
-				participantActivityStore.setParticipantHandRaised({
-					sessionId: 'session-id-2',
-					raisedHand: { state: true, timestamp: 2 },
-				})
-
-				expect(participantActivityStore.getParticipantRaisedHand(['session-id-1']))
-					.toStrictEqual({ state: true, timestamp: 1 })
-
-				expect(participantActivityStore.getParticipantRaisedHand(['session-id-2']))
-					.toStrictEqual({ state: true, timestamp: 2 })
-
-				expect(participantActivityStore.getParticipantRaisedHand(['session-id-another']))
-					.toStrictEqual({ state: false, timestamp: null })
-			})
-
-			test('get raised hands after lowering', () => {
-				participantActivityStore.setParticipantHandRaised({
-					sessionId: 'session-id-2',
-					raisedHand: { state: true, timestamp: 1 },
-				})
-				participantActivityStore.setParticipantHandRaised({
-					sessionId: 'session-id-2',
-					raisedHand: { state: false, timestamp: 3 },
-				})
-
-				expect(participantActivityStore.getParticipantRaisedHand(['session-id-2']))
-					.toStrictEqual({ state: false, timestamp: null })
-			})
-
-			test('clears raised hands state after leaving call', async () => {
-				participantActivityStore.setParticipantHandRaised({
-					sessionId: 'session-id-2',
-					raisedHand: { state: true, timestamp: 1 },
-				})
-				await store.dispatch('leaveCall', {
-					token: TOKEN,
-					participantIdentifier: {
-						attendeeId: 1,
-						sessionId: 'session-id-1',
-					},
-				})
-
-				expect(participantActivityStore.getParticipantRaisedHand(['session-id-2']))
-					.toStrictEqual({ state: false, timestamp: null })
-			})
-
-			test('get raised hands with multiple session ids only returns first found', () => {
-				participantActivityStore.setParticipantHandRaised({
-					sessionId: 'session-id-2',
-					raisedHand: { state: true, timestamp: 1 },
-				})
-				participantActivityStore.setParticipantHandRaised({
-					sessionId: 'session-id-3',
-					raisedHand: { state: true, timestamp: 1 },
-				})
-
-				expect(participantActivityStore.getParticipantRaisedHand(['session-id-1', 'session-id-2', 'session-id-3']))
-					.toStrictEqual({ state: true, timestamp: 1 })
-			})
+			expect(participantActivityStore.purgeRaisedHandsState).toHaveBeenCalledTimes(1)
 		})
 	})
 

--- a/src/store/participantsStore.spec.js
+++ b/src/store/participantsStore.spec.js
@@ -33,6 +33,7 @@ import {
 import SessionStorage from '../services/SessionStorage.js'
 import { useActorStore } from '../stores/actor.ts'
 import { useGuestNameStore } from '../stores/guestName.ts'
+import { useParticipantActivityStore } from '../stores/participantActivity.ts'
 import { useSessionStore } from '../stores/session.ts'
 import { useTokenStore } from '../stores/token.ts'
 import { generateOCSErrorResponse, generateOCSResponse } from '../test-helpers.js'
@@ -85,12 +86,14 @@ describe('participantsStore', () => {
 	let guestNameStore = null
 	let actorStore
 	let tokenStore
+	let participantActivityStore
 
 	beforeEach(() => {
 		setActivePinia(createPinia())
 		guestNameStore = useGuestNameStore()
 		actorStore = useActorStore()
 		tokenStore = useTokenStore()
+		participantActivityStore = useParticipantActivityStore()
 
 		testStoreConfig = cloneDeep(participantsStore)
 		store = createStore(testStoreConfig)
@@ -734,41 +737,41 @@ describe('participantsStore', () => {
 
 		describe('raised hand', () => {
 			test('get whether participants raised hands with single session id', () => {
-				store.dispatch('setParticipantHandRaised', {
+				participantActivityStore.setParticipantHandRaised({
 					sessionId: 'session-id-1',
 					raisedHand: { state: true, timestamp: 1 },
 				})
-				store.dispatch('setParticipantHandRaised', {
+				participantActivityStore.setParticipantHandRaised({
 					sessionId: 'session-id-2',
 					raisedHand: { state: true, timestamp: 2 },
 				})
 
-				expect(store.getters.getParticipantRaisedHand(['session-id-1']))
+				expect(participantActivityStore.getParticipantRaisedHand(['session-id-1']))
 					.toStrictEqual({ state: true, timestamp: 1 })
 
-				expect(store.getters.getParticipantRaisedHand(['session-id-2']))
+				expect(participantActivityStore.getParticipantRaisedHand(['session-id-2']))
 					.toStrictEqual({ state: true, timestamp: 2 })
 
-				expect(store.getters.getParticipantRaisedHand(['session-id-another']))
+				expect(participantActivityStore.getParticipantRaisedHand(['session-id-another']))
 					.toStrictEqual({ state: false, timestamp: null })
 			})
 
 			test('get raised hands after lowering', () => {
-				store.dispatch('setParticipantHandRaised', {
+				participantActivityStore.setParticipantHandRaised({
 					sessionId: 'session-id-2',
 					raisedHand: { state: true, timestamp: 1 },
 				})
-				store.dispatch('setParticipantHandRaised', {
+				participantActivityStore.setParticipantHandRaised({
 					sessionId: 'session-id-2',
 					raisedHand: { state: false, timestamp: 3 },
 				})
 
-				expect(store.getters.getParticipantRaisedHand(['session-id-2']))
+				expect(participantActivityStore.getParticipantRaisedHand(['session-id-2']))
 					.toStrictEqual({ state: false, timestamp: null })
 			})
 
 			test('clears raised hands state after leaving call', async () => {
-				store.dispatch('setParticipantHandRaised', {
+				participantActivityStore.setParticipantHandRaised({
 					sessionId: 'session-id-2',
 					raisedHand: { state: true, timestamp: 1 },
 				})
@@ -780,21 +783,21 @@ describe('participantsStore', () => {
 					},
 				})
 
-				expect(store.getters.getParticipantRaisedHand(['session-id-2']))
+				expect(participantActivityStore.getParticipantRaisedHand(['session-id-2']))
 					.toStrictEqual({ state: false, timestamp: null })
 			})
 
 			test('get raised hands with multiple session ids only returns first found', () => {
-				store.dispatch('setParticipantHandRaised', {
+				participantActivityStore.setParticipantHandRaised({
 					sessionId: 'session-id-2',
 					raisedHand: { state: true, timestamp: 1 },
 				})
-				store.dispatch('setParticipantHandRaised', {
+				participantActivityStore.setParticipantHandRaised({
 					sessionId: 'session-id-3',
 					raisedHand: { state: true, timestamp: 1 },
 				})
 
-				expect(store.getters.getParticipantRaisedHand(['session-id-1', 'session-id-2', 'session-id-3']))
+				expect(participantActivityStore.getParticipantRaisedHand(['session-id-1', 'session-id-2', 'session-id-3']))
 					.toStrictEqual({ state: true, timestamp: 1 })
 			})
 		})

--- a/src/stores/__tests__/participantActivity.spec.js
+++ b/src/stores/__tests__/participantActivity.spec.js
@@ -1,0 +1,188 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { createPinia, setActivePinia } from 'pinia'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useActorStore } from '../actor.ts'
+import { useParticipantActivityStore } from '../participantActivity.ts'
+
+describe('participantActivityStore', () => {
+	let participantActivityStore
+	let actorStore
+
+	beforeEach(() => {
+		setActivePinia(createPinia())
+		participantActivityStore = useParticipantActivityStore()
+		actorStore = useActorStore()
+	})
+
+	describe('raised hand', () => {
+		it('returns raised hand state for single session id', () => {
+			participantActivityStore.setParticipantHandRaised({
+				sessionId: 'session-id-1',
+				raisedHand: { state: true, timestamp: 1 },
+			})
+			participantActivityStore.setParticipantHandRaised({
+				sessionId: 'session-id-2',
+				raisedHand: { state: true, timestamp: 2 },
+			})
+
+			expect(participantActivityStore.getParticipantRaisedHand(['session-id-1']))
+				.toStrictEqual({ state: true, timestamp: 1 })
+
+			expect(participantActivityStore.getParticipantRaisedHand(['session-id-2']))
+				.toStrictEqual({ state: true, timestamp: 2 })
+
+			expect(participantActivityStore.getParticipantRaisedHand(['session-id-another']))
+				.toStrictEqual({ state: false, timestamp: null })
+		})
+
+		it('returns false state after hand is lowered', () => {
+			participantActivityStore.setParticipantHandRaised({
+				sessionId: 'session-id-2',
+				raisedHand: { state: true, timestamp: 1 },
+			})
+			participantActivityStore.setParticipantHandRaised({
+				sessionId: 'session-id-2',
+				raisedHand: { state: false, timestamp: 3 },
+			})
+
+			expect(participantActivityStore.getParticipantRaisedHand(['session-id-2']))
+				.toStrictEqual({ state: false, timestamp: null })
+		})
+
+		it('clears all raised hand entries on purgeRaisedHandsState', () => {
+			participantActivityStore.setParticipantHandRaised({
+				sessionId: 'session-id-1',
+				raisedHand: { state: true, timestamp: 1 },
+			})
+			participantActivityStore.setParticipantHandRaised({
+				sessionId: 'session-id-2',
+				raisedHand: { state: true, timestamp: 2 },
+			})
+
+			participantActivityStore.purgeRaisedHandsState()
+
+			expect(participantActivityStore.getParticipantRaisedHand(['session-id-1']))
+				.toStrictEqual({ state: false, timestamp: null })
+			expect(participantActivityStore.getParticipantRaisedHand(['session-id-2']))
+				.toStrictEqual({ state: false, timestamp: null })
+		})
+
+		it('returns first matching session from list of session ids', () => {
+			participantActivityStore.setParticipantHandRaised({
+				sessionId: 'session-id-2',
+				raisedHand: { state: true, timestamp: 1 },
+			})
+			participantActivityStore.setParticipantHandRaised({
+				sessionId: 'session-id-3',
+				raisedHand: { state: true, timestamp: 2 },
+			})
+
+			expect(participantActivityStore.getParticipantRaisedHand(['session-id-1', 'session-id-2', 'session-id-3']))
+				.toStrictEqual({ state: true, timestamp: 1 })
+		})
+
+		it('throws if sessionId is empty', () => {
+			expect(() => participantActivityStore.setParticipantHandRaised({
+				sessionId: '',
+				raisedHand: { state: true, timestamp: 1 },
+			}))
+				.toThrow('Missing or empty sessionId argument in call to setParticipantHandRaised')
+		})
+	})
+
+	describe('speaking', () => {
+		it('creates speaking entry on first setSpeaking call', () => {
+			participantActivityStore.setSpeaking({ attendeeId: 1, isSpeaking: true })
+
+			expect(participantActivityStore.getParticipantSpeakingInformation(1)).toMatchObject({
+				isSpeaking: true,
+				totalCountedTime: 0,
+			})
+		})
+
+		it('returns undefined for unknown attendeeId', () => {
+			expect(participantActivityStore.getParticipantSpeakingInformation(999)).toBeUndefined()
+		})
+
+		it('does not accumulate time on false to false transition', () => {
+			vi.useFakeTimers()
+
+			participantActivityStore.setSpeaking({ attendeeId: 1, isSpeaking: false })
+			vi.advanceTimersByTime(5_000)
+			participantActivityStore.setSpeaking({ attendeeId: 1, isSpeaking: false })
+
+			expect(participantActivityStore.getParticipantSpeakingInformation(1).totalCountedTime).toBe(0)
+		})
+
+		it('accumulates time on interval ticks while speaking', () => {
+			vi.useFakeTimers()
+
+			participantActivityStore.setSpeaking({ attendeeId: 1, isSpeaking: true })
+			expect(participantActivityStore.getParticipantSpeakingInformation(1).totalCountedTime).toBe(0)
+
+			vi.advanceTimersByTime(1_000)
+			expect(participantActivityStore.getParticipantSpeakingInformation(1).totalCountedTime).toBe(1000)
+
+			vi.advanceTimersByTime(1_000)
+			expect(participantActivityStore.getParticipantSpeakingInformation(1).totalCountedTime).toBe(2000)
+		})
+
+		it('accumulates time when participant stops speaking', () => {
+			vi.useFakeTimers()
+
+			participantActivityStore.setSpeaking({ attendeeId: 1, isSpeaking: true })
+			vi.advanceTimersByTime(3_000)
+			participantActivityStore.setSpeaking({ attendeeId: 1, isSpeaking: false })
+
+			expect(participantActivityStore.getParticipantSpeakingInformation(1).totalCountedTime).toBe(3000)
+			expect(participantActivityStore.getParticipantSpeakingInformation(1).isSpeaking).toBe(false)
+		})
+
+		it('stops interval when last participant stops speaking', () => {
+			vi.useFakeTimers()
+
+			participantActivityStore.setSpeaking({ attendeeId: 1, isSpeaking: true })
+			vi.advanceTimersByTime(1_000)
+			participantActivityStore.setSpeaking({ attendeeId: 1, isSpeaking: false })
+
+			const totalAfterStop = participantActivityStore.getParticipantSpeakingInformation(1).totalCountedTime
+
+			vi.advanceTimersByTime(5_000)
+
+			expect(participantActivityStore.getParticipantSpeakingInformation(1).totalCountedTime).toBe(totalAfterStop)
+		})
+
+		it('keeps interval running when one of multiple participants stops speaking', () => {
+			vi.useFakeTimers()
+
+			participantActivityStore.setSpeaking({ attendeeId: 1, isSpeaking: true })
+			participantActivityStore.setSpeaking({ attendeeId: 2, isSpeaking: true })
+
+			vi.advanceTimersByTime(1_000)
+			participantActivityStore.setSpeaking({ attendeeId: 1, isSpeaking: false })
+
+			vi.advanceTimersByTime(1_000)
+
+			expect(participantActivityStore.getParticipantSpeakingInformation(2).totalCountedTime).toBeGreaterThan(1000)
+		})
+
+		it('purges all speaking entries and stops interval', () => {
+			vi.useFakeTimers()
+
+			participantActivityStore.setSpeaking({ attendeeId: 1, isSpeaking: true })
+			participantActivityStore.setSpeaking({ attendeeId: 2, isSpeaking: true })
+			participantActivityStore.purgeSpeakingState()
+
+			expect(participantActivityStore.getParticipantSpeakingInformation(1)).toBeUndefined()
+			expect(participantActivityStore.getParticipantSpeakingInformation(2)).toBeUndefined()
+
+			// Advance time to confirm the interval was stopped and creates no new entries
+			vi.advanceTimersByTime(5_000)
+			expect(participantActivityStore.getParticipantSpeakingInformation(1)).toBeUndefined()
+		})
+	})
+})

--- a/src/stores/__tests__/participantActivity.spec.js
+++ b/src/stores/__tests__/participantActivity.spec.js
@@ -18,6 +18,72 @@ describe('participantActivityStore', () => {
 		actorStore = useActorStore()
 	})
 
+	describe('typing', () => {
+		const TOKEN = 'XXTOKENXX'
+
+		it('adds typing signal for participant', () => {
+			participantActivityStore.setTyping({ token: TOKEN, sessionId: 'session-id-1', isTyping: true })
+
+			expect(participantActivityStore.externalTypingSignals(TOKEN)).toEqual(['session-id-1'])
+		})
+
+		it('removes typing signal when participant stops typing', () => {
+			participantActivityStore.setTyping({ token: TOKEN, sessionId: 'session-id-1', isTyping: true })
+			participantActivityStore.setTyping({ token: TOKEN, sessionId: 'session-id-1', isTyping: false })
+
+			expect(participantActivityStore.externalTypingSignals(TOKEN)).toEqual([])
+		})
+
+		it('excludes current actor session from external typing signals', () => {
+			actorStore.setCurrentParticipant({ sessionId: 'local-session-id', attendeeId: 1 })
+
+			participantActivityStore.setTyping({ token: TOKEN, sessionId: 'local-session-id', isTyping: true })
+			participantActivityStore.setTyping({ token: TOKEN, sessionId: 'remote-session-id', isTyping: true })
+
+			expect(participantActivityStore.externalTypingSignals(TOKEN)).toEqual(['remote-session-id'])
+		})
+
+		it('detects self typing via isSelfActorTyping', () => {
+			actorStore.setCurrentParticipant({ sessionId: 'local-session-id', attendeeId: 1 })
+
+			expect(participantActivityStore.isSelfActorTyping(TOKEN)).toBe(false)
+
+			participantActivityStore.setTyping({ token: TOKEN, sessionId: 'local-session-id', isTyping: true })
+
+			expect(participantActivityStore.isSelfActorTyping(TOKEN)).toBe(true)
+		})
+
+		it('automatically expires typing signal after 15 seconds', () => {
+			vi.useFakeTimers()
+
+			participantActivityStore.setTyping({ token: TOKEN, sessionId: 'session-id-1', isTyping: true })
+			expect(participantActivityStore.externalTypingSignals(TOKEN)).toEqual(['session-id-1'])
+
+			vi.advanceTimersByTime(15_000)
+			expect(participantActivityStore.externalTypingSignals(TOKEN)).toEqual([])
+		})
+
+		it('purges all typing entries and clears timeouts', () => {
+			vi.useFakeTimers()
+
+			participantActivityStore.setTyping({ token: TOKEN, sessionId: 'session-id-1', isTyping: true })
+			participantActivityStore.setTyping({ token: TOKEN, sessionId: 'session-id-2', isTyping: true })
+
+			participantActivityStore.purgeTypingState()
+
+			expect(participantActivityStore.externalTypingSignals(TOKEN)).toEqual([])
+			vi.advanceTimersByTime(15_000)
+			expect(participantActivityStore.externalTypingSignals(TOKEN)).toEqual([])
+		})
+
+		it('does nothing when there is no typing state to purge', () => {
+			expect(() => participantActivityStore.purgeTypingState()).not.toThrow()
+			expect(participantActivityStore.externalTypingSignals(TOKEN)).toEqual([])
+		})
+
+		/* Additional test cases located in src/utils/SignalingTypingHandler.spec.js */
+	})
+
 	describe('raised hand', () => {
 		it('returns raised hand state for single session id', () => {
 			participantActivityStore.setParticipantHandRaised({

--- a/src/stores/participantActivity.ts
+++ b/src/stores/participantActivity.ts
@@ -22,12 +22,18 @@ type SpeakingPayload = {
 	isSpeaking: boolean
 }
 
+type RaisedHandState = {
+	state: boolean
+	timestamp: number | null
+}
+
 /**
  * Store for participant activity used in chat and call (typing, speaking, raised hands)
  */
 export const useParticipantActivityStore = defineStore('participantActivity', () => {
 	const typing = reactive<Record<string, Record<string, TypingState>>>({})
 	const speaking = reactive<Record<string, SpeakingState>>({})
+	const raisedHands = reactive<Record<string, RaisedHandState>>({})
 
 	let speakingInterval: ReturnType<typeof setInterval> | null = null
 
@@ -189,6 +195,48 @@ export const useParticipantActivityStore = defineStore('participantActivity', ()
 		}
 	}
 
+	/**
+	 * Get the raised hand state for the first matching sessionId.
+	 *
+	 * @param sessionIds - list of session IDs to look up
+	 */
+	function getParticipantRaisedHand(sessionIds: string[]): RaisedHandState {
+		for (const sessionId of sessionIds) {
+			if (raisedHands[sessionId]) {
+				// note: only the raised states are stored, so no need to confirm
+				return raisedHands[sessionId]
+			}
+		}
+		return { state: false, timestamp: null }
+	}
+
+	/**
+	 * Set or clear the raised hand state for a participant.
+	 *
+	 * @param payload - the wrapping object.
+	 * @param payload.sessionId - the Nextcloud session ID of the participant.
+	 * @param payload.raisedHand - the raised hand state, or false to lower the hand.
+	 */
+	function setParticipantHandRaised({ sessionId, raisedHand }: { sessionId: string, raisedHand: RaisedHandState | false }) {
+		if (!sessionId) {
+			throw new Error('Missing or empty sessionId argument in call to setParticipantHandRaised')
+		}
+		if (raisedHand && raisedHand.state) {
+			raisedHands[sessionId] = raisedHand
+		} else {
+			delete raisedHands[sessionId]
+		}
+	}
+
+	/**
+	 * Clear all raised hand states (called when leaving a call).
+	 */
+	function purgeRaisedHandsState() {
+		for (const sessionId in raisedHands) {
+			delete raisedHands[sessionId]
+		}
+	}
+
 	return {
 		typing,
 		externalTypingSignals,
@@ -199,5 +247,10 @@ export const useParticipantActivityStore = defineStore('participantActivity', ()
 		getParticipantSpeakingInformation,
 		setSpeaking,
 		purgeSpeakingState,
+
+		raisedHands,
+		getParticipantRaisedHand,
+		setParticipantHandRaised,
+		purgeRaisedHandsState,
 	}
 })

--- a/src/stores/participantActivity.ts
+++ b/src/stores/participantActivity.ts
@@ -12,9 +12,9 @@ type TypingState = {
 }
 
 /**
- * Store for signaling state used in chat and call (typing, speaking, raised hands)
+ * Store for participant activity used in chat and call (typing, speaking, raised hands)
  */
-export const useSignalingStateStore = defineStore('signalingState', () => {
+export const useParticipantActivityStore = defineStore('participantActivity', () => {
 	const typing = reactive<Record<string, Record<string, TypingState>>>({})
 
 	const actorStore = useActorStore()

--- a/src/stores/participantActivity.ts
+++ b/src/stores/participantActivity.ts
@@ -11,11 +11,25 @@ type TypingState = {
 	expirationTimeout: ReturnType<typeof setTimeout>
 }
 
+type SpeakingState = {
+	isSpeaking: boolean
+	lastTimestamp: number
+	totalCountedTime: number
+}
+
+type SpeakingPayload = {
+	attendeeId: number
+	isSpeaking: boolean
+}
+
 /**
  * Store for participant activity used in chat and call (typing, speaking, raised hands)
  */
 export const useParticipantActivityStore = defineStore('participantActivity', () => {
 	const typing = reactive<Record<string, Record<string, TypingState>>>({})
+	const speaking = reactive<Record<string, SpeakingState>>({})
+
+	let speakingInterval: ReturnType<typeof setInterval> | null = null
 
 	const actorStore = useActorStore()
 
@@ -79,9 +93,111 @@ export const useParticipantActivityStore = defineStore('participantActivity', ()
 		}
 	}
 
+	/**
+	 * Gets the speaking information for the participant.
+	 *
+	 * @param attendeeId - attendee's ID for the participant in conversation.
+	 */
+	function getParticipantSpeakingInformation(attendeeId: SpeakingPayload['attendeeId']) {
+		return speaking[attendeeId]
+	}
+
+	/**
+	 * Update speaking information for a participant.
+	 *
+	 * @param data - the wrapping object.
+	 * @param data.attendeeId - the attendee ID of the participant in conversation.
+	 * @param data.isSpeaking - whether the participant is speaking or not
+	 */
+	function updateTimeSpeaking({ attendeeId, isSpeaking }: SpeakingPayload) {
+		if (!speaking[attendeeId]) {
+			return
+		}
+
+		const currentTimestamp = Date.now()
+		const currentSpeakingState = speaking[attendeeId].isSpeaking
+
+		if (!currentSpeakingState && !isSpeaking) {
+			// false -> false, no updates
+			return
+		}
+
+		if (currentSpeakingState) {
+			// true -> false / true -> true, participant is still speaking or finished to speak, update total time
+			speaking[attendeeId].totalCountedTime += (currentTimestamp - speaking[attendeeId].lastTimestamp)
+		}
+
+		// false -> true / true -> false / true -> true, update timestamp of last check / signal
+		speaking[attendeeId].lastTimestamp = currentTimestamp
+	}
+
+	/**
+	 * Sets the speaking status of a participant in a conversation / call.
+	 *
+	 * Note that "updateParticipant" should not be called to add a "speaking"
+	 * property to an existing participant, as the participant would be reset
+	 * when the participants are purged whenever they are fetched again.
+	 * Similarly, "addParticipant" can not be called either to add a participant
+	 * if it was not fetched yet but the call model reported it as being
+	 * speaking, as the attendeeId would be unknown.
+	 *
+	 * @param data - the wrapping object.
+	 * @param data.attendeeId - the attendee ID of the participant in conversation.
+	 * @param data.isSpeaking - whether the participant is speaking or not
+	 */
+	function setSpeaking({ attendeeId, isSpeaking }: SpeakingPayload) {
+		// We should update time before speaking state, to be able to check previous state
+		updateTimeSpeaking({ attendeeId, isSpeaking })
+		// create a dummy object for current call
+		if (!speaking[attendeeId]) {
+			speaking[attendeeId] = { isSpeaking, lastTimestamp: Date.now(), totalCountedTime: 0 }
+		}
+		speaking[attendeeId].isSpeaking = isSpeaking
+
+		if (!speakingInterval && isSpeaking) {
+			speakingInterval = setInterval(updateIntervalTimeSpeaking, 1000)
+		}
+	}
+
+	/**
+	 * Update speaking time for all currently speaking attendees.
+	 */
+	function updateIntervalTimeSpeaking() {
+		if (!speakingInterval) {
+			return
+		}
+
+		for (const attendeeId in speaking) {
+			if (speaking[attendeeId].isSpeaking) {
+				updateTimeSpeaking({ attendeeId: +attendeeId, isSpeaking: true })
+			}
+		}
+	}
+
+	/**
+	 * Purge the speaking information for recent call when local participant leaves call
+	 * (including cases when the call ends for everyone).
+	 */
+	function purgeSpeakingState() {
+		for (const attendeeId in speaking) {
+			delete speaking[attendeeId]
+		}
+
+		if (speakingInterval) {
+			clearInterval(speakingInterval)
+			speakingInterval = null
+		}
+	}
+
 	return {
+		typing,
 		externalTypingSignals,
 		isSelfActorTyping,
 		setTyping,
+
+		speaking,
+		getParticipantSpeakingInformation,
+		setSpeaking,
+		purgeSpeakingState,
 	}
 })

--- a/src/stores/participantActivity.ts
+++ b/src/stores/participantActivity.ts
@@ -4,7 +4,7 @@
  */
 
 import { defineStore } from 'pinia'
-import { reactive } from 'vue'
+import { onScopeDispose, reactive } from 'vue'
 import { useActorStore } from './actor.ts'
 
 type TypingState = {
@@ -38,6 +38,12 @@ export const useParticipantActivityStore = defineStore('participantActivity', ()
 	let speakingInterval: ReturnType<typeof setInterval> | null = null
 
 	const actorStore = useActorStore()
+
+	onScopeDispose(() => {
+		purgeTypingState()
+		purgeSpeakingState()
+		purgeRaisedHandsState()
+	})
 
 	/**
 	 * Get the array of external session ids for a conversation (excluding current user)
@@ -96,6 +102,19 @@ export const useParticipantActivityStore = defineStore('participantActivity', ()
 			typing[token][sessionId] = { expirationTimeout }
 		} else {
 			delete typing[token][sessionId]
+		}
+	}
+
+	/**
+	 * Purge the typing information for all conversations (called when leaving).
+	 */
+	function purgeTypingState() {
+		for (const token in typing) {
+			for (const sessionId in typing[token]) {
+				clearTimeout(typing[token][sessionId].expirationTimeout)
+				delete typing[token][sessionId]
+			}
+			delete typing[token]
 		}
 	}
 
@@ -162,6 +181,13 @@ export const useParticipantActivityStore = defineStore('participantActivity', ()
 
 		if (!speakingInterval && isSpeaking) {
 			speakingInterval = setInterval(updateIntervalTimeSpeaking, 1000)
+		}
+
+		// Stop interval ticks if nobody is speaking
+		if (!isSpeaking && speakingInterval
+			&& Object.values(speaking).every((attendee) => !attendee.isSpeaking)) {
+			clearInterval(speakingInterval)
+			speakingInterval = null
 		}
 	}
 
@@ -242,6 +268,7 @@ export const useParticipantActivityStore = defineStore('participantActivity', ()
 		externalTypingSignals,
 		isSelfActorTyping,
 		setTyping,
+		purgeTypingState,
 
 		speaking,
 		getParticipantSpeakingInformation,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -319,7 +319,7 @@ export interface LocalMediaModel extends SuperEmittedMixin<LocalMediaModel> {
 		virtualBackgroundUrl: string | null
 		localScreen: unknown | null
 		token: string
-		raisedHand: { state: boolean, timestamp: Date }
+		raisedHand: { state: boolean, timestamp: number | null }
 	}
 
 	get(key: string): unknown

--- a/src/utils/SignalingTypingHandler.js
+++ b/src/utils/SignalingTypingHandler.js
@@ -4,8 +4,8 @@
  */
 
 import { useActorStore } from '../stores/actor.ts'
+import { useParticipantActivityStore } from '../stores/participantActivity.ts'
 import pinia from '../stores/pinia.ts'
-import { useSignalingStateStore } from '../stores/signalingState.ts'
 import { useTokenStore } from '../stores/token.ts'
 import SignalingParticipantList from './SignalingParticipantList.js'
 
@@ -19,7 +19,7 @@ import SignalingParticipantList from './SignalingParticipantList.js'
  */
 export default function SignalingTypingHandler() {
 	this._actorStore = useActorStore(pinia)
-	this._signalingStateStore = useSignalingStateStore(pinia)
+	this._participantActivityStore = useParticipantActivityStore(pinia)
 	this._tokenStore = useTokenStore(pinia)
 
 	this._signaling = null
@@ -91,7 +91,7 @@ SignalingTypingHandler.prototype = {
 			})
 		}
 
-		this._signalingStateStore.setTyping({
+		this._participantActivityStore.setTyping({
 			token: this._tokenStore.token,
 			sessionId: this._actorStore.sessionId,
 			isTyping: typing,
@@ -108,7 +108,7 @@ SignalingTypingHandler.prototype = {
 			return
 		}
 
-		this._signalingStateStore.setTyping({
+		this._participantActivityStore.setTyping({
 			token: this._tokenStore.token,
 			sessionId: participant.nextcloudSessionId,
 			isTyping: data.type === 'startedTyping',
@@ -116,7 +116,7 @@ SignalingTypingHandler.prototype = {
 	},
 
 	_handleParticipantsJoined(SignalingParticipantList, participants) {
-		if (!this._signalingStateStore.isSelfActorTyping(this._tokenStore.token)) {
+		if (!this._participantActivityStore.isSelfActorTyping(this._tokenStore.token)) {
 			return
 		}
 
@@ -130,7 +130,7 @@ SignalingTypingHandler.prototype = {
 
 	_handleParticipantsLeft(SignalingParticipantList, participants) {
 		for (const participant of participants) {
-			this._signalingStateStore.setTyping({
+			this._participantActivityStore.setTyping({
 				token: this._tokenStore.token,
 				sessionId: participant.nextcloudSessionId,
 				isTyping: false,

--- a/src/utils/SignalingTypingHandler.spec.js
+++ b/src/utils/SignalingTypingHandler.spec.js
@@ -8,8 +8,8 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import Vuex from 'vuex'
 import storeConfig from '../store/storeConfig.js'
 import { useActorStore } from '../stores/actor.ts'
+import { useParticipantActivityStore } from '../stores/participantActivity.ts'
 import pinia from '../stores/pinia.ts'
-import { useSignalingStateStore } from '../stores/signalingState.ts'
 import { useTokenStore } from '../stores/token.ts'
 import SignalingTypingHandler from './SignalingTypingHandler.js'
 
@@ -24,7 +24,7 @@ vi.mock('vuex', async () => {
 
 describe('SignalingTypingHandler', () => {
 	let actorStore
-	let signalingStateStore
+	let participantActivityStore
 	let tokenStore
 
 	let signaling
@@ -97,7 +97,7 @@ describe('SignalingTypingHandler', () => {
 		})
 		store = new Vuex.Store(testStoreConfig)
 		actorStore = useActorStore()
-		signalingStateStore = useSignalingStateStore()
+		participantActivityStore = useParticipantActivityStore()
 		tokenStore = useTokenStore()
 
 		signaling = new function() {
@@ -150,8 +150,8 @@ describe('SignalingTypingHandler', () => {
 		vi.clearAllMocks()
 		tokenStore.token = ''
 		tokenStore.lastJoinedConversationToken = null
-		// Dispose signalingStateStore so its setup re-runs and captures the new vuex store reference
-		useSignalingStateStore(pinia).$dispose()
+		// Dispose participantActivityStore so its setup re-runs and captures the new vuex store reference
+		useParticipantActivityStore(pinia).$dispose()
 	})
 
 	describe('start typing', () => {
@@ -169,7 +169,7 @@ describe('SignalingTypingHandler', () => {
 
 			signalingTypingHandler.setTyping(true)
 
-			expect(signalingStateStore.externalTypingSignals(TOKEN)).toEqual([])
+			expect(participantActivityStore.externalTypingSignals(TOKEN)).toEqual([])
 			expect(signaling.emit).toHaveBeenCalledTimes(0)
 		})
 
@@ -189,7 +189,7 @@ describe('SignalingTypingHandler', () => {
 
 			signalingTypingHandler.setTyping(true)
 
-			expect(signalingStateStore.externalTypingSignals(TOKEN)).toEqual([])
+			expect(participantActivityStore.externalTypingSignals(TOKEN)).toEqual([])
 			expect(signaling.emit).toHaveBeenCalledTimes(1)
 			expect(signaling.emit).toHaveBeenCalledWith('message', { type: 'startedTyping', to: 'user1SignalingSessionId' })
 		})
@@ -212,7 +212,7 @@ describe('SignalingTypingHandler', () => {
 
 			signalingTypingHandler.setTyping(true)
 
-			expect(signalingStateStore.externalTypingSignals(TOKEN)).toEqual([])
+			expect(participantActivityStore.externalTypingSignals(TOKEN)).toEqual([])
 			expect(signaling.emit).toHaveBeenCalledTimes(2)
 			expect(signaling.emit).toHaveBeenNthCalledWith(1, 'message', { type: 'startedTyping', to: 'user1SignalingSessionId' })
 			expect(signaling.emit).toHaveBeenNthCalledWith(2, 'message', { type: 'startedTyping', to: 'guest1SignalingSessionId' })
@@ -229,7 +229,7 @@ describe('SignalingTypingHandler', () => {
 			signalingTypingHandler.setSignaling(signaling)
 
 			// Typing is not set once finally joined the room.
-			expect(signalingStateStore.externalTypingSignals(TOKEN)).toEqual([])
+			expect(participantActivityStore.externalTypingSignals(TOKEN)).toEqual([])
 			expect(signaling.emit).toHaveBeenCalledTimes(0)
 		})
 
@@ -245,7 +245,7 @@ describe('SignalingTypingHandler', () => {
 			tokenStore.updateLastJoinedConversationToken(TOKEN)
 
 			// Typing is not set once finally joined the room.
-			expect(signalingStateStore.externalTypingSignals(TOKEN)).toEqual([])
+			expect(participantActivityStore.externalTypingSignals(TOKEN)).toEqual([])
 			expect(signaling.emit).toHaveBeenCalledTimes(0)
 		})
 	})
@@ -266,7 +266,7 @@ describe('SignalingTypingHandler', () => {
 			signalingTypingHandler.setTyping(true)
 			signalingTypingHandler.setTyping(false)
 
-			expect(signalingStateStore.externalTypingSignals(TOKEN)).toEqual([])
+			expect(participantActivityStore.externalTypingSignals(TOKEN)).toEqual([])
 			expect(signaling.emit).toHaveBeenCalledTimes(0)
 		})
 
@@ -287,7 +287,7 @@ describe('SignalingTypingHandler', () => {
 			signalingTypingHandler.setTyping(true)
 			signalingTypingHandler.setTyping(false)
 
-			expect(signalingStateStore.externalTypingSignals(TOKEN)).toEqual([])
+			expect(participantActivityStore.externalTypingSignals(TOKEN)).toEqual([])
 			expect(signaling.emit).toHaveBeenCalledTimes(2)
 			expect(signaling.emit).toHaveBeenNthCalledWith(1, 'message', { type: 'startedTyping', to: 'user1SignalingSessionId' })
 			expect(signaling.emit).toHaveBeenNthCalledWith(2, 'message', { type: 'stoppedTyping', to: 'user1SignalingSessionId' })
@@ -312,7 +312,7 @@ describe('SignalingTypingHandler', () => {
 			signalingTypingHandler.setTyping(true)
 			signalingTypingHandler.setTyping(false)
 
-			expect(signalingStateStore.externalTypingSignals(TOKEN)).toEqual([])
+			expect(participantActivityStore.externalTypingSignals(TOKEN)).toEqual([])
 			expect(signaling.emit).toHaveBeenCalledTimes(4)
 			expect(signaling.emit).toHaveBeenNthCalledWith(1, 'message', { type: 'startedTyping', to: 'user1SignalingSessionId' })
 			expect(signaling.emit).toHaveBeenNthCalledWith(2, 'message', { type: 'startedTyping', to: 'guest1SignalingSessionId' })
@@ -332,7 +332,7 @@ describe('SignalingTypingHandler', () => {
 			signalingTypingHandler.setSignaling(signaling)
 
 			// Typing is not set once finally joined the room.
-			expect(signalingStateStore.externalTypingSignals(TOKEN)).toEqual([])
+			expect(participantActivityStore.externalTypingSignals(TOKEN)).toEqual([])
 			expect(signaling.emit).toHaveBeenCalledTimes(0)
 		})
 
@@ -349,7 +349,7 @@ describe('SignalingTypingHandler', () => {
 			tokenStore.updateLastJoinedConversationToken(TOKEN)
 
 			// Typing is not set once finally joined the room.
-			expect(signalingStateStore.externalTypingSignals(TOKEN)).toEqual([])
+			expect(participantActivityStore.externalTypingSignals(TOKEN)).toEqual([])
 			expect(signaling.emit).toHaveBeenCalledTimes(0)
 		})
 	})
@@ -376,7 +376,7 @@ describe('SignalingTypingHandler', () => {
 				from: 'user1SignalingSessionId',
 			}])
 
-			expect(signalingStateStore.externalTypingSignals(TOKEN)).toEqual([
+			expect(participantActivityStore.externalTypingSignals(TOKEN)).toEqual([
 				expectedUser1Participant.sessionIds[0],
 			])
 		})
@@ -404,7 +404,7 @@ describe('SignalingTypingHandler', () => {
 				from: 'user1SignalingSessionId',
 			}])
 
-			expect(signalingStateStore.externalTypingSignals(TOKEN)).toEqual([])
+			expect(participantActivityStore.externalTypingSignals(TOKEN)).toEqual([])
 		})
 	})
 
@@ -434,7 +434,7 @@ describe('SignalingTypingHandler', () => {
 				from: 'user1SignalingSessionId',
 			}])
 
-			expect(signalingStateStore.externalTypingSignals(TOKEN)).toEqual([])
+			expect(participantActivityStore.externalTypingSignals(TOKEN)).toEqual([])
 		})
 
 		test('in another room', () => {
@@ -464,7 +464,7 @@ describe('SignalingTypingHandler', () => {
 				from: 'user1SignalingSessionId',
 			}])
 
-			expect(signalingStateStore.externalTypingSignals(TOKEN)).toEqual([])
+			expect(participantActivityStore.externalTypingSignals(TOKEN)).toEqual([])
 		})
 	})
 
@@ -488,7 +488,7 @@ describe('SignalingTypingHandler', () => {
 			localParticipantInSignalingParticipantList,
 		]])
 
-		expect(signalingStateStore.externalTypingSignals(TOKEN)).toEqual([])
+		expect(participantActivityStore.externalTypingSignals(TOKEN)).toEqual([])
 		expect(signaling.emit).toHaveBeenCalledTimes(1)
 		expect(signaling.emit).toHaveBeenCalledWith('message', { type: 'startedTyping', to: 'user1SignalingSessionId' })
 	})
@@ -515,7 +515,7 @@ describe('SignalingTypingHandler', () => {
 			user1ParticipantInSignalingParticipantList,
 		]])
 
-		expect(signalingStateStore.externalTypingSignals(TOKEN)).toEqual([])
+		expect(participantActivityStore.externalTypingSignals(TOKEN)).toEqual([])
 		expect(signaling.emit).toHaveBeenCalledTimes(2)
 		expect(signaling.emit).toHaveBeenNthCalledWith(1, 'message', { type: 'startedTyping', to: 'guest1SignalingSessionId' })
 		expect(signaling.emit).toHaveBeenNthCalledWith(2, 'message', { type: 'startedTyping', to: 'user1SignalingSessionId' })
@@ -544,7 +544,7 @@ describe('SignalingTypingHandler', () => {
 			user1ParticipantInSignalingParticipantList,
 		]])
 
-		expect(signalingStateStore.externalTypingSignals(TOKEN)).toEqual([])
+		expect(participantActivityStore.externalTypingSignals(TOKEN)).toEqual([])
 		expect(signaling.emit).toHaveBeenCalledTimes(2)
 		expect(signaling.emit).toHaveBeenNthCalledWith(1, 'message', { type: 'startedTyping', to: 'guest1SignalingSessionId' })
 		expect(signaling.emit).toHaveBeenNthCalledWith(2, 'message', { type: 'stoppedTyping', to: 'guest1SignalingSessionId' })
@@ -582,7 +582,7 @@ describe('SignalingTypingHandler', () => {
 			guest1ParticipantInSignalingParticipantList,
 		]])
 
-		expect(signalingStateStore.externalTypingSignals(TOKEN)).toEqual([
+		expect(participantActivityStore.externalTypingSignals(TOKEN)).toEqual([
 			expectedGuest2Participant.sessionIds[0],
 		])
 	})
@@ -623,7 +623,7 @@ describe('SignalingTypingHandler', () => {
 			guest1ParticipantInSignalingParticipantList,
 		]])
 
-		expect(signalingStateStore.externalTypingSignals(TOKEN)).toEqual([
+		expect(participantActivityStore.externalTypingSignals(TOKEN)).toEqual([
 			expectedGuest2Participant.sessionIds[0],
 		])
 	})
@@ -647,7 +647,7 @@ describe('SignalingTypingHandler', () => {
 
 			signalingTypingHandler.setTyping(true)
 
-			expect(signalingStateStore.externalTypingSignals(TOKEN)).toEqual([])
+			expect(participantActivityStore.externalTypingSignals(TOKEN)).toEqual([])
 			expect(signaling.emit).toHaveBeenCalledTimes(0)
 		})
 
@@ -674,7 +674,7 @@ describe('SignalingTypingHandler', () => {
 				from: 'user1SignalingSessionId',
 			}])
 
-			expect(signalingStateStore.externalTypingSignals(TOKEN)).toEqual([])
+			expect(participantActivityStore.externalTypingSignals(TOKEN)).toEqual([])
 		})
 	})
 })

--- a/src/utils/webrtc/SpeakingStatusHandler.js
+++ b/src/utils/webrtc/SpeakingStatusHandler.js
@@ -12,12 +12,14 @@
  */
 
 import { useActorStore } from '../../stores/actor.ts'
+import { useParticipantActivityStore } from '../../stores/participantActivity.ts'
 import pinia from '../../stores/pinia.ts'
 import { useTokenStore } from '../../stores/token.ts'
 export default class SpeakingStatusHandler {
 	// Constants, properties
 	#store
 	#actorStore
+	#participantActivityStore
 	#tokenStore
 	#localMediaModel
 	#localCallParticipantModel
@@ -33,6 +35,7 @@ export default class SpeakingStatusHandler {
 	constructor(store, localMediaModel, localCallParticipantModel, callParticipantCollection) {
 		this.#store = store
 		this.#actorStore = useActorStore(pinia)
+		this.#participantActivityStore = useParticipantActivityStore(pinia)
 		this.#tokenStore = useTokenStore(pinia)
 		this.#localMediaModel = localMediaModel
 		this.#localCallParticipantModel = localCallParticipantModel
@@ -70,7 +73,7 @@ export default class SpeakingStatusHandler {
 			callParticipantModel.off('change:stoppedSpeaking', this.#handleSpeakingBound)
 		})
 
-		this.#store.dispatch('purgeSpeakingStore')
+		this.#participantActivityStore.purgeSpeakingState()
 	}
 
 	/**
@@ -99,12 +102,12 @@ export default class SpeakingStatusHandler {
 	 * Dispatch speaking status of local participant to the store
 	 *
 	 * @param {object} localMediaModel the local media model
-	 * @param {boolean} speaking whether the participant is speaking or not
+	 * @param {boolean} isSpeaking whether the participant is speaking or not
 	 */
-	#handleLocalSpeaking(localMediaModel, speaking) {
-		this.#store.dispatch('setSpeaking', {
+	#handleLocalSpeaking(localMediaModel, isSpeaking) {
+		this.#participantActivityStore.setSpeaking({
 			attendeeId: this.#actorStore.attendeeId,
-			speaking,
+			isSpeaking,
 		})
 	}
 
@@ -113,9 +116,9 @@ export default class SpeakingStatusHandler {
 	 * changes.
 	 */
 	#handleLocalPeerId() {
-		this.#store.dispatch('setSpeaking', {
+		this.#participantActivityStore.setSpeaking({
 			attendeeId: this.#actorStore.attendeeId,
-			speaking: this.#localMediaModel.attributes.speaking,
+			isSpeaking: this.#localMediaModel.attributes.speaking,
 		})
 	}
 
@@ -123,9 +126,9 @@ export default class SpeakingStatusHandler {
 	 * Dispatch speaking status of participant to the store
 	 *
 	 * @param {object} callParticipantModel the participant model
-	 * @param {boolean} speaking whether the participant is speaking or not
+	 * @param {boolean} isSpeaking whether the participant is speaking or not
 	 */
-	#handleSpeaking(callParticipantModel, speaking) {
+	#handleSpeaking(callParticipantModel, isSpeaking) {
 		const attendeeId = this.#store.getters.findParticipant(
 			this.#tokenStore.token,
 			{ sessionId: callParticipantModel.attributes.nextcloudSessionId },
@@ -135,9 +138,9 @@ export default class SpeakingStatusHandler {
 			return
 		}
 
-		this.#store.dispatch('setSpeaking', {
+		this.#participantActivityStore.setSpeaking({
 			attendeeId,
-			speaking,
+			isSpeaking,
 		})
 	}
 }

--- a/src/utils/webrtc/SpeakingStatusHandler.js
+++ b/src/utils/webrtc/SpeakingStatusHandler.js
@@ -129,6 +129,7 @@ export default class SpeakingStatusHandler {
 	 * @param {boolean} isSpeaking whether the participant is speaking or not
 	 */
 	#handleSpeaking(callParticipantModel, isSpeaking) {
+		// TODO consider using sessionStore.getSession(sessionId) to look up attendeeId
 		const attendeeId = this.#store.getters.findParticipant(
 			this.#tokenStore.token,
 			{ sessionId: callParticipantModel.attributes.nextcloudSessionId },


### PR DESCRIPTION
## ☑️ Resolves

* Follow-up to  #18297
* Extract additional state from participantsStore:
	* speaking (signaling only + interval to update)
	* raised hand (signaling only)
* Add tests for migrated code

### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

## 🖌️ UI Checklist

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required