### PR TITLE
fix(external-call): Return existing room instead of failing on duplicate

### DIFF
--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -864,6 +864,10 @@ class RoomController extends AEnvironmentAwareOCSController {
 				allowInternalTypes: $allowInternalTypes,
 			);
 		} catch (CreationException $e) {
+			$room = $e->getRoom();
+			if ($room instanceof Room) {
+				return new DataResponse($this->formatRoom($room, $this->participantService->getParticipant($room, $actorUserId, false)), Http::STATUS_OK);
+			}
 			return new DataResponse(['error' => $e->getReason()], Http::STATUS_BAD_REQUEST);
 		} catch (PasswordException $e) {
 			return new DataResponse(['error' => 'password', 'message' => $e->getHint()], Http::STATUS_BAD_REQUEST);

--- a/lib/Exceptions/RoomProperty/CreationException.php
+++ b/lib/Exceptions/RoomProperty/CreationException.php
@@ -8,6 +8,8 @@ declare(strict_types=1);
 
 namespace OCA\Talk\Exceptions\RoomProperty;
 
+use OCA\Talk\Room;
+
 class CreationException extends \InvalidArgumentException {
 	public const REASON_AVATAR = 'avatar';
 	public const REASON_DESCRIPTION = 'description';
@@ -31,6 +33,7 @@ class CreationException extends \InvalidArgumentException {
 	 */
 	public function __construct(
 		private readonly string $reason,
+		private readonly ?Room $room = null,
 	) {
 		parent::__construct($reason);
 	}
@@ -40,5 +43,12 @@ class CreationException extends \InvalidArgumentException {
 	 */
 	public function getReason(): string {
 		return $this->reason;
+	}
+
+	/**
+	 * Room for the object when it already existed
+	 */
+	public function getRoom(): ?Room {
+		return $this->room;
 	}
 }

--- a/lib/Service/RoomService.php
+++ b/lib/Service/RoomService.php
@@ -222,8 +222,8 @@ class RoomService {
 
 		if ($objectType === Room::OBJECT_TYPE_EXTERNAL_CALL) {
 			try {
-				$this->manager->getRoomByObject(Room::OBJECT_TYPE_EXTERNAL_CALL, $objectId);
-				throw new CreationException(CreationException::REASON_OBJECT);
+				$room = $this->manager->getRoomByObject(Room::OBJECT_TYPE_EXTERNAL_CALL, $objectId);
+				throw new CreationException(CreationException::REASON_OBJECT, $room);
 			} catch (RoomNotFoundException) {
 				// Object ID is unique, continue
 			}

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -1207,8 +1207,12 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 		$this->sendRequest('POST', '/apps/spreed/api/' . $apiVersion . '/room', $body, $headers);
 		$this->assertStatusCode($this->response, $statusCode);
 
-		if ($statusCode === 201) {
+		if ($statusCode === 201 || $statusCode === 200) {
 			$response = $this->getDataFromResponse($this->response);
+			if ($statusCode === 200 && isset(self::$identifierToToken[$identifier])) {
+				// The room already existed, so the same room has to be returned
+				Assert::assertSame(self::$identifierToToken[$identifier], $response['token'], 'Token of existing room does not match');
+			}
 			self::$identifierToToken[$identifier] = $response['token'];
 			self::$identifierToId[$identifier] = $response['id'];
 			self::$tokenToIdentifier[$response['token']] = $identifier;

--- a/tests/integration/features/conversation-1/create-external-service.feature
+++ b/tests/integration/features/conversation-1/create-external-service.feature
@@ -24,6 +24,55 @@ Feature: conversation-1/create-external-service
     And user "participant1" gets external call url for room "room" with 200 (v4)
       | url | https://example.tld/webapp3/m/210987654321-afed-3210-9c8b-7a6f5e4d |
 
+  Scenario: External call service creating a room with a duplicate object id returns the existing room
+    Given the following "spreed" app config is set
+      | external_call_service_shared_secret | aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa |
+      | external_call_service_auth_user | nextcloud |
+      | external_call_service_iframe_field | targetUrl |
+    Given external call server is started
+    When external call service creates room "room" with secret "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" with 201 (v4)
+      | roomType | 3 |
+      | roomName | room |
+      | owner | participant1 |
+      | objectType | external_call |
+      | objectId | d4e5f6a7-b8c9-0123-defa-123456789012 |
+    When external call service creates room "room" with secret "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" with 200 (v4)
+      | roomType | 3 |
+      | roomName | second attempt |
+      | owner | participant1 |
+      | objectType | external_call |
+      | objectId | d4e5f6a7-b8c9-0123-defa-123456789012 |
+    Then user "participant1" is participant of the following rooms (v4)
+      | id   | name | type | participantType | objectType    | objectId                             |
+      | room | room | 3    | 1               | external_call | d4e5f6a7-b8c9-0123-defa-123456789012 |
+    Then user "participant1" sees the following system messages in room "room" with 200 (v1)
+      | room | actorType     | actorId | systemMessage        | message                         | silent | messageParameters |
+      | room | guests        | system  | user_added           | System added you                | !ISSET | {"actor":{"type":"guest","id":"guest\/system","name":"System","mention-id":"guest\/system"},"user":{"type":"user","id":"participant1","name":"participant1-displayname","mention-id":"participant1"}} |
+      | room | guests        | system  | conversation_created | System created the conversation | !ISSET | {"actor":{"type":"guest","id":"guest\/system","name":"System","mention-id":"guest\/system"}} |
+
+  Scenario: External call service creating a room with a different object id creates a second room
+    Given the following "spreed" app config is set
+      | external_call_service_shared_secret | aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa |
+      | external_call_service_auth_user | nextcloud |
+      | external_call_service_iframe_field | targetUrl |
+    Given external call server is started
+    When external call service creates room "room1" with secret "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" with 201 (v4)
+      | roomType | 3 |
+      | roomName | room1 |
+      | owner | participant1 |
+      | objectType | external_call |
+      | objectId | d4e5f6a7-b8c9-0123-defa-123456789012 |
+    When external call service creates room "room2" with secret "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" with 201 (v4)
+      | roomType | 3 |
+      | roomName | room2 |
+      | owner | participant1 |
+      | objectType | external_call |
+      | objectId | e5f6a7b8-c9d0-1234-efab-234567890123 |
+    Then user "participant1" is participant of the following rooms (v4)
+      | id    | name  | type | participantType | objectType    | objectId                             |
+      | room1 | room1 | 3    | 1               | external_call | d4e5f6a7-b8c9-0123-defa-123456789012 |
+      | room2 | room2 | 3    | 1               | external_call | e5f6a7b8-c9d0-1234-efab-234567890123 |
+
   Scenario: Unauthenticated user without external service header is rejected
     Given the following "spreed" app config is set
       | external_call_service               | https://external-service.example.org/ |


### PR DESCRIPTION
### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

## 🛠️ API Checklist
### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
