### PR TITLE
fix: get rid of legacy prop

### DIFF
--- a/src/components/ConversationSettings/ConversationSettingsDialog.vue
+++ b/src/components/ConversationSettings/ConversationSettingsDialog.vue
@@ -10,15 +10,16 @@
 		:name="t('spreed', 'Conversation settings')"
 		:open="showSettings"
 		showNavigation
-		legacy
 		noVersion
 		@update:open="handleHideSettings">
 		<NcAppSettingsSection
 			id="basic-info"
 			:name="t('spreed', 'Basic Info')">
-			<BasicInfo
-				:conversation="conversation"
-				:canFullModerate="canFullModerate" />
+			<div class="app-settings-subsection">
+				<BasicInfo
+					:conversation="conversation"
+					:canFullModerate="canFullModerate" />
+			</div>
 		</NcAppSettingsSection>
 
 		<template v-if="!isBreakoutRoom">
@@ -33,12 +34,14 @@
 			<NcAppSettingsSection
 				id="conversation-settings"
 				:name="selfIsOwnerOrModerator ? t('spreed', 'Moderation') : t('spreed', 'Setup overview')">
-				<ListableSettings v-if="!isNoteToSelf && !isGuest && !isOneToOne" :token="token" :canModerate="canFullModerate" />
-				<MentionsSettings v-if="!isNoteToSelf && !isOneToOne" :token="token" :canModerate="canFullModerate" />
-				<LinkShareSettings v-if="!isNoteToSelf" :token="token" :canModerate="canFullModerate" />
-				<RecordingConsentSettings v-if="!isNoteToSelf && !isOneToOneFormer && recordingConsentAvailable" :token="token" :canModerate="selfIsOwnerOrModerator" />
-				<ExpirationSettings v-if="!isOneToOneFormer && hasMessageExpirationFeature" :token="token" :canModerate="selfIsOwnerOrModerator" />
-				<BanSettings v-if="supportBanV1 && canFullModerate" :token="token" />
+				<div class="app-settings-subsection">
+					<ListableSettings v-if="!isNoteToSelf && !isGuest && !isOneToOne" :token="token" :canModerate="canFullModerate" />
+					<MentionsSettings v-if="!isNoteToSelf && !isOneToOne" :token="token" :canModerate="canFullModerate" />
+					<LinkShareSettings v-if="!isNoteToSelf" :token="token" :canModerate="canFullModerate" />
+					<RecordingConsentSettings v-if="!isNoteToSelf && !isOneToOneFormer && recordingConsentAvailable" :token="token" :canModerate="selfIsOwnerOrModerator" />
+					<ExpirationSettings v-if="!isOneToOneFormer && hasMessageExpirationFeature" :token="token" :canModerate="selfIsOwnerOrModerator" />
+					<BanSettings v-if="supportBanV1 && canFullModerate" :token="token" />
+				</div>
 			</NcAppSettingsSection>
 
 			<!-- Meeting: lobby and sip -->
@@ -46,8 +49,10 @@
 				v-if="canFullModerate && !isNoteToSelf"
 				id="meeting"
 				:name="meetingHeader">
-				<LobbySettings :token="token" />
-				<SipSettings v-if="canUserEnableSIP" />
+				<div class="app-settings-subsection">
+					<LobbySettings :token="token" />
+					<SipSettings v-if="canUserEnableSIP" />
+				</div>
 			</NcAppSettingsSection>
 
 			<!-- Conversation permissions -->
@@ -55,7 +60,9 @@
 				v-if="canFullModerate && !isNoteToSelf"
 				id="permissions"
 				:name="t('spreed', 'Permissions')">
-				<ConversationPermissionsSettings :token="token" />
+				<div class="app-settings-subsection">
+					<ConversationPermissionsSettings :token="token" />
+				</div>
 			</NcAppSettingsSection>
 
 			<!-- Live transcription -->
@@ -63,18 +70,22 @@
 				v-if="canConfigureLiveTranscription"
 				id="live-transcription"
 				:name="t('spreed', 'Live transcription')">
-				<LiveTranscriptionSettings :token="token" />
+				<div class="app-settings-subsection">
+					<LiveTranscriptionSettings :token="token" />
+				</div>
 			</NcAppSettingsSection>
 			<NcAppSettingsSection
 				v-else-if="hintLiveTranscription"
 				id="live-transcription"
 				:name="t('spreed', 'Live transcription')">
-				<NcCheckboxRadioSwitch
-					:description="t('spreed', 'Live transcriptions app is not installed')"
-					type="switch"
-					disabled>
-					{{ t('spreed', 'Enable live transcription') }}
-				</NcCheckboxRadioSwitch>
+				<div class="app-settings-subsection">
+					<NcCheckboxRadioSwitch
+						:description="t('spreed', 'Live transcriptions app is not installed')"
+						type="switch"
+						disabled>
+						{{ t('spreed', 'Enable live transcription') }}
+					</NcCheckboxRadioSwitch>
+				</div>
 			</NcAppSettingsSection>
 
 			<!-- Breakout rooms -->
@@ -82,7 +93,9 @@
 				v-if="canConfigureBreakoutRooms"
 				id="breakout-rooms"
 				:name="t('spreed', 'Breakout Rooms')">
-				<BreakoutRoomsSettings :token="token" />
+				<div class="app-settings-subsection">
+					<BreakoutRoomsSettings :token="token" />
+				</div>
 			</NcAppSettingsSection>
 
 			<!-- Matterbridge settings -->
@@ -90,7 +103,9 @@
 				v-if="canFullModerate && matterbridgeEnabled"
 				id="matterbridge"
 				:name="t('spreed', 'Matterbridge')">
-				<MatterbridgeSettings />
+				<div class="app-settings-subsection">
+					<MatterbridgeSettings />
+				</div>
 			</NcAppSettingsSection>
 
 			<!-- Bots settings -->
@@ -98,7 +113,9 @@
 				v-if="selfIsOwnerOrModerator && supportBotsV1"
 				id="bots"
 				:name="t('spreed', 'Bots')">
-				<BotsSettings :token="token" />
+				<div class="app-settings-subsection">
+					<BotsSettings :token="token" />
+				</div>
 			</NcAppSettingsSection>
 
 			<!-- Destructive actions -->
@@ -106,26 +123,28 @@
 				v-if="canLeaveConversation || canDeleteConversation || showPreserveConversationSetting"
 				id="dangerzone"
 				:name="t('spreed', 'Danger zone')">
-				<PreserveConversationSettings v-if="showPreserveConversationSetting" :token="token" />
-				<LockingSettings v-if="canFullModerate && !isNoteToSelf" :token="token" />
-				<template v-if="supportsArchive">
-					<h4 class="app-settings-section__subtitle">
-						{{ t('spreed', 'Archive conversation') }}
-					</h4>
-					<p class="app-settings-section__hint">
-						{{ t('spreed', 'Archived conversations are hidden from the conversation list by default. However, they will still appear when you search for the conversation name or access a list of archived conversations.') }}
-					</p>
-					<NcCheckboxRadioSwitch
-						type="switch"
-						:modelValue="isArchived"
-						@update:modelValue="toggleArchiveConversation">
-						{{ t('spreed', 'Archive conversation') }}
-					</NcCheckboxRadioSwitch>
-				</template>
-				<DangerZone
-					:conversation="conversation"
-					:canLeaveConversation="canLeaveConversation"
-					:canDeleteConversation="canDeleteConversation" />
+				<div class="app-settings-subsection">
+					<PreserveConversationSettings v-if="showPreserveConversationSetting" :token="token" />
+					<LockingSettings v-if="canFullModerate && !isNoteToSelf" :token="token" />
+					<template v-if="supportsArchive">
+						<h4 class="app-settings-section__subtitle">
+							{{ t('spreed', 'Archive conversation') }}
+						</h4>
+						<p class="app-settings-section__hint">
+							{{ t('spreed', 'Archived conversations are hidden from the conversation list by default. However, they will still appear when you search for the conversation name or access a list of archived conversations.') }}
+						</p>
+						<NcCheckboxRadioSwitch
+							type="switch"
+							:modelValue="isArchived"
+							@update:modelValue="toggleArchiveConversation">
+							{{ t('spreed', 'Archive conversation') }}
+						</NcCheckboxRadioSwitch>
+					</template>
+					<DangerZone
+						:conversation="conversation"
+						:canLeaveConversation="canLeaveConversation"
+						:canDeleteConversation="canDeleteConversation" />
+				</div>
 			</NcAppSettingsSection>
 		</template>
 	</NcAppSettingsDialog>
@@ -375,6 +394,11 @@ export default {
 	font-weight: bold;
 	font-size: var(--default-font-size);
 	margin: calc(var(--default-grid-baseline) * 4) 0 var(--default-grid-baseline) 0;
+}
+
+// TODO remove wrapper when migrated to NcFormGroup / modern settings
+:deep(.app-settings-subsection) {
+	padding-inline-start: var(--app-settings-section-text-offset);
 }
 
 :deep(.app-settings-subsection:not(:first-child)) {


### PR DESCRIPTION
## ☑️ Resolves

- content non-wrapped with class 'app-settings-subsection' showed huge gaps, that are not expected with 'legacy-style' components
- temporarily wrap in div until migrated
- remove deprecated 'legacy' prop

### AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

See section names drifted off to the right, slight change in vertical gaps (in some places)

🏚️ Before | 🏡 After
-- | --
<img width="686" height="689" alt="image" src="https://github.com/user-attachments/assets/383a0a8e-08ff-4c47-9d76-5b322fecb48a" /> | <img width="685" height="687" alt="image" src="https://github.com/user-attachments/assets/4c847430-73cf-4ff1-891c-8ee8a76e2790" />
<img width="687" height="714" alt="image" src="https://github.com/user-attachments/assets/f8bf45db-898d-4668-9a64-1f0e04264dbf" /> | <img width="684" height="688" alt="image" src="https://github.com/user-attachments/assets/eb292f1b-d84b-4431-ae23-4ef9982dc7d8" />
<img width="687" height="449" alt="image" src="https://github.com/user-attachments/assets/c58f9128-26df-4a73-abb5-58bdf81a52fd" /> | <img width="691" height="450" alt="image" src="https://github.com/user-attachments/assets/f05ec775-72b6-47b4-bf73-b92cb51521ba" />
<img width="685" height="868" alt="image" src="https://github.com/user-attachments/assets/8dcb1bbe-e171-47d1-a438-7b4554dbe53d" /> | <img width="686" height="868" alt="image" src="https://github.com/user-attachments/assets/37010828-257e-46d9-aaf2-4eb72a7ec06d" />


### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required