### PR TITLE
fix: use inline methods for debounced functions

### DIFF
--- a/src/components/AdminSettings/AllowedGroups.vue
+++ b/src/components/AdminSettings/AllowedGroups.vue
@@ -35,7 +35,7 @@
 				trackBy="id"
 				label="displayname"
 				noWrap
-				@search="debounceSearchGroup" />
+				@search="debounceSearchGroup($event)" />
 			<NcButton
 				variant="primary"
 				:disabled="loading"
@@ -61,7 +61,7 @@
 				trackBy="id"
 				label="displayname"
 				noWrap
-				@search="debounceSearchGroup" />
+				@search="debounceSearchGroup($event)" />
 			<NcButton
 				variant="primary"
 				:disabled="loading"
@@ -87,7 +87,7 @@
 				trackBy="id"
 				label="displayname"
 				noWrap
-				@search="debounceSearchGroup" />
+				@search="debounceSearchGroup($event)" />
 			<NcButton
 				variant="primary"
 				:disabled="loading"

--- a/src/components/AdminSettings/FederationSettings.vue
+++ b/src/components/AdminSettings/FederationSettings.vue
@@ -76,7 +76,7 @@
 					trackBy="id"
 					label="displayname"
 					noWrap
-					@search="debounceSearchGroup" />
+					@search="debounceSearchGroup($event)" />
 
 				<NcButton
 					variant="primary"

--- a/src/components/AdminSettings/RecordingServers.vue
+++ b/src/components/AdminSettings/RecordingServers.vue
@@ -31,8 +31,8 @@
 					:index="index"
 					:loading="loading"
 					@removeServer="removeServer"
-					@update:server="debounceUpdateServers"
-					@update:verify="debounceUpdateServers" />
+					@update:server="debounceUpdateServers()"
+					@update:verify="debounceUpdateServers()" />
 			</TransitionWrapper>
 
 			<NcButton
@@ -56,7 +56,7 @@
 				:placeholder="t('spreed', 'Shared secret')"
 				:label="t('spreed', 'Shared secret')"
 				labelVisible
-				@update:modelValue="debounceUpdateServers" />
+				@update:modelValue="debounceUpdateServers()" />
 
 			<template v-if="servers.length && recordingConsentCapability">
 				<h3>{{ t('spreed', 'Recording consent') }}</h3>

--- a/src/components/AdminSettings/SIPBridge.vue
+++ b/src/components/AdminSettings/SIPBridge.vue
@@ -84,7 +84,7 @@
 				trackBy="id"
 				label="displayname"
 				noWrap
-				@search="debounceSearchGroup" />
+				@search="debounceSearchGroup($event)" />
 			<p class="settings-hint settings-hint--after-select">
 				{{ t('spreed', 'Only users of the following groups can enable SIP in conversations they moderate') }}
 			</p>

--- a/src/components/AdminSettings/StunServers.vue
+++ b/src/components/AdminSettings/StunServers.vue
@@ -25,7 +25,7 @@
 				:index="index"
 				:loading="loading"
 				@removeServer="removeServer"
-				@update:server="debounceUpdateServers" />
+				@update:server="debounceUpdateServers()" />
 		</TransitionWrapper>
 
 		<NcButton

--- a/src/components/AdminSettings/TurnServers.vue
+++ b/src/components/AdminSettings/TurnServers.vue
@@ -27,10 +27,10 @@
 				:index="index"
 				:loading="loading"
 				@removeServer="removeServer"
-				@update:schemes="debounceUpdateServers"
-				@update:server="debounceUpdateServers"
-				@update:secret="debounceUpdateServers"
-				@update:protocols="debounceUpdateServers" />
+				@update:schemes="debounceUpdateServers()"
+				@update:server="debounceUpdateServers()"
+				@update:secret="debounceUpdateServers()"
+				@update:protocols="debounceUpdateServers()" />
 		</TransitionWrapper>
 
 		<NcButton

--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -340,7 +340,7 @@
 					:compact="isCompact"
 					:showTags="supportTags && !showArchived"
 					class="scroller"
-					@scroll="debounceHandleScroll" />
+					@scroll="debounceHandleScroll()" />
 				<NcButton
 					v-if="!showThreadsList && lastUnreadMentionBelowViewportIndex !== null && !filters.includes('mentions')"
 					class="unread-mention-button"


### PR DESCRIPTION
## ☑️ Resolves

- fix "Typeerror: cannot convert undefined or null to object"
- debounced methods may be called from script or template
- method handlers (template) and inline handlers (template + script) are passing a different context
- for method handlers, 'this' is undefined, and debounce library silently throws
- see Vue "Method vs. Inline Detection"

Alternative would be to have method handlers, that call debounceFunctions() - but is it better?

### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

<img width="298" height="77" alt="2026-07-24_11h56_06" src="https://github.com/user-attachments/assets/3b99a00f-4ada-44b4-84db-cb30fec8f460" />

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [x] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required