### PR TITLE
fix(tags): count unread conversations, not total messages

### DIFF
--- a/src/components/LeftSidebar/ConversationsList/ConversationsListVirtual.vue
+++ b/src/components/LeftSidebar/ConversationsList/ConversationsListVirtual.vue
@@ -67,7 +67,8 @@ const listItems = computed<VirtualListItem[]>(() => {
 		otherUnreadMention: boolean
 		otherUnreadMentionDirect: boolean
 	}>((acc, conversation) => {
-		const unreadCount = conversation.unreadMessages || 0
+		// Count amount of unread conversations, highlight if any has a direct or group mention
+		const unreadCount = conversation.unreadMessages ? 1 : 0
 		const unreadMention = conversation.unreadMention
 		const unreadMentionDirect = conversation.unreadMentionDirect
 			|| (!!unreadCount && [CONVERSATION.TYPE.ONE_TO_ONE, CONVERSATION.TYPE.ONE_TO_ONE_FORMER].includes(conversation.type))


### PR DESCRIPTION
## ☑️ Resolves

* Visually reduce the counter to only represent 'how many conversations unread', not 'how many messages in total'
* Aligned with mobile clients

### AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
Screenshot before | Screenshot after
<img width="172" height="145" alt="2026-07-23_10h11_39" src="https://github.com/user-attachments/assets/96fdb06b-10d0-43d5-b897-2f7ea63ac843" /> | <img width="170" height="145" alt="2026-07-23_10h12_14" src="https://github.com/user-attachments/assets/6bc3dac3-38e9-4eab-930e-ce4fc015d8bb" />

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [x] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required