### PR TITLE
chore: update update-nextcloud-openapi workflow

### DIFF
--- a/.github/workflows/update-nextcloud-openapi.yml
+++ b/.github/workflows/update-nextcloud-openapi.yml
@@ -18,7 +18,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branches: ['main', 'master', 'stable33', 'stable32']
+        branches:
+          - ${{ github.event.repository.default_branch }}
+          - 'stable34'
+          - 'stable33'
+          - 'stable32'
 
     name: Update Nextcloud OpenAPI types from core
 
@@ -29,22 +33,12 @@ jobs:
           echo "APP_NAME=${GITHUB_REPOSITORY##*/}" >> $GITHUB_ENV
 
       - name: Checkout server
-        if: ${{ matrix.branches != 'main' }}
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           submodules: true
           repository: nextcloud/server
-          ref: ${{ matrix.branches }}
-
-      - name: Checkout server (Main)
-        if: ${{ matrix.branches == 'main' }}
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-          submodules: true
-          repository: nextcloud/server
-          ref: master
+          ref: ${{ matrix.branches == 'main' && 'master' || matrix.branches }}
 
       - name: Checkout app
         id: checkout
@@ -73,15 +67,18 @@ jobs:
         if: steps.checkout.outcome == 'success'
         run: npm i -g 'npm@${{ steps.versions.outputs.npmVersion }}'
 
-      - name: Install dependencies & generate types
+      - name: Install dependencies
         if: steps.checkout.outcome == 'success'
         working-directory: apps/${{ env.APP_NAME }}
         env:
           CYPRESS_INSTALL_BINARY: 0
           PUPPETEER_SKIP_DOWNLOAD: true
-        run: |
-          npm ci
-          npm run ts:generate-core-types --if-present
+        run: npm ci
+
+      - name: Generate types
+        if: steps.checkout.outcome == 'success'
+        working-directory: apps/${{ env.APP_NAME }}
+        run: npm run ts:generate-core-types
 
       - name: Create Pull Request
         if: steps.checkout.outcome == 'success'

--- a/.github/workflows/update-nextcloud-openapi.yml.patch
+++ b/.github/workflows/update-nextcloud-openapi.yml.patch
@@ -1,9 +1,0 @@
-diff --git a/.github/workflows/update-nextcloud-openapi.yml b/.github/workflows/update-nextcloud-openapi.yml
-index 8bb2d794c0..2d4befebab 100644
---- a/.github/workflows/update-nextcloud-openapi.yml
-+++ b/.github/workflows/update-nextcloud-openapi.yml
-@@ -99,4 +99,3 @@ jobs:
-             Auto-generated update of Nextcloud OpenAPI types
-           labels: |
-             dependencies
--            3. to review


### PR DESCRIPTION
## ☑️ Resolves

- Ref: #18722
- adjust to using branch matrix
- deduplicate 'server checkout' step
- split `npm ci` and `npm generate` - step fails siently
- remove patch (local workflow, redundant)
- add stable34 to matrix

### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI