### PR TITLE
chore(build): add approve-scripts for trusted packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,5 +114,9 @@
   "engines": {
     "node": "^24.0.0",
     "npm": "^11.3.0"
+  },
+  "allowScripts": {
+    "@parcel/watcher@2.5.1": true,
+    "core-js@3.37.0": true
   }
 }


### PR DESCRIPTION
## ☑️ Resolves

Inspired by https://github.com/nextcloud/talk-desktop/pull/1806
- Covers following packages that give warnings:
  - @parcel/watcher (~22M weekly downloads)
  - core-js (~49M weekly downloads)
- `npm install --allow-git=none` and adding `.npmrc` with same flag yields no errors, so nothing to prepare before npm@12

### AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI