### PR TITLE
chore(deps): add redocly declaration for core types

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -48,7 +48,7 @@ SPDX-FileCopyrightText = "none"
 SPDX-License-Identifier = "CC0-1.0"
 
 [[annotations]]
-path = ["package.json", "package-lock.json", ".git-blame-ignore-revs", "**/package.json", "**/package-lock.json", "composer.json", "composer.patches.json", "composer.lock", "**/composer.json", "**/composer.lock", "patches.lock.json", ".gitignore", ".l10nignore", "psalm.xml", "tests/psalm-baseline.xml", "vendor-bin/**/composer.json", "vendor-bin/**/composer.lock", ".tx/config", "**/phpunit.xml", "tsconfig.json", "redocly.yaml"]
+path = ["package.json", "package-lock.json", ".git-blame-ignore-revs", "**/package.json", "**/package-lock.json", "composer.json", "composer.patches.json", "composer.lock", "**/composer.json", "**/composer.lock", "patches.lock.json", ".gitignore", ".l10nignore", "psalm.xml", "tests/psalm-baseline.xml", "vendor-bin/**/composer.json", "vendor-bin/**/composer.lock", ".tx/config", "**/phpunit.xml", "tsconfig.json"]
 precedence = "aggregate"
 SPDX-FileCopyrightText = "none"
 SPDX-License-Identifier = "CC0-1.0"

--- a/redocly.yaml
+++ b/redocly.yaml
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+# Config for Nextcloud Talk API types (ResponseDefinitions -> OpenAPI declaration)
+# apis uses explicit output paths provided per JSON input source
+
 apis:
     openapi@v1:
         root: ./openapi.json

--- a/src/types/redocly.yaml
+++ b/src/types/redocly.yaml
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+# Minimal config for core Nextcloud types (see generate-core-types.sh).
+# CLI uses explicit input/output paths provided by script instead of redocly.yaml at root.
+rules:
+    struct: off


### PR DESCRIPTION
## ☑️ Resolves

* Fix failing jobs e.g. here: https://github.com/nextcloud/spreed/actions/runs/29676759065
* Add redocly.yaml file, so for external files it doesn't consider root redocly (which only specifies spreed OpenAPI)

### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI