### PR TITLE
fix(call): mix call audio on all iOS browsers

### DIFF
--- a/src/utils/browserCheck.ts
+++ b/src/utils/browserCheck.ts
@@ -16,6 +16,8 @@ const os = parser.getOS()
  */
 
 export const isMac = os.name === 'macOS'
+// Note: all browsers on iOS are using the WebKit engine
+export const isIOS = os.name === 'iOS'
 
 /**
  * Per-browser flags and a major version

--- a/src/utils/webrtc/CallParticipantsAudioPlayer.js
+++ b/src/utils/webrtc/CallParticipantsAudioPlayer.js
@@ -171,9 +171,15 @@ CallParticipantsAudioPlayer.prototype = {
 	},
 
 	async _setAudioElementOutput(deviceId, audioElement = null) {
-		if (audioElement instanceof HTMLAudioElement) {
-			await audioElement.setSinkId(deviceId)
-			console.debug('Set audio output to %s', deviceId)
+		if (audioElement instanceof HTMLAudioElement && mediaDevicesManager.isAudioOutputSelectSupported) {
+			try {
+				await audioElement.setSinkId(deviceId)
+				console.debug('Set audio output to %s', deviceId)
+			} catch (error) {
+				// "setSinkId" requires a user gesture on Safari/iOS.
+				// Audio will stay attached to the default output device.
+				console.warn('Could not set audio output device', error)
+			}
 		}
 	},
 

--- a/src/utils/webrtc/index.js
+++ b/src/utils/webrtc/index.js
@@ -9,7 +9,7 @@ import BrowserStorage from '../../services/BrowserStorage.js'
 import { getTalkConfig } from '../../services/CapabilitiesManager.ts'
 import { fetchSignalingSettings } from '../../services/signalingService.js'
 import store from '../../store/index.js'
-import { isSafari } from '../browserCheck.ts'
+import { isIOS, isSafari } from '../browserCheck.ts'
 import CancelableRequest from '../CancelableRequest.ts'
 import Encryption from '../e2ee/encryption.js'
 import Signaling from '../signaling.js'
@@ -254,7 +254,7 @@ async function signalingJoinCall(token, flags, silent, recordingConsent, silentF
 			callAnalyzer = new CallAnalyzer(localMediaModel, null, callParticipantCollection)
 		}
 
-		const mixAudio = isSafari
+		const mixAudio = isIOS || isSafari
 		callParticipantsAudioPlayer = new CallParticipantsAudioPlayer(callParticipantCollection, mixAudio)
 
 		const _signaling = signaling


### PR DESCRIPTION
## ☑️ Resolves

Fix `NotAllowedError` on iOS and `not a function` on Android within audio context:
- All iOS browsers atm are using Webkit engine underneath and share some behaviour
- Webkit requires user-gesture for AudioElement.setSinkId()
- not all callers in Talk are user-driven, e.g. peer.js connection
- should be circumvented by using mixAudio for all iOS devices
- catch a NotAllowed error as known and non-critical

Based on Sentry reports

### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required