### PR TITLE
refactor: split search requests from LeftSidebar

### DIFF
--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -16,7 +16,7 @@
 								ref="searchBox"
 								v-model:value="searchText"
 								v-model:isFocused="isFocused"
-								:listRef="[scroller, searchResults]"
+								:listRef="[scroller, searchResultsPossibleConversations]"
 								@input="debounceFetchSearchResults"
 								@abortSearch="abortSearch" />
 						</div>
@@ -358,7 +358,7 @@
 				:searchText="searchText"
 				:searchResultsLoading="searchResultsLoading"
 				:conversationsList="conversationsList"
-				:searchResults="searchResults"
+				:searchResults="searchResultsPossibleConversations"
 				:searchResultsListedConversations="searchResultsListedConversations"
 				@abortSearch="abortSearch"
 				@createNewConversation="createConversation"
@@ -396,8 +396,6 @@
 </template>
 
 <script>
-import { isCancel } from '@nextcloud/axios'
-import { showError } from '@nextcloud/dialogs'
 import { emit } from '@nextcloud/event-bus'
 import { t } from '@nextcloud/l10n'
 import { useIsMobile } from '@nextcloud/vue/composables/useIsMobile'
@@ -457,9 +455,7 @@ import {
 import {
 	createLegacyConversation,
 	fetchNoteToSelfConversation,
-	searchListedConversations,
 } from '../../services/conversationsService.ts'
-import { autocompleteQuery } from '../../services/coreService.ts'
 import { EventBus } from '../../services/EventBus.ts'
 import { talkBroadcastChannel } from '../../services/talkBroadcastChannel.js'
 import { useActorStore } from '../../stores/actor.ts'
@@ -469,7 +465,6 @@ import { useFederationStore } from '../../stores/federation.ts'
 import { useSettingsStore } from '../../stores/settings.ts'
 import { useTalkHashStore } from '../../stores/talkHash.js'
 import { useTokenStore } from '../../stores/token.ts'
-import CancelableRequest from '../../utils/CancelableRequest.ts'
 import {
 	filterConversation,
 	hasCall,
@@ -478,6 +473,7 @@ import {
 	sortConversationsList,
 } from '../../utils/conversation.ts'
 import { requestTabLeadership } from '../../utils/requestTabLeadership.js'
+import { useSearchConversationsResults } from './SearchConversationsResults/useSearchConversationsResults.ts'
 
 const isFederationEnabled = getTalkConfig('local', 'federation', 'enabled')
 const canModerateSipDialOut = hasTalkFeature('local', 'sip-support-dialout')
@@ -583,6 +579,14 @@ export default {
 
 		const LIST_HEADING_ID = 'left-sidebar-list-heading'
 
+		const {
+			searchResultsPossibleConversations,
+			searchResultsListedConversations,
+			searchResultsLoading,
+			search,
+			abortSearchRequests,
+		} = useSearchConversationsResults()
+
 		return {
 			token: useGetToken(),
 			initializeNavigation,
@@ -613,18 +617,19 @@ export default {
 			chatExtrasStore: useChatExtrasStore(),
 			tokenStore: useTokenStore(),
 			tagsStore,
+
+			searchResultsPossibleConversations,
+			searchResultsListedConversations,
+			searchResultsLoading,
+			search,
+			abortSearchRequests,
 		}
 	},
 
 	data() {
 		return {
 			searchText: '',
-			searchResults: [],
-			searchResultsListedConversations: [],
-			searchResultsLoading: true,
 			canStartConversations: getTalkConfig('local', 'conversations', 'can-create'),
-			cancelSearchPossibleConversations: () => {},
-			cancelSearchListedConversations: () => {},
 			debounceFetchSearchResults: () => {},
 			debounceFetchConversations: () => {},
 			debounceHandleScroll: () => {},
@@ -857,12 +862,6 @@ export default {
 		EventBus.off('open-conversations-list:show', this.showModalListConversations)
 		EventBus.off('call-phone-dialog:show', this.showModalCallPhoneDialog)
 
-		this.cancelSearchPossibleConversations()
-		this.cancelSearchPossibleConversations = null
-
-		this.cancelSearchListedConversations()
-		this.cancelSearchListedConversations = null
-
 		if (this.refreshTimer) {
 			clearInterval(this.refreshTimer)
 			this.refreshTimer = null
@@ -933,56 +932,6 @@ export default {
 			this.$refs.scroller.scrollToItem(this.lastUnreadMentionBelowViewportIndex)
 		},
 
-		async fetchPossibleConversations() {
-			try {
-				// FIXME: move to conversationsStore
-				this.cancelSearchPossibleConversations('canceled')
-				const { request, cancel } = CancelableRequest(autocompleteQuery)
-				this.cancelSearchPossibleConversations = cancel
-
-				const response = await request({
-					searchText: this.searchText,
-					token: 'new',
-					onlyUsers: !this.canStartConversations,
-				})
-
-				const oneToOneMap = this.conversationsList.reduce((acc, result) => {
-					if (result.type === CONVERSATION.TYPE.ONE_TO_ONE) {
-						acc.push(result.name)
-					}
-					return acc
-				}, [this.actorStore.userId])
-
-				this.searchResults = response?.data?.ocs?.data.filter((match) => {
-					return !(match.source === ATTENDEE.ACTOR_TYPE.USERS && oneToOneMap.includes(match.id))
-				}) ?? []
-			} catch (exception) {
-				if (isCancel(exception)) {
-					return
-				}
-				console.error('Error searching for possible conversations', exception)
-				showError(t('spreed', 'An error occurred while performing the search'))
-			}
-		},
-
-		async fetchListedConversations() {
-			try {
-				// FIXME: move to conversationsStore
-				this.cancelSearchListedConversations('canceled')
-				const { request, cancel } = CancelableRequest(searchListedConversations)
-				this.cancelSearchListedConversations = cancel
-
-				const response = await request(this.searchText)
-				this.searchResultsListedConversations = response.data.ocs.data
-			} catch (exception) {
-				if (isCancel(exception)) {
-					return
-				}
-				console.error('Error searching for open conversations', exception)
-				showError(t('spreed', 'An error occurred while performing the search'))
-			}
-		},
-
 		async fetchSearchResults() {
 			if (!this.isSearching) {
 				return
@@ -993,9 +942,7 @@ export default {
 			this.showThreadsList = false
 
 			this.resetNavigation()
-			this.searchResultsLoading = true
-			await Promise.all([this.fetchPossibleConversations(), this.fetchListedConversations()])
-			this.searchResultsLoading = false
+			await this.search(this.searchText)
 			this.initializeNavigation()
 		},
 
@@ -1055,12 +1002,7 @@ export default {
 		abortSearch() {
 			this.searchText = ''
 			this.isFocused = false
-			if (this.cancelSearchPossibleConversations) {
-				this.cancelSearchPossibleConversations()
-			}
-			if (this.cancelSearchListedConversations) {
-				this.cancelSearchListedConversations()
-			}
+			this.abortSearchRequests()
 		},
 
 		showSettings() {

--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -942,8 +942,10 @@ export default {
 			this.showThreadsList = false
 
 			this.resetNavigation()
-			await this.search(this.searchText)
-			this.initializeNavigation()
+			// Re-initialize navigation only for successfull result
+			if (await this.search(this.searchText)) {
+				this.initializeNavigation()
+			}
 		},
 
 		/**

--- a/src/components/LeftSidebar/SearchConversationsResults/useSearchConversationsResults.spec.js
+++ b/src/components/LeftSidebar/SearchConversationsResults/useSearchConversationsResults.spec.js
@@ -1,0 +1,367 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { showError } from '@nextcloud/dialogs'
+import { mount } from '@vue/test-utils'
+import { CanceledError } from 'axios'
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { h } from 'vue'
+import { createStore } from 'vuex'
+import { ATTENDEE, CONVERSATION } from '../../../constants.ts'
+import { searchListedConversations } from '../../../services/conversationsService.ts'
+import { autocompleteQuery } from '../../../services/coreService.ts'
+import { useActorStore } from '../../../stores/actor.ts'
+import { generateOCSResponse } from '../../../test-helpers.js'
+import { useSearchConversationsResults } from './useSearchConversationsResults.ts'
+
+vi.mock('../../../services/conversationsService', () => ({
+	searchListedConversations: vi.fn(),
+}))
+vi.mock('../../../services/coreService', () => ({
+	autocompleteQuery: vi.fn(),
+}))
+
+describe('useSearchConversationsResults', () => {
+	let vuexStore
+	let conversationsList
+	// Pending requests of each service, in the order they were created
+	let listedRequests
+	let possibleRequests
+	// Whether aborting a request rejects it. Set to false to emulate requests
+	// that already left the pending state, so that aborting them has no effect
+	let abortRejectsRequests
+
+	const CURRENT_USER = 'current-user'
+
+	/**
+	 * Create a promise that the test resolves or rejects on demand,
+	 * emulating a request that is still in flight
+	 *
+	 * @param {AbortSignal} [signal] abort signal of the cancelable request
+	 * @return {object} the deferred request
+	 */
+	function createDeferred(signal) {
+		let resolve
+		let reject
+		const promise = new Promise((res, rej) => {
+			resolve = res
+			reject = rej
+		})
+		// Emulate axios rejecting a request once it is aborted
+		if (abortRejectsRequests) {
+			signal?.addEventListener('abort', () => reject(new CanceledError()))
+		}
+
+		return { promise, resolve, reject }
+	}
+
+	/**
+	 * Build an autocomplete result with the given id and source
+	 *
+	 * @param {string} id id of the result
+	 * @param {string} source actor type of the result
+	 * @return {object} the autocomplete result
+	 */
+	function autocompleteResult(id, source) {
+		return {
+			id,
+			source,
+			label: id,
+			icon: '',
+			status: '',
+			subline: '',
+			shareWithDisplayNameUnique: '',
+		}
+	}
+
+	/**
+	 * Mount a host component to provide a lifecycle scope for the composable
+	 *
+	 * @return {object} the composable and the host component wrapper
+	 */
+	function mountComposable() {
+		let composable
+		const wrapper = mount({
+			setup() {
+				composable = useSearchConversationsResults()
+				return () => h('div')
+			},
+		}, {
+			global: {
+				plugins: [vuexStore],
+			},
+		})
+
+		return { composable, wrapper }
+	}
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+		setActivePinia(createPinia())
+		useActorStore().setCurrentUser({ uid: CURRENT_USER, displayName: CURRENT_USER })
+
+		conversationsList = []
+		vuexStore = createStore({
+			getters: {
+				conversationsList: () => conversationsList,
+			},
+		})
+
+		// By default requests stay pending, so that tests settle them in the required order.
+		// Tests that do not depend on the order arrange their responses with 'mock*ValueOnce'
+		listedRequests = []
+		possibleRequests = []
+		abortRejectsRequests = true
+		searchListedConversations.mockImplementation((query, options) => {
+			const request = createDeferred(options?.signal)
+			listedRequests.push(request)
+			return request.promise
+		})
+		autocompleteQuery.mockImplementation((payload, options) => {
+			const request = createDeferred(options?.signal)
+			possibleRequests.push(request)
+			return request.promise
+		})
+	})
+
+	describe('successful search', () => {
+		test('applies the results and stops loading', async () => {
+			// Arrange
+			const listedResponse = generateOCSResponse({ payload: [{ id: 1, token: 'listed' }] })
+			const possibleResponse = generateOCSResponse({ payload: [autocompleteResult('one', ATTENDEE.ACTOR_TYPE.USERS)] })
+			searchListedConversations.mockResolvedValueOnce(listedResponse)
+			autocompleteQuery.mockResolvedValueOnce(possibleResponse)
+			const { composable } = mountComposable()
+
+			// Act: search for conversations
+			const search = composable.search('query')
+
+			// Assert
+			expect(composable.searchResultsLoading.value).toBeTruthy()
+			await expect(search).resolves.toBeTruthy()
+			expect(composable.searchResultsListedConversations.value).toEqual([{ id: 1, token: 'listed' }])
+			expect(composable.searchResultsPossibleConversations.value).toEqual([autocompleteResult('one', ATTENDEE.ACTOR_TYPE.USERS)])
+			expect(composable.searchResultsLoading.value).toBeFalsy()
+			expect(showError).not.toHaveBeenCalled()
+		})
+
+		test('requests groups and teams if the user can create conversations', async () => {
+			// Arrange
+			searchListedConversations.mockResolvedValueOnce(generateOCSResponse({ payload: [] }))
+			autocompleteQuery.mockResolvedValueOnce(generateOCSResponse({ payload: [] }))
+			const { composable } = mountComposable()
+
+			// Act: search for conversations
+			await composable.search('query')
+
+			// Assert
+			expect(autocompleteQuery).toHaveBeenCalledWith(
+				{ searchText: 'query', token: 'new', onlyUsers: false },
+				expect.objectContaining({ signal: expect.any(AbortSignal) }),
+			)
+			expect(searchListedConversations).toHaveBeenCalledWith('query', expect.anything())
+		})
+
+		test('filters out the current user and known one-to-one conversations', async () => {
+			// Arrange
+			conversationsList = [
+				{ id: 1, name: 'one', type: CONVERSATION.TYPE.ONE_TO_ONE },
+				{ id: 2, name: 'two', type: CONVERSATION.TYPE.GROUP },
+			]
+			searchListedConversations.mockResolvedValueOnce(generateOCSResponse({ payload: [] }))
+			autocompleteQuery.mockResolvedValueOnce(generateOCSResponse({
+				payload: [
+					// Filtered out: the current user
+					autocompleteResult(CURRENT_USER, ATTENDEE.ACTOR_TYPE.USERS),
+					// Filtered out: a one-to-one conversation exists already
+					autocompleteResult('one', ATTENDEE.ACTOR_TYPE.USERS),
+					// Kept: only a group conversation exists with this user
+					autocompleteResult('two', ATTENDEE.ACTOR_TYPE.USERS),
+					// Kept: not a user, so the one-to-one check does not apply
+					autocompleteResult('one', ATTENDEE.ACTOR_TYPE.GROUPS),
+				],
+			}))
+			const { composable } = mountComposable()
+
+			// Act: search for conversations
+			await composable.search('query')
+
+			// Assert
+			expect(composable.searchResultsPossibleConversations.value).toEqual([
+				autocompleteResult('two', ATTENDEE.ACTOR_TYPE.USERS),
+				autocompleteResult('one', ATTENDEE.ACTOR_TYPE.GROUPS),
+			])
+		})
+	})
+
+	describe('outdated search', () => {
+		test('does not apply results of a superseded search', async () => {
+			// Arrange
+			const { composable } = mountComposable()
+
+			// Act: let the results of a search arrive, but supersede it before they are processed
+			const outdatedSearch = composable.search('outdated')
+			listedRequests[0].resolve(generateOCSResponse({ payload: [{ id: 1, token: 'outdated' }] }))
+			possibleRequests[0].resolve(generateOCSResponse({ payload: [autocompleteResult('outdated', ATTENDEE.ACTOR_TYPE.USERS)] }))
+			const currentSearch = composable.search('current')
+
+			// Assert: nothing is applied while the newest search is still pending
+			await expect(outdatedSearch).resolves.toBeFalsy()
+			expect(composable.searchResultsListedConversations.value).toEqual([])
+			expect(composable.searchResultsPossibleConversations.value).toEqual([])
+			expect(composable.searchResultsLoading.value).toBeTruthy()
+
+			// Act: the newest search receives its results
+			listedRequests[1].resolve(generateOCSResponse({ payload: [{ id: 2, token: 'current' }] }))
+			possibleRequests[1].resolve(generateOCSResponse({ payload: [autocompleteResult('current', ATTENDEE.ACTOR_TYPE.USERS)] }))
+
+			// Assert
+			await expect(currentSearch).resolves.toBeTruthy()
+			expect(composable.searchResultsListedConversations.value).toEqual([{ id: 2, token: 'current' }])
+			expect(composable.searchResultsPossibleConversations.value).toEqual([autocompleteResult('current', ATTENDEE.ACTOR_TYPE.USERS)])
+			expect(composable.searchResultsLoading.value).toBeFalsy()
+		})
+
+		test('cancels pending requests of a superseded search', async () => {
+			// Arrange
+			const { composable } = mountComposable()
+
+			// Act: supersede a search while its requests are still pending
+			const outdatedSearch = composable.search('outdated')
+			composable.search('current')
+
+			// Assert
+			await expect(outdatedSearch).resolves.toBeFalsy()
+			expect(showError).not.toHaveBeenCalled()
+		})
+
+		test('reports an aborted search as not applied', async () => {
+			// Arrange
+			const { composable } = mountComposable()
+
+			// Act: abort a search while its requests are still pending
+			const search = composable.search('query')
+			composable.abortSearchRequests()
+
+			// Assert
+			await expect(search).resolves.toBeFalsy()
+			expect(composable.searchResultsListedConversations.value).toEqual([])
+			expect(composable.searchResultsPossibleConversations.value).toEqual([])
+			expect(showError).not.toHaveBeenCalled()
+		})
+
+		test('aborts a pending search on unmount', async () => {
+			// Arrange
+			const { composable, wrapper } = mountComposable()
+
+			// Act: unmount the consumer while the requests are still pending
+			const search = composable.search('query')
+			wrapper.unmount()
+
+			// Assert
+			await expect(search).resolves.toBeFalsy()
+			expect(showError).not.toHaveBeenCalled()
+		})
+	})
+
+	describe('failing search', () => {
+		let consoleError
+
+		beforeEach(() => {
+			// Test setup makes console.error throw, but failures are expected here
+			consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+		})
+
+		test('shows a single error and clears the results if both requests fail', async () => {
+			// Arrange: populate the results with an earlier successful search
+			searchListedConversations.mockResolvedValueOnce(generateOCSResponse({ payload: [{ id: 1, token: 'listed' }] }))
+			autocompleteQuery.mockResolvedValueOnce(generateOCSResponse({ payload: [autocompleteResult('one', ATTENDEE.ACTOR_TYPE.USERS)] }))
+			const { composable } = mountComposable()
+			await composable.search('query')
+
+			searchListedConversations.mockRejectedValueOnce(new Error('Listed conversations are not available'))
+			autocompleteQuery.mockRejectedValueOnce(new Error('Autocomplete is not available'))
+
+			// Act: search again, with both requests failing
+			const search = composable.search('failing')
+
+			// Assert
+			await expect(search).resolves.toBeTruthy()
+			expect(consoleError).toHaveBeenCalledTimes(2)
+			expect(showError).toHaveBeenCalledTimes(1)
+			expect(composable.searchResultsListedConversations.value).toEqual([])
+			expect(composable.searchResultsPossibleConversations.value).toEqual([])
+			expect(composable.searchResultsLoading.value).toBeFalsy()
+		})
+
+		test('keeps the successful results if only one request fails', async () => {
+			// Arrange
+			searchListedConversations.mockRejectedValueOnce(new Error('Listed conversations are not available'))
+			autocompleteQuery.mockResolvedValueOnce(generateOCSResponse({ payload: [autocompleteResult('one', ATTENDEE.ACTOR_TYPE.USERS)] }))
+			const { composable } = mountComposable()
+
+			// Act: search with only one of the requests failing
+			const search = composable.search('query')
+
+			// Assert
+			await expect(search).resolves.toBeTruthy()
+			expect(showError).toHaveBeenCalledTimes(1)
+			expect(composable.searchResultsListedConversations.value).toEqual([])
+			expect(composable.searchResultsPossibleConversations.value).toEqual([autocompleteResult('one', ATTENDEE.ACTOR_TYPE.USERS)])
+			expect(composable.searchResultsLoading.value).toBeFalsy()
+		})
+
+		test('does not report a failure of a superseded search', async () => {
+			// Arrange
+			const { composable } = mountComposable()
+
+			// Act: let the requests of a search fail, but supersede it before they are handled
+			const outdatedSearch = composable.search('outdated')
+			listedRequests[0].reject(new Error('Listed conversations are not available'))
+			possibleRequests[0].reject(new Error('Autocomplete is not available'))
+			const currentSearch = composable.search('current')
+
+			// Assert: the failure of the outdated search is not reported to the user
+			await expect(outdatedSearch).resolves.toBeFalsy()
+			expect(showError).not.toHaveBeenCalled()
+
+			// Act: the newest search receives its results
+			listedRequests[1].resolve(generateOCSResponse({ payload: [{ id: 2, token: 'current' }] }))
+			possibleRequests[1].resolve(generateOCSResponse({ payload: [autocompleteResult('current', ATTENDEE.ACTOR_TYPE.USERS)] }))
+
+			// Assert
+			await expect(currentSearch).resolves.toBeTruthy()
+			expect(composable.searchResultsListedConversations.value).toEqual([{ id: 2, token: 'current' }])
+			expect(composable.searchResultsPossibleConversations.value).toEqual([autocompleteResult('current', ATTENDEE.ACTOR_TYPE.USERS)])
+		})
+
+		test('does not clear newer results when a superseded search fails late', async () => {
+			// Arrange: the outdated requests already left the pending state,
+			// so cancelling them has no effect
+			abortRejectsRequests = false
+			const { composable } = mountComposable()
+
+			// Act: supersede a search and let the newest one succeed first
+			const outdatedSearch = composable.search('outdated')
+			const currentSearch = composable.search('current')
+			listedRequests[1].resolve(generateOCSResponse({ payload: [{ id: 2, token: 'current' }] }))
+			possibleRequests[1].resolve(generateOCSResponse({ payload: [autocompleteResult('current', ATTENDEE.ACTOR_TYPE.USERS)] }))
+
+			// Assert
+			await expect(currentSearch).resolves.toBeTruthy()
+
+			// Act: only then the outdated search fails
+			listedRequests[0].reject(new Error('Listed conversations are not available'))
+			possibleRequests[0].reject(new Error('Autocomplete is not available'))
+
+			// Assert: the results of the newest search are kept
+			await expect(outdatedSearch).resolves.toBeFalsy()
+			expect(showError).not.toHaveBeenCalled()
+			expect(composable.searchResultsListedConversations.value).toEqual([{ id: 2, token: 'current' }])
+			expect(composable.searchResultsPossibleConversations.value).toEqual([autocompleteResult('current', ATTENDEE.ACTOR_TYPE.USERS)])
+		})
+	})
+})

--- a/src/components/LeftSidebar/SearchConversationsResults/useSearchConversationsResults.ts
+++ b/src/components/LeftSidebar/SearchConversationsResults/useSearchConversationsResults.ts
@@ -1,0 +1,167 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type {
+	AutocompleteResult,
+	Conversation,
+} from '../../../types/index.ts'
+
+import { isCancel } from '@nextcloud/axios'
+import { showError } from '@nextcloud/dialogs'
+import { t } from '@nextcloud/l10n'
+import { onBeforeUnmount, ref } from 'vue'
+import { useStore } from 'vuex'
+import { ATTENDEE, CONVERSATION } from '../../../constants.ts'
+import { getTalkConfig } from '../../../services/CapabilitiesManager.ts'
+import { searchListedConversations } from '../../../services/conversationsService.ts'
+import { autocompleteQuery } from '../../../services/coreService.ts'
+import { useActorStore } from '../../../stores/actor.ts'
+import CancelableRequest from '../../../utils/CancelableRequest.ts'
+
+const canStartConversations = getTalkConfig('local', 'conversations', 'can-create')
+
+/**
+ * Composable to control logic for fetching search results:
+ * - listed conversations
+ * - possible conversations (users, groups, teams)
+ *
+ * Has only single consumer (LeftSidebar.vue)
+ */
+export function useSearchConversationsResults() {
+	const actorStore = useActorStore()
+	const vuexStore = useStore()
+
+	const searchResultsListedConversations = ref<Conversation[]>([])
+	const searchResultsPossibleConversations = ref<AutocompleteResult[]>([])
+	const searchResultsLoading = ref(true)
+
+	let cancelSearchListedConversations: ReturnType<typeof CancelableRequest>['cancel'] | null = null
+	let cancelSearchPossibleConversations: ReturnType<typeof CancelableRequest>['cancel'] | null = null
+
+	onBeforeUnmount(() => {
+		abortSearchRequests()
+	})
+
+	/**
+	 * Get list of possible conversations (users, groups, teams) and write to ref
+	 *
+	 * @param query search text
+	 */
+	async function fetchPossibleConversations(query: string) {
+		const { request, cancel } = CancelableRequest(autocompleteQuery)
+		try {
+			// Cancel previous search request if pending, and store reference to new one
+			cancelSearchPossibleConversations?.()
+			cancelSearchPossibleConversations = cancel
+
+			const response = await request({
+				searchText: query,
+				token: 'new',
+				onlyUsers: !canStartConversations,
+			})
+
+			// Get all known user ids of 1:1 conversations
+			const oneToOneMap = new Set(vuexStore.getters.conversationsList.reduce(
+				(acc: string[], conversation: Conversation) => {
+					if (conversation.type === CONVERSATION.TYPE.ONE_TO_ONE) {
+						acc.push(conversation.name)
+					}
+					return acc
+				},
+				// Include self
+				[actorStore.userId],
+			))
+
+			// and filter them out
+			searchResultsPossibleConversations.value = response.data.ocs.data.filter((match) => {
+				return !(match.source === ATTENDEE.ACTOR_TYPE.USERS && oneToOneMap.has(match.id))
+			})
+		} catch (exception) {
+			if (isCancel(exception)) {
+				return
+			}
+			console.error('Error searching for possible conversations', exception)
+			throw exception
+		} finally {
+			if (cancelSearchPossibleConversations === cancel) {
+				cancelSearchPossibleConversations = null
+			}
+		}
+	}
+
+	/**
+	 * Get list of listable conversations (open to registered users) and write to ref
+	 *
+	 * @param query search text
+	 */
+	async function fetchListedConversations(query: string) {
+		const { request, cancel } = CancelableRequest(searchListedConversations)
+		try {
+			// Cancel previous search request if pending, and store reference to new one
+			cancelSearchListedConversations?.()
+			cancelSearchListedConversations = cancel
+
+			const response = await request(query)
+			searchResultsListedConversations.value = response.data.ocs.data
+		} catch (exception) {
+			if (isCancel(exception)) {
+				return
+			}
+			console.error('Error searching for open conversations', exception)
+			throw exception
+		} finally {
+			if (cancelSearchListedConversations === cancel) {
+				cancelSearchListedConversations = null
+			}
+		}
+	}
+
+	/**
+	 * Fetch and prepare results (in parallel)
+	 *
+	 * @param query search text
+	 */
+	async function search(query: string) {
+		searchResultsLoading.value = true
+
+		const promiseResults = await Promise.allSettled([
+			fetchListedConversations(query),
+			fetchPossibleConversations(query),
+		])
+
+		if (
+			cancelSearchListedConversations !== null
+			|| cancelSearchPossibleConversations !== null
+		) {
+			// New search request was triggered, do not proceed
+			return
+		}
+
+		if (promiseResults.some((result) => result.status === 'rejected')) {
+			showError(t('spreed', 'An error occurred while performing the search'))
+		}
+
+		searchResultsLoading.value = false
+	}
+
+	/**
+	 * Abort running requests and cleanup cancel functions
+	 */
+	function abortSearchRequests() {
+		cancelSearchListedConversations?.()
+		cancelSearchListedConversations = null
+
+		cancelSearchPossibleConversations?.()
+		cancelSearchPossibleConversations = null
+	}
+
+	return {
+		searchResultsPossibleConversations,
+		searchResultsListedConversations,
+		searchResultsLoading,
+		search,
+		abortSearchRequests,
+	}
+}

--- a/src/components/LeftSidebar/SearchConversationsResults/useSearchConversationsResults.ts
+++ b/src/components/LeftSidebar/SearchConversationsResults/useSearchConversationsResults.ts
@@ -39,6 +39,9 @@ export function useSearchConversationsResults() {
 
 	let cancelSearchListedConversations: ReturnType<typeof CancelableRequest>['cancel'] | null = null
 	let cancelSearchPossibleConversations: ReturnType<typeof CancelableRequest>['cancel'] | null = null
+	// Generation counter - increases with every started or aborted search.
+	// Results of a search are only applied with matching generation
+	let searchGeneration = 0
 
 	onBeforeUnmount(() => {
 		abortSearchRequests()
@@ -48,8 +51,9 @@ export function useSearchConversationsResults() {
 	 * Get list of possible conversations (users, groups, teams) and write to ref
 	 *
 	 * @param query search text
+	 * @param generation search generation
 	 */
-	async function fetchPossibleConversations(query: string) {
+	async function fetchPossibleConversations(query: string, generation: number) {
 		const { request, cancel } = CancelableRequest(autocompleteQuery)
 		try {
 			// Cancel previous search request if pending, and store reference to new one
@@ -61,6 +65,11 @@ export function useSearchConversationsResults() {
 				token: 'new',
 				onlyUsers: !canStartConversations,
 			})
+
+			if (generation !== searchGeneration) {
+				// Results are outdated
+				return
+			}
 
 			// Get all known user ids of 1:1 conversations
 			const oneToOneMap = new Set(vuexStore.getters.conversationsList.reduce(
@@ -83,6 +92,10 @@ export function useSearchConversationsResults() {
 				return
 			}
 			console.error('Error searching for possible conversations', exception)
+			if (generation === searchGeneration) {
+				// Drop results of the failed search
+				searchResultsPossibleConversations.value = []
+			}
 			throw exception
 		} finally {
 			if (cancelSearchPossibleConversations === cancel) {
@@ -95,8 +108,9 @@ export function useSearchConversationsResults() {
 	 * Get list of listable conversations (open to registered users) and write to ref
 	 *
 	 * @param query search text
+	 * @param generation search generation
 	 */
-	async function fetchListedConversations(query: string) {
+	async function fetchListedConversations(query: string, generation: number) {
 		const { request, cancel } = CancelableRequest(searchListedConversations)
 		try {
 			// Cancel previous search request if pending, and store reference to new one
@@ -104,12 +118,22 @@ export function useSearchConversationsResults() {
 			cancelSearchListedConversations = cancel
 
 			const response = await request(query)
+
+			if (generation !== searchGeneration) {
+				// Results are outdated
+				return
+			}
+
 			searchResultsListedConversations.value = response.data.ocs.data
 		} catch (exception) {
 			if (isCancel(exception)) {
 				return
 			}
 			console.error('Error searching for open conversations', exception)
+			if (generation === searchGeneration) {
+				// Drop results of the failed search
+				searchResultsListedConversations.value = []
+			}
 			throw exception
 		} finally {
 			if (cancelSearchListedConversations === cancel) {
@@ -122,21 +146,20 @@ export function useSearchConversationsResults() {
 	 * Fetch and prepare results (in parallel)
 	 *
 	 * @param query search text
+	 * @return whether the results of this search were applied
 	 */
-	async function search(query: string) {
+	async function search(query: string): Promise<boolean> {
+		const generation = ++searchGeneration
 		searchResultsLoading.value = true
 
 		const promiseResults = await Promise.allSettled([
-			fetchListedConversations(query),
-			fetchPossibleConversations(query),
+			fetchListedConversations(query, generation),
+			fetchPossibleConversations(query, generation),
 		])
 
-		if (
-			cancelSearchListedConversations !== null
-			|| cancelSearchPossibleConversations !== null
-		) {
-			// New search request was triggered, do not proceed
-			return
+		if (generation !== searchGeneration) {
+			// Search was superseded by a newer one or aborted, do not proceed
+			return false
 		}
 
 		if (promiseResults.some((result) => result.status === 'rejected')) {
@@ -144,12 +167,16 @@ export function useSearchConversationsResults() {
 		}
 
 		searchResultsLoading.value = false
+		return true
 	}
 
 	/**
 	 * Abort running requests and cleanup cancel functions
 	 */
 	function abortSearchRequests() {
+		// Invalidate a pending search, so that its results are not applied
+		searchGeneration++
+
 		cancelSearchListedConversations?.()
 		cancelSearchListedConversations = null
 

--- a/src/components/RightSidebar/SearchMessages/SearchMessagesTab.vue
+++ b/src/components/RightSidebar/SearchMessages/SearchMessagesTab.vue
@@ -11,6 +11,7 @@ import type {
 	SearchMessagePayload,
 	UnifiedSearchResponse,
 	UnifiedSearchResultEntry,
+	UnifiedSearchResultEntryWithRouterLink,
 } from '../../../types/index.ts'
 
 import { isCancel } from '@nextcloud/axios'
@@ -36,7 +37,7 @@ import { useArrowNavigation } from '../../../composables/useArrowNavigation.js'
 import { useGetToken } from '../../../composables/useGetToken.ts'
 import { useIsInCall } from '../../../composables/useIsInCall.js'
 import { ATTENDEE } from '../../../constants.ts'
-import { searchMessages } from '../../../services/coreService.ts'
+import { searchMessagesInCurrentConversation } from '../../../services/coreService.ts'
 import { EventBus } from '../../../services/EventBus.ts'
 import CancelableRequest from '../../../utils/CancelableRequest.ts'
 
@@ -53,15 +54,7 @@ const searchBox = ref<InstanceType<typeof SearchBox> | null>(null)
 const { initializeNavigation, resetNavigation } = useArrowNavigation(searchMessagesTab, searchBox)
 
 const isFocused = ref(false)
-const searchResults = ref<(UnifiedSearchResultEntry & {
-	to: {
-		name: string
-		hash: string
-		params: {
-			token: string
-		}
-	}
-})[]>([])
+const searchResults = ref<UnifiedSearchResultEntryWithRouterLink[]>([])
 const searchText = ref('')
 const fromUser = ref<IUserData | undefined>(undefined)
 const sinceDate = ref<Date | null>(null)
@@ -182,7 +175,7 @@ async function fetchSearchResults(isNew = true): Promise<void> {
 		cancelSearchFn()
 		resetNavigation()
 
-		const { request, cancel } = CancelableRequest(searchMessages)
+		const { request, cancel } = CancelableRequest(searchMessagesInCurrentConversation)
 		cancelSearchFn = cancel
 
 		if (isNew) {

--- a/src/services/coreService.ts
+++ b/src/services/coreService.ts
@@ -105,6 +105,18 @@ async function deleteTaskById(id: number, options?: AxiosRequestConfig): Promise
  * @param options
  */
 async function searchMessages(params: SearchMessagePayload, options?: AxiosRequestConfig): UnifiedSearchResponse {
+	return axios.get(generateOcsUrl('search/providers/talk-message/search'), {
+		...options,
+		params,
+	})
+}
+
+/**
+ *
+ * @param params
+ * @param options
+ */
+async function searchMessagesInCurrentConversation(params: SearchMessagePayload, options?: AxiosRequestConfig): UnifiedSearchResponse {
 	return axios.get(generateOcsUrl('search/providers/talk-message-current/search'), {
 		...options,
 		params,
@@ -117,4 +129,5 @@ export {
 	getTaskById,
 	getUserProfile,
 	searchMessages,
+	searchMessagesInCurrentConversation,
 }

--- a/src/types/core.ts
+++ b/src/types/core.ts
@@ -117,6 +117,15 @@ export type SearchMessagePayload = operationsCore['unified_search-search']['para
 export type UnifiedSearchResultEntry = componentsCore['schemas']['UnifiedSearchResultEntry'] & {
 	attributes: MessageSearchResultAttributes
 }
+export type UnifiedSearchResultEntryWithRouterLink = UnifiedSearchResultEntry & {
+	to: {
+		name: string
+		hash: string
+		params: {
+			token: string
+		}
+	}
+}
 export type UnifiedSearchResponse = ApiResponse<operationsCore['unified_search-search']['responses'][200]['content']['application/json'] & {
 	ocs: {
 		meta: componentsCore['schemas']['OCSMeta']

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -653,6 +653,7 @@ export type {
 	SearchMessagePayload,
 	UnifiedSearchResponse,
 	UnifiedSearchResultEntry,
+	UnifiedSearchResultEntryWithRouterLink,
 } from './core.ts'
 
 // Translation API


### PR DESCRIPTION
## ☑️ Resolves

* Extracted as pre-requisite for #16344 
	* introduce and type search provider API for future support of messages search
	* extract search requests logic from LeftSidebar

### AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI

## 🖌️ UI Checklist

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required