### PR TITLE
fix: release media devices when lifting lobby

### DIFF
--- a/src/components/MediaSettings/MediaSettings.vue
+++ b/src/components/MediaSettings/MediaSettings.vue
@@ -657,11 +657,8 @@ export default {
 				} else {
 					this.clearVirtualBackground()
 				}
-			} else {
-				// Disable virtual background when closing
-				this.clearVirtualBackground()
-				this.unsubscribeFromDevices(PARTICIPANT.PERMISSIONS.MAX_DEFAULT)
 			}
+			// Teardown should be handled in close() to cover both NcDialog and div use-cases
 		},
 
 		audioInputId(audioInputId) {
@@ -753,6 +750,11 @@ export default {
 		},
 
 		close() {
+			if (this.show) {
+				// Disable virtual background and release devices when closing
+				this.clearVirtualBackground()
+				this.unsubscribeFromDevices(PARTICIPANT.PERMISSIONS.MAX_DEFAULT)
+			}
 			this.show = false
 			this.updatedBackground = undefined
 			this.audioDeviceStateChanged = false

--- a/src/composables/useDevices.js
+++ b/src/composables/useDevices.js
@@ -5,7 +5,7 @@
 
 import { createSharedComposable } from '@vueuse/core'
 import createHark from 'hark'
-import { computed, onBeforeUnmount, ref, watch } from 'vue'
+import { computed, onScopeDispose, ref, watch } from 'vue'
 import { PARTICIPANT } from '../constants.ts'
 import { useSoundsStore } from '../stores/sounds.js'
 import attachMediaStream from '../utils/attachmediastream.js'
@@ -131,9 +131,9 @@ export const useDevices = createSharedComposable(function() {
 	})
 
 	/**
-	 * Called for shared composable when all subscribers are unmounted (onScopeDispose)
+	 * Called for shared composable when all subscribers are unmounted
 	 */
-	onBeforeUnmount(() => {
+	onScopeDispose(() => {
 		stopDevices()
 	})
 


### PR DESCRIPTION
## ☑️ Resolves

- `useDevices` is a shared composable
	- should use `onScopeDispose` (was `onBeforeUnmount`)
- handle equally for any `isDialog` flag
	- when false (lobby screen), unsubscribe wasn't called
	- media was not transmitted anywhere, just device was occupied

### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

Should be visible with Chromium browser:

🏚️ Before | 🏡 After
-- | --
Camera LED lit | Camera LED off


### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [x] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required