### PR TITLE
fix(tags): show unread conversations and active calls under collapsed section

### DIFF
--- a/src/components/LeftSidebar/ConversationsList/ConversationsListVirtual.vue
+++ b/src/components/LeftSidebar/ConversationsList/ConversationsListVirtual.vue
@@ -14,10 +14,12 @@ import ConversationItem from './ConversationItem.vue'
 import ConversationTagHeader from './ConversationTagHeader.vue'
 import { AVATAR, CONVERSATION } from '../../../constants.ts'
 import { useConversationTagsStore } from '../../../stores/conversationTags.ts'
+import { hasCall, hasUnreadMessages } from '../../../utils/conversation.ts'
 
 export type VirtualListItem = (Conversation | TagHeaderItem) & { _key?: string }
 
 const props = defineProps<{
+	token?: string
 	listAriaLabelledBy?: string
 	conversations: Conversation[]
 	loading?: boolean
@@ -173,7 +175,10 @@ const listItems = computed<VirtualListItem[]>(() => {
 
 		acc.push(header)
 		if (section.tag.collapsed) {
-			return acc
+			// Show currently active conversation and all unread conversations under this tag
+			section.conversations = section.conversations.filter((conversation) => {
+				return conversation.token === props.token || hasUnreadMessages(conversation) || hasCall(conversation)
+			})
 		}
 
 		acc.push(...section.conversations.map((conversation) => ({ ...conversation, _key: `${section.tag.id}:${conversation.token}` })))

--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -333,6 +333,7 @@
 					v-else
 					v-show="sortedConversationsList.length > 0"
 					ref="scroller"
+					:token="token"
 					:listAriaLabelledBy="LIST_HEADING_ID"
 					:conversations="sortedConversationsList"
 					:loading="!conversationsInitialised"


### PR DESCRIPTION
## ☑️ Resolves

* Hardcoded frontend version of #18674
	* In case of future request for toggle, original can be reopened / used as a reference
	* Unread messages, mentions, 1:1 chats and chats with active call are now exposed under collapsed section and won't be missed

### AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="203" height="139" alt="2026-07-15_15h27_56" src="https://github.com/user-attachments/assets/ee148649-4433-4221-a186-7a889cb20ce2" /> | <img width="203" height="195" alt="2026-07-15_15h26_12" src="https://github.com/user-attachments/assets/7788f48d-1ee6-4d25-b41b-579d103d7868" />


### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required