### PR TITLE
fix(call): return proper permission errors when starting a call is not allowed

### DIFF
--- a/docs/call.md
+++ b/docs/call.md
@@ -53,6 +53,7 @@
         + `200 OK`
         + `400 Bad Request` When recording consent is required but was not given
         + `403 Forbidden` When the conversation is read-only
+        + `403 Forbidden` When the user is not allowed to start a call and no call is currently active
         + `403 Forbidden` When the conversation is a federated conversation and the host server did not allow joining the call
         + `404 Not Found` When the conversation could not be found for the participant
         + `404 Not Found` When the user did not join the conversation before

--- a/docs/call.md
+++ b/docs/call.md
@@ -53,6 +53,7 @@
         + `200 OK`
         + `400 Bad Request` When recording consent is required but was not given
         + `403 Forbidden` When the conversation is read-only
+        + `403 Forbidden` When the conversation is a federated conversation and the host server did not allow joining the call
         + `404 Not Found` When the conversation could not be found for the participant
         + `404 Not Found` When the user did not join the conversation before
         + `412 Precondition Failed` When the lobby is active and the user is not a moderator

--- a/lib/Controller/CallController.php
+++ b/lib/Controller/CallController.php
@@ -228,10 +228,11 @@ class CallController extends AEnvironmentAwareOCSController {
 	 *                               or the capability is {@see RecordingService::CONSENT_REQUIRED_OPTIONAL}
 	 *                               and the conversation `recordingConsent` value is {@see RecordingService::CONSENT_REQUIRED_YES} )
 	 * @param list<string> $silentFor Send no call notification for previous participants
-	 * @return DataResponse<Http::STATUS_OK|Http::STATUS_NOT_FOUND, null, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>
+	 * @return DataResponse<Http::STATUS_OK|Http::STATUS_FORBIDDEN|Http::STATUS_NOT_FOUND, null, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>
 	 *
 	 * 200: Call joined successfully
 	 * 400: No recording consent was given
+	 * 403: Host server of the federated conversation does not allow joining the call
 	 * 404: Call not found
 	 */
 	#[FederationSupported]

--- a/lib/Controller/SignalingController.php
+++ b/lib/Controller/SignalingController.php
@@ -937,8 +937,18 @@ class SignalingController extends OCSController {
 			if ($participant->getSession() instanceof Session) {
 				if ($inCall !== null) {
 					$lastJoinedCall = $this->timeFactory->getDateTime();
-					$this->participantService->changeInCall($room, $participant, $inCall, lastJoinedCall: $lastJoinedCall->getTimestamp());
-					$this->roomService->setActiveSince($room, $participant, $lastJoinedCall, callFlag: $inCall, silent: false);
+					try {
+						$this->participantService->changeInCall($room, $participant, $inCall, lastJoinedCall: $lastJoinedCall->getTimestamp());
+						$this->roomService->setActiveSince($room, $participant, $lastJoinedCall, callFlag: $inCall, silent: false);
+					} catch (ForbiddenException) {
+						return new DataResponse([
+							'type' => 'error',
+							'error' => [
+								'code' => 'start_call_not_allowed',
+								'message' => 'The participant is not allowed to start a call.',
+							],
+						]);
+					}
 				}
 				$this->sessionService->updateLastPing($participant->getSession(), $this->timeFactory->getTime());
 			}

--- a/lib/Federation/Proxy/TalkV1/Controller/CallController.php
+++ b/lib/Federation/Proxy/TalkV1/Controller/CallController.php
@@ -73,11 +73,12 @@ class CallController {
 	 * @psalm-param int-mask-of<Participant::FLAG_*> $flags
 	 * @param bool $silent Join the call silently
 	 * @param bool $recordingConsent Agreement to be recorded
-	 * @return DataResponse<Http::STATUS_OK|Http::STATUS_NOT_FOUND, null, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>
+	 * @return DataResponse<Http::STATUS_OK|Http::STATUS_FORBIDDEN|Http::STATUS_NOT_FOUND, null, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>
 	 * @throws CannotReachRemoteException
 	 *
 	 * 200: Federated user is now in the call
 	 * 400: Conditions to join not met
+	 * 403: Host server does not allow the user to join the call
 	 * 404: Room not found
 	 */
 	public function joinFederatedCall(Room $room, Participant $participant, int $flags, bool $silent, bool $recordingConsent): DataResponse {
@@ -96,7 +97,7 @@ class CallController {
 		);
 
 		$statusCode = $proxy->getStatusCode();
-		if (!in_array($statusCode, [Http::STATUS_OK, Http::STATUS_BAD_REQUEST, Http::STATUS_NOT_FOUND], true)) {
+		if (!in_array($statusCode, [Http::STATUS_OK, Http::STATUS_BAD_REQUEST, Http::STATUS_FORBIDDEN, Http::STATUS_NOT_FOUND], true)) {
 			$this->proxy->logUnexpectedStatusCode(__METHOD__, $proxy->getStatusCode());
 			throw new CannotReachRemoteException();
 		}

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -5992,6 +5992,36 @@
                             }
                         }
                     },
+                    "403": {
+                        "description": "Host server of the federated conversation does not allow joining the call",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "nullable": true
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
                     "404": {
                         "description": "Call not found",
                         "content": {

--- a/openapi.json
+++ b/openapi.json
@@ -5880,6 +5880,36 @@
                             }
                         }
                     },
+                    "403": {
+                        "description": "Host server of the federated conversation does not allow joining the call",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "nullable": true
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
                     "404": {
                         "description": "Call not found",
                         "content": {

--- a/src/types/openapi/openapi-full.ts
+++ b/src/types/openapi/openapi-full.ts
@@ -5341,6 +5341,20 @@ export interface operations {
                     };
                 };
             };
+            /** @description Host server of the federated conversation does not allow joining the call */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: unknown;
+                        };
+                    };
+                };
+            };
             /** @description Call not found */
             404: {
                 headers: {

--- a/src/types/openapi/openapi.ts
+++ b/src/types/openapi/openapi.ts
@@ -4746,6 +4746,20 @@ export interface operations {
                     };
                 };
             };
+            /** @description Host server of the federated conversation does not allow joining the call */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: unknown;
+                        };
+                    };
+                };
+            };
             /** @description Call not found */
             404: {
                 headers: {

--- a/tests/integration/features/federation/call.feature
+++ b/tests/integration/features/federation/call.feature
@@ -62,6 +62,44 @@ Feature: federation/call
       | users           | participant2              | 7      |
     And user "participant2" sees 2 peers in call "LOCAL::room" with 200 (v4)
 
+  Scenario: Federated user can not start a call when the host only allows moderators to start calls
+    Given the following "spreed" app config is set
+      | start_calls | 2 |
+    And user "participant1" creates room "room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    And user "participant1" adds federated_user "participant2" to room "room" with 200 (v4)
+    And using server "REMOTE"
+    And user "participant2" has the following invitations (v1)
+      | remoteServerUrl | remoteToken | state | inviterCloudId     | inviterDisplayName       |
+      | LOCAL           | room        | 0     | participant1@LOCAL | participant1-displayname |
+    And user "participant2" accepts invite to room "room" of server "LOCAL" with 200 (v1)
+      | id          | name | type | remoteServer | remoteToken |
+      | LOCAL::room | room | 2    | LOCAL        | room        |
+    And user "participant2" joins room "LOCAL::room" with 200 (v4)
+    # The federated user is not a moderator on the host, so they are not allowed to start the call there
+    When user "participant2" joins call "LOCAL::room" with 403 (v4)
+      | flags | 7 |
+    Then user "participant2" is participant of room "LOCAL::room" (v4)
+      | callFlag |
+      | 0        |
+    # A moderator of the host starts the call
+    And using server "LOCAL"
+    And user "participant1" joins room "room" with 200 (v4)
+    And user "participant1" joins call "room" with 200 (v4)
+      | flags | 3 |
+    # Now the federated user is allowed to join the already running call
+    And using server "REMOTE"
+    And user "participant2" joins call "LOCAL::room" with 200 (v4)
+      | flags | 7 |
+    And user "participant2" is participant of room "LOCAL::room" (v4)
+      | callFlag |
+      | 7        |
+    And user "participant2" sees the following attendees in room "LOCAL::room" with 200 (v4)
+      | actorType       | actorId                   | inCall |
+      | federated_users | participant1@{$LOCAL_URL} | 3      |
+      | users           | participant2              | 7      |
+
   Scenario: update call flags
     Given user "participant1" creates room "room" (v4)
       | roomType | 2 |


### PR DESCRIPTION
## ☑️ Resolves

* Extracted from #18647 as discussed with @nickvergessen - the two error-handling fixes, separated from the feature so they can be tested individually and backported.

Both issues can occur when the host restricts who may start calls, for example when start_calls is set to “Moderators only”:

- Federation: The participant’s server determines the call button state using its own start_calls setting. It does not know the host’s setting. If the host is more restrictive, the federated participant still sees an active “Start call” button. The host then returns the correct 403, but the proxying server wraps it in a CannotReachRemoteException. The user sees what looks like a connection error instead of a permission error.
- Signaling/HPB: If the backend join path tries to mark the first participant as in-call when that participant is not allowed to start the call, Talk throws a ForbiddenException. The exception currently escapes instead of being returned as a structured backend error. SIP dial-in is one way to reach this path.


### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

---

<!--
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
░░░███████░░░█████████░░█████░
░░███░░░███░░░███░░░███░░███░░
░░█████████░░░████████░░░███░░
░░███░░░███░░░███░░░░░░░░███░░
░█████░█████░█████░░░░░░█████░
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching frontend/UI code
-->

## 🛠️ API Checklist

### 🚧 Tasks

### How to test

**Federation fix:**
1. On the host: set "Start calls" to "Moderators only" (Talk admin settings)
2. Invite a federated user (non-moderator) to a conversation, no active call
3. Federated user clicks "Start call"
- Before: generic connection/reach error (`CannotReachRemoteException`)
- After: proper 403 / permission feedback

**Signaling fix:**
1. Same restriction; trigger a call start via the signaling backend for a
   participant who may not start (e.g. SIP dial-in into a not-yet-started call)
- Before: uncaught `ForbiddenException`, unstructured error at the HPB
- After: structured `start_call_not_allowed` backend error
### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability not needed 

Should be backportable to all supported stable branches; #18647 will be rebased on top once this is merged