### PR TITLE
fix(conversations): parse first name from complex display names

### DIFF
--- a/src/utils/__tests__/getDisplayName.spec.js
+++ b/src/utils/__tests__/getDisplayName.spec.js
@@ -1,0 +1,70 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import { describe, expect, it } from 'vitest'
+import { getFirstName } from '../getDisplayName.ts'
+
+describe('getDisplayName', () => {
+	describe('getFirstName', () => {
+		const TEST_CASES = [
+			// Natural order
+			['Hermes Conrad', 'Hermes'],
+			['Hermes', 'Hermes'],
+			['  Hermes   Conrad  ', 'Hermes'],
+			['Philip J. Fry', 'Philip'],
+			// Inverted "Lastname, Firstname" order
+			['Conrad, Hermes', 'Hermes'],
+			['Smith, John Jacob', 'John'],
+			['van der Berg, Anna', 'Anna'],
+			['Doe, John (Contracting)', 'John'],
+			// Suffixes and post-nominal credentials
+			['Martin Luther King, Jr.', 'Martin'],
+			['Jane Smith, MD', 'Jane'],
+			['Mary Williams, MD, PhD', 'Mary'],
+			['Anna Schmidt, MSc', 'Anna'],
+			['Tom Baker, CEO', 'Tom'],
+			['King, Martin Luther, Jr.', 'Martin'],
+			// Salutations, also stacked
+			['Dr. Jane Smith', 'Jane'],
+			['Mr. John Doe', 'John'],
+			['Prof. Dr. Hans Müller', 'Hans'],
+			['Herr Hans Müller', 'Hans'],
+			['Frau Anna Schmidt', 'Anna'],
+			['Mme Marie Curie', 'Marie'],
+			['Mlle Jeanne Dupont', 'Jeanne'],
+			['Me Jean Dupont', 'Jean'],
+			['Pr Pierre Bernard', 'Pierre'],
+			// Leading initials ("goes by middle name")
+			['R. Jason Smith', 'Jason'],
+			['R. J. Smith', 'R.'],
+			// Cyrillic and Greek initials
+			['А. С. Пушкин', 'А.'],
+			['Пушкин, Александр Сергеевич', 'Александр'],
+			['Γ. Κώστας Παπαδόπουλος', 'Κώστας'],
+			// CJK names (family name first, single characters are not initials)
+			['李明', '李明'],
+			['山田 太郎', '山田'],
+			['山田　太郎', '山田'],
+			['王 小明', '王'],
+			['李 明', '李'],
+			// Bracketed annotations
+			['John Doe (Contracting)', 'John'],
+			['(Contracting)', '(Contracting)'],
+			['[Bot] Weather', 'Weather'],
+			['{External} John Doe', 'John'],
+			// Degenerate input
+			['Conrad,', 'Conrad'],
+			[', Hermes', 'Hermes'],
+			['', ''],
+			['   ', ''],
+		]
+
+		it.each(TEST_CASES)(
+			'should return "%s" => "%s"',
+			(input, output) => {
+				expect(getFirstName(input)).toBe(output)
+			},
+		)
+	})
+})

--- a/src/utils/getDisplayName.ts
+++ b/src/utils/getDisplayName.ts
@@ -6,6 +6,101 @@ import { getLanguage, t } from '@nextcloud/l10n'
 import { ATTENDEE } from '../constants.ts'
 
 /**
+ * Suffixes and post-nominal credentials that may follow a comma in a display name
+ * (e.g. "Martin Luther King, Jr." or "Mary Williams, RN, BSN").
+ * Based on https://github.com/joshfraser/JavaScript-Name-Parser
+ */
+const SUFFIX_PATTERN = new RegExp('^(?:'
+	+ 'i{1,3}|iv|v|senior|junior|jr|sr' // generational
+	+ '|phd|apr|rph|pe|md|ma|msc|bsc|ba|bs|dmd|cme|bsn|mba' // academic / professional
+	+ '|ceo|cto|cfo|coo' // job titles
+	+ ')$', 'i')
+
+/**
+ * Salutations / honorific prefixes that may precede a given name (e.g. "Dr. Jane Smith")
+ */
+const SALUTATION_PATTERN = /^(?:mr|mrs|ms|miss|master|mister|dr|rev|fr|prof|herr|frau|mme|mlle|me|pr)$/i
+
+/**
+ * Normalizes a word for pattern matching (strips periods and commas, e.g. "Ph.D." => "PhD")
+ *
+ * @param word single word of a name
+ */
+function normalizeWord(word: string): string {
+	return word.replace(/[.,]/g, '')
+}
+
+/**
+ * Checks whether a word is a name suffix or post-nominal credential ("Jr.", "MD")
+ *
+ * @param word single word of a name
+ */
+function isSuffix(word: string): boolean {
+	return SUFFIX_PATTERN.test(normalizeWord(word))
+}
+
+/**
+ * Checks whether a word is a salutation ("Mr.", "Dr.")
+ *
+ * @param word single word of a name
+ */
+function isSalutation(word: string): boolean {
+	return SALUTATION_PATTERN.test(normalizeWord(word))
+}
+
+/**
+ * Checks whether a word is a single-letter initial ("R.", "J", "А.").
+ * Restricted to alphabetic scripts: a single CJK character is a complete name component, not an initial
+ *
+ * @param word single word of a name
+ */
+function isInitial(word: string): boolean {
+	return /^[\p{Script=Latin}\p{Script=Cyrillic}\p{Script=Greek}]$/u.test(normalizeWord(word))
+}
+
+/**
+ * Returns the first (given) name of a display name.
+ *
+ * Handles the inverted enterprise-directory convention ("Lastname, Firstname"),
+ * comma-separated suffixes and credentials ("Martin Luther King, Jr.", "Jane Smith, MD"),
+ * bracketed annotations ("Doe, John (Contracting)", "[Bot] Weather") and salutations ("Prof. Dr. Jane Smith").
+ * Falls back to the trimmed input if nothing better can be extracted.
+ *
+ * @param fullName display name of a user
+ */
+export function getFirstName(fullName: string): string {
+	// Drop bracketed annotations: "Doe, John (Contracting)" => "Doe, John"
+	const cleanedName = fullName.replace(/\([^()]*\)|\[[^[\]]*\]|\{[^{}]*\}/g, ' ').trim()
+
+	// Word lists of comma-separated segments: "King, Martin Luther, Jr." => [['King'], ['Martin', 'Luther'], ['Jr.']]
+	const segments = cleanedName.split(',')
+		.map((segment) => segment.split(/\s+/).filter(Boolean))
+		.filter((words) => words.length)
+
+	// Drop trailing segments consisting only of suffixes: [['King'], ['Martin', 'Luther'], ['Jr.']] => [['King'], ['Martin', 'Luther']]
+	while (segments.length > 1 && segments.at(-1)!.every(isSuffix)) {
+		segments.pop()
+	}
+
+	// A remaining comma indicates inverted "Lastname, Firstname" order: [['King'], ['Martin', 'Luther']] => ['Martin', 'Luther']
+	let givenWords = (segments.length > 1 ? segments[1] : segments[0]) ?? []
+
+	// Skip leading salutations, also stacked ones: ['Prof.', 'Dr.', 'Jane', 'Smith'] => ['Jane', 'Smith']
+	while (givenWords.length > 1 && isSalutation(givenWords[0])) {
+		givenWords = givenWords.slice(1)
+	}
+
+	// "R. Jason Smith" goes by the middle name, but "R. J. Smith" goes by initials
+	const firstName = (givenWords.length > 1 && isInitial(givenWords[0]) && !isInitial(givenWords[1]))
+		? givenWords[1]
+		: givenWords[0]
+
+	return firstName
+		|| cleanedName.split(/\s+/)[0]
+		|| fullName.trim()
+}
+
+/**
  * Returns display name with 'Guest' or 'Deleted user' fallback if not provided
  *
  * @param displayName possible name of participant
@@ -15,7 +110,7 @@ import { ATTENDEE } from '../constants.ts'
 export function getDisplayNameWithFallback(displayName: string, source: string, firstNameOnly: boolean = false): string {
 	if (displayName?.trim()) {
 		return firstNameOnly
-			? displayName.trim().split(' ').shift()!
+			? getFirstName(displayName)
 			: displayName.trim()
 	}
 


### PR DESCRIPTION
## ☑️ Resolves

- Adds better handling of:
	- inverted "Lastname, Firstname";
	- comma-separated suffixes and credentials;
	- parenthesized annotations;
	- salutations and leading initials.


### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="192" height="74" alt="2026-07-16_11h54_16" src="https://github.com/user-attachments/assets/ee894ea2-863d-4c8a-8c0b-350b563c02a6" /> | <img width="189" height="72" alt="image" src="https://github.com/user-attachments/assets/64eb379f-933f-41a6-97a6-e6f42d7f0fa3" />


### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required