### PR TITLE
fix(call): do not downscale screenshare on Firefox

### DIFF
--- a/src/utils/webrtc/simplewebrtc/peer.js
+++ b/src/utils/webrtc/simplewebrtc/peer.js
@@ -356,6 +356,22 @@ function mungeSdpForSimulcasting(sdp) {
 }
 /* eslint-enable */
 
+/**
+ * Raises the "max-fs" (maximum frame size in macroblocks - 16x16 px)
+ * codec parameter in an SDP so high-resolution screens are not downscaled.
+ * Firefox defaults the VP8/VP9 "max-fs" to ~QHD (2560×1440px):
+ *  - a=fmtp:120 max-fs=12288;max-fr=60
+ * Raising it lets Firefox encode up to ~4K (3840×2160px):
+ *  - a=fmtp:120 max-fs=36864;max-fr=60
+ * Other browsers are not noticed to be affected with that limitation.
+ *
+ * @param {string} sdp the SDP string to munge
+ * @return {string} the updated SDP string
+ */
+function mungeSdpForScreenMaxFs(sdp) {
+	return sdp.replace(/max-fs=\d+/g, 'max-fs=' + 36864)
+}
+
 Peer.prototype.offer = function(options) {
 	const sendVideo = this.sendVideoIfAvailable && this.type !== 'screen'
 	if (sendVideo && this.enableSimulcast && adapter.browserDetails.browser === 'firefox') {
@@ -399,6 +415,12 @@ Peer.prototype.offer = function(options) {
 			} else if (adapter.browserDetails.browser !== 'firefox') {
 				console.debug('Simulcast can only be enabled on Chrome or Firefox')
 			}
+		}
+
+		// SDP munging only needed for Firefox screensharing (for 4K screens)
+		if (this.type === 'screen' && adapter.browserDetails.browser === 'firefox') {
+			console.debug('Raising VP8/9 max-fs for Firefox screensharing')
+			offer.sdp = mungeSdpForScreenMaxFs(offer.sdp)
 		}
 
 		this.pc.setLocalDescription(offer).then(function() {


### PR DESCRIPTION
## ☑️ Resolves

- Ref #2199 ; was noticed while closing:
- Firefox defaults the VP8/VP9 "max-fs" to ~QHD (~2560×1440 px):
`a=fmtp:120 max-fs=12288;max-fr=60`
- Raising it lets Firefox encode up to 4K (3840×2160 px):
`a=fmtp:120 max-fs=36864;max-fr=60`

### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="779" height="490" alt="2026-07-22_12h57_43" src="https://github.com/user-attachments/assets/17f9258b-21db-4f64-aa0b-22964bf88a6c" /> | <img width="778" height="460" alt="2026-07-22_12h53_37" src="https://github.com/user-attachments/assets/076ad3a9-b88d-4439-a7f5-0a29085983ac" />
<img width="694" height="67" alt="2026-07-22_13h02_09" src="https://github.com/user-attachments/assets/cb8e4711-e341-48ba-a3bc-088ab9444edf" /> | <img width="681" height="70" alt="2026-07-22_13h00_18" src="https://github.com/user-attachments/assets/ed8f3d57-df10-4a3d-8749-4754ff8c4aae" />


### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [x] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required