### PR TITLE
refactor(VideosGrid): add usePagination composable

### DIFF
--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -115,7 +115,6 @@
 					:isStripe="devMode ? !isGrid : (!isGrid || !callParticipantModels.length)"
 					:isRecording="isRecording"
 					:token="token"
-					:hasPagination="true"
 					:isOverlap="showFullPage"
 					:callParticipantModels="callParticipantModels"
 					:screens="screens"

--- a/src/components/CallView/Grid/VideosGrid.vue
+++ b/src/components/CallView/Grid/VideosGrid.vue
@@ -164,7 +164,8 @@
 <script>
 import { t } from '@nextcloud/l10n'
 import debounce from 'debounce'
-import { computed, inject, ref, toRef, useTemplateRef } from 'vue'
+import { computed, inject, ref, toRef, useTemplateRef, watch } from 'vue'
+import { useStore } from 'vuex'
 import NcButton from '@nextcloud/vue/components/NcButton'
 import IconChevronDown from 'vue-material-design-icons/ChevronDown.vue'
 import IconChevronLeft from 'vue-material-design-icons/ChevronLeft.vue'
@@ -309,7 +310,204 @@ export default {
 			stripeOpen,
 		})
 
+		const vuexStore = useStore()
+
+		// The videos array. This is the total number of grid elements.
+		// Depending on the grid dimensions and `videosCap`, these videos are
+		// shown in one or more grid 'pages'.
+		const videos = computed(() => {
+			if (devMode.value) {
+				return Array.from(Array(dummies.value).keys())
+			}
+
+			return props.callParticipantModels
+		})
+
+		// Number of grid slots (videos per page) at any given moment, clamped to
+		// `videosCap` (`0` means no cap).
+		// The local video always takes one slot, unless it is not shown (stripe
+		// or recording mode).
+		// The cap is primarily enforced by shrinking the grid layout (see
+		// `computeGridDimensions`); this clamp keeps the "videos per page" math
+		// consistent even before the layout has been recomputed.
+		const slots = computed(() => {
+			const noLocalVideoReserve = props.isStripe || props.isRecording
+			const gridSlots = gridDimensions.rows.value * gridDimensions.columns.value
+			const slots = noLocalVideoReserve ? gridSlots : gridSlots - 1
+			return videosCap ? Math.min(videosCap, slots) : slots
+		})
+
+		// Speakers recently promoted to the first page and the history of
+		// promotions, used to keep the relative order of the tiles stable.
+		const tempPromotedModels = ref([])
+		const promotedHistoryMask = ref([])
+		const unpromoteSpeakerTimer = {}
+
+		const participantsInitialised = computed(() => vuexStore.getters.participantsInitialised(props.token))
+
+		const isGuestNonModerator = computed(() => {
+			return actorStore.isActorGuest
+				&& vuexStore.getters.conversation(props.token).participantType !== PARTICIPANT.TYPE.GUEST_MODERATOR
+		})
+
+		/**
+		 * @param {object} callParticipantModel the participant model
+		 */
+		function isModelWithVideo(callParticipantModel) {
+			return callParticipantModel.attributes.videoAvailable
+				&& (typeof callParticipantModel.attributes.stream === 'object')
+		}
+
+		/**
+		 * @param {object} callParticipantModel the participant model
+		 */
+		function isModelWithAudio(callParticipantModel) {
+			const participant = vuexStore.getters.getParticipantBySessionId(props.token, callParticipantModel.attributes.nextcloudSessionId)
+			if (!participant) {
+				return false
+			}
+			return participant?.permissions & PARTICIPANT.PERMISSIONS.PUBLISH_AUDIO
+		}
+
+		/**
+		 * @param {Map} tilesMap map of session ids to models
+		 * @param {Array} orderMask ordered session ids to sort the tiles by
+		 */
+		function getOrderedTiles(tilesMap, orderMask) {
+			const orderedTiles = []
+			const rest = []
+			// Get the ordered tiles
+			orderMask.forEach((id) => {
+				if (tilesMap.has(id)) {
+					orderedTiles.push(tilesMap.get(id))
+				}
+			})
+
+			// Add remaining tiles not in orderMask to rest
+			tilesMap.forEach((tile, id) => {
+				if (!orderMask.includes(id)) {
+					rest.push(tile)
+				}
+			})
+
+			return [...orderedTiles, ...rest]
+		}
+
+		const orderedVideos = computed(() => {
+			// Dynamic ordering is not possible for guests because
+			// participants store is not initialized
+			if (isGuestNonModerator.value || devMode.value) {
+				return videos.value
+			}
+
+			const objectMap = {
+				modelsWithScreenshare: [],
+				modelsTempPromoted: [],
+				modelsWithVideoEnabled: [],
+				modelsWithAudioOnly: [],
+				modelsWithNoPermissions: [],
+			}
+			const screensSet = new Set(props.screens)
+			const tempPromotedModelsSet = new Set(tempPromotedModels.value.map((model) => model.attributes.nextcloudSessionId))
+			const videoTilesMap = new Map()
+			const audioTilesMap = new Map()
+
+			props.callParticipantModels.forEach((model) => {
+				if (screensSet.has(model.attributes.peerId)) {
+					objectMap.modelsWithScreenshare.push(model)
+				} else if (tempPromotedModelsSet.has(model.attributes.nextcloudSessionId)) {
+					objectMap.modelsTempPromoted.push(model)
+				} else if (isModelWithVideo(model)) {
+					videoTilesMap.set(model.attributes.nextcloudSessionId, model)
+				} else if (participantsInitialised.value && isModelWithAudio(model)) {
+					audioTilesMap.set(model.attributes.nextcloudSessionId, model)
+				} else {
+					objectMap.modelsWithNoPermissions.push(model)
+				}
+			})
+
+			objectMap.modelsWithVideoEnabled = getOrderedTiles(videoTilesMap, promotedHistoryMask.value)
+			objectMap.modelsWithAudioOnly = getOrderedTiles(audioTilesMap, promotedHistoryMask.value)
+
+			return [
+				...objectMap.modelsWithScreenshare,
+				...objectMap.modelsTempPromoted,
+				...objectMap.modelsWithVideoEnabled,
+				...objectMap.modelsWithAudioOnly,
+				...objectMap.modelsWithNoPermissions,
+			]
+		})
+
+		/**
+		 * @param {object} model the speaker model to unpromote
+		 */
+		function unpromoteSpeaker(model) {
+			// remove model from the temp promoted speakers
+			const index = tempPromotedModels.value.indexOf(model)
+			if (index === -1) {
+				return
+			}
+
+			tempPromotedModels.value.splice(index, 1)
+		}
+
+		/**
+		 * @param {object} model the speaker model to promote
+		 */
+		function promoteSpeaker(model) {
+			const id = model.attributes.nextcloudSessionId
+
+			// if model is already in the first page, do nothing
+			if (orderedVideos.value.slice(0, slots.value).find((video) => video.attributes.nextcloudSessionId === id)) {
+				return
+			}
+
+			if (props.screens.includes(model.attributes.peerId)) {
+				// tiles with screenshare have a better priority position already
+				// do nothing
+				return
+			}
+
+			// add the model
+			if (!tempPromotedModels.value.includes(model)) {
+				// remove model from the order history if it exists
+				const modelIndex = promotedHistoryMask.value.indexOf(id)
+				if (modelIndex !== -1) {
+					promotedHistoryMask.value.splice(modelIndex, 1)
+				}
+
+				tempPromotedModels.value.unshift(model)
+				// add model to the beginning of the orderedVideos in its category
+				promotedHistoryMask.value.unshift(id)
+			}
+		}
+
+		const speakers = computed(() => props.callParticipantModels.filter((model) => model.attributes.speaking))
+
+		const speakersWithAudioOff = computed(() => tempPromotedModels.value.filter((model) => !model.attributes.audioAvailable))
+
+		watch(speakers, (models) => {
+			models.forEach((model) => {
+				promoteSpeaker(model)
+				clearTimeout(unpromoteSpeakerTimer[model.attributes.nextcloudSessionId])
+			})
+		})
+
+		watch(speakersWithAudioOff, (newModels, oldModels) => {
+			newModels.forEach((speaker) => {
+				if (oldModels.includes(speaker)) {
+					return
+				}
+				unpromoteSpeakerTimer[speaker.attributes.nextcloudSessionId] = setTimeout(() => {
+					unpromoteSpeaker(speaker)
+				}, 10000)
+			})
+		})
+
 		return {
+			videos,
+			slots,
+			orderedVideos,
 			devMode,
 			dummies,
 			screenshotMode,
@@ -328,9 +526,6 @@ export default {
 			// The current page
 			currentPage: 0,
 			debounceHandleWheelEvent: () => {},
-			tempPromotedModels: [],
-			unpromoteSpeakerTimer: {},
-			promotedHistoryMask: [],
 		}
 	},
 
@@ -340,17 +535,6 @@ export default {
 				return t('spreed', 'Collapse stripe')
 			} else {
 				return t('spreed', 'Expand stripe')
-			}
-		},
-
-		// The videos array. This is the total number of grid elements.
-		// Depending on `gridWidth`, `gridHeight`, `minWidth`, `minHeight` and
-		// `videosCap`, these videos are shown in one or more grid 'pages'.
-		videos() {
-			if (this.devMode) {
-				return Array.from(Array(this.dummies).keys())
-			} else {
-				return this.callParticipantModels
 			}
 		},
 
@@ -398,22 +582,6 @@ export default {
 			// however, if a screen share is in progress, it means the video of the presenting user is not visible,
 			// so we can show it in the stripe
 			return this.videos.length <= 1 && !this.screens.length
-		},
-
-		// The local video always takes one slot if the grid view is not shown as a stripe.
-		// In recording mode the local video is not shown, so all slots are available.
-		noLocalVideoReserve() {
-			return this.isStripe || this.isRecording
-		},
-
-		// Number of grid slots (videos per page) at any given moment, clamped to
-		// `videosCap` (`0` means no cap).
-		// The cap is primarily enforced by shrinking the grid layout (see
-		// `computeGridDimensions`); this clamp keeps the "videos per page" math
-		// consistent even before the layout has been recomputed.
-		slots() {
-			const slots = this.noLocalVideoReserve ? this.rows * this.columns : this.rows * this.columns - 1
-			return this.videosCap ? Math.min(this.videosCap, slots) : slots
 		},
 
 		// Grid pages at any given moment
@@ -465,68 +633,6 @@ export default {
 			}
 		},
 
-		participantsInitialised() {
-			return this.$store.getters.participantsInitialised(this.token)
-		},
-
-		isGuestNonModerator() {
-			return this.actorStore.isActorGuest
-				&& this.$store.getters.conversation(this.token).participantType !== PARTICIPANT.TYPE.GUEST_MODERATOR
-		},
-
-		orderedVideos() {
-			// Dynamic ordering is not possible for guests because
-			// participants store is not initialized
-			if (this.isGuestNonModerator || this.devMode) {
-				return this.videos
-			}
-
-			const objectMap = {
-				modelsWithScreenshare: [],
-				modelsTempPromoted: [],
-				modelsWithVideoEnabled: [],
-				modelsWithAudioOnly: [],
-				modelsWithNoPermissions: [],
-			}
-			const screensSet = new Set(this.screens)
-			const tempPromotedModelsSet = new Set(this.tempPromotedModels.map((model) => model.attributes.nextcloudSessionId))
-			const videoTilesMap = new Map()
-			const audioTilesMap = new Map()
-
-			this.callParticipantModels.forEach((model) => {
-				if (screensSet.has(model.attributes.peerId)) {
-					objectMap.modelsWithScreenshare.push(model)
-				} else if (tempPromotedModelsSet.has(model.attributes.nextcloudSessionId)) {
-					objectMap.modelsTempPromoted.push(model)
-				} else if (this.isModelWithVideo(model)) {
-					videoTilesMap.set(model.attributes.nextcloudSessionId, model)
-				} else if (this.participantsInitialised && this.isModelWithAudio(model)) {
-					audioTilesMap.set(model.attributes.nextcloudSessionId, model)
-				} else {
-					objectMap.modelsWithNoPermissions.push(model)
-				}
-			})
-
-			objectMap.modelsWithVideoEnabled = this.getOrderedTiles(videoTilesMap, this.promotedHistoryMask)
-			objectMap.modelsWithAudioOnly = this.getOrderedTiles(audioTilesMap, this.promotedHistoryMask)
-
-			return [
-				...objectMap.modelsWithScreenshare,
-				...objectMap.modelsTempPromoted,
-				...objectMap.modelsWithVideoEnabled,
-				...objectMap.modelsWithAudioOnly,
-				...objectMap.modelsWithNoPermissions,
-			]
-		},
-
-		speakers() {
-			return this.callParticipantModels.filter((model) => model.attributes.speaking)
-		},
-
-		speakersWithAudioOff() {
-			return this.tempPromotedModels.filter((model) => !model.attributes.audioAvailable)
-		},
-
 		devStripe: {
 			get() {
 				return this.isStripe
@@ -550,24 +656,6 @@ export default {
 			if (this.currentPage >= this.numberOfPages) {
 				this.currentPage = Math.max(0, this.numberOfPages - 1)
 			}
-		},
-
-		speakers(models) {
-			models.forEach((model) => {
-				this.promoteSpeaker(model)
-				clearTimeout(this.unpromoteSpeakerTimer[model.attributes.nextcloudSessionId])
-			})
-		},
-
-		speakersWithAudioOff(newModels, oldModels) {
-			newModels.forEach((speaker) => {
-				if (oldModels.includes(speaker)) {
-					return
-				}
-				this.unpromoteSpeakerTimer[speaker.attributes.nextcloudSessionId] = setTimeout(() => {
-					this.unpromoteSpeaker(speaker)
-				}, 10000)
-			})
 		},
 	},
 
@@ -668,77 +756,6 @@ export default {
 
 		isSelected(callParticipantModel) {
 			return callParticipantModel.attributes.peerId === this.callViewStore.selectedVideoPeerId
-		},
-
-		isModelWithVideo(callParticipantModel) {
-			return callParticipantModel.attributes.videoAvailable
-				&& (typeof callParticipantModel.attributes.stream === 'object')
-		},
-
-		isModelWithAudio(callParticipantModel) {
-			const participant = this.$store.getters.getParticipantBySessionId(this.token, callParticipantModel.attributes.nextcloudSessionId)
-			if (!participant) {
-				return false
-			}
-			return participant?.permissions & PARTICIPANT.PERMISSIONS.PUBLISH_AUDIO
-		},
-
-		unpromoteSpeaker(model) {
-			// remove model from the temp promoted speakers
-			const index = this.tempPromotedModels.indexOf(model)
-			if (index === -1) {
-				return
-			}
-
-			this.tempPromotedModels.splice(index, 1)
-		},
-
-		promoteSpeaker(model) {
-			const id = model.attributes.nextcloudSessionId
-
-			// if model is already in the first page, do nothing
-			if (this.orderedVideos.slice(0, this.slots).find((video) => video.attributes.nextcloudSessionId === id)) {
-				return
-			}
-
-			if (this.screens.includes(model.attributes.peerId)) {
-				// tiles with screenshare have a better priority position already
-				// do nothing
-				return
-			}
-
-			// add the model
-			if (!this.tempPromotedModels.includes(model)) {
-				// remove model from the order history if it exists
-				const modelIndex = this.promotedHistoryMask.indexOf(id)
-				if (modelIndex !== -1) {
-					this.promotedHistoryMask.splice(modelIndex, 1)
-				}
-
-				this.tempPromotedModels.unshift(model)
-				// add model to the beginning of the orderedVideos in its category
-				this.promotedHistoryMask.unshift(id)
-			}
-		},
-
-		getOrderedTiles(tilesMap, orderMask) {
-			const orderedTiles = []
-			const rest = []
-			// Get the ordered tiles
-			orderMask.forEach((id) => {
-				if (tilesMap.has(id)) {
-					orderedTiles.push(tilesMap.get(id))
-				}
-			})
-
-			// Add remaining tiles not in orderMask to rest
-			tilesMap.forEach((tile, id) => {
-				if (!orderMask.includes(id)) {
-					rest.push(tile)
-				}
-			})
-
-			return [...orderedTiles, ...rest]
 		},
 	},
 }

--- a/src/components/CallView/Grid/VideosGrid.vue
+++ b/src/components/CallView/Grid/VideosGrid.vue
@@ -31,7 +31,7 @@
 						variant="tertiary-no-background"
 						class="grid-navigation grid-navigation__previous"
 						:aria-label="t('spreed', 'Previous page of videos')"
-						@click="handleClickPrevious">
+						@click="previous">
 						<template #icon>
 							<IconChevronLeft
 								class="bidirectional-icon"
@@ -97,7 +97,7 @@
 						variant="tertiary-no-background"
 						class="grid-navigation grid-navigation__next"
 						:aria-label="t('spreed', 'Next page of videos')"
-						@click="handleClickNext">
+						@click="next">
 						<template #icon>
 							<IconChevronRight
 								class="bidirectional-icon"
@@ -183,6 +183,7 @@ import { useCallViewStore } from '../../../stores/callView.ts'
 import { GRID_GAP } from './gridLayout.ts'
 import { placeholderImage, placeholderModel, placeholderName, placeholderSharedData } from './gridPlaceholders.ts'
 import { useGridDimensions } from './useGridDimensions.ts'
+import { usePagination } from './usePagination.ts'
 
 // Max number of videos per page. `0`, the default value, means no cap
 const videosCap = getTalkConfig('local', 'call', 'grid-limit') || 0
@@ -504,10 +505,29 @@ export default {
 			})
 		})
 
+		const pagination = usePagination(orderedVideos, slots)
+		const { currentPage, numberOfPages, displayedVideos, next, previous } = pagination
+
+		// Hide or display the `grid-navigation` buttons
+		const hasNextPage = computed(() => props.hasPagination && pagination.hasNextPage.value)
+		const hasPreviousPage = computed(() => props.hasPagination && pagination.hasPreviousPage.value)
+
+		// Reset current page when switching between stripe and full grid,
+		// as the previous page is meaningless in the new mode.
+		// The grid layout itself is recomputed by `useGridDimensions`.
+		watch(() => props.isStripe, () => {
+			currentPage.value = 0
+		})
+
 		return {
 			videos,
-			slots,
-			orderedVideos,
+			currentPage,
+			numberOfPages,
+			displayedVideos,
+			hasNextPage,
+			hasPreviousPage,
+			next,
+			previous,
 			devMode,
 			dummies,
 			screenshotMode,
@@ -523,8 +543,6 @@ export default {
 
 	data() {
 		return {
-			// The current page
-			currentPage: 0,
 			debounceHandleWheelEvent: () => {},
 		}
 	},
@@ -556,55 +574,11 @@ export default {
 			return (this.gridHeight - GRID_GAP * (this.rows - 1)) / this.rows
 		},
 
-		// Array of videos that are being displayed in the grid at any given
-		// moment
-		// TODO: properly handle resizes when not on first page:
-		// currently if the user is not on the 'first page', upon resize the
-		// current position in the videos array is lost (`slots` changes, so
-		// `currentPage * slots` points at a different window of the videos)
-		displayedVideos() {
-			if (!this.slots) {
-				return []
-			}
-
-			const slots = this.slots
-
-			// Slice the `videos` array to display the current page of videos
-			if (((this.currentPage + 1) * slots) >= this.orderedVideos.length) {
-				return this.orderedVideos.slice(this.currentPage * slots)
-			}
-
-			return this.orderedVideos.slice(this.currentPage * slots, (this.currentPage + 1) * slots)
-		},
-
 		isLessThanTwoVideos() {
 			// without screen share, we don't want to duplicate videos if we were to show them in the stripe
 			// however, if a screen share is in progress, it means the video of the presenting user is not visible,
 			// so we can show it in the stripe
 			return this.videos.length <= 1 && !this.screens.length
-		},
-
-		// Grid pages at any given moment
-		numberOfPages() {
-			return Math.ceil(this.videosCount / this.slots)
-		},
-
-		// Hides or displays the `grid-navigation next` button
-		hasNextPage() {
-			if (this.displayedVideos.length !== 0 && this.hasPagination) {
-				return this.displayedVideos.at(-1) !== this.orderedVideos.at(-1)
-			} else {
-				return false
-			}
-		},
-
-		// Hides or displays the `grid-navigation previous` button
-		hasPreviousPage() {
-			if (this.displayedVideos.length !== 0 && this.hasPagination) {
-				return this.displayedVideos[0] !== this.orderedVideos[0]
-			} else {
-				return false
-			}
 		},
 
 		// Computed css to reactively style the grid
@@ -641,21 +615,6 @@ export default {
 			set(value) {
 				this.callViewStore.setCallViewMode({ token: this.token, isGrid: !value, clearLast: false })
 			},
-		},
-	},
-
-	watch: {
-		isStripe() {
-			// Reset current page when switching between stripe and full grid,
-			// as the previous page is meaningless in the new mode.
-			// The grid layout itself is recomputed by `useGridDimensions`.
-			this.currentPage = 0
-		},
-
-		numberOfPages() {
-			if (this.currentPage >= this.numberOfPages) {
-				this.currentPage = Math.max(0, this.numberOfPages - 1)
-			}
 		},
 	},
 
@@ -725,20 +684,10 @@ export default {
 			}
 
 			if (event.deltaY < 0 && this.hasPreviousPage) {
-				this.handleClickPrevious()
+				this.previous()
 			} else if (event.deltaY > 0 && this.hasNextPage) {
-				this.handleClickNext()
+				this.next()
 			}
-		},
-
-		handleClickNext() {
-			this.currentPage++
-			console.debug('handleclicknext, ', 'currentPage ', this.currentPage, 'slots ', this.slots, 'videos.length ', this.videos.length)
-		},
-
-		handleClickPrevious() {
-			this.currentPage--
-			console.debug('handleclickprevious, ', 'currentPage ', this.currentPage, 'slots ', this.slots, 'videos.length ', this.videos.length)
 		},
 
 		handleClickStripeCollapse() {

--- a/src/components/CallView/Grid/VideosGrid.vue
+++ b/src/components/CallView/Grid/VideosGrid.vue
@@ -497,15 +497,20 @@ export default {
 			})
 		})
 
+		const videosCount = computed(() => orderedVideos.value.length)
+
 		const {
 			currentPage,
 			numberOfPages,
-			displayedVideos,
+			currentPageBounds,
 			hasNextPage,
 			hasPreviousPage,
 			next,
 			previous,
-		} = usePagination(orderedVideos, slots)
+		} = usePagination(videosCount, slots)
+
+		// The window of the ordered videos shown on the current page
+		const displayedVideos = computed(() => orderedVideos.value.slice(...currentPageBounds.value))
 
 		// Reset current page when switching between stripe and full grid,
 		// as the previous page is meaningless in the new mode.

--- a/src/components/CallView/Grid/VideosGrid.vue
+++ b/src/components/CallView/Grid/VideosGrid.vue
@@ -206,14 +206,6 @@ export default {
 
 	props: {
 		/**
-		 * Display the overflow of videos in separate pages;
-		 */
-		hasPagination: {
-			type: Boolean,
-			default: false,
-		},
-
-		/**
 		 * To be set to true when the grid is in the promoted view.
 		 */
 		isStripe: {
@@ -505,12 +497,15 @@ export default {
 			})
 		})
 
-		const pagination = usePagination(orderedVideos, slots)
-		const { currentPage, numberOfPages, displayedVideos, next, previous } = pagination
-
-		// Hide or display the `grid-navigation` buttons
-		const hasNextPage = computed(() => props.hasPagination && pagination.hasNextPage.value)
-		const hasPreviousPage = computed(() => props.hasPagination && pagination.hasPreviousPage.value)
+		const {
+			currentPage,
+			numberOfPages,
+			displayedVideos,
+			hasNextPage,
+			hasPreviousPage,
+			next,
+			previous,
+		} = usePagination(orderedVideos, slots)
 
 		// Reset current page when switching between stripe and full grid,
 		// as the previous page is meaningless in the new mode.

--- a/src/components/CallView/Grid/gridLayout.ts
+++ b/src/components/CallView/Grid/gridLayout.ts
@@ -79,40 +79,28 @@ function slotsFor(columns: number, rows: number, noLocalVideoReserve: boolean): 
 }
 
 /**
- * Maximum number of columns that fit the given width.
+ * Maximum number of tiles that fit along one axis (columns or rows) given the
+ * available size along that axis.
  *
- * A small hysteresis based on the current number of columns avoids flickering
- * when resizing within `GRID_GAP` px of the threshold for the current amount of
- * columns.
+ * A small hysteresis based on the current tile count avoids flickering when
+ * resizing within `GRID_GAP` px of the threshold for the current amount of
+ * tiles.
  *
- * @param gridWidth - available grid width in px
- * @param minWidth - minimum tile width in px
- * @param currentColumns - current number of columns
+ * @param size - available grid size in px along the axis
+ * @param minSize - minimum tile size in px along the axis
+ * @param currentCount - current number of tiles along the axis
  */
-function computeColumnsMax(gridWidth: number, minWidth: number, currentColumns: number): number {
-	// Max amount of columns that fits on screen, including gaps for the current layout
-	const approxColumnsMax = Math.floor((gridWidth - GRID_GAP * (currentColumns - 1)) / minWidth)
-	// Max amount of columns that fits on screen if we tried to fit one more column
-	const hypotheticalColumnsMax = Math.floor((gridWidth - GRID_GAP * currentColumns) / minWidth)
-	// If we are about to change the columns amount, check whether one more column could fit.
+function computeAxisMax(size: number, minSize: number, currentCount: number): number {
+	// Max amount of tiles that fits on screen, including gaps for the current layout
+	const approxMax = Math.floor((size - GRID_GAP * (currentCount - 1)) / minSize)
+	// Max amount of tiles that fits on screen if we tried to fit one more tile
+	const hypotheticalMax = Math.floor((size - GRID_GAP * currentCount) / minSize)
+	// If we are about to change the tile count, check whether one more tile could fit.
 	// This helps to avoid flickering when resizing within GRID_GAP px of the
-	// minimal gridWidth for the current amount of columns.
-	const columnsMax = approxColumnsMax === currentColumns ? approxColumnsMax : hypotheticalColumnsMax
-	// Return at least 1 column
-	return Math.max(columnsMax, 1)
-}
-
-/**
- * Maximum number of rows that fit the given height.
- *
- * @param gridHeight - available grid height in px
- * @param minHeight - minimum tile height in px
- * @param currentRows - current number of rows
- */
-function computeRowsMax(gridHeight: number, minHeight: number, currentRows: number): number {
-	const rowsMax = Math.floor((gridHeight - GRID_GAP * (currentRows - 1)) / minHeight)
-	// Return at least 1 row
-	return Math.max(rowsMax, 1)
+	// minimal size for the current amount of tiles.
+	const axisMax = approxMax === currentCount ? approxMax : hypotheticalMax
+	// Return at least 1 tile
+	return Math.max(axisMax, 1)
 }
 
 /**
@@ -161,8 +149,8 @@ export function computeGridDimensions({
 
 	// Start from the largest grid that fits the available space, then shrink it
 	// to fit the number of tiles we actually have.
-	let columns = computeColumnsMax(gridWidth, minWidth, currentColumns)
-	let rows = computeRowsMax(gridHeight, minHeight, currentRows)
+	let columns = computeAxisMax(gridWidth, minWidth, currentColumns)
+	let rows = computeAxisMax(gridHeight, minHeight, currentRows)
 
 	// No need to shrink more if 1 row and 1 column
 	if (rows === 1 && columns === 1) {

--- a/src/components/CallView/Grid/usePagination.spec.ts
+++ b/src/components/CallView/Grid/usePagination.spec.ts
@@ -1,0 +1,160 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { describe, expect, test } from 'vitest'
+import { nextTick, ref } from 'vue'
+import { usePagination } from './usePagination.ts'
+
+/**
+ * Create a pagination over `count` videos with `slots` videos per page.
+ *
+ * @param count - number of videos in the list
+ * @param slots - number of videos per page
+ */
+function createPagination(count: number, slots: number) {
+	const videos = ref(Array.from(Array(count).keys()))
+	const slotsRef = ref(slots)
+	return { videos, slots: slotsRef, ...usePagination(videos, slotsRef) }
+}
+
+describe('usePagination', () => {
+	describe('page computation', () => {
+		test('shows all videos on a single page when they fit', () => {
+			const { displayedVideos, numberOfPages, hasNextPage, hasPreviousPage } = createPagination(4, 6)
+
+			expect(displayedVideos.value).toEqual([0, 1, 2, 3])
+			expect(numberOfPages.value).toBe(1)
+			expect(hasNextPage.value).toBe(false)
+			expect(hasPreviousPage.value).toBe(false)
+		})
+
+		test('splits the videos into pages of the given size', () => {
+			const { displayedVideos, numberOfPages, hasNextPage } = createPagination(7, 3)
+
+			expect(numberOfPages.value).toBe(3)
+			expect(displayedVideos.value).toEqual([0, 1, 2])
+			expect(hasNextPage.value).toBe(true)
+		})
+
+		test('shows nothing while the layout is not known yet (0 slots)', () => {
+			const { displayedVideos, numberOfPages, hasNextPage, hasPreviousPage } = createPagination(7, 0)
+
+			expect(displayedVideos.value).toEqual([])
+			expect(numberOfPages.value).toBe(0)
+			expect(hasNextPage.value).toBe(false)
+			expect(hasPreviousPage.value).toBe(false)
+		})
+
+		test('handles an empty list of videos', () => {
+			const { displayedVideos, numberOfPages, hasNextPage, hasPreviousPage } = createPagination(0, 6)
+
+			expect(displayedVideos.value).toEqual([])
+			expect(numberOfPages.value).toBe(0)
+			expect(hasNextPage.value).toBe(false)
+			expect(hasPreviousPage.value).toBe(false)
+		})
+	})
+
+	describe('navigation', () => {
+		test('navigates forward through the pages', () => {
+			const pagination = createPagination(7, 3)
+
+			pagination.next()
+			expect(pagination.currentPage.value).toBe(1)
+			expect(pagination.displayedVideos.value).toEqual([3, 4, 5])
+			expect(pagination.hasPreviousPage.value).toBe(true)
+
+			pagination.next()
+			expect(pagination.currentPage.value).toBe(2)
+			expect(pagination.displayedVideos.value).toEqual([6])
+			expect(pagination.hasNextPage.value).toBe(false)
+		})
+
+		test('navigates backward through the pages', () => {
+			const pagination = createPagination(7, 3)
+
+			pagination.next()
+			pagination.previous()
+
+			expect(pagination.currentPage.value).toBe(0)
+			expect(pagination.displayedVideos.value).toEqual([0, 1, 2])
+			expect(pagination.hasPreviousPage.value).toBe(false)
+		})
+
+		test('does not navigate past the last page', () => {
+			const pagination = createPagination(7, 3)
+
+			pagination.next()
+			pagination.next()
+			pagination.next()
+
+			expect(pagination.currentPage.value).toBe(2)
+			expect(pagination.displayedVideos.value).toEqual([6])
+		})
+
+		test('does not navigate before the first page', () => {
+			const pagination = createPagination(7, 3)
+
+			pagination.previous()
+
+			expect(pagination.currentPage.value).toBe(0)
+			expect(pagination.displayedVideos.value).toEqual([0, 1, 2])
+		})
+	})
+
+	describe('reactivity to input changes', () => {
+		test('clamps the current page when videos leave', async () => {
+			const pagination = createPagination(7, 3)
+
+			pagination.next()
+			pagination.next()
+			expect(pagination.currentPage.value).toBe(2)
+
+			// Only one page left
+			pagination.videos.value = pagination.videos.value.slice(0, 3)
+			await nextTick()
+
+			expect(pagination.currentPage.value).toBe(0)
+			expect(pagination.displayedVideos.value).toEqual([0, 1, 2])
+		})
+
+		test('clamps the current page when the page grows on resize', async () => {
+			const pagination = createPagination(7, 3)
+
+			pagination.next()
+			pagination.next()
+			expect(pagination.currentPage.value).toBe(2)
+
+			// All videos fit on one page now
+			pagination.slots.value = 7
+			await nextTick()
+
+			expect(pagination.currentPage.value).toBe(0)
+			expect(pagination.displayedVideos.value).toEqual([0, 1, 2, 3, 4, 5, 6])
+		})
+
+		test('clamps the current page when all videos leave', async () => {
+			const pagination = createPagination(7, 3)
+
+			pagination.next()
+			pagination.videos.value = []
+			await nextTick()
+
+			expect(pagination.currentPage.value).toBe(0)
+			expect(pagination.displayedVideos.value).toEqual([])
+			expect(pagination.hasPreviousPage.value).toBe(false)
+		})
+
+		test('shows the new page when videos join', () => {
+			const pagination = createPagination(3, 3)
+			expect(pagination.hasNextPage.value).toBe(false)
+
+			pagination.videos.value = [...pagination.videos.value, 3]
+
+			expect(pagination.numberOfPages.value).toBe(2)
+			expect(pagination.hasNextPage.value).toBe(true)
+		})
+	})
+})

--- a/src/components/CallView/Grid/usePagination.spec.ts
+++ b/src/components/CallView/Grid/usePagination.spec.ts
@@ -4,11 +4,14 @@
  */
 
 import { describe, expect, test } from 'vitest'
-import { nextTick, ref } from 'vue'
+import { computed, nextTick, ref } from 'vue'
 import { usePagination } from './usePagination.ts'
 
 /**
  * Create a pagination over `count` videos with `slots` videos per page.
+ *
+ * The composable only works with counts and index bounds, so `displayedVideos`
+ * is derived here the same way the caller does, by slicing the list.
  *
  * @param count - number of videos in the list
  * @param slots - number of videos per page
@@ -16,7 +19,9 @@ import { usePagination } from './usePagination.ts'
 function createPagination(count: number, slots: number) {
 	const videos = ref(Array.from(Array(count).keys()))
 	const slotsRef = ref(slots)
-	return { videos, slots: slotsRef, ...usePagination(videos, slotsRef) }
+	const pagination = usePagination(computed(() => videos.value.length), slotsRef)
+	const displayedVideos = computed(() => videos.value.slice(...pagination.currentPageBounds.value))
+	return { videos, slots: slotsRef, displayedVideos, ...pagination }
 }
 
 describe('usePagination', () => {

--- a/src/components/CallView/Grid/usePagination.ts
+++ b/src/components/CallView/Grid/usePagination.ts
@@ -8,35 +8,40 @@ import type { Ref } from 'vue'
 import { computed, ref, watch } from 'vue'
 
 /**
- * Paginates a reactive list of videos into pages of `slots` items each.
+ * Paginates a list of `videosCount` videos into pages of `slots` items each.
+ *
+ * The composable only deals with counts and indexes; slicing the actual list
+ * is left to the caller, which slices it with `currentPageBounds`.
  *
  * The current page is clamped whenever the number of pages shrinks (e.g. on
  * resize or when participants leave), so the pagination never points past the
  * end of the list.
  *
- * @param videos - the ordered list of videos to paginate
+ * @param videosCount - the number of videos to paginate
  * @param slots - number of videos per page (`0` while the grid layout is not
  *   yet known, in which case nothing is displayed)
  */
-export function usePagination<T>(videos: Readonly<Ref<readonly T[]>>, slots: Readonly<Ref<number>>) {
+export function usePagination(videosCount: Readonly<Ref<number>>, slots: Readonly<Ref<number>>) {
 	const currentPage = ref(0)
 
 	const numberOfPages = computed(() => {
-		return slots.value > 0 ? Math.ceil(videos.value.length / slots.value) : 0
+		return slots.value > 0 ? Math.ceil(videosCount.value / slots.value) : 0
 	})
 
-	// The window of the videos array shown on the current page
-	const displayedVideos = computed(() => {
+	// The `[start, end)` index range of the videos shown on the current page,
+	// ready to be spread into `Array.prototype.slice`.
+	const currentPageBounds = computed<[number, number]>(() => {
 		if (slots.value <= 0) {
-			return []
+			return [0, 0]
 		}
 
-		return videos.value.slice(currentPage.value * slots.value, (currentPage.value + 1) * slots.value)
+		const start = currentPage.value * slots.value
+		return [start, start + slots.value]
 	})
 
 	const hasNextPage = computed(() => currentPage.value < numberOfPages.value - 1)
 
-	const hasPreviousPage = computed(() => currentPage.value > 0 && displayedVideos.value.length > 0)
+	const hasPreviousPage = computed(() => currentPage.value > 0)
 
 	/**
 	 * Advance to the next page, if there is one.
@@ -66,7 +71,7 @@ export function usePagination<T>(videos: Readonly<Ref<readonly T[]>>, slots: Rea
 	return {
 		currentPage,
 		numberOfPages,
-		displayedVideos,
+		currentPageBounds,
 		hasNextPage,
 		hasPreviousPage,
 		next,

--- a/src/components/CallView/Grid/usePagination.ts
+++ b/src/components/CallView/Grid/usePagination.ts
@@ -1,0 +1,75 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { Ref } from 'vue'
+
+import { computed, ref, watch } from 'vue'
+
+/**
+ * Paginates a reactive list of videos into pages of `slots` items each.
+ *
+ * The current page is clamped whenever the number of pages shrinks (e.g. on
+ * resize or when participants leave), so the pagination never points past the
+ * end of the list.
+ *
+ * @param videos - the ordered list of videos to paginate
+ * @param slots - number of videos per page (`0` while the grid layout is not
+ *   yet known, in which case nothing is displayed)
+ */
+export function usePagination<T>(videos: Readonly<Ref<readonly T[]>>, slots: Readonly<Ref<number>>) {
+	const currentPage = ref(0)
+
+	const numberOfPages = computed(() => {
+		return slots.value > 0 ? Math.ceil(videos.value.length / slots.value) : 0
+	})
+
+	// The window of the videos array shown on the current page
+	const displayedVideos = computed(() => {
+		if (slots.value <= 0) {
+			return []
+		}
+
+		return videos.value.slice(currentPage.value * slots.value, (currentPage.value + 1) * slots.value)
+	})
+
+	const hasNextPage = computed(() => currentPage.value < numberOfPages.value - 1)
+
+	const hasPreviousPage = computed(() => currentPage.value > 0 && displayedVideos.value.length > 0)
+
+	/**
+	 * Advance to the next page, if there is one.
+	 */
+	function next() {
+		if (hasNextPage.value) {
+			currentPage.value++
+		}
+	}
+
+	/**
+	 * Go back to the previous page, if there is one.
+	 */
+	function previous() {
+		if (hasPreviousPage.value) {
+			currentPage.value--
+		}
+	}
+
+	// Keep the current page within bounds when the page count shrinks
+	watch(numberOfPages, () => {
+		if (currentPage.value >= numberOfPages.value) {
+			currentPage.value = Math.max(0, numberOfPages.value - 1)
+		}
+	})
+
+	return {
+		currentPage,
+		numberOfPages,
+		displayedVideos,
+		hasNextPage,
+		hasPreviousPage,
+		next,
+		previous,
+	}
+}


### PR DESCRIPTION
## ☑️ Resolves

* Step 2 of refactoring Grid view. What it includes: 
- Extract Pagination logic into composable
- Move ordered logic temporarily to setup in the same component (it will be moved to another composable next as it is complex and independent computation wise) 
- Use the new composable and remove the logic from the component. 

The purpose is to seperate independent logics from the component and wire them together one by one. 

### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

NO VISUAL CHANGES

<!-- ☀️ Light theme | 🌑 Dark Theme -->


### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required