### PR TITLE
feat: prepare UI base for classified conversations, announcements, channels

### DIFF
--- a/src/components/NewConversationDialog/NewConversationSetupPage.vue
+++ b/src/components/NewConversationDialog/NewConversationSetupPage.vue
@@ -105,9 +105,11 @@ import NcIconSvgWrapper from '@nextcloud/vue/components/NcIconSvgWrapper'
 import NcPasswordField from '@nextcloud/vue/components/NcPasswordField'
 import NcTextArea from '@nextcloud/vue/components/NcTextArea'
 import NcTextField from '@nextcloud/vue/components/NcTextField'
+import IconBullhornOutline from 'vue-material-design-icons/BullhornOutline.vue'
 import IconForumOutline from 'vue-material-design-icons/ForumOutline.vue'
 import IconMonitorAccount from 'vue-material-design-icons/MonitorAccount.vue'
 import IconPresentation from 'vue-material-design-icons/Presentation.vue'
+import IconShieldLockOutline from 'vue-material-design-icons/ShieldLockOutline.vue'
 import ConversationAvatarEditor from '../ConversationSettings/ConversationAvatarEditor.vue'
 import ListableSettings from '../ConversationSettings/ListableSettings.vue'
 import IconVolumeHighOutline from '../../../img/material-icons/volume-high-outline.svg?raw'
@@ -126,6 +128,9 @@ const presetIcons = {
 	[CONVERSATION.PRESET.VOICE_ROOM]: { svg: IconVolumeHighOutline },
 	[CONVERSATION.PRESET.PRESENTATION]: { icon: IconPresentation },
 	[CONVERSATION.PRESET.WEBINAR]: { icon: IconMonitorAccount },
+	[CONVERSATION.PRESET.CLASSIFIED]: { icon: IconShieldLockOutline },
+	[CONVERSATION.PRESET.CHANNEL]: { icon: IconBullhornOutline },
+	[CONVERSATION.PRESET.ANNOUNCEMENT]: { icon: IconBullhornOutline },
 }
 
 /**
@@ -272,7 +277,7 @@ export default {
 					value: preset.identifier,
 					label: preset.name,
 					description: preset.description,
-					...presetIcons[preset.identifier],
+					...(presetIcons[preset.identifier] ?? presetIcons[CONVERSATION.PRESET.DEFAULT]),
 				}))
 		},
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -83,6 +83,9 @@ export const CONVERSATION = {
 		NONE: 0,
 		VOICE_ROOM: 1,
 		PRESERVE: 2,
+		CLASSIFIED: 4,
+		CHANNEL: 8,
+		ANNOUNCEMENT: 16,
 	},
 
 	PRESET: {
@@ -91,6 +94,9 @@ export const CONVERSATION = {
 		VOICE_ROOM: 'voiceroom',
 		PRESENTATION: 'presentation',
 		WEBINAR: 'webinar',
+		CLASSIFIED: 'classified',
+		CHANNEL: 'channel',
+		ANNOUNCEMENT: 'announcement',
 	},
 
 	STATE: {
@@ -148,6 +154,8 @@ export const CONVERSATION = {
 		EXTENDED: 'extended_conversation',
 		INSTANT_MEETING: 'instant_meeting',
 		EXTERNAL_CALL: 'external_call',
+		CLASSIFIED: 'classified',
+		CLASSIFIED_PERSIST: 'classified_persist',
 		DEFAULT: '',
 	},
 

--- a/src/utils/conversation.ts
+++ b/src/utils/conversation.ts
@@ -17,6 +17,36 @@ const supportsArchive = hasTalkFeature('local', 'archived-conversations-v2')
 const supportsAvatar = hasTalkFeature('local', 'avatar')
 
 /**
+ * Check if the conversation is classified (CLASSIFIED attribute bit is set)
+ * Feature is supported with `classified-conversations` capability.
+ *
+ * @param conversation conversation object
+ */
+export function isClassifiedConversation(conversation: Conversation | undefined): boolean {
+	return Boolean(conversation && conversation.attributes & CONVERSATION.ATTRIBUTE.CLASSIFIED)
+}
+
+/**
+ * Check if the conversation is a channel (CHANNEL attribute bit is set)
+ * Feature is supported with `announcement-preset` capability.
+ *
+ * @param conversation conversation object
+ */
+export function isChannelConversation(conversation: Conversation | undefined): boolean {
+	return Boolean(conversation && conversation.attributes & CONVERSATION.ATTRIBUTE.CHANNEL)
+}
+
+/**
+ * Check if the conversation is an announcement (CHANNEL+ANNOUNCEMENT attribute bits are set)
+ * Feature is supported with `announcement-preset` capability.
+ *
+ * @param conversation conversation object
+ */
+export function isAnnouncementConversation(conversation: Conversation | undefined): boolean {
+	return isChannelConversation(conversation) && Boolean(conversation!.attributes & CONVERSATION.ATTRIBUTE.ANNOUNCEMENT)
+}
+
+/**
  * check if the conversation has unread messages
  *
  * @param conversation conversation object


### PR DESCRIPTION
## ☑️ Resolves

* Sets the constants and the base for new planned presets
  * Improves old clients compatibility
* Adds icons in NewConversationDialog on creation
  * Only visible when preset provided by server (backport-safe)
  * Fallback icon if none provided

### AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

<img width="396" height="323" alt="2026-07-24_15h18_03" src="https://github.com/user-attachments/assets/eeaa63f3-b0c5-431e-abfb-726d8eed0fcf" />

- [ ] Need ideas for Channel / Announcement distinguish

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required