### PR TITLE
Less technical icon for filter action menu

### DIFF
--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -29,7 +29,7 @@
 								class="filters"
 								:class="{ 'hidden-visually': isSearching }">
 								<template #icon>
-									<IconFilterCogOutline :size="20" />
+									<IconFilterVariant :size="20" />
 								</template>
 								<NcActionCaption :name="t('spreed', 'Filter conversations by')" />
 
@@ -72,7 +72,7 @@
 									class="filter-actions__clearbutton"
 									@click="handleFilter(null)">
 									<template #icon>
-										<IconFilterRemoveOutline :size="20" />
+										<IconFilterVariantRemove :size="20" />
 									</template>
 									{{ t('spreed', 'Clear filters') }}
 								</NcActionButton>
@@ -304,7 +304,7 @@
 					<template #action>
 						<NcButton v-if="isFiltered" @click="handleFilter(null)">
 							<template #icon>
-								<IconFilterRemoveOutline :size="20" />
+								<IconFilterVariantRemove :size="20" />
 							</template>
 							{{ t('spreed', 'Clear filter') }}
 						</NcButton>
@@ -422,8 +422,8 @@ import IconCalendarBlankOutline from 'vue-material-design-icons/CalendarBlankOut
 import IconChatPlusOutline from 'vue-material-design-icons/ChatPlusOutline.vue'
 import IconClockOutline from 'vue-material-design-icons/ClockOutline.vue'
 import IconCogOutline from 'vue-material-design-icons/CogOutline.vue'
-import IconFilterCogOutline from 'vue-material-design-icons/FilterCogOutline.vue'
-import IconFilterRemoveOutline from 'vue-material-design-icons/FilterRemoveOutline.vue'
+import IconFilterVariant from 'vue-material-design-icons/FilterVariant.vue'
+import IconFilterVariantRemove from 'vue-material-design-icons/FilterVariantRemove.vue'
 import IconFormatListBulleted from 'vue-material-design-icons/FormatListBulleted.vue'
 import IconForumOutline from 'vue-material-design-icons/ForumOutline.vue'
 import IconHomeOutline from 'vue-material-design-icons/HomeOutline.vue'
@@ -545,8 +545,8 @@ export default {
 		IconAt,
 		IconMessageBadgeOutline,
 		IconMessageOutline,
-		IconFilterCogOutline,
-		IconFilterRemoveOutline,
+		IconFilterVariant,
+		IconFilterVariantRemove,
 		IconArchiveOutline,
 		IconArrowLeft,
 		IconCalendarBlankOutline,

--- a/src/components/RightSidebar/SearchMessages/SearchMessagesTab.vue
+++ b/src/components/RightSidebar/SearchMessages/SearchMessagesTab.vue
@@ -27,7 +27,7 @@ import NcEmptyContent from '@nextcloud/vue/components/NcEmptyContent'
 import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
 import NcSelectUsers from '@nextcloud/vue/components/NcSelectUsers'
 import IconCalendarRangeOutline from 'vue-material-design-icons/CalendarRangeOutline.vue'
-import IconFilterOutline from 'vue-material-design-icons/FilterOutline.vue'
+import IconFilterVariant from 'vue-material-design-icons/FilterVariant.vue'
 import IconMessageOutline from 'vue-material-design-icons/MessageOutline.vue'
 import SearchBox from '../../UIShared/SearchBox.vue'
 import TransitionWrapper from '../../UIShared/TransitionWrapper.vue'
@@ -267,7 +267,7 @@ watch([searchText, fromUser, sinceDate, untilDate], debounceFetchSearchResults)
 						:title="t('spreed', 'Search options')"
 						variant="tertiary-no-background">
 						<template #icon>
-							<IconFilterOutline :size="15" />
+							<IconFilterVariant :size="15" />
 						</template>
 					</NcButton>
 				</div>


### PR DESCRIPTION
## ☑️ Resolves

The "filter-cog" icon as icon for the filter/sort/grouping action menu at the top of the navigation looks very technical. Better would be to use the simpler and nicer looking filter-variant icon.

### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="709" height="894" alt="Screenshot From 2026-07-14 14-48-31" src="https://github.com/user-attachments/assets/60f8d2db-9b45-437c-910c-ce48f9c88e09" />|<img width="709" height="894" alt="Screenshot From 2026-07-14 14-47-21" src="https://github.com/user-attachments/assets/9a0c8bae-131a-4bc9-9621-1834937070f4" />




### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [x] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
  - [conversations.rst](https://github.com/nextcloud/documentation/blob/master/user_manual/talk/conversations.rst#filter-your-conversations), or more specifically the images `clear-filter.png` and `filters-menu.png` could be updated but not a blocker as they hadn’t been updated with the previous icon either.

