### PR TITLE
Browse other conversations during a call

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -325,6 +325,24 @@ export default {
 				return
 			}
 
+			// While a call is ongoing, keep its signaling session alive and let the
+			// user browse other conversations without joining or leaving them, so
+			// the call is never interrupted. The call view is shown again when
+			// navigating back to its conversation.
+			const joinedToken = SessionStorage.getItem('joined_conversation')
+			const activeCallToken = joinedToken && this.$store.getters.isInCall(joinedToken) ? joinedToken : null
+			if (activeCallToken && to.name === 'conversation' && from.params.token !== to.params.token) {
+				if (to.params.token !== activeCallToken && !this.$store.getters.conversation(to.params.token)) {
+					const result = await this.fetchSingleConversation(to.params.token)
+					if (!result) {
+						// If the conversation is not found, block further navigation
+						return
+					}
+				}
+				next()
+				return
+			}
+
 			if (from.name === 'conversation' && from.params.token !== to.params.token) {
 				// Await to properly close session / leave call before joining another one
 				await this.$store.dispatch('leaveConversation', { token: from.params.token })
@@ -377,9 +395,11 @@ export default {
 			if (from.name === 'conversation' && to.name === 'conversation' && from.params.token === to.params.token) {
 				// Navigating within the same conversation
 				beforeRouteChangeListener(to, from, next)
-			} else if (!this.warnLeaving || this.skipLeaveWarning || this.isVoiceRoom(from.params.token)) {
+			} else if (!this.warnLeaving || this.skipLeaveWarning || this.isVoiceRoom(from.params.token) || to.name === 'conversation') {
 				// Safe to navigate
 				// Note: voice rooms are intended to be left without confirmation.
+				// Note: navigating to another conversation during a call keeps the
+				// call alive (see beforeRouteChangeListener), so no warning is needed.
 				beforeRouteChangeListener(to, from, next)
 			} else {
 				spawnDialog(ConfirmDialog, {

--- a/src/components/NewMessage/NewMessage.vue
+++ b/src/components/NewMessage/NewMessage.vue
@@ -544,7 +544,7 @@ export default {
 		},
 
 		disabled() {
-			return this.isReadOnly || this.noChatPermission || !this.currentConversationIsJoined || this.isRecordingAudio
+			return this.isReadOnly || this.noChatPermission || (!this.currentConversationIsJoined && !this.isBrowsingDuringCall) || this.isRecordingAudio
 		},
 
 		scheduleMessageTime() {
@@ -571,7 +571,7 @@ export default {
 				return t('spreed', 'This conversation has been locked')
 			} else if (this.noChatPermission) {
 				return t('spreed', 'No permission to post messages in this conversation')
-			} else if (!this.currentConversationIsJoined) {
+			} else if (!this.currentConversationIsJoined && !this.isBrowsingDuringCall) {
 				return t('spreed', 'Joining conversation …')
 			} else if (this.silentChat) {
 				return t('spreed', 'Write a message without notification')
@@ -636,6 +636,17 @@ export default {
 
 		currentConversationIsJoined() {
 			return this.tokenStore.currentConversationIsJoined
+		},
+
+		/**
+		 * Whether this conversation is being browsed while a call is ongoing in
+		 * another conversation. In that case the conversation is not joined
+		 * (its signaling session would interrupt the call), but the user can
+		 * still read and post messages over the REST API.
+		 */
+		isBrowsingDuringCall() {
+			const callToken = this.tokenStore.lastJoinedConversationToken
+			return Boolean(callToken) && callToken !== this.token && this.$store.getters.isInCall(callToken)
 		},
 
 		currentUploadId() {


### PR DESCRIPTION
**Ref:** #12299 (also #17605, #18373) — invited by @Antreesy in nextcloud/talk-desktop#1775

#### Summary
While in a call, you can now navigate to other conversations without leaving the call. The call keeps running and its view is shown again when you return to its conversation — no separate window, no re-dial.

#### How it works
The signaling session can only be in one room at a time, so during a call it stays pinned to the call's conversation:

- `App.vue` route guard: while a call is ongoing, navigating to another conversation neither leaves the call's conversation nor joins the target one — it just loads the target (fetch) and switches the view. `MainView` already renders per-token, so the call view shows on the call's conversation and the chat view on the others. The "leave call" navigation warning is skipped for conversation→conversation moves (the call is not left).
- `NewMessage.vue`: a browsed conversation is not signaling-joined, so it's shown in a lightweight read/write mode — messages are read and posted over the REST API (`isBrowsingDuringCall`).

#### Known limitation / trade-off
Browsed conversations during a call are not signaling-joined (joining would switch the single signaling session away from the call and drop it). As a result, they lack live signaling features: new messages appear in the chat view with a delay of a few seconds (polling, while the conversation list updates faster), and typing indicators are not shown there. Making browsed conversations fully real-time would require running two signaling sessions in one page (a larger refactor of `utils/webrtc`), which can be a follow-up.

#### Testing
Tested with a real second participant via the Talk Desktop client on macOS: switching between conversations during a call keeps the call alive on both sides (no re-dial), and reading/posting in browsed conversations works.
