### PR TITLE
fix(upload): use a v4 UUID with an insecure-context fallback

### DIFF
--- a/src/stores/upload.ts
+++ b/src/stores/upload.ts
@@ -36,6 +36,7 @@ import {
 	separateDuplicateUploads,
 } from '../utils/fileUpload.ts'
 import { parseUploadError } from '../utils/propfindErrorParse.ts'
+import { randomUuid } from '../utils/randomUuid.ts'
 import { useActorStore } from './actor.ts'
 import { useChatExtrasStore } from './chatExtras.ts'
 import { useSettingsStore } from './settings.ts'
@@ -469,7 +470,7 @@ export const useUploadStore = defineStore('upload', () => {
 			// resolves the final name (and any conflicts) when postAttachment
 			// moves the file out of Draft.
 			for (const [index] of getInitialisedUploads(uploadId)) {
-				const tempName = crypto.randomUUID()
+				const tempName = randomUuid()
 				markFileAsPendingUpload({ uploadId, index, sharePath: '/' + draftFolderPath + '/' + tempName })
 			}
 			return

--- a/src/utils/randomUuid.spec.ts
+++ b/src/utils/randomUuid.spec.ts
@@ -1,0 +1,44 @@
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { randomUuid } from './randomUuid.ts'
+
+// Canonical RFC 4122 version 4 UUID: version nibble is 4, variant nibble is 8/9/a/b
+const UUID_V4_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+
+describe('randomUuid', () => {
+	afterEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	test('returns a valid v4 UUID when crypto.randomUUID is available', () => {
+		expect(typeof crypto.randomUUID).toBe('function')
+		expect(randomUuid()).toMatch(UUID_V4_REGEX)
+	})
+
+	test('falls back to getRandomValues when crypto.randomUUID is undefined', () => {
+		const originalRandomUUID = crypto.randomUUID
+		try {
+			// Simulate an insecure context (plain HTTP), where randomUUID is missing
+			// @ts-expect-error - emulate the insecure-context runtime where the method is absent
+			crypto.randomUUID = undefined
+
+			const getRandomValuesSpy = vi.spyOn(crypto, 'getRandomValues')
+
+			const uuid = randomUuid()
+
+			expect(getRandomValuesSpy).toHaveBeenCalled()
+			expect(uuid).toMatch(UUID_V4_REGEX)
+		} finally {
+			crypto.randomUUID = originalRandomUUID
+		}
+	})
+
+	test('generates unique values on repeated calls', () => {
+		const values = new Set(Array.from({ length: 100 }, () => randomUuid()))
+		expect(values.size).toBe(100)
+	})
+})

--- a/src/utils/randomUuid.ts
+++ b/src/utils/randomUuid.ts
@@ -1,0 +1,44 @@
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * Generate an RFC 4122 version 4 (random) UUID.
+ *
+ * `crypto.randomUUID()` is only exposed in secure contexts (HTTPS or
+ * localhost). When Talk is served over plain HTTP it is `undefined`, which
+ * makes `crypto.randomUUID()` throw. In that case we fall back to
+ * `crypto.getRandomValues()`, which is available in insecure contexts too,
+ * and assemble the UUID manually.
+ *
+ * @return a random UUID in the canonical `xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx` form
+ */
+function randomUuid(): string {
+	if (typeof crypto.randomUUID === 'function') {
+		return crypto.randomUUID()
+	}
+
+	// Fallback for insecure contexts (plain HTTP): crypto.randomUUID is not
+	// available, but crypto.getRandomValues still is.
+	const bytes = crypto.getRandomValues(new Uint8Array(16))
+
+	// Set the version to 4 (0100) in the high nibble of byte 6
+	bytes[6] = (bytes[6] & 0x0f) | 0x40
+	// Set the variant to RFC 4122 (10xx) in the two high bits of byte 8
+	bytes[8] = (bytes[8] & 0x3f) | 0x80
+
+	const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0'))
+
+	return [
+		hex.slice(0, 4).join(''),
+		hex.slice(4, 6).join(''),
+		hex.slice(6, 8).join(''),
+		hex.slice(8, 10).join(''),
+		hex.slice(10, 16).join(''),
+	].join('-')
+}
+
+export {
+	randomUuid,
+}


### PR DESCRIPTION
## What

Talk fails to upload files over plain HTTP with `TypeError: crypto.randomUUID is not a function` (#18733).

## Root cause

`crypto.randomUUID()` is only exposed in **secure contexts** (HTTPS / localhost). When Talk is served over plain HTTP it is `undefined`, so the call that builds a temporary upload name (`src/stores/upload.ts`) throws.

## Fix

Add a `randomUuid()` helper (`src/utils/randomUuid.ts`) that returns `crypto.randomUUID()` when it's available and otherwise generates an RFC 4122 v4 UUID from `crypto.getRandomValues()` — which is available in insecure contexts too — setting the version (`0x40`) and variant (`0x80`) bits and formatting it as `8-4-4-4-12`. The upload call site now uses it. It was the only `crypto.randomUUID` use in `src/` (the E2EE code and the existing `getRandomValues` utilities are unaffected).

## Tests

`src/utils/randomUuid.spec.ts` (vitest): valid v4 shape; the fallback path (with `crypto.randomUUID` undefined) still yields a valid v4 and calls `getRandomValues`; 100 calls are unique.

## Verification

`vitest` (helper 3/3, upload store 13/13), `eslint`, and `vue-tsc --noEmit` (whole project) all pass.

---

*AI disclosure: this PR was drafted with Claude Code (AI-assisted). Verified with the new unit test, the upload-store test, eslint, and the project type-check. DCO sign-off included.*
