### PR TITLE
refactor(CallView): extract videos reordering logic

### DIFF
--- a/src/components/CallView/Grid/VideosGrid.vue
+++ b/src/components/CallView/Grid/VideosGrid.vue
@@ -46,7 +46,7 @@
 						:style="gridStyle"
 						@wheel="debounceHandleWheelEvent">
 						<template v-if="!devMode && !(isLessThanTwoVideos && isStripe)">
-							<EmptyCallView v-if="videos.length === 0 && !isStripe" class="video" :isGrid="true" />
+							<EmptyCallView v-if="orderedVideos.length === 0 && !isStripe" class="video" :isGrid="true" />
 							<VideoVue
 								v-for="callParticipantModel in displayedVideos"
 								:key="callParticipantModel.attributes.peerId"
@@ -165,7 +165,6 @@
 import { t } from '@nextcloud/l10n'
 import debounce from 'debounce'
 import { computed, inject, ref, toRef, useTemplateRef, watch } from 'vue'
-import { useStore } from 'vuex'
 import NcButton from '@nextcloud/vue/components/NcButton'
 import IconChevronDown from 'vue-material-design-icons/ChevronDown.vue'
 import IconChevronLeft from 'vue-material-design-icons/ChevronLeft.vue'
@@ -176,14 +175,13 @@ import EmptyCallView from '../shared/EmptyCallView.vue'
 import LocalVideo from '../shared/LocalVideo.vue'
 import VideoBottomBar from '../shared/VideoBottomBar.vue'
 import VideoVue from '../shared/VideoVue.vue'
-import { PARTICIPANT } from '../../../constants.ts'
 import { getTalkConfig } from '../../../services/CapabilitiesManager.ts'
-import { useActorStore } from '../../../stores/actor.ts'
 import { useCallViewStore } from '../../../stores/callView.ts'
 import { GRID_GAP } from './gridLayout.ts'
 import { placeholderImage, placeholderModel, placeholderName, placeholderSharedData } from './gridPlaceholders.ts'
 import { useGridDimensions } from './useGridDimensions.ts'
 import { usePagination } from './usePagination.ts'
+import { useTileOrdering } from './useTileOrdering.ts'
 
 // Max number of videos per page. `0`, the default value, means no cap
 const videosCap = getTalkConfig('local', 'call', 'grid-limit') || 0
@@ -278,7 +276,6 @@ export default {
 		// The number of dummy videos in dev mode
 		const dummies = ref(4)
 
-		const actorStore = useActorStore()
 		const callViewStore = useCallViewStore()
 
 		// Template refs for the elements measured by the grid layout
@@ -303,19 +300,6 @@ export default {
 			stripeOpen,
 		})
 
-		const vuexStore = useStore()
-
-		// The videos array. This is the total number of grid elements.
-		// Depending on the grid dimensions and `videosCap`, these videos are
-		// shown in one or more grid 'pages'.
-		const videos = computed(() => {
-			if (devMode.value) {
-				return Array.from(Array(dummies.value).keys())
-			}
-
-			return props.callParticipantModels
-		})
-
 		// Number of grid slots (videos per page) at any given moment, clamped to
 		// `videosCap` (`0` means no cap).
 		// The local video always takes one slot, unless it is not shown (stripe
@@ -330,171 +314,23 @@ export default {
 			return videosCap ? Math.min(videosCap, slots) : slots
 		})
 
-		// Speakers recently promoted to the first page and the history of
-		// promotions, used to keep the relative order of the tiles stable.
-		const tempPromotedModels = ref([])
-		const promotedHistoryMask = ref([])
-		const unpromoteSpeakerTimer = {}
-
-		const participantsInitialised = computed(() => vuexStore.getters.participantsInitialised(props.token))
-
-		const isGuestNonModerator = computed(() => {
-			return actorStore.isActorGuest
-				&& vuexStore.getters.conversation(props.token).participantType !== PARTICIPANT.TYPE.GUEST_MODERATOR
+		// Orders the tiles and keeps recently active speakers promoted to the
+		// first page.
+		const { orderedParticipantModels } = useTileOrdering({
+			callParticipantModels: toRef(() => props.callParticipantModels),
+			screens: toRef(() => props.screens),
+			token: toRef(() => props.token),
+			slots,
 		})
 
-		/**
-		 * @param {object} callParticipantModel the participant model
-		 */
-		function isModelWithVideo(callParticipantModel) {
-			return callParticipantModel.attributes.videoAvailable
-				&& (typeof callParticipantModel.attributes.stream === 'object')
-		}
-
-		/**
-		 * @param {object} callParticipantModel the participant model
-		 */
-		function isModelWithAudio(callParticipantModel) {
-			const participant = vuexStore.getters.getParticipantBySessionId(props.token, callParticipantModel.attributes.nextcloudSessionId)
-			if (!participant) {
-				return false
-			}
-			return participant?.permissions & PARTICIPANT.PERMISSIONS.PUBLISH_AUDIO
-		}
-
-		/**
-		 * @param {Map} tilesMap map of session ids to models
-		 * @param {Array} orderMask ordered session ids to sort the tiles by
-		 */
-		function getOrderedTiles(tilesMap, orderMask) {
-			const orderedTiles = []
-			const rest = []
-			// Get the ordered tiles
-			orderMask.forEach((id) => {
-				if (tilesMap.has(id)) {
-					orderedTiles.push(tilesMap.get(id))
-				}
-			})
-
-			// Add remaining tiles not in orderMask to rest
-			tilesMap.forEach((tile, id) => {
-				if (!orderMask.includes(id)) {
-					rest.push(tile)
-				}
-			})
-
-			return [...orderedTiles, ...rest]
-		}
-
+		// The tiles to lay out across the grid pages. In developer mode these are
+		// dummy placeholder tiles; otherwise the ordered participant models.
 		const orderedVideos = computed(() => {
-			// Dynamic ordering is not possible for guests because
-			// participants store is not initialized
-			if (isGuestNonModerator.value || devMode.value) {
-				return videos.value
+			if (devMode.value) {
+				return Array.from(Array(dummies.value).keys())
 			}
 
-			const objectMap = {
-				modelsWithScreenshare: [],
-				modelsTempPromoted: [],
-				modelsWithVideoEnabled: [],
-				modelsWithAudioOnly: [],
-				modelsWithNoPermissions: [],
-			}
-			const screensSet = new Set(props.screens)
-			const tempPromotedModelsSet = new Set(tempPromotedModels.value.map((model) => model.attributes.nextcloudSessionId))
-			const videoTilesMap = new Map()
-			const audioTilesMap = new Map()
-
-			props.callParticipantModels.forEach((model) => {
-				if (screensSet.has(model.attributes.peerId)) {
-					objectMap.modelsWithScreenshare.push(model)
-				} else if (tempPromotedModelsSet.has(model.attributes.nextcloudSessionId)) {
-					objectMap.modelsTempPromoted.push(model)
-				} else if (isModelWithVideo(model)) {
-					videoTilesMap.set(model.attributes.nextcloudSessionId, model)
-				} else if (participantsInitialised.value && isModelWithAudio(model)) {
-					audioTilesMap.set(model.attributes.nextcloudSessionId, model)
-				} else {
-					objectMap.modelsWithNoPermissions.push(model)
-				}
-			})
-
-			objectMap.modelsWithVideoEnabled = getOrderedTiles(videoTilesMap, promotedHistoryMask.value)
-			objectMap.modelsWithAudioOnly = getOrderedTiles(audioTilesMap, promotedHistoryMask.value)
-
-			return [
-				...objectMap.modelsWithScreenshare,
-				...objectMap.modelsTempPromoted,
-				...objectMap.modelsWithVideoEnabled,
-				...objectMap.modelsWithAudioOnly,
-				...objectMap.modelsWithNoPermissions,
-			]
-		})
-
-		/**
-		 * @param {object} model the speaker model to unpromote
-		 */
-		function unpromoteSpeaker(model) {
-			// remove model from the temp promoted speakers
-			const index = tempPromotedModels.value.indexOf(model)
-			if (index === -1) {
-				return
-			}
-
-			tempPromotedModels.value.splice(index, 1)
-		}
-
-		/**
-		 * @param {object} model the speaker model to promote
-		 */
-		function promoteSpeaker(model) {
-			const id = model.attributes.nextcloudSessionId
-
-			// if model is already in the first page, do nothing
-			if (orderedVideos.value.slice(0, slots.value).find((video) => video.attributes.nextcloudSessionId === id)) {
-				return
-			}
-
-			if (props.screens.includes(model.attributes.peerId)) {
-				// tiles with screenshare have a better priority position already
-				// do nothing
-				return
-			}
-
-			// add the model
-			if (!tempPromotedModels.value.includes(model)) {
-				// remove model from the order history if it exists
-				const modelIndex = promotedHistoryMask.value.indexOf(id)
-				if (modelIndex !== -1) {
-					promotedHistoryMask.value.splice(modelIndex, 1)
-				}
-
-				tempPromotedModels.value.unshift(model)
-				// add model to the beginning of the orderedVideos in its category
-				promotedHistoryMask.value.unshift(id)
-			}
-		}
-
-		const speakers = computed(() => props.callParticipantModels.filter((model) => model.attributes.speaking))
-
-		const speakersWithAudioOff = computed(() => tempPromotedModels.value.filter((model) => !model.attributes.audioAvailable))
-
-		watch(speakers, (models) => {
-			models.forEach((model) => {
-				promoteSpeaker(model)
-				clearTimeout(unpromoteSpeakerTimer[model.attributes.nextcloudSessionId])
-			})
-		})
-
-		watch(speakersWithAudioOff, (newModels, oldModels) => {
-			newModels.forEach((speaker) => {
-				if (oldModels.includes(speaker)) {
-					return
-				}
-				unpromoteSpeakerTimer[speaker.attributes.nextcloudSessionId] = setTimeout(() => {
-					unpromoteSpeaker(speaker)
-				}, 10000)
-			})
+			return orderedParticipantModels.value
 		})
 
 		const videosCount = computed(() => orderedVideos.value.length)
@@ -520,7 +356,7 @@ export default {
 		})
 
 		return {
-			videos,
+			orderedVideos,
 			currentPage,
 			numberOfPages,
 			displayedVideos,
@@ -533,7 +369,6 @@ export default {
 			screenshotMode,
 			videosCap,
 			callViewStore,
-			actorStore,
 			gridWrapper,
 			grid,
 			stripeOpen,
@@ -558,12 +393,12 @@ export default {
 
 		// Number of video components (it does not include the local video)
 		videosCount() {
-			if (!this.isStripe && this.videos.length === 0) {
+			if (!this.isStripe && this.orderedVideos.length === 0) {
 				// Count the emptycontent as a grid element
 				return 1
 			}
 
-			return this.videos.length
+			return this.orderedVideos.length
 		},
 
 		videoWidth() {
@@ -578,7 +413,7 @@ export default {
 			// without screen share, we don't want to duplicate videos if we were to show them in the stripe
 			// however, if a screen share is in progress, it means the video of the presenting user is not visible,
 			// so we can show it in the stripe
-			return this.videos.length <= 1 && !this.screens.length
+			return this.orderedVideos.length <= 1 && !this.screens.length
 		},
 
 		// Computed css to reactively style the grid
@@ -588,7 +423,7 @@ export default {
 
 			// If there are no other videos the empty call view is shown above
 			// the local video.
-			if (this.videos.length === 0 && !this.isStripe) {
+			if (this.orderedVideos.length === 0 && !this.isStripe) {
 				columns = 1
 				rows = 2
 			}

--- a/src/components/CallView/Grid/useTileOrdering.spec.ts
+++ b/src/components/CallView/Grid/useTileOrdering.spec.ts
@@ -159,4 +159,88 @@ describe('useTileOrdering', () => {
 			expect(orderedParticipantModels.value).toEqual([first, second])
 		})
 	})
+
+	describe('participant churn', () => {
+		test('drops a departed participant and keeps ordering the rest', async () => {
+			const a = makeModel({ audioPublisher: true, audioAvailable: true })
+			const b = makeModel({ audioPublisher: true, audioAvailable: true })
+			const c = makeModel({ audioPublisher: true, audioAvailable: true })
+			const models = [a, b, c]
+			allModels = models
+
+			const { orderedParticipantModels, callParticipantModels } = createOrdering({ models, slots: 1 })
+
+			// b speaks and gets promoted to the front
+			b.attributes.speaking = true
+			await nextTick()
+			expect(orderedParticipantModels.value).toEqual([b, a, c])
+
+			// b leaves the call
+			allModels = [a, c]
+			callParticipantModels.value = [a, c]
+			await nextTick()
+			expect(orderedParticipantModels.value).toEqual([a, c])
+
+			// promotion still works for the remaining participants
+			c.attributes.speaking = true
+			await nextTick()
+			expect(orderedParticipantModels.value).toEqual([c, a])
+		})
+
+		test('keeps the promoted place when a participant reconnects with the same session', async () => {
+			const a = makeModel({ audioPublisher: true, audioAvailable: true })
+			const b = makeModel({ audioPublisher: true, audioAvailable: true })
+			const models = [a, b]
+			allModels = models
+
+			const { orderedParticipantModels, callParticipantModels } = createOrdering({ models, slots: 1 })
+
+			// b speaks and gets promoted to the front
+			b.attributes.speaking = true
+			await nextTick()
+			expect(orderedParticipantModels.value).toEqual([b, a])
+
+			// b drops out of the call and comes back with the same session id
+			allModels = [a]
+			callParticipantModels.value = [a]
+			await nextTick()
+			b.attributes.speaking = false
+			allModels = [a, b]
+			callParticipantModels.value = [a, b]
+			await nextTick()
+
+			expect(orderedParticipantModels.value).toEqual([b, a])
+		})
+
+		test('lets a pending unpromote timer of a departed participant run out harmlessly', async () => {
+			vi.useFakeTimers()
+			try {
+				const a = makeModel({ audioPublisher: true, audioAvailable: true })
+				const b = makeModel({ audioPublisher: true, audioAvailable: true })
+				const models = [a, b]
+				allModels = models
+
+				const { orderedParticipantModels, callParticipantModels } = createOrdering({ models, slots: 1 })
+
+				// b speaks (gets promoted) and then its audio goes off, which
+				// schedules an unpromote timer for it.
+				b.attributes.speaking = true
+				await nextTick()
+				b.attributes.audioAvailable = false
+				await nextTick()
+
+				// b leaves the call before the timer fires
+				allModels = [a]
+				callParticipantModels.value = [a]
+				await nextTick()
+
+				vi.runAllTimers()
+				await nextTick()
+
+				expect(orderedParticipantModels.value).toEqual([a])
+			} finally {
+				vi.useRealTimers()
+			}
+		})
+	})
 })

--- a/src/components/CallView/Grid/useTileOrdering.spec.ts
+++ b/src/components/CallView/Grid/useTileOrdering.spec.ts
@@ -1,0 +1,162 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { OrderingModel } from './useTileOrdering.ts'
+
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { effectScope, nextTick, reactive, ref } from 'vue'
+import { useStore } from 'vuex'
+import { ATTENDEE, PARTICIPANT } from '../../../constants.ts'
+import { useActorStore } from '../../../stores/actor.ts'
+import { useTileOrdering } from './useTileOrdering.ts'
+
+vi.mock('vuex')
+
+type ModelAttributes = Partial<OrderingModel['attributes']> & { audioPublisher?: boolean }
+
+let sessionCounter = 0
+
+/**
+ * Build a call participant model with the reactive attributes the ordering
+ * logic reads.
+ *
+ * @param attributes - the attributes to seed the model with. `audioPublisher`
+ *   is a test-only flag that makes the mocked participant getter grant the
+ *   PUBLISH_AUDIO permission for this model's session.
+ */
+function makeModel(attributes: ModelAttributes = {}): OrderingModel & { audioPublisher: boolean } {
+	const { audioPublisher = false, ...rest } = attributes
+	return {
+		audioPublisher,
+		attributes: reactive({
+			peerId: `peer-${sessionCounter}`,
+			nextcloudSessionId: `session-${sessionCounter++}`,
+			...rest,
+		}),
+	}
+}
+
+/**
+ * Instantiate the composable with sensible defaults, overridable per test.
+ *
+ * @param options - overrides for the reactive inputs
+ * @param options.models - the call participant models
+ * @param options.screens - peer ids sharing their screen
+ * @param options.slots - number of tiles on the first page
+ */
+function createOrdering({
+	models = [] as ReturnType<typeof makeModel>[],
+	screens = [] as string[],
+	slots = 4,
+} = {}) {
+	const callParticipantModels = ref(models)
+	const screensRef = ref(screens)
+	const slotsRef = ref(slots)
+
+	// Run inside an effect scope so the composable's watchers and scope
+	// cleanup (onScopeDispose) have a scope to attach to, as they would in a
+	// component.
+	const scope = effectScope()
+	const { orderedParticipantModels } = scope.run(() => useTileOrdering({
+		callParticipantModels,
+		screens: screensRef,
+		token: ref('token'),
+		slots: slotsRef,
+	}))!
+
+	return { callParticipantModels, screens: screensRef, slots: slotsRef, orderedParticipantModels, scope }
+}
+
+describe('useTileOrdering', () => {
+	beforeEach(() => {
+		sessionCounter = 0
+		setActivePinia(createPinia())
+
+		vi.mocked(useStore).mockReturnValue({
+			getters: {
+				participantsInitialised: () => true,
+				conversation: () => ({ participantType: PARTICIPANT.TYPE.USER }),
+				getParticipantBySessionId: (_token: string, sessionId: string) => {
+					const model = allModels.find((m) => m.attributes.nextcloudSessionId === sessionId)
+					if (!model?.audioPublisher) {
+						return undefined
+					}
+					return { permissions: PARTICIPANT.PERMISSIONS.PUBLISH_AUDIO }
+				},
+			},
+		} as unknown as ReturnType<typeof useStore>)
+	})
+
+	// Registry the mocked getter looks models up in
+	let allModels: ReturnType<typeof makeModel>[] = []
+
+	describe('bypass', () => {
+		test('returns the models in source order for guests', () => {
+			const actorStore = useActorStore()
+			actorStore.actorType = ATTENDEE.ACTOR_TYPE.GUESTS
+
+			// A screenshare that would otherwise be reordered to the front
+			const video = makeModel({ videoAvailable: true, stream: {} })
+			const screenshare = makeModel()
+			const models = [video, screenshare]
+			allModels = models
+			const { orderedParticipantModels } = createOrdering({ models, screens: [screenshare.attributes.peerId] })
+
+			expect(orderedParticipantModels.value).toEqual(models)
+		})
+	})
+
+	describe('categorisation', () => {
+		test('orders tiles by category: screenshare, video, audio, no permissions', () => {
+			const screenshare = makeModel()
+			const video = makeModel({ videoAvailable: true, stream: {} })
+			const audio = makeModel({ audioPublisher: true })
+			const noPermissions = makeModel()
+			// Deliberately shuffled input order
+			const models = [noPermissions, audio, screenshare, video]
+			allModels = models
+
+			const { orderedParticipantModels } = createOrdering({
+				models,
+				screens: [screenshare.attributes.peerId],
+			})
+
+			expect(orderedParticipantModels.value).toEqual([screenshare, video, audio, noPermissions])
+		})
+	})
+
+	describe('speaker promotion', () => {
+		test('promotes a speaker that is not on the first page', async () => {
+			const first = makeModel({ audioPublisher: true, audioAvailable: true })
+			const second = makeModel({ audioPublisher: true, audioAvailable: true })
+			const models = [first, second]
+			allModels = models
+
+			const { orderedParticipantModels } = createOrdering({ models, slots: 1 })
+			expect(orderedParticipantModels.value).toEqual([first, second])
+
+			// The second tile starts speaking while off the first page
+			second.attributes.speaking = true
+			await nextTick()
+
+			expect(orderedParticipantModels.value).toEqual([second, first])
+		})
+
+		test('does not promote a speaker already on the first page', async () => {
+			const first = makeModel({ audioPublisher: true, audioAvailable: true })
+			const second = makeModel({ audioPublisher: true, audioAvailable: true })
+			const models = [first, second]
+			allModels = models
+
+			const { orderedParticipantModels } = createOrdering({ models, slots: 2 })
+
+			first.attributes.speaking = true
+			await nextTick()
+
+			expect(orderedParticipantModels.value).toEqual([first, second])
+		})
+	})
+})

--- a/src/components/CallView/Grid/useTileOrdering.ts
+++ b/src/components/CallView/Grid/useTileOrdering.ts
@@ -67,9 +67,10 @@ export function useTileOrdering({
 	const vuexStore = useStore()
 	const actorStore = useActorStore()
 
-	// Speakers recently promoted to the first page and the history of
-	// promotions, used to keep the relative order of the tiles stable.
-	const tempPromotedModels = ref<OrderingModel[]>([])
+	// Session ids of the speakers recently promoted to the first page and the
+	// history of promotions, used to keep the relative order of the tiles
+	// stable. Only ids are kept, so no participant model is referenced here.
+	const tempPromotedSessionIds = ref(new Set<string>())
 	const promotedHistoryMask = ref<string[]>([])
 	const unpromoteSpeakerTimer: Record<string, ReturnType<typeof setTimeout>> = {}
 
@@ -142,14 +143,13 @@ export function useTileOrdering({
 			modelsWithNoPermissions: [] as OrderingModel[],
 		}
 		const screensSet = new Set(screens.value)
-		const tempPromotedModelsSet = new Set(tempPromotedModels.value.map((model) => model.attributes.nextcloudSessionId))
 		const videoTilesMap = new Map<string, OrderingModel>()
 		const audioTilesMap = new Map<string, OrderingModel>()
 
 		callParticipantModels.value.forEach((model) => {
 			if (screensSet.has(model.attributes.peerId)) {
 				objectMap.modelsWithScreenshare.push(model)
-			} else if (tempPromotedModelsSet.has(model.attributes.nextcloudSessionId)) {
+			} else if (tempPromotedSessionIds.value.has(model.attributes.nextcloudSessionId)) {
 				objectMap.modelsTempPromoted.push(model)
 			} else if (isModelWithVideo(model)) {
 				videoTilesMap.set(model.attributes.nextcloudSessionId, model)
@@ -173,16 +173,10 @@ export function useTileOrdering({
 	})
 
 	/**
-	 * @param model the speaker model to unpromote
+	 * @param sessionId session id of the speaker to unpromote
 	 */
-	function unpromoteSpeaker(model: OrderingModel) {
-		// remove model from the temp promoted speakers
-		const index = tempPromotedModels.value.indexOf(model)
-		if (index === -1) {
-			return
-		}
-
-		tempPromotedModels.value.splice(index, 1)
+	function unpromoteSpeaker(sessionId: string) {
+		tempPromotedSessionIds.value.delete(sessionId)
 	}
 
 	/**
@@ -207,38 +201,47 @@ export function useTileOrdering({
 			return
 		}
 
-		// add the model
-		if (!tempPromotedModels.value.includes(model)) {
-			// remove model from the order history if it exists
-			const modelIndex = promotedHistoryMask.value.indexOf(id)
-			if (modelIndex !== -1) {
-				promotedHistoryMask.value.splice(modelIndex, 1)
+		// add the speaker
+		if (!tempPromotedSessionIds.value.has(id)) {
+			// remove the speaker from the order history if it exists
+			const maskIndex = promotedHistoryMask.value.indexOf(id)
+			if (maskIndex !== -1) {
+				promotedHistoryMask.value.splice(maskIndex, 1)
 			}
 
-			tempPromotedModels.value.unshift(model)
-			// add model to the beginning of the ordered models in its category
+			tempPromotedSessionIds.value.add(id)
+			// add speaker to the beginning of the ordered models in its category
 			promotedHistoryMask.value.unshift(id)
 		}
 	}
 
 	const speakers = computed(() => callParticipantModels.value.filter((model) => model.attributes.speaking))
 
-	const speakersWithAudioOff = computed(() => tempPromotedModels.value.filter((model) => !model.attributes.audioAvailable))
+	const promotedSessionIdsWithAudioOff = computed(() => {
+		const sessionIdsWithAudio = new Set(callParticipantModels.value
+			.filter(({ attributes }) => attributes.audioAvailable)
+			.map(({ attributes }) => attributes.nextcloudSessionId))
+		// All that aren't in Set - muted or disconnected
+		return [...tempPromotedSessionIds.value].filter((id) => !sessionIdsWithAudio.has(id))
+	})
 
 	watch(speakers, (models) => {
 		models.forEach((model) => {
 			promoteSpeaker(model)
 			clearTimeout(unpromoteSpeakerTimer[model.attributes.nextcloudSessionId])
+			delete unpromoteSpeakerTimer[model.attributes.nextcloudSessionId]
 		})
 	})
 
-	watch(speakersWithAudioOff, (newModels, oldModels) => {
-		newModels.forEach((speaker) => {
-			if (oldModels.includes(speaker)) {
+	watch(promotedSessionIdsWithAudioOff, (sessionIds) => {
+		sessionIds.forEach((sessionId) => {
+			if (unpromoteSpeakerTimer[sessionId]) {
+				// an unpromote is already pending for this speaker
 				return
 			}
-			unpromoteSpeakerTimer[speaker.attributes.nextcloudSessionId] = setTimeout(() => {
-				unpromoteSpeaker(speaker)
+			unpromoteSpeakerTimer[sessionId] = setTimeout(() => {
+				delete unpromoteSpeakerTimer[sessionId]
+				unpromoteSpeaker(sessionId)
 			}, UNPROMOTE_DELAY)
 		})
 	})

--- a/src/components/CallView/Grid/useTileOrdering.ts
+++ b/src/components/CallView/Grid/useTileOrdering.ts
@@ -106,17 +106,20 @@ export function useTileOrdering({
 	 */
 	function getOrderedTiles(tilesMap: Map<string, OrderingModel>, orderMask: string[]) {
 		const orderedTiles: OrderingModel[] = []
-		const rest: OrderingModel[] = []
-		// Get the ordered tiles
+		const orderedIds = new Set<string>()
+		// Emit the tiles referenced by the mask, in mask order
 		orderMask.forEach((id) => {
-			if (tilesMap.has(id)) {
-				orderedTiles.push(tilesMap.get(id)!)
+			const tile = tilesMap.get(id)
+			if (tile) {
+				orderedTiles.push(tile)
+				orderedIds.add(id)
 			}
 		})
 
-		// Add remaining tiles not in orderMask to rest
+		// Append the remaining tiles in their original (insertion) order
+		const rest: OrderingModel[] = []
 		tilesMap.forEach((tile, id) => {
-			if (!orderMask.includes(id)) {
+			if (!orderedIds.has(id)) {
 				rest.push(tile)
 			}
 		})

--- a/src/components/CallView/Grid/useTileOrdering.ts
+++ b/src/components/CallView/Grid/useTileOrdering.ts
@@ -1,0 +1,251 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { Ref } from 'vue'
+
+import { computed, onScopeDispose, ref, watch } from 'vue'
+import { useStore } from 'vuex'
+import { PARTICIPANT } from '../../../constants.ts'
+import { useActorStore } from '../../../stores/actor.ts'
+
+/**
+ * Time (in ms) a speaker whose audio went off stays promoted before being
+ * demoted again.
+ */
+const UNPROMOTE_DELAY = 10000
+
+/**
+ * Minimal shape of a call participant model the ordering logic relies on.
+ * The real models expose many more attributes, but only these are read here.
+ */
+export type OrderingModel = {
+	attributes: {
+		peerId: string
+		nextcloudSessionId: string
+		stream?: object | null
+		videoAvailable?: boolean
+		audioAvailable?: boolean
+		speaking?: boolean
+	}
+}
+
+type UseTileOrderingOptions = {
+	/** All call participant models, in their source order */
+	callParticipantModels: Readonly<Ref<OrderingModel[]>>
+	/** Peer ids currently sharing their screen */
+	screens: Readonly<Ref<string[]>>
+	/** Token of the conversation the grid belongs to */
+	token: Readonly<Ref<string>>
+	/** Number of tiles shown on the first page (used to skip already-visible speakers) */
+	slots: Readonly<Ref<number>>
+}
+
+/**
+ * Orders the call participant tiles and keeps recently active speakers promoted
+ * to the first page.
+ *
+ * Tiles are grouped by category (screenshare > temporarily promoted speakers >
+ * video enabled > audio only > no permissions) and, within the video and audio
+ * groups, sorted by a promotion history mask so that a speaker keeps its
+ * relative position once promoted. Guests (whose participant store is not
+ * initialised) bypass the ordering and get the models in their source order.
+ *
+ * @param options - the reactive inputs driving the ordering
+ * @param options.callParticipantModels - all call participant models
+ * @param options.screens - peer ids currently sharing their screen
+ * @param options.token - token of the conversation the grid belongs to
+ * @param options.slots - number of tiles shown on the first page
+ */
+export function useTileOrdering({
+	callParticipantModels,
+	screens,
+	token,
+	slots,
+}: UseTileOrderingOptions) {
+	const vuexStore = useStore()
+	const actorStore = useActorStore()
+
+	// Speakers recently promoted to the first page and the history of
+	// promotions, used to keep the relative order of the tiles stable.
+	const tempPromotedModels = ref<OrderingModel[]>([])
+	const promotedHistoryMask = ref<string[]>([])
+	const unpromoteSpeakerTimer: Record<string, ReturnType<typeof setTimeout>> = {}
+
+	const participantsInitialised = computed(() => vuexStore.getters.participantsInitialised(token.value))
+
+	const isGuestNonModerator = computed(() => {
+		return actorStore.isActorGuest
+			&& vuexStore.getters.conversation(token.value)?.participantType !== PARTICIPANT.TYPE.GUEST_MODERATOR
+	})
+
+	/**
+	 * @param callParticipantModel the participant model
+	 */
+	function isModelWithVideo(callParticipantModel: OrderingModel): boolean {
+		return !!callParticipantModel.attributes.videoAvailable
+			&& callParticipantModel.attributes.stream !== null
+			&& (typeof callParticipantModel.attributes.stream === 'object')
+	}
+
+	/**
+	 * @param callParticipantModel the participant model
+	 */
+	function isModelWithAudio(callParticipantModel: OrderingModel): boolean {
+		const participant = vuexStore.getters.getParticipantBySessionId(token.value, callParticipantModel.attributes.nextcloudSessionId)
+		if (!participant) {
+			return false
+		}
+		return !!(participant?.permissions & PARTICIPANT.PERMISSIONS.PUBLISH_AUDIO)
+	}
+
+	/**
+	 * @param tilesMap map of session ids to models
+	 * @param orderMask ordered session ids to sort the tiles by
+	 */
+	function getOrderedTiles(tilesMap: Map<string, OrderingModel>, orderMask: string[]) {
+		const orderedTiles: OrderingModel[] = []
+		const rest: OrderingModel[] = []
+		// Get the ordered tiles
+		orderMask.forEach((id) => {
+			if (tilesMap.has(id)) {
+				orderedTiles.push(tilesMap.get(id)!)
+			}
+		})
+
+		// Add remaining tiles not in orderMask to rest
+		tilesMap.forEach((tile, id) => {
+			if (!orderMask.includes(id)) {
+				rest.push(tile)
+			}
+		})
+
+		return [...orderedTiles, ...rest]
+	}
+
+	const orderedParticipantModels = computed<OrderingModel[]>(() => {
+		// Dynamic ordering is not possible for guests because
+		// participants store is not initialized
+		if (isGuestNonModerator.value) {
+			return callParticipantModels.value
+		}
+
+		const objectMap = {
+			modelsWithScreenshare: [] as OrderingModel[],
+			modelsTempPromoted: [] as OrderingModel[],
+			modelsWithVideoEnabled: [] as OrderingModel[],
+			modelsWithAudioOnly: [] as OrderingModel[],
+			modelsWithNoPermissions: [] as OrderingModel[],
+		}
+		const screensSet = new Set(screens.value)
+		const tempPromotedModelsSet = new Set(tempPromotedModels.value.map((model) => model.attributes.nextcloudSessionId))
+		const videoTilesMap = new Map<string, OrderingModel>()
+		const audioTilesMap = new Map<string, OrderingModel>()
+
+		callParticipantModels.value.forEach((model) => {
+			if (screensSet.has(model.attributes.peerId)) {
+				objectMap.modelsWithScreenshare.push(model)
+			} else if (tempPromotedModelsSet.has(model.attributes.nextcloudSessionId)) {
+				objectMap.modelsTempPromoted.push(model)
+			} else if (isModelWithVideo(model)) {
+				videoTilesMap.set(model.attributes.nextcloudSessionId, model)
+			} else if (participantsInitialised.value && isModelWithAudio(model)) {
+				audioTilesMap.set(model.attributes.nextcloudSessionId, model)
+			} else {
+				objectMap.modelsWithNoPermissions.push(model)
+			}
+		})
+
+		objectMap.modelsWithVideoEnabled = getOrderedTiles(videoTilesMap, promotedHistoryMask.value)
+		objectMap.modelsWithAudioOnly = getOrderedTiles(audioTilesMap, promotedHistoryMask.value)
+
+		return [
+			...objectMap.modelsWithScreenshare,
+			...objectMap.modelsTempPromoted,
+			...objectMap.modelsWithVideoEnabled,
+			...objectMap.modelsWithAudioOnly,
+			...objectMap.modelsWithNoPermissions,
+		]
+	})
+
+	/**
+	 * @param model the speaker model to unpromote
+	 */
+	function unpromoteSpeaker(model: OrderingModel) {
+		// remove model from the temp promoted speakers
+		const index = tempPromotedModels.value.indexOf(model)
+		if (index === -1) {
+			return
+		}
+
+		tempPromotedModels.value.splice(index, 1)
+	}
+
+	/**
+	 * @param model the speaker model to promote
+	 */
+	function promoteSpeaker(model: OrderingModel) {
+		const id = model.attributes.nextcloudSessionId
+
+		if (slots.value <= 0) {
+			// Nothing to promote
+			return
+		}
+
+		// if model is already in the first page, do nothing
+		if (orderedParticipantModels.value.slice(0, slots.value).find((video) => video.attributes.nextcloudSessionId === id)) {
+			return
+		}
+
+		if (screens.value.includes(model.attributes.peerId)) {
+			// tiles with screenshare have a better priority position already
+			// do nothing
+			return
+		}
+
+		// add the model
+		if (!tempPromotedModels.value.includes(model)) {
+			// remove model from the order history if it exists
+			const modelIndex = promotedHistoryMask.value.indexOf(id)
+			if (modelIndex !== -1) {
+				promotedHistoryMask.value.splice(modelIndex, 1)
+			}
+
+			tempPromotedModels.value.unshift(model)
+			// add model to the beginning of the ordered models in its category
+			promotedHistoryMask.value.unshift(id)
+		}
+	}
+
+	const speakers = computed(() => callParticipantModels.value.filter((model) => model.attributes.speaking))
+
+	const speakersWithAudioOff = computed(() => tempPromotedModels.value.filter((model) => !model.attributes.audioAvailable))
+
+	watch(speakers, (models) => {
+		models.forEach((model) => {
+			promoteSpeaker(model)
+			clearTimeout(unpromoteSpeakerTimer[model.attributes.nextcloudSessionId])
+		})
+	})
+
+	watch(speakersWithAudioOff, (newModels, oldModels) => {
+		newModels.forEach((speaker) => {
+			if (oldModels.includes(speaker)) {
+				return
+			}
+			unpromoteSpeakerTimer[speaker.attributes.nextcloudSessionId] = setTimeout(() => {
+				unpromoteSpeaker(speaker)
+			}, UNPROMOTE_DELAY)
+		})
+	})
+
+	// Cancel any pending unpromote timers when the owning scope is torn down.
+	onScopeDispose(() => {
+		Object.values(unpromoteSpeakerTimer).forEach((timer) => clearTimeout(timer))
+	})
+
+	return {
+		orderedParticipantModels,
+	}
+}


### PR DESCRIPTION
Extracted reordering logic. it uses stores that are only consumed by that logic. I also improved computation complexity in mapping tiles order. 

The architecture is the following

<img width="633" height="523" alt="image" src="https://github.com/user-attachments/assets/3bd1b319-69a1-4118-acc9-c697590c0184" />


### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

NO VISUAL CHANGES

<!-- ☀️ Light theme | 🌑 Dark Theme -->


### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [x] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required

---