### PR TITLE
fix(chat): update conversation state from call system messages

### DIFF
--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -604,8 +604,8 @@ const actions = {
 			MESSAGE.SYSTEM_TYPE.CALL_ENDED_EVERYONE,
 		].includes(message.systemMessage)) {
 			// Overwrite the conversation.hasCall property so people can join
-			// after seeing the message in the chat.
-			if (conversation?.lastMessage && message.id > conversation.lastMessage.id) {
+			// after seeing the message in the chat. Only for new/live messages.
+			if (fromRealtime) {
 				context.dispatch('overwriteHasCallByChat', {
 					token,
 					hasCall: message.systemMessage === MESSAGE.SYSTEM_TYPE.CALL_STARTED,


### PR DESCRIPTION
## ☑️ Resolves

* Fix #18613
	* code to update lastMessage was moved around in 8c9e7dbef2 and introduced a regression for given check
	* fromRealTime is more correct guard here

### AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
Check skipped, hasCall not updated | Check is truthy, hasCall updated, button rendered

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required