### PR TITLE
Add "Mark as read" action to chat notifications

### DIFF
--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -928,7 +928,24 @@ class Notifier implements INotifier {
 
 			$notification->addParsedAction($action);
 		} else {
-			$notification = $this->addActionButton($notification, 'chat_view', $l->t('View chat'), false);
+			$notification = $this->addActionButton($notification, 'chat_view', $l->t('View chat'));
+
+			$action = $notification->createAction();
+			$action->setLabel('mark_read')
+				->setParsedLabel($l->t('Mark as read'))
+				->setLink(
+					$this->url->linkToOCSRouteAbsolute(
+						'spreed.Chat.setReadMarker',
+						[
+							'apiVersion' => 'v1',
+							'token' => $room->getToken(),
+							'lastReadMessage' => $message->getMessageId(),
+						]
+					),
+					IAction::TYPE_POST
+				);
+
+			$notification->addParsedAction($action);
 		}
 
 		if (array_key_exists('user', $richSubjectParameters) && $richSubjectParameters['user'] === null) {


### PR DESCRIPTION
Currently the notifications only have the primary "View chat" and the default "Dismiss" x. A very useful addition would be a secondary "Mark as read" button which directly marks the message as read and removes the notification.


## ☑️ Resolves

* Fix #6035

### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="587" height="542" alt="Screenshot From 2026-07-22 12-22-46" src="https://github.com/user-attachments/assets/a5159dfb-9135-4eeb-90e6-811581cdef4e" />|<img width="587" height="542" alt="Screenshot From 2026-07-22 12-21-08" src="https://github.com/user-attachments/assets/a434c632-7c20-4040-8dbb-2ed5a13abd1c" />


### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [x] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible: Notifications are not covered by tests yet at all so I didn’t want to start with smth potentially wrong
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
