### PR TITLE
fix(call): reapply videoConstrainer on source change

### DIFF
--- a/src/utils/webrtc/SentVideoQualityThrottler.js
+++ b/src/utils/webrtc/SentVideoQualityThrottler.js
@@ -66,6 +66,8 @@ SentVideoQualityThrottler.prototype = {
 		this._localMediaModel.off('change:videoAvailable', this._handleLocalVideoAvailableChangeBound)
 
 		this._stopListeningToChanges()
+
+		this._videoConstrainer.destroy()
 	},
 
 	_handleLocalVideoAvailableChange(localMediaModel, videoAvailable) {

--- a/src/utils/webrtc/VideoConstrainer.js
+++ b/src/utils/webrtc/VideoConstrainer.js
@@ -34,11 +34,50 @@ function VideoConstrainer(trackConstrainer) {
 	// least once.
 	this._currentQuality = undefined
 
+	// The last quality requested through `applyConstraints`.
+	this._lastRequestedQuality = undefined
+
+	// The track being constrained. Used to tell an external track replacement
+	// apart from the constrainer re-setting the same track while applying.
+	this._constrainedTrack = null
+
 	this._knownValidConstraintsForQuality = {}
+
+	this._handleOutputTrackSetBound = this._handleOutputTrackSet.bind(this)
+	this._trackConstrainer.on('outputTrackSet', this._handleOutputTrackSetBound)
 }
 VideoConstrainer.prototype = {
 
+	destroy() {
+		this._trackConstrainer.off('outputTrackSet', this._handleOutputTrackSetBound)
+	},
+
+	_handleOutputTrackSet(trackConstrainer, trackId, track) {
+		if (!track || track.kind !== 'video') {
+			return
+		}
+
+		if (this._lastRequestedQuality === undefined) {
+			// Initialization - no constrains were applied yet
+			return
+		}
+
+		if (track === this._constrainedTrack) {
+			// Ignore the events the constrainer emits while re-setting the same track
+			return
+		}
+
+		// The output track was replaced (e.g. camera source).
+		// Previous constraints might not be valid for the new one, so drop
+		// known constraints and reapply the last requested quality on the new track.
+		this._knownValidConstraintsForQuality = {}
+		this._currentQuality = undefined
+		void this.applyConstraints(this._lastRequestedQuality)
+	},
+
 	async applyConstraints(quality) {
+		this._lastRequestedQuality = quality
+
 		if (this._pendingApplyConstraintsCount) {
 			console.debug('Deferring applying constraints for quality ' + quality)
 
@@ -81,6 +120,9 @@ VideoConstrainer.prototype = {
 			return
 		}
 
+		// Remember the track being constrained before applying
+		this._constrainedTrack = this._trackConstrainer.getOutputTrack()
+
 		await this._applyRoughConstraints(this._trackConstrainer, quality)
 
 		// Quality may not actually match the default constraints, but it is the
@@ -91,7 +133,7 @@ VideoConstrainer.prototype = {
 	},
 
 	_logAppliedSettings(quality) {
-		const outputTrack = this._trackConstrainer.getOutputTrack()
+		const outputTrack = this._constrainedTrack
 		if (!outputTrack || !outputTrack.getSettings) {
 			return
 		}


### PR DESCRIPTION
## ☑️ Resolves

* Fix #8815
* Issue is actually in two parts:
	* 1 - 16:9 is constrained to 4:3 - was due to strict constraints, changed before. UI for local video might still be locked to 4:3 aspect ration, but full video is translate - there are other isues ope for that topic
	* 2 - constraints are not re-applied after source change / camera state change -> new video stream goes as-is - fixed with this PR

### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

To test - try `fix/noid/video-constraints-p1` base branch - logger is in place, but nothing triggers `applyConstraints` after initialized first time.

Before: only first resolution will be seen
After:
<img width="370" height="184" alt="2026-07-22_11h04_06" src="https://github.com/user-attachments/assets/6fa90e7f-9b04-481d-b668-bbba9c391752" />


### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [x] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required