### PR TITLE
feat: render AudioPlayer for all supported audio files

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/AudioPlayer.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/AudioPlayer.vue
@@ -4,14 +4,19 @@
 -->
 
 <template>
-	<audio
-		ref="audioPlayer"
-		class="audio-player"
-		controls
-		:src="fileURL"
-		@ended="handleEnded">
-		{{ t('spreed', 'Your browser does not support playing audio files') }}
-	</audio>
+	<div class="audio-player">
+		<audio
+			ref="audioPlayer"
+			class="audio-player__audio"
+			controls
+			:src="fileURL"
+			@ended="handleEnded">
+			{{ t('spreed', 'Your browser does not support playing audio files') }}
+		</audio>
+		<span v-if="showFileName" class="audio-player__name" :title="name">
+			{{ name }}
+		</span>
+	</div>
 </template>
 
 <script>
@@ -66,6 +71,11 @@ export default {
 		nextMessageId: {
 			type: Number,
 			default: 0,
+		},
+
+		showFileName: {
+			type: Boolean,
+			default: false,
 		},
 	},
 
@@ -137,5 +147,18 @@ export default {
 
 .audio-player {
 	margin: 12px 0;
+
+	&__name {
+		display: block;
+		max-width: 100%;
+		overflow: hidden;
+		white-space: nowrap;
+		text-overflow: ellipsis;
+		font-weight: bold;
+	}
+
+	&__audio {
+		display: block;
+	}
 }
 </style>

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
@@ -247,6 +247,7 @@ export default {
 					localUrl: this.fallbackLocalUrl,
 					messageId: Number(this.messageId),
 					nextMessageId: Number(this.nextMessageId),
+					showFileName: this.shouldShowFileDetail && !this.isVoiceMessage,
 				}
 			}
 			return {

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
@@ -89,6 +89,7 @@ import { getTalkConfig } from '../../../../../services/CapabilitiesManager.ts'
 import { useActorStore } from '../../../../../stores/actor.ts'
 import { useSharedItemsStore } from '../../../../../stores/sharedItems.ts'
 import { useUploadStore } from '../../../../../stores/upload.ts'
+import { canPlayAudio } from '../../../../../utils/sounds.js'
 
 const PREVIEW_TYPE = {
 	TEMPORARY: 0,
@@ -227,7 +228,7 @@ export default {
 
 		// This is used to decide which outer element type to use
 		filePreviewElement() {
-			if (this.isVoiceMessage && !this.isSharedItems) {
+			if (this.isAudioPlayer) {
 				return AudioPlayer
 			} else if (this.isUploadEditor || this.isTemporaryUpload) {
 				return 'div'
@@ -238,7 +239,7 @@ export default {
 		filePreviewBinding() {
 			if (this.isUploadEditor || this.isTemporaryUpload) {
 				return
-			} else if (this.isVoiceMessage && !this.isSharedItems) {
+			} else if (this.isAudioPlayer) {
 				return {
 					name: this.file.name,
 					path: this.file.path,
@@ -392,6 +393,26 @@ export default {
 
 		isVoiceMessage() {
 			return this.itemType === SHARED_ITEM.TYPES.VOICE
+		},
+
+		isPlayableAudio() {
+			return this.itemType === SHARED_ITEM.TYPES.AUDIO
+				&& canPlayAudio(this.file.mimetype)
+		},
+
+		isAudioPlayer() {
+			if (this.isSharedItems) {
+				return false
+			}
+			if (this.isVoiceMessage) {
+				// Voise messages are rendered in Upload editor
+				return true
+			}
+			if (this.isUploadEditor) {
+				return false
+			}
+
+			return this.isPlayableAudio
 		},
 
 		isPlayable() {

--- a/src/utils/sounds.js
+++ b/src/utils/sounds.js
@@ -12,6 +12,22 @@ import { useTokenStore } from '../stores/token.ts'
 const soundsStore = useSoundsStore(pinia)
 const tokenStore = useTokenStore(pinia)
 
+const audioProbe = document.createElement('audio')
+const canPlayAudioCache = new Map()
+
+/**
+ * Checks whether the browser can natively play the given audio mimetype.
+ *
+ * @param {string} mimetype the audio mimetype to check, e.g. 'audio/mpeg'
+ * @return {boolean} true if the mimetype is playable
+ */
+export function canPlayAudio(mimetype) {
+	if (!canPlayAudioCache.has(mimetype)) {
+		canPlayAudioCache.set(mimetype, !!audioProbe.canPlayType(mimetype))
+	}
+	return canPlayAudioCache.get(mimetype)
+}
+
 /**
  * Checks if the current conversation is a voice room.
  */


### PR DESCRIPTION
## ☑️ Resolves

- before was limited to voice messages
- auto play feature inherited and still works
- file name is rendered for audio-files
- add reusable util to cache supported mimetypes

### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="215" height="189" alt="2026-07-13_11h22_50" src="https://github.com/user-attachments/assets/d93dcac8-8d36-4ed2-9f93-2b6854af4db5" /> | <img width="208" height="153" alt="2026-07-13_11h21_40" src="https://github.com/user-attachments/assets/df12d943-4244-4c32-87ca-72856b4d0f89" />


### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required