### PR TITLE
fix: recompute virtual list after changing compact state

### DIFF
--- a/src/components/LeftSidebar/ConversationsList/ConversationsListVirtual.vue
+++ b/src/components/LeftSidebar/ConversationsList/ConversationsListVirtual.vue
@@ -8,7 +8,7 @@ import type { Conversation, ConversationTag } from '../../../types/index.ts'
 import type { TagHeaderItem } from './ConversationTagHeader.vue'
 
 import { useVirtualList } from '@vueuse/core'
-import { computed } from 'vue'
+import { computed, watch } from 'vue'
 import LoadingPlaceholder from '../../UIShared/LoadingPlaceholder.vue'
 import ConversationItem from './ConversationItem.vue'
 import ConversationTagHeader from './ConversationTagHeader.vue'
@@ -204,6 +204,9 @@ const { list, containerProps, wrapperProps } = useVirtualList<VirtualListItem>(l
 	itemHeight: getItemHeight,
 	overscan: 10,
 })
+
+// FIXME upstream: useVirtualList does not watch for totalHeight or itemHeight changes
+watch(itemHeight, () => containerProps.onScroll())
 
 /**
  * Get the index of the first fully visible virtual-list item in the viewport.


### PR DESCRIPTION
## ☑️ Resolves

* Fix #16586
	* Upstream issue: useVirtualList doesn't watch for totalHeight change (which we do)

### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
Screenshot before | Screenshot after
<img width="192" height="339" alt="2026-07-10_11h01_09" src="https://github.com/user-attachments/assets/4e2d1e14-93d9-40b2-988b-ff7e05773eb9" /> | <img width="190" height="339" alt="image" src="https://github.com/user-attachments/assets/d9a6ab58-b4df-4974-8f87-c01acedd1ffd" />


### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required