### PR TITLE
Browse other conversations during a call (with a second signaling session)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -64,6 +64,7 @@ import { useCallViewStore } from './stores/callView.ts'
 import { useSidebarStore } from './stores/sidebar.ts'
 import { useTokenStore } from './stores/token.ts'
 import { checkBrowser } from './utils/browserCheck.ts'
+import { mountBrowseSignaling, unmountBrowseSignaling } from './utils/webrtc/browseSignaling.js'
 import { signalingKill } from './utils/webrtc/index.js'
 
 /** Internal handlers for 'joined-conversation' watcher (voice-, breakout- rooms) */
@@ -123,6 +124,9 @@ export default {
 			isRefreshingCurrentConversation: false,
 			skipLeaveWarning: false,
 			recordingConsentGiven: false,
+			// Token of the call kept alive in the background while browsing
+			// another conversation during a call, or null.
+			activeBrowseCallToken: null,
 			debounceRefreshCurrentConversation: () => {},
 		}
 	},
@@ -169,6 +173,21 @@ export default {
 		},
 
 		/**
+		 * Whether the conversation held in the background during browsing (see
+		 * `activeBrowseCallToken`) still has an ongoing call. Used to tear the
+		 * secondary browse session down when the call ends remotely. Depends on
+		 * the reactive `isInCall` getter for a real token, so it updates when
+		 * the call ends.
+		 *
+		 * @return {boolean}
+		 */
+		browsedCallStillActive() {
+			return this.activeBrowseCallToken
+				? this.$store.getters.isInCall(this.activeBrowseCallToken)
+				: false
+		},
+
+		/**
 		 * The current conversation
 		 *
 		 * @return {object} The conversation object.
@@ -207,6 +226,21 @@ export default {
 					toggle?.removeAttribute('data-theme-dark')
 				}
 			},
+		},
+
+		browsedCallStillActive(active) {
+			// The call ended (possibly remotely) while browsing another
+			// conversation: drop the secondary browse session and properly join
+			// the conversation that is now being viewed.
+			if (this.activeBrowseCallToken && !active) {
+				const endedCallToken = this.activeBrowseCallToken
+				this.activeBrowseCallToken = null
+				unmountBrowseSignaling()
+				if (this.token && this.token !== endedCallToken
+					&& !this.tokenStore.currentConversationIsJoined) {
+					this.$store.dispatch('joinConversation', { token: this.token })
+				}
+			}
 		},
 
 		unreadCountsMap: {
@@ -325,6 +359,38 @@ export default {
 				return
 			}
 
+			// While a call is ongoing, keep its signaling session (and the call)
+			// alive and let the user browse other conversations without joining
+			// or leaving them. The browsed conversation is kept live-updated by a
+			// secondary lightweight signaling session (new messages, typing),
+			// while the call view is shown again when navigating back to the
+			// call's conversation.
+			// Read fresh on every navigation (not via a cached computed): the
+			// call token comes from non-reactive SessionStorage, so a computed
+			// would keep a stale value and the guard would not fire.
+			const joinedToken = SessionStorage.getItem('joined_conversation')
+			const activeCallToken = joinedToken && this.$store.getters.isInCall(joinedToken) ? joinedToken : null
+			if (activeCallToken && to.name === 'conversation' && from.params.token !== to.params.token) {
+				if (to.params.token === activeCallToken) {
+					// Returning to the call: drop the secondary browse session.
+					this.activeBrowseCallToken = null
+					unmountBrowseSignaling()
+				} else {
+					// Browsing another conversation during the call.
+					if (!this.$store.getters.conversation(to.params.token)) {
+						const result = await this.fetchSingleConversation(to.params.token)
+						if (!result) {
+							// If the conversation is not found, block further navigation
+							return
+						}
+					}
+					this.activeBrowseCallToken = activeCallToken
+					mountBrowseSignaling(to.params.token)
+				}
+				next()
+				return
+			}
+
 			if (from.name === 'conversation' && from.params.token !== to.params.token) {
 				// Await to properly close session / leave call before joining another one
 				await this.$store.dispatch('leaveConversation', { token: from.params.token })
@@ -377,9 +443,11 @@ export default {
 			if (from.name === 'conversation' && to.name === 'conversation' && from.params.token === to.params.token) {
 				// Navigating within the same conversation
 				beforeRouteChangeListener(to, from, next)
-			} else if (!this.warnLeaving || this.skipLeaveWarning || this.isVoiceRoom(from.params.token)) {
+			} else if (!this.warnLeaving || this.skipLeaveWarning || this.isVoiceRoom(from.params.token) || to.name === 'conversation') {
 				// Safe to navigate
 				// Note: voice rooms are intended to be left without confirmation.
+				// Note: navigating to another conversation during a call keeps the
+				// call alive (see beforeRouteChangeListener), so no warning is needed.
 				beforeRouteChangeListener(to, from, next)
 			} else {
 				spawnDialog(ConfirmDialog, {

--- a/src/components/NewMessage/NewMessage.vue
+++ b/src/components/NewMessage/NewMessage.vue
@@ -544,7 +544,7 @@ export default {
 		},
 
 		disabled() {
-			return this.isReadOnly || this.noChatPermission || !this.currentConversationIsJoined || this.isRecordingAudio
+			return this.isReadOnly || this.noChatPermission || (!this.currentConversationIsJoined && !this.isBrowsingDuringCall) || this.isRecordingAudio
 		},
 
 		scheduleMessageTime() {
@@ -571,7 +571,7 @@ export default {
 				return t('spreed', 'This conversation has been locked')
 			} else if (this.noChatPermission) {
 				return t('spreed', 'No permission to post messages in this conversation')
-			} else if (!this.currentConversationIsJoined) {
+			} else if (!this.currentConversationIsJoined && !this.isBrowsingDuringCall) {
 				return t('spreed', 'Joining conversation …')
 			} else if (this.silentChat) {
 				return t('spreed', 'Write a message without notification')
@@ -636,6 +636,20 @@ export default {
 
 		currentConversationIsJoined() {
 			return this.tokenStore.currentConversationIsJoined
+		},
+
+		/**
+		 * Whether this conversation is being browsed while a call is ongoing in
+		 * another conversation. In that case the conversation is not "joined" as
+		 * the primary signaling session stays pinned to the call, but the user
+		 * can still read and post messages (and a secondary signaling session
+		 * keeps it live-updated), so the input must not be disabled.
+		 *
+		 * @return {boolean}
+		 */
+		isBrowsingDuringCall() {
+			const callToken = this.tokenStore.lastJoinedConversationToken
+			return Boolean(callToken) && callToken !== this.token && this.$store.getters.isInCall(callToken)
 		},
 
 		currentUploadId() {

--- a/src/services/talkSessionUniqueTabId.spec.ts
+++ b/src/services/talkSessionUniqueTabId.spec.ts
@@ -1,0 +1,48 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { afterEach, describe, expect, test } from 'vitest'
+import {
+	getBrowseSessionRequestConfig,
+	getBrowseSessionTabId,
+	resetBrowseSessionTabId,
+} from './talkSessionUniqueTabId.ts'
+
+const HEADER = 'x-nextcloud-talk-session-tab-id'
+
+describe('talkSessionUniqueTabId - browse session', () => {
+	afterEach(() => {
+		resetBrowseSessionTabId()
+	})
+
+	test('generates a stable browse tab id across calls', () => {
+		const first = getBrowseSessionTabId()
+		const second = getBrowseSessionTabId()
+		expect(first).toBe(second)
+		expect(first).toHaveLength(64)
+	})
+
+	test('rotates the browse tab id on reset', () => {
+		const before = getBrowseSessionTabId()
+		resetBrowseSessionTabId()
+		const after = getBrowseSessionTabId()
+		expect(after).not.toBe(before)
+	})
+
+	test('request config carries the browse tab id header', () => {
+		const config = getBrowseSessionRequestConfig()
+		expect((config.headers as Record<string, string>)[HEADER]).toBe(getBrowseSessionTabId())
+	})
+
+	test('request config merges provided config and headers', () => {
+		const config = getBrowseSessionRequestConfig({
+			params: { token: 'abc' },
+			headers: { 'X-Custom': '1' },
+		})
+		expect(config.params).toEqual({ token: 'abc' })
+		expect((config.headers as Record<string, string>)['X-Custom']).toBe('1')
+		expect((config.headers as Record<string, string>)[HEADER]).toBe(getBrowseSessionTabId())
+	})
+})

--- a/src/services/talkSessionUniqueTabId.ts
+++ b/src/services/talkSessionUniqueTabId.ts
@@ -51,7 +51,56 @@ export function setTalkSessionUniqueTabIdHeader() {
 	}
 
 	axios.interceptors.request.use((config) => {
-		config.headers[X_NEXTCLOUD_TALK_SESSION_TAB_ID] = tabId
+		// Do not clobber an explicitly set tab id. A request targeting a
+		// secondary Talk session (see getBrowseSessionRequestConfig) sets its
+		// own id, which must reach the server unchanged so it is mapped to a
+		// separate session instead of the primary one.
+		if (!config.headers[X_NEXTCLOUD_TALK_SESSION_TAB_ID]) {
+			config.headers[X_NEXTCLOUD_TALK_SESSION_TAB_ID] = tabId
+		}
 		return config
 	})
+}
+
+/**
+ * Secondary, ephemeral tab id used to open a second Talk session from the same
+ * tab (e.g. to browse another conversation with live updates while a call is
+ * ongoing). Since https://github.com/nextcloud/spreed/pull/17230 the server
+ * maps requests to distinct sessions by this id, so a different id yields a
+ * second session without dropping the primary one.
+ */
+let browseSessionTabId: string | null = null
+
+/**
+ * Get (creating it on first use) the secondary tab id for the browse session.
+ */
+export function getBrowseSessionTabId(): string {
+	if (!browseSessionTabId) {
+		browseSessionTabId = generateRandomId(64)
+	}
+	return browseSessionTabId
+}
+
+/**
+ * Rotate the secondary tab id, so the next browse session is a fresh one on the
+ * server. Call this after fully tearing down a browse session.
+ */
+export function resetBrowseSessionTabId(): void {
+	browseSessionTabId = null
+}
+
+/**
+ * Build an axios request config that routes the request through the secondary
+ * browse Talk session instead of the primary one.
+ *
+ * @param config additional axios request config to merge
+ */
+export function getBrowseSessionRequestConfig(config: Record<string, unknown> = {}): Record<string, unknown> {
+	return {
+		...config,
+		headers: {
+			...(config.headers as Record<string, string> ?? {}),
+			[X_NEXTCLOUD_TALK_SESSION_TAB_ID]: getBrowseSessionTabId(),
+		},
+	}
 }

--- a/src/utils/SignalingTypingHandler.js
+++ b/src/utils/SignalingTypingHandler.js
@@ -98,6 +98,17 @@ SignalingTypingHandler.prototype = {
 		})
 	},
 
+	/**
+	 * Token the received typing status has to be attributed to: the room the
+	 * signaling connection is currently joined to. For the primary connection
+	 * this is the viewed conversation (so behaviour is unchanged), but a
+	 * secondary "browse" connection is joined to a different room than the one
+	 * viewed, so relying on the viewed token would misattribute the status.
+	 */
+	_attributionToken() {
+		return this._signaling?.currentRoomToken ?? this._tokenStore.token
+	},
+
 	_handleMessage(data) {
 		if (data.type !== 'startedTyping' && data.type !== 'stoppedTyping') {
 			return
@@ -109,7 +120,7 @@ SignalingTypingHandler.prototype = {
 		}
 
 		this._participantActivityStore.setTyping({
-			token: this._tokenStore.token,
+			token: this._attributionToken(),
 			sessionId: participant.nextcloudSessionId,
 			isTyping: data.type === 'startedTyping',
 		})
@@ -131,7 +142,7 @@ SignalingTypingHandler.prototype = {
 	_handleParticipantsLeft(SignalingParticipantList, participants) {
 		for (const participant of participants) {
 			this._participantActivityStore.setTyping({
-				token: this._tokenStore.token,
+				token: this._attributionToken(),
 				sessionId: participant.nextcloudSessionId,
 				isTyping: false,
 			})

--- a/src/utils/signaling.js
+++ b/src/utils/signaling.js
@@ -116,12 +116,33 @@ Signaling.Base.prototype._trigger = function(ev, args) {
 		}
 	}
 
+	// A secondary "browse" signaling connection (used to keep receiving live
+	// updates for a conversation that is only being browsed while a call is
+	// ongoing in another conversation) must not leak its events onto the global
+	// EventBus, as those are consumed app-wide and would interfere with the
+	// primary connection that holds the call. Only the explicitly allow-listed
+	// events are forwarded; local per-instance handlers always run.
+	if (this._eventBusEmitAllowlist && !this._eventBusEmitAllowlist.has(ev)) {
+		return
+	}
+
 	// Convert webrtc event names to kebab-case for "vue/custom-event-name-casing"
 	const kebabCase = (string) => string
 		.replace(/([a-z])([A-Z])/g, '$1-$2')
 		.replace(/[\s_]+/g, '-')
 		.toLowerCase()
 	EventBus.emit('signaling-' + kebabCase(ev), args)
+}
+
+/**
+ * Restrict which events of this signaling instance are forwarded to the global
+ * EventBus. Pass an iterable of camelCase event names (as passed to _trigger),
+ * or null to forward everything (the default).
+ *
+ * @param {Iterable<string>|null} events allow-listed event names
+ */
+Signaling.Base.prototype.setEventBusEmitAllowlist = function(events) {
+	this._eventBusEmitAllowlist = events ? new Set(events) : null
 }
 
 Signaling.Base.prototype.setSettings = function(settings) {

--- a/src/utils/signalingEventBusAllowlist.spec.js
+++ b/src/utils/signalingEventBusAllowlist.spec.js
@@ -1,0 +1,53 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { EventBus } from '../services/EventBus.ts'
+import Signaling from './signaling.js'
+
+describe('Signaling._trigger EventBus allow-list', () => {
+	afterEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	test('forwards every event to the EventBus by default', () => {
+		const base = new Signaling.Base()
+		const emitSpy = vi.spyOn(EventBus, 'emit')
+		const handler = vi.fn()
+		base.on('fooEvent', handler)
+
+		base._trigger('fooEvent', ['x'])
+
+		expect(handler).toHaveBeenCalledWith('x')
+		expect(emitSpy).toHaveBeenCalledWith('signaling-foo-event', ['x'])
+	})
+
+	test('with an allow-list, only listed events reach the EventBus but local handlers always run', () => {
+		const base = new Signaling.Base()
+		base.setEventBusEmitAllowlist(['supportedFeatures'])
+		const emitSpy = vi.spyOn(EventBus, 'emit')
+		const handler = vi.fn()
+		base.on('joinRoom', handler)
+
+		// Not allow-listed: local handler runs, nothing leaks to the EventBus.
+		base._trigger('joinRoom', ['token'])
+		expect(handler).toHaveBeenCalledWith('token')
+		expect(emitSpy).not.toHaveBeenCalledWith('signaling-join-room', ['token'])
+
+		// Allow-listed: forwarded to the EventBus.
+		base._trigger('supportedFeatures', [['chat-relay']])
+		expect(emitSpy).toHaveBeenCalledWith('signaling-supported-features', [['chat-relay']])
+	})
+
+	test('passing null restores forwarding of every event', () => {
+		const base = new Signaling.Base()
+		base.setEventBusEmitAllowlist(['supportedFeatures'])
+		base.setEventBusEmitAllowlist(null)
+		const emitSpy = vi.spyOn(EventBus, 'emit')
+
+		base._trigger('joinRoom', ['token'])
+		expect(emitSpy).toHaveBeenCalledWith('signaling-join-room', ['token'])
+	})
+})

--- a/src/utils/webrtc/browseSignaling.js
+++ b/src/utils/webrtc/browseSignaling.js
@@ -1,0 +1,247 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import axios from '@nextcloud/axios'
+import { generateOcsUrl } from '@nextcloud/router'
+import { PRIVACY } from '../../constants.ts'
+import { getTalkConfig } from '../../services/CapabilitiesManager.ts'
+import { fetchSignalingSettings } from '../../services/signalingService.js'
+import { getBrowseSessionRequestConfig, resetBrowseSessionTabId } from '../../services/talkSessionUniqueTabId.ts'
+import store from '../../store/index.js'
+import Signaling from '../signaling.js'
+import SignalingTypingHandler from '../SignalingTypingHandler.js'
+
+/**
+ * Secondary, lightweight signaling connection used to keep a conversation
+ * live-updated (new messages via chat-relay, typing indicators) while it is
+ * only being *browsed* during a call that is held by the primary connection in
+ * another conversation.
+ *
+ * It intentionally never joins a call, never sets up WebRTC/media, and does not
+ * leak its events onto the global EventBus (only the chat-relay related ones,
+ * which are token-scoped, reach the app). The primary connection - and the
+ * call it holds - is therefore never touched.
+ *
+ * Only the High-Performance Backend (standalone signaling) supports this. With
+ * the internal signaling there is no cheap second connection, so callers should
+ * fall back to the REST/polling browsing behaviour.
+ */
+
+const enableTypingIndicators = getTalkConfig('local', 'chat', 'typing-privacy') === PRIVACY.PUBLIC
+
+let browseSignaling = null
+let browseTypingHandler = null
+let browseToken = null
+let participantsRefreshTimeout = null
+/** Serializes mount/switch/unmount so overlapping navigations cannot race. */
+let pendingOperation = Promise.resolve()
+
+/**
+ * Token currently browsed with a live secondary session, or null.
+ *
+ * @return {string|null}
+ */
+function getBrowseSignalingToken() {
+	return browseToken
+}
+
+/**
+ * REST-join the conversation on a *separate* Talk session (secondary tab id),
+ * so the primary session that holds the call is left untouched.
+ *
+ * @param {string} token conversation token
+ * @return {Promise<string|null>} the Nextcloud session id, or null on failure
+ */
+async function restJoinBrowseSession(token) {
+	try {
+		const response = await axios.post(
+			generateOcsUrl('apps/spreed/api/v4/room/{token}/participants/active', { token }),
+			{ force: false },
+			getBrowseSessionRequestConfig(),
+		)
+		return response.data.ocs.data.sessionId
+	} catch (error) {
+		console.error('[browseSignaling] Failed to open browse session for', token, error)
+		return null
+	}
+}
+
+/**
+ * REST-leave the secondary Talk session.
+ *
+ * @param {string} token conversation token
+ */
+async function restLeaveBrowseSession(token) {
+	try {
+		await axios.delete(
+			generateOcsUrl('apps/spreed/api/v4/room/{token}/participants/active', { token }),
+			getBrowseSessionRequestConfig(),
+		)
+	} catch (error) {
+		console.warn('[browseSignaling] Failed to close browse session for', token, error)
+	}
+}
+
+/**
+ * Tear down the current secondary session, if any.
+ */
+async function teardown() {
+	clearTimeout(participantsRefreshTimeout)
+	participantsRefreshTimeout = null
+
+	if (browseTypingHandler) {
+		browseTypingHandler.destroy()
+		browseTypingHandler = null
+	}
+
+	const token = browseToken
+	if (browseSignaling) {
+		try {
+			await browseSignaling.leaveRoom(token)
+		} catch (error) {
+			console.warn('[browseSignaling] leaveRoom failed', error)
+		}
+		browseSignaling.disconnect()
+		browseSignaling = null
+	}
+
+	if (token) {
+		await restLeaveBrowseSession(token)
+	}
+
+	browseToken = null
+	resetBrowseSessionTabId()
+}
+
+/**
+ * Bring up a secondary session for the given conversation.
+ *
+ * @param {string} token conversation token
+ * @return {Promise<boolean>} true if a live session was established, false if
+ *         the caller should fall back to REST/polling browsing
+ */
+async function setup(token) {
+	const settings = await fetchSignalingSettingsForBrowse(token)
+	if (!settings) {
+		return false
+	}
+
+	if (settings.signalingMode === 'internal') {
+		// No High-Performance Backend: a second connection would be a second
+		// long-polling loop with no chat-relay. Fall back to REST/polling.
+		return false
+	}
+
+	const sessionId = await restJoinBrowseSession(token)
+	if (!sessionId) {
+		return false
+	}
+
+	browseSignaling = Signaling.createConnection(settings)
+	// Keep the secondary connection from interfering with the primary one:
+	// forward only the "supportedFeatures" event, which the chat needs to know
+	// that live chat-relay is available for the browsed conversation.
+	browseSignaling.setEventBusEmitAllowlist(['supportedFeatures'])
+
+	if (enableTypingIndicators) {
+		browseTypingHandler = new SignalingTypingHandler()
+		browseTypingHandler.setSignaling(browseSignaling)
+	}
+
+	// The browsed conversation is not joined the normal way, so the usual
+	// participant fetching (useGetParticipants) never runs for it. Load and keep
+	// its participant list fresh from the browse session's own room events, so
+	// participant-dependent UI works while browsing - notably the typing
+	// indicator, which matches typing signals against known participant sessions.
+	const refreshBrowseParticipants = () => {
+		if (browseToken !== token) {
+			return
+		}
+		clearTimeout(participantsRefreshTimeout)
+		participantsRefreshTimeout = setTimeout(() => {
+			if (browseToken === token) {
+				store.dispatch('fetchParticipants', { token })
+			}
+		}, 500)
+	}
+	browseSignaling.on('usersInRoom', refreshBrowseParticipants)
+	browseSignaling.on('usersJoined', refreshBrowseParticipants)
+	browseSignaling.on('usersLeft', refreshBrowseParticipants)
+
+	browseToken = token
+
+	// joinRoom defers internally until the hello handshake completed.
+	browseSignaling.joinRoom(token, sessionId)
+
+	// Initial participant load (covers participants already present before we
+	// joined, in case no incoming room event follows).
+	store.dispatch('fetchParticipants', { token })
+
+	return true
+}
+
+/**
+ * Fetch signaling settings through the secondary Talk session.
+ *
+ * @param {string} token conversation token
+ * @return {Promise<object|null>}
+ */
+async function fetchSignalingSettingsForBrowse(token) {
+	try {
+		const response = await fetchSignalingSettings({ token }, getBrowseSessionRequestConfig())
+		const settings = response.data.ocs.data
+		settings.token = token
+		return settings
+	} catch (error) {
+		console.error('[browseSignaling] Failed to fetch signaling settings for', token, error)
+		return null
+	}
+}
+
+/**
+ * Start (or switch to) a live secondary session for the browsed conversation.
+ * Safe to call repeatedly; only one secondary session exists at a time.
+ *
+ * @param {string} token conversation token to browse live
+ * @return {Promise<boolean>} whether a live session is active for the token
+ */
+function mountBrowseSignaling(token) {
+	pendingOperation = pendingOperation.then(async () => {
+		if (browseToken === token && browseSignaling) {
+			return true
+		}
+		if (browseToken) {
+			await teardown()
+		}
+		return setup(token)
+	}).catch((error) => {
+		console.error('[browseSignaling] mount failed', error)
+		return false
+	})
+	return pendingOperation
+}
+
+/**
+ * Tear down the secondary session (call when returning to the call
+ * conversation or when the call ends).
+ *
+ * @return {Promise<void>}
+ */
+function unmountBrowseSignaling() {
+	pendingOperation = pendingOperation.then(async () => {
+		if (browseToken) {
+			await teardown()
+		}
+	}).catch((error) => {
+		console.error('[browseSignaling] unmount failed', error)
+	})
+	return pendingOperation
+}
+
+export {
+	getBrowseSignalingToken,
+	mountBrowseSignaling,
+	unmountBrowseSignaling,
+}


### PR DESCRIPTION
# Browse other conversations during a call (with a second signaling session)

Fixes #12299

## Summary

While a call is ongoing, the user can now navigate to and interact with other
conversations **in the same window**, without the call being interrupted and
without opening a second window or tab. The browsed conversation stays
**live-updated** — new messages arrive instantly via chat-relay and typing
indicators are shown — because it is backed by a **second, lightweight signaling
session**.

This supersedes the earlier single-session attempt (#18787), which was correctly
rejected for lacking the second signaling session described in the dev notes on
this issue. The approach here follows those notes directly:

> - track Talk-session-scope items depending on a unique (tab) id … from here it's
>   theoretically possible to send different HTTP requests from the same tab to
>   different rooms
> - after the ability to distinguish HTTP requests, maintain a second signaling
>   (websocket) connection, maybe simplified

## How it works

The primary signaling + WebRTC singleton stays **pinned to the call** and is
never touched. For the conversation being browsed, a separate, lightweight
signaling connection is opened that:

- **Runs on a second Talk session in the same tab.** The tab-id request header
  (`x-nextcloud-talk-session-tab-id`, #17230) is now applied non-destructively,
  and browse requests carry a dedicated *secondary* tab-id, so the server maps
  them to a distinct session (`TalkSession` keys sessions by tab-id) instead of
  the one holding the call.
- **Never joins a call and never sets up WebRTC/media** — it only handles
  chat-relay (instant messages) and typing.
- **Does not leak its events onto the global EventBus.** A per-instance
  allow-list forwards only `supportedFeatures`; the token-scoped chat-relay
  message events flow as usual, so the call state is never affected.

Lifecycle: the secondary session is mounted when navigating to another
conversation during a call, switched when browsing further, and torn down when
returning to the call's conversation or when the call ends.

On the **internal** (non-HPB) signaling backend there is no cheap second
connection, so it transparently falls back to the previous REST/polling browsing
behaviour.

## What the user sees

- The call keeps running (audio in the background) while browsing another
  conversation; returning to the call's conversation shows the call view again.
- Messages posted in the browsed conversation arrive instantly.
- The "is typing …" indicator works in the browsed conversation.

## Files

- `utils/webrtc/browseSignaling.js` (new) — lifecycle of the secondary chat-only
  signaling session; also loads/refreshes the browsed conversation's participant
  list (needed by participant-dependent UI such as the typing indicator, which
  is not fetched the usual way while browsing).
- `services/talkSessionUniqueTabId.ts` — secondary tab-id + a non-clobbering
  request interceptor and a helper to route a request through the browse session.
- `utils/signaling.js` — optional per-instance allow-list for events forwarded to
  the global EventBus (`setEventBusEmitAllowlist`).
- `utils/SignalingTypingHandler.js` — attribute received typing to the room the
  signaling connection is joined to (identical behaviour for the primary
  connection, correct for the secondary one).
- `App.vue` — navigation guard that keeps the call alive while browsing, plus
  mount/switch/teardown of the browse session and teardown on call end.
- `components/NewMessage/NewMessage.vue` — enable the composer while browsing
  during a call.

## Requirements

Live updates for the browsed conversation require the High-Performance Backend
and multiple Talk sessions per device (#17230). Without them, browsing falls back
to REST/polling.

## Trade-offs

Only one browsed conversation is kept live at a time (the one currently viewed),
which keeps the second connection cheap — in line with the "maybe simplified"
note.

## Testing

- **Manual**, Talk Desktop client against a production server: start a call in
  conversation A, browse conversation B — the call is not interrupted; a message
  and typing from another participant in B appear live; returning to A the call
  is intact; ending the call while browsing tears the session down. The server
  shows two distinct Talk sessions (call + browse) and a single call session.
- **Unit tests** added for the secondary tab-id helper and the EventBus
  allow-list.
- Full `lint`, `stylelint`, `ts:check` and unit suite pass.
