### PR TITLE
fix(external-calls): reset external call view when switching conversation

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -64,6 +64,7 @@ import { useCallViewStore } from './stores/callView.ts'
 import { useSidebarStore } from './stores/sidebar.ts'
 import { useTokenStore } from './stores/token.ts'
 import { checkBrowser } from './utils/browserCheck.ts'
+import { hasExternalCallService } from './utils/conversation.ts'
 import { signalingKill } from './utils/webrtc/index.js'
 
 /** Internal handlers for 'joined-conversation' watcher (voice-, breakout- rooms) */
@@ -326,6 +327,11 @@ export default {
 			}
 
 			if (from.name === 'conversation' && from.params.token !== to.params.token) {
+				// Tear down the external call service view when leaving conversation,
+				// so iframe is not carried into the next one
+				if (hasExternalCallService(this.$store.getters.conversation(from.params.token))) {
+					this.callViewStore.leaveExternalCall()
+				}
 				// Await to properly close session / leave call before joining another one
 				await this.$store.dispatch('leaveConversation', { token: from.params.token })
 			}

--- a/src/components/ExternalCallView.vue
+++ b/src/components/ExternalCallView.vue
@@ -94,8 +94,7 @@ function onMessage(event: MessageEvent) {
  */
 function onIframeRemoved() {
 	externalWrapperObserver?.disconnect()
-	callViewStore.setExternalCallServiceUrl(null)
-	callViewStore.setForceCallView(false)
+	callViewStore.leaveExternalCall()
 }
 </script>
 

--- a/src/components/TopBar/CallButton.vue
+++ b/src/components/TopBar/CallButton.vue
@@ -129,7 +129,7 @@ import { useSoundsStore } from '../../stores/sounds.js'
 import { useTalkHashStore } from '../../stores/talkHash.js'
 import { useTokenStore } from '../../stores/token.ts'
 import { blockCalls, unsupportedWarning } from '../../utils/browserCheck.ts'
-import { isConversationPhoneRoom } from '../../utils/conversation.ts'
+import { hasExternalCallService, isConversationPhoneRoom } from '../../utils/conversation.ts'
 import { messagePleaseReload } from '../../utils/talkDesktopUtils.ts'
 
 export default {
@@ -243,12 +243,6 @@ export default {
 			return !this.hideText && (!this.isMobile || !this.shrinkOnMobile)
 		},
 
-		hasExternalCallService() {
-			return this.conversation.objectType === CONVERSATION.OBJECT_TYPE.EXTERNAL_CALL
-				&& !getTalkConfig('local', 'call', 'enabled')
-				&& getTalkConfig('local', 'call', 'external-call-service')
-		},
-
 		showRecordingWarning() {
 			return [
 				CALL.RECORDING.VIDEO_STARTING,
@@ -281,7 +275,7 @@ export default {
 		startCallButtonDisabled() {
 			return this.disabled
 				|| (this.callViewStore.callHasJustEnded && !this.hasCall)
-				|| (!this.conversation.canStartCall && !this.hasExternalCallService && !this.hasCall)
+				|| (!this.conversation.canStartCall && !hasExternalCallService(this.conversation) && !this.hasCall)
 				|| this.isInLobby
 				|| this.conversation.readOnly
 				|| this.isNextcloudTalkHashDirty
@@ -338,7 +332,7 @@ export default {
 		},
 
 		showStartCallButton() {
-			return (getTalkConfig(this.token, 'call', 'enabled') || this.hasExternalCallService)
+			return (getTalkConfig(this.token, 'call', 'enabled') || hasExternalCallService(this.conversation))
 				&& this.conversation.type !== CONVERSATION.TYPE.NOTE_TO_SELF
 				&& this.conversation.readOnly === CONVERSATION.STATE.READ_WRITE
 				&& (!this.conversation.remoteServer || hasTalkFeature(this.token, 'federation-v2'))
@@ -430,7 +424,7 @@ export default {
 		},
 
 		handleClick() {
-			if (this.hasExternalCallService) {
+			if (hasExternalCallService(this.conversation)) {
 				// Another service is in charge, trigger iframe rendering in MainView
 				this.handleExternalCall()
 				return

--- a/src/stores/__tests__/callView.spec.js
+++ b/src/stores/__tests__/callView.spec.js
@@ -230,6 +230,25 @@ describe('callViewStore', () => {
 			expect(callViewStore.forceCallView).toBeTruthy()
 		})
 
+		it('sets value on externalCallServiceUrl', () => {
+			expect(callViewStore.externalCallServiceUrl).toBe(null)
+			callViewStore.setExternalCallServiceUrl('https://example.com/meeting')
+			expect(callViewStore.externalCallServiceUrl).toBe('https://example.com/meeting')
+		})
+
+		it('resets external call service view state on leaveExternalCall', () => {
+			// Arrange: mimic being in an external call
+			callViewStore.setExternalCallServiceUrl('https://example.com/meeting')
+			callViewStore.setForceCallView(true)
+
+			// Act
+			callViewStore.leaveExternalCall()
+
+			// Assert: stale iframe URL and forced call view are cleared
+			expect(callViewStore.externalCallServiceUrl).toBe(null)
+			expect(callViewStore.forceCallView).toBe(false)
+		})
+
 		it('sets value on isViewerOverlay', () => {
 			expect(callViewStore.isViewerOverlay).toBeFalsy()
 			callViewStore.setIsViewerOverlay(true)

--- a/src/stores/callView.ts
+++ b/src/stores/callView.ts
@@ -65,6 +65,11 @@ export const useCallViewStore = defineStore('callView', {
 			this.externalCallServiceUrl = url
 		},
 
+		leaveExternalCall() {
+			this.setExternalCallServiceUrl(null)
+			this.setForceCallView(false)
+		},
+
 		setIsViewerOverlay(value: boolean) {
 			this.isViewerOverlay = value
 		},

--- a/src/utils/conversation.ts
+++ b/src/utils/conversation.ts
@@ -8,7 +8,7 @@ import type { Conversation, EventTimeRange } from '../types/index.ts'
 
 import { toValue } from 'vue'
 import { CONVERSATION, PARTICIPANT } from '../constants.ts'
-import { hasTalkFeature } from '../services/CapabilitiesManager.ts'
+import { getTalkConfig, hasTalkFeature } from '../services/CapabilitiesManager.ts'
 import { ONE_HOUR_IN_MS } from './formattedTime.ts'
 
 type Filter = 'unread' | 'mentions' | 'events'
@@ -44,6 +44,17 @@ export function hasUnreadMentions(conversation: Conversation): boolean {
  */
 export function hasCall(conversation: Conversation): boolean {
 	return conversation.hasCall && conversation.notificationCalls === PARTICIPANT.NOTIFY_CALLS.ON
+}
+
+/**
+ * check whether the conversation is created to use an external call service
+ *
+ * @param conversation conversation object
+ */
+export function hasExternalCallService(conversation?: Conversation): boolean {
+	return conversation?.objectType === CONVERSATION.OBJECT_TYPE.EXTERNAL_CALL
+		&& !getTalkConfig('local', 'call', 'enabled')
+		&& !!(getTalkConfig('local', 'call', 'external-call-service'))
 }
 
 /**

--- a/src/views/MainView.vue
+++ b/src/views/MainView.vue
@@ -21,10 +21,9 @@ import { useIsInCall } from '../composables/useIsInCall.js'
 import { useJoinCall } from '../composables/useJoinCall.ts'
 import { watchJoinedConversation } from '../composables/useJoinedConversation.ts'
 import { CALL, CONVERSATION } from '../constants.ts'
-import { getTalkConfig } from '../services/CapabilitiesManager.ts'
 import { useActorStore } from '../stores/actor.ts'
 import { useSettingsStore } from '../stores/settings.ts'
-import { isConversationPhoneRoom } from '../utils/conversation.ts'
+import { hasExternalCallService, isConversationPhoneRoom } from '../utils/conversation.ts'
 
 const props = defineProps<{
 	token: string
@@ -55,9 +54,7 @@ const connectionFailed = computed(() => store.getters.connectionFailed(props.tok
 const isVoiceRoom = computed(() => Boolean(store.getters.conversation(props.token)?.attributes & CONVERSATION.ATTRIBUTE.VOICE_ROOM))
 const isInExternalCall = computed(() => {
 	const conversation = store.getters.conversation(props.token) as Conversation | undefined
-	return conversation?.objectType === CONVERSATION.OBJECT_TYPE.EXTERNAL_CALL && isInCall.value
-		&& !getTalkConfig('local', 'call', 'enabled')
-		&& getTalkConfig('local', 'call', 'external-call-service')
+	return hasExternalCallService(conversation) && isInCall.value
 })
 
 watch([() => props.token, isVoiceRoom], ([newToken, newIsVoiceRoom]) => {


### PR DESCRIPTION
## ☑️ Resolves

- Fix #18765 
	- Actual fix is in `src/App.vue`
- Conversation switch was incorrectly handled
	- Extracted `hasExternalCallService` util to reuse across project
	- Add trigger for destroying iframe on router guard (leave conversation path)

### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

## 🖌️ UI Checklist

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required