### PR TITLE
Shorten device menu labels to Microphone, Speaker, Camera

### DIFF
--- a/src/components/CallView/shared/LocalAudioControlButton.vue
+++ b/src/components/CallView/shared/LocalAudioControlButton.vue
@@ -51,7 +51,8 @@
 				<IconChevronUp :size="16" />
 			</template>
 			<template v-if="isAudioAllowed">
-				<NcActionCaption :name="t('spreed', 'Select a microphone')" />
+				<!-- TRANSLATORS: Caption above the list of microphones to select from -->
+				<NcActionCaption :name="t('spreed', 'Microphone')" />
 				<NcActionButton
 					v-for="device in audioInputDevices"
 					:key="device.deviceId ?? 'none'"
@@ -66,7 +67,8 @@
 			</template>
 			<NcActionSeparator v-if="isAudioAllowed && audioOutputSupported" />
 			<template v-if="audioOutputSupported">
-				<NcActionCaption :name="t('spreed', 'Select a speaker')" />
+				<!-- TRANSLATORS: Caption above the list of speakers (audio output devices) to select from -->
+				<NcActionCaption :name="t('spreed', 'Speaker')" />
 				<NcActionButton
 					v-for="device in audioOutputDevices"
 					:key="device.deviceId ?? 'none'"

--- a/src/components/CallView/shared/LocalVideoControlButton.vue
+++ b/src/components/CallView/shared/LocalVideoControlButton.vue
@@ -29,7 +29,8 @@
 			<template #icon>
 				<IconChevronUp :size="16" />
 			</template>
-			<NcActionCaption :name="t('spreed', 'Select a video device')" />
+			<!-- TRANSLATORS: Caption above the list of cameras (video devices) to select from -->
+			<NcActionCaption :name="t('spreed', 'Camera')" />
 			<NcActionButton
 				v-for="device in videoDevices"
 				:key="device.deviceId ?? 'none'"


### PR DESCRIPTION
## ☑️ Resolves

The microphone and camera menus (while in a call) have unneeded extra wording. "Select a microphone" can be shortened to "Microphone", same with "Speaker" and "Video device".
Also, "Video device" could be less technical with "Camera".

Yes, it can be something else than a camera, like some video feed. But with that logic we could also call "Microphone" an "Input device" and "Speaker" an "Output device". But that's all very technical.

"Microphone" and "Camera" is the language that browsers (and humans) use.

### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="522" height="506" alt="Screenshot From 2026-07-14 15-48-13" src="https://github.com/user-attachments/assets/9decc091-136e-43e1-84e8-f926daf4e0c4" />|<img width="522" height="506" alt="Screenshot From 2026-07-14 15-49-31" src="https://github.com/user-attachments/assets/e11f213e-2a73-48bd-942f-32745989b122" />




### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [x] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
