### PR TITLE
fix(call): apply softer resolution constraints to camera

### DIFF
--- a/src/utils/webrtc/VideoConstrainer.js
+++ b/src/utils/webrtc/VideoConstrainer.js
@@ -86,6 +86,18 @@ VideoConstrainer.prototype = {
 		// Quality may not actually match the default constraints, but it is the
 		// best that can be done.
 		this._currentQuality = quality
+
+		this._logAppliedSettings(quality)
+	},
+
+	_logAppliedSettings(quality) {
+		const outputTrack = this._trackConstrainer.getOutputTrack()
+		if (!outputTrack || !outputTrack.getSettings) {
+			return
+		}
+
+		const { width, height, frameRate } = outputTrack.getSettings()
+		console.debug('Camera picked resolution for quality %d: %dx%d @ %s fps', quality, width, height, frameRate)
 	},
 
 	async _applyRoughConstraints(trackConstrainer, quality) {
@@ -169,10 +181,14 @@ VideoConstrainer.prototype = {
 		if (quality === QUALITY.HIGH) {
 			return {
 				width: {
-					min: 1440,
+					max: 1920,
+					ideal: 1920,
+					min: 1280,
 				},
 				height: {
-					min: 1080,
+					max: 1080,
+					ideal: 1080,
+					min: 720,
 				},
 				frameRate: {
 					max: 30,
@@ -186,10 +202,14 @@ VideoConstrainer.prototype = {
 		if (quality === QUALITY.MEDIUM) {
 			return {
 				width: {
-					min: 720,
+					max: 1280,
+					ideal: 1280,
+					min: 640,
 				},
 				height: {
-					min: 540,
+					max: 720,
+					ideal: 720,
+					min: 480,
 				},
 				frameRate: {
 					max: 30,
@@ -245,9 +265,13 @@ VideoConstrainer.prototype = {
 		return {
 			width: {
 				max: 320,
+				ideal: 240,
+				min: 160,
 			},
 			height: {
 				max: 240,
+				ideal: 180,
+				min: 120,
 			},
 			frameRate: {
 				max: 30,


### PR DESCRIPTION
## ☑️ Resolves

* Ref #16266
* Change constraints to satisfy wider range of quality:
	* HIGH: 1080p - 720p
	* MEDIUM: 720p - 480p
	* LOW: 480p - 320p
	* VERY_LOW: 320p - 240p
	* THUMBNAIL: 240p - 120p
* `_applyRoughResolutionConstraints()` still works as before, if e.g. HIGH quality is requested, but camera can't provide 720p -> min border degrades to 720 / 1.5 = 480p
* add logger to see final pick for resolution (other logs provide only constraints requested)

### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

Tested with 2 cameras: 1080p and 720p

🏚️ Before | 🏡 After
-- | --
<img width="365" height="246" alt="2026-07-22_11h07_09" src="https://github.com/user-attachments/assets/c5e4d53c-99cd-40e5-b71a-3a02854dfa98" /> | <img width="370" height="184" alt="2026-07-22_11h04_06" src="https://github.com/user-attachments/assets/8ce595fc-dc09-4a95-ac91-f9d5a7b95e69" />

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [x] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required