### PR TITLE
feat(upload): compress images

### DIFF
--- a/src/components/NewMessage/NewMessageUploadEditor.vue
+++ b/src/components/NewMessage/NewMessageUploadEditor.vue
@@ -65,6 +65,12 @@
 				type="switch">
 				{{ t('spreed', 'Allow editing of uploaded files') }}
 			</NcCheckboxRadioSwitch>
+			<NcCheckboxRadioSwitch
+				v-if="hasImages"
+				v-model="skipCompression"
+				type="switch">
+				{{ t('spreed', 'Send images without compression') }}
+			</NcCheckboxRadioSwitch>
 
 			<div v-if="!supportMediaCaption" class="upload-editor__actions">
 				<NcButton variant="tertiary" @click="handleDismiss">
@@ -106,6 +112,7 @@ import { useGetToken } from '../../composables/useGetToken.ts'
 import { MESSAGE } from '../../constants.ts'
 import { getTalkConfig, hasTalkFeature } from '../../services/CapabilitiesManager.ts'
 import { useUploadStore } from '../../stores/upload.ts'
+import { supportImageCompression } from '../../utils/imageCompression.ts'
 
 export default {
 	name: 'NewMessageUploadEditor',
@@ -124,6 +131,7 @@ export default {
 	setup() {
 		const isDraggingOver = ref(false)
 		const allowUpdate = ref(false)
+		const skipCompression = ref(false)
 		const dialogMaskId = `new-message-upload-${useId()}`
 		const dialogHeaderId = `new-message-upload-header-${useId()}`
 		const modalContainerId = '#' + dialogMaskId
@@ -132,6 +140,7 @@ export default {
 			modalContainerId,
 			isDraggingOver,
 			allowUpdate,
+			skipCompression,
 			dialogMaskId,
 			dialogHeaderId,
 			token: useGetToken(),
@@ -147,6 +156,10 @@ export default {
 
 		supportConversationSubfolders() {
 			return getTalkConfig(this.token, 'attachments', 'conversation-subfolders') === true
+		},
+
+		hasImages() {
+			return this.files.some(([, f]) => supportImageCompression(f.file.type))
 		},
 
 		currentUploadId() {
@@ -200,8 +213,9 @@ export default {
 					this.$refs.submitButton.$el.focus()
 				}
 			} else {
-				// Reset user's choice at closing
+				// Reset user's choices at closing
 				this.allowUpdate = false
+				this.skipCompression = false
 			}
 		},
 	},
@@ -220,6 +234,7 @@ export default {
 				caption: null,
 				options: null,
 				allowUpdate: this.supportConversationSubfolders ? this.allowUpdate : undefined,
+				compressImages: this.hasImages ? !this.skipCompression : undefined,
 			})
 		},
 
@@ -237,6 +252,7 @@ export default {
 						parent: temporaryMessage.parent,
 					},
 					allowUpdate: this.supportConversationSubfolders ? this.allowUpdate : undefined,
+					compressImages: this.hasImages ? !this.skipCompression : undefined,
 				})
 			} else {
 				this.uploadStore.discardUpload(this.currentUploadId)

--- a/src/stores/__tests__/upload.spec.js
+++ b/src/stores/__tests__/upload.spec.js
@@ -506,6 +506,29 @@ describe('fileUploadStore', () => {
 				})
 			})
 
+			test('keeps the caption when the probe predicts a rename', async () => {
+				conversationGetter.mockReturnValue({ type: 2, displayName: 'Room' })
+				probeAttachmentFolder.mockResolvedValue(generateOCSResponse({ payload: {
+					folder: DRAFT_PATH,
+					renames: [{ 'photo.jpg': 'photo (1).jpg' }],
+				} }))
+
+				const file = { name: 'photo.jpg', type: 'image/jpeg', size: 100, lastModified: 0 }
+				uploadStore.initialiseUpload({ uploadId: 'upload-id1', token: TOKEN, files: [file] })
+
+				await uploadStore.uploadFiles({ token: TOKEN, uploadId: 'upload-id1', caption: 'text-caption', options: null })
+
+				expect(vuexStoreDispatch).toHaveBeenLastCalledWith('addTemporaryMessage', {
+					token: TOKEN,
+					message: expect.objectContaining({
+						message: 'text-caption',
+						messageParameters: expect.objectContaining({
+							file: expect.objectContaining({ name: 'photo (1).jpg' }),
+						}),
+					}),
+				})
+			})
+
 			test('falls back to shareFile when the probe endpoint fails', async () => {
 				conversationGetter.mockReturnValue({ type: 2, displayName: 'My Room' })
 				probeAttachmentFolder.mockRejectedValueOnce(new Error('boom'))

--- a/src/stores/__tests__/upload.spec.js
+++ b/src/stores/__tests__/upload.spec.js
@@ -13,6 +13,7 @@ import { getDavClient } from '../../services/DavClient.ts'
 import { postAttachment, probeAttachmentFolder, shareFile } from '../../services/filesSharingServices.ts'
 import { generateOCSResponse } from '../../test-helpers.js'
 import { findUniquePath } from '../../utils/fileUpload.ts'
+import { compressImage } from '../../utils/imageCompression.ts'
 import { useActorStore } from '../actor.ts'
 import { useSettingsStore } from '../settings.ts'
 import { useUploadStore } from '../upload.ts'
@@ -43,6 +44,14 @@ vi.mock('../../services/filesSharingServices.ts', () => ({
 	probeAttachmentFolder: vi.fn(),
 	shareFile: vi.fn(),
 }))
+// Only the re-encoding itself is mocked; it has its own unit test
+vi.mock('../../utils/imageCompression.ts', async (importOriginal) => {
+	const imageCompression = await importOriginal()
+	return {
+		...imageCompression,
+		compressImage: vi.fn(),
+	}
+})
 vi.mock('../../services/CapabilitiesManager.ts', async (importOriginal) => {
 	const actual = await importOriginal()
 	return {
@@ -557,6 +566,98 @@ describe('fileUploadStore', () => {
 				expect(probeAttachmentFolder).not.toHaveBeenCalled()
 				expect(postAttachment).not.toHaveBeenCalled()
 				expect(shareFile).toHaveBeenCalledTimes(1)
+			})
+		})
+
+		describe('image compression', () => {
+			const TOKEN = 'XXTOKENXX'
+
+			/**
+			 * Creates a file of the given type and byte size.
+			 * Use real File instances, as the store compares result to the original by identity
+			 *
+			 * @param name the file name
+			 * @param type the MIME type
+			 * @param size the byte size
+			 */
+			function makeFile(name, type, size) {
+				return new File([new Uint8Array(size)], name, { type, lastModified: Date.UTC(2021, 3, 27, 15, 30, 0) })
+			}
+
+			/** An image as selected by the user */
+			function makeImage() {
+				return makeFile('pngimage.png', 'image/png', 4096)
+			}
+
+			/** The re-encoded image as returned by compressImage() */
+			function makeCompressed() {
+				return makeFile('pngimage.webp', 'image/webp', 1024)
+			}
+
+			beforeEach(() => {
+				uploadMock.mockResolvedValue()
+				shareFile.mockResolvedValue({ data: { ocs: { data: { id: '1' } } } })
+				findUniquePath.mockImplementation((client, userRoot, path) => {
+					return Promise.resolve({ uniquePath: path + 'uniq', suffix: 1 })
+				})
+				// Default to a flat attachment-folder upload; enabled per test where needed
+				getTalkConfig.mockReturnValue(false)
+			})
+
+			afterEach(() => {
+				getTalkConfig.mockReturnValue(true)
+			})
+
+			test('does not compress anything when not requested', async () => {
+				const file = makeImage()
+				uploadStore.initialiseUpload({ uploadId: 'upload-id1', token: TOKEN, files: [file] })
+
+				await uploadStore.uploadFiles({ token: TOKEN, uploadId: 'upload-id1', options: null })
+
+				expect(compressImage).not.toHaveBeenCalled()
+				expect(uploadMock).toHaveBeenCalledWith(expect.anything(), file)
+			})
+
+			test('compresses only supported and non-empty files', async () => {
+				const image = makeImage()
+				const text = makeFile('textfile.txt', 'text/plain', 111)
+				const gif = makeFile('animation.gif', 'image/gif', 4096)
+				const empty = makeFile('empty.png', 'image/png', 0)
+
+				uploadStore.initialiseUpload({ uploadId: 'upload-id1', token: TOKEN, files: [image, text, gif, empty] })
+				compressImage.mockResolvedValue(makeCompressed())
+
+				await uploadStore.uploadFiles({ token: TOKEN, uploadId: 'upload-id1', options: null, compressImages: true })
+
+				expect(compressImage).toHaveBeenCalledTimes(1)
+				expect(compressImage).toHaveBeenCalledWith(image)
+			})
+
+			test('keeps the caption and the parent of the temporary message', async () => {
+				const compressed = makeCompressed()
+				const parent = { id: 42, message: 'parent message' }
+
+				uploadStore.initialiseUpload({ uploadId: 'upload-id1', token: TOKEN, files: [makeImage()] })
+				compressImage.mockResolvedValue(compressed)
+
+				await uploadStore.uploadFiles({
+					token: TOKEN,
+					uploadId: 'upload-id1',
+					caption: 'text-caption',
+					options: { parent },
+					compressImages: true,
+				})
+
+				expect(vuexStoreDispatch).toHaveBeenLastCalledWith('addTemporaryMessage', {
+					token: TOKEN,
+					message: expect.objectContaining({
+						message: 'text-caption',
+						parent,
+						messageParameters: expect.objectContaining({
+							file: expect.objectContaining({ name: compressed.name }),
+						}),
+					}),
+				})
 			})
 		})
 

--- a/src/stores/upload.ts
+++ b/src/stores/upload.ts
@@ -35,6 +35,7 @@ import {
 	hasDuplicateUploadNames,
 	separateDuplicateUploads,
 } from '../utils/fileUpload.ts'
+import { compressImage, supportImageCompression } from '../utils/imageCompression.ts'
 import { parseUploadError } from '../utils/propfindErrorParse.ts'
 import { useActorStore } from './actor.ts'
 import { useChatExtrasStore } from './chatExtras.ts'
@@ -57,6 +58,7 @@ type UploadFilesPayload = {
 	caption?: string
 	options: Pick<ChatMessage, | 'threadId' | 'threadTitle' | 'silent' | 'parent'> | null
 	allowUpdate?: boolean
+	compressImages?: boolean
 }
 
 type PerformSharePayload = {
@@ -359,6 +361,49 @@ export const useUploadStore = defineStore('upload', () => {
 	}
 
 	/**
+	 * Re-encodes an initialised image upload in place, replacing the staged file
+	 * and its local preview URL.
+	 *
+	 * Returns the compressed file, or null when the original was kept
+	 * (unsupported type, no size gain, or a failed encode). Callers use the
+	 * return value to update the temporary message parameters.
+	 *
+	 * @param uploadId unique identifier
+	 * @param index the index of the file within the upload
+	 */
+	async function compressUploadedImage(uploadId: string, index: string): Promise<File | null> {
+		const uploadedFile = uploads[uploadId].files[index]
+		const currentFile = uploadedFile.file
+		if (!supportImageCompression(currentFile.type) || currentFile.size < 1) {
+			return null
+		}
+
+		try {
+			// @ts-expect-error: UploadFile.file is a custom type, not a File
+			const compressed = await compressImage(currentFile)
+			if (!compressed) {
+				// Compression was not beneficial, the original file is kept
+				return null
+			}
+
+			// @ts-expect-error: UploadFile.file is a custom type, not a File
+			uploads[uploadId].files[index].file = compressed
+			uploads[uploadId].files[index].totalSize = compressed.size
+
+			const referenceId = uploadedFile.temporaryMessage.referenceId
+			if (localUrls[referenceId]) {
+				URL.revokeObjectURL(localUrls[referenceId])
+			}
+			localUrls[referenceId] = URL.createObjectURL(compressed)
+
+			return compressed
+		} catch (error) {
+			console.error('Failed to compress image, uploading original: ', error)
+			return null
+		}
+	}
+
+	/**
 	 * Uploads the files to the root directory of the user
 	 *
 	 * @param payload the wrapping object
@@ -367,8 +412,9 @@ export const useUploadStore = defineStore('upload', () => {
 	 * @param payload.caption The text caption to the media
 	 * @param payload.options The share options
 	 * @param payload.allowUpdate Whether to grant update permissions
+	 * @param payload.compressImages Whether to re-encode uploaded images
 	 */
-	async function uploadFiles({ token, uploadId, caption, options, allowUpdate }: UploadFilesPayload) {
+	async function uploadFiles({ token, uploadId, caption, options, allowUpdate, compressImages }: UploadFilesPayload) {
 		if (currentUploadId.value === uploadId) {
 			currentUploadId.value = undefined
 		}
@@ -379,11 +425,29 @@ export const useUploadStore = defineStore('upload', () => {
 		// If caption is provided, attach to the last temporary message
 		const lastIndex = getInitialisedUploads(uploadId).at(-1)![0]
 		for (const [index, uploadedFile] of getInitialisedUploads(uploadId)) {
+			// Compress before building the temporary message, so that the caption,
+			// the parent and the final file parameters are applied in a single pass
+			// and the backend receives the final file names (e.g. .webp instead of .png)
+			const compressed = compressImages
+				? await compressUploadedImage(uploadId, index)
+				: null
+
 			// Store the previously created temporary message
 			const message = {
 				...uploadedFile.temporaryMessage,
 				parent: options?.parent ? options.parent : uploadedFile.temporaryMessage.parent,
 				message: index === lastIndex && caption ? caption : '{file}',
+				messageParameters: compressed
+					? {
+							...uploadedFile.temporaryMessage.messageParameters,
+							file: {
+								...uploadedFile.temporaryMessage.messageParameters.file,
+								file: compressed,
+								name: compressed.name,
+								mimetype: compressed.type,
+							},
+						}
+					: uploadedFile.temporaryMessage.messageParameters,
 			}
 			// Add temporary messages (files) to the messages list
 			vuexStore.dispatch('addTemporaryMessage', { token, message })
@@ -545,7 +609,7 @@ export const useUploadStore = defineStore('upload', () => {
 			try {
 				markFileAsUploading({ uploadId, index })
 				const uploader = getUploader()
-				// @ts-expect-error: Type File is not assignable to type
+				// @ts-expect-error: UploadFile.file is a custom type, not a File
 				await uploader.upload(uploadedFile.sharePath!, currentFile)
 				markFileAsSuccessUpload({ uploadId, index })
 			} catch (exception) {

--- a/src/stores/upload.ts
+++ b/src/stores/upload.ts
@@ -449,6 +449,9 @@ export const useUploadStore = defineStore('upload', () => {
 						}
 					: uploadedFile.temporaryMessage.messageParameters,
 			}
+			// FIXME use a single source of truth, only create temp.message at this step
+			// Keep the caption and parent in sync between uploadStore and messagesStore
+			uploads[uploadId].files[index].temporaryMessage = message
 			// Add temporary messages (files) to the messages list
 			vuexStore.dispatch('addTemporaryMessage', { token, message })
 			// Scroll the message list

--- a/src/test-setup.js
+++ b/src/test-setup.js
@@ -102,6 +102,29 @@ global.OCP = {
 }
 global.IS_DESKTOP = false
 
+/** Mock toDataUrl() for jsdom */
+HTMLCanvasElement.prototype.toDataURL = vi.fn((type = 'image/png') => `data:${type};base64,AAAA`)
+
+/**
+ * Mock OffscreenCanvas for jsdom.
+ * Methods are defined on the prototype, as feature detection relies on it.
+ * Spy on the prototype methods to adjust the behaviour in tests.
+ */
+global.OffscreenCanvas = class OffscreenCanvas {
+	constructor(width, height) {
+		this.width = width
+		this.height = height
+	}
+
+	getContext() {
+		return { fillRect: vi.fn(), drawImage: vi.fn() }
+	}
+
+	convertToBlob({ type } = {}) {
+		return Promise.resolve(new Blob([], { type }))
+	}
+}
+
 /**
  * Polyfill for Blob.prototype.arrayBuffer
  * Required as jsdom breaks Nodejs's native Blob

--- a/src/utils/__tests__/imageCompression.spec.js
+++ b/src/utils/__tests__/imageCompression.spec.js
@@ -1,0 +1,165 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { compressImage } from '../imageCompression.ts'
+
+/** Fake 2D rendering context shared by all canvases of a single test */
+let context
+/** Whether getContext() should return a context at all */
+let contextAvailable
+/** All canvases created during a test, in order of creation */
+let canvases
+/** Options the canvas encoder was called with, in order */
+let encodeCalls
+/** Descriptor of the blob returned by the canvas encoder */
+let encoded
+/** The bitmap returned by the mocked createImageBitmap() */
+let bitmap
+
+/**
+ * Builds a blob of the given type and byte size
+ *
+ * @param descriptor the blob descriptor
+ * @param descriptor.type the MIME type of the blob
+ * @param descriptor.size the byte size of the blob
+ */
+function makeBlob({ type, size }) {
+	return new Blob([new Uint8Array(size)], { type })
+}
+
+/**
+ * Creates a File of the given type and byte size
+ *
+ * @param name the file name
+ * @param options the file options
+ * @param options.type the MIME type of the file
+ * @param options.size the byte size of the file
+ * @param options.lastModified the last modification timestamp
+ */
+function makeFile(name, { type = 'image/png', size = 4096, lastModified = 1600000000000 } = {}) {
+	return new File([new Uint8Array(size)], name, { type, lastModified })
+}
+
+describe('imageCompression', () => {
+	beforeEach(() => {
+		context = {
+			imageSmoothingQuality: undefined,
+			fillStyle: undefined,
+			fillRect: vi.fn(),
+			drawImage: vi.fn(),
+		}
+		contextAvailable = true
+		canvases = []
+		encodeCalls = []
+		encoded = { type: 'image/webp', size: 512 }
+		bitmap = { width: 800, height: 600, close: vi.fn() }
+
+		global.createImageBitmap = vi.fn(() => Promise.resolve(bitmap))
+
+		// Adjust the OffscreenCanvas mocked in test-setup.js
+		vi.spyOn(OffscreenCanvas.prototype, 'getContext').mockImplementation(function() {
+			canvases.push(this)
+			return contextAvailable ? context : null
+		})
+		vi.spyOn(OffscreenCanvas.prototype, 'convertToBlob').mockImplementation(({ type, quality }) => {
+			encodeCalls.push({ type, quality })
+			return Promise.resolve(makeBlob(encoded))
+		})
+	})
+
+	afterEach(() => {
+		vi.restoreAllMocks()
+		delete global.createImageBitmap
+	})
+
+	describe('compressImage', () => {
+		it('re-encodes the image as WebP and adjusts the extension', async () => {
+			const file = makeFile('pngimage.png', { type: 'image/png', size: 4096 })
+
+			const result = await compressImage(file)
+
+			expect(result).not.toBe(file)
+			expect(result.name).toBe('pngimage.webp')
+			expect(result.type).toBe('image/webp')
+			expect(result.size).toBe(512)
+			expect(encodeCalls).toEqual([{ type: 'image/webp', quality: 0.8 }])
+		})
+
+		it('preserves the last modification time of the original file', async () => {
+			const file = makeFile('pngimage.png', { lastModified: 1234567890000 })
+
+			const result = await compressImage(file)
+
+			expect(result.lastModified).toBe(1234567890000)
+		})
+
+		it('scales oversized images down, preserving the aspect ratio', async () => {
+			bitmap = { width: 2560, height: 1440, close: vi.fn() }
+
+			await compressImage(makeFile('pngimage.png'))
+
+			expect(canvases.at(-1)).toMatchObject({ width: 1280, height: 720 })
+			expect(context.drawImage).toHaveBeenCalledWith(bitmap, 0, 0, 1280, 720)
+		})
+
+		it('scales by the longer side for portrait images', async () => {
+			bitmap = { width: 1000, height: 4000, close: vi.fn() }
+
+			await compressImage(makeFile('pngimage.png'))
+
+			expect(canvases.at(-1)).toMatchObject({ width: 320, height: 1280 })
+		})
+
+		it('does not upscale images smaller than the limit', async () => {
+			bitmap = { width: 320, height: 240, close: vi.fn() }
+
+			await compressImage(makeFile('pngimage.png'))
+
+			expect(canvases.at(-1)).toMatchObject({ width: 320, height: 240 })
+			expect(context.drawImage).toHaveBeenCalledWith(bitmap, 0, 0, 320, 240)
+		})
+
+		it('honours the given quality and maximum side', async () => {
+			bitmap = { width: 1000, height: 500, close: vi.fn() }
+
+			await compressImage(makeFile('pngimage.png'), 0.5, 100)
+
+			expect(canvases.at(-1)).toMatchObject({ width: 100, height: 50 })
+			expect(encodeCalls).toEqual([{ type: 'image/webp', quality: 0.5 }])
+		})
+
+		it('returns null when re-encoding does not reduce the size', async () => {
+			const file = makeFile('pngimage.png', { size: 512 })
+			encoded = { type: 'image/webp', size: 512 }
+
+			const result = await compressImage(file)
+
+			expect(result).toBeNull()
+		})
+
+		it('trusts the encoder type over the requested one', async () => {
+			// Some engines silently fall back to a lossless PNG encode
+			encoded = { type: 'image/png', size: 512 }
+
+			const result = await compressImage(makeFile('pngimage.png'))
+
+			expect(result.name).toBe('pngimage.png')
+			expect(result.type).toBe('image/png')
+		})
+
+		it.each([
+			['pngimage.png', 'pngimage.webp'],
+			['my.photo.from.2026.jpeg', 'my.photo.from.2026.webp'],
+			['no-extension', 'no-extension.webp'],
+			// A leading dot is treated as an extension separator
+			['.hidden', '.webp'],
+		])('renames %s to %s', async (name, expectedName) => {
+			const result = await compressImage(makeFile(name))
+
+			expect(result.name).toBe(expectedName)
+		})
+	})
+})

--- a/src/utils/imageCompression.ts
+++ b/src/utils/imageCompression.ts
@@ -1,0 +1,204 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * Types to re-encode on upload.
+ *
+ * Excluded types:
+ * - GIF - to keep the animation;
+ * - SVG - not worth to resterize the vector;
+ * - HEIC/HEIF, TIFF, RAW - need a heavy library.
+ */
+const COMPRESSIBLE_TYPES = [
+	'image/avif',
+	'image/bmp',
+	'image/jpeg',
+	'image/png',
+	'image/webp',
+	'image/x-icon',
+]
+
+/** Unified output format (lossy WebP is ~25-35% smaller than JPEG and supports an alpha channel) */
+const OUTPUT_TYPE = 'image/webp'
+/** Fallback used where WebP encoding is unavailable */
+const FALLBACK_TYPE = 'image/jpeg'
+/** Default image compression quality for formats with lossy compression support (80%) */
+const COMPRESS_QUALITY = 0.8
+/** Default max resolution of compressed image in pixels (matches HD resolution) */
+const COMPRESS_MAX_RESOLUTION = 1280
+
+const EXTENSIONS = {
+	'image/webp': '.webp',
+	'image/jpeg': '.jpg',
+	'image/png': '.png',
+}
+
+type EncodableCanvas = OffscreenCanvas | HTMLCanvasElement
+
+let isOffscreenCanvasSupported: boolean
+
+/**
+ * Detect whether OffscreenCanvas can be used (missing on Safari < 16.4 and some engines without a 2D encoder)
+ */
+function supportOffscreenCanvas(): boolean {
+	isOffscreenCanvasSupported ??= typeof OffscreenCanvas !== 'undefined'
+		&& typeof OffscreenCanvas.prototype.convertToBlob === 'function'
+
+	return isOffscreenCanvasSupported
+}
+
+let isWebpEncodingSupported: boolean
+
+/**
+ * Detect whether the canvas encoder can produce WebP (missing on Safari < 16.4).
+ * Browser fallback is lossless PNG encode.
+ */
+function supportWebpEncoding(): boolean {
+	if (typeof isWebpEncodingSupported !== 'undefined') {
+		return isWebpEncodingSupported
+	}
+	if (typeof document === 'undefined') {
+		return false
+	}
+	try {
+		const canvas = document.createElement('canvas')
+		canvas.width = 1
+		canvas.height = 1
+		isWebpEncodingSupported ??= canvas.toDataURL('image/webp')?.startsWith('data:image/webp') ?? false
+	} catch (error) {
+		isWebpEncodingSupported ??= false
+	}
+	return isWebpEncodingSupported
+}
+
+/**
+ * Creates the canvas for off-screen encoding.
+ *
+ * @param width The canvas width in pixels
+ * @param height The canvas height in pixels
+ */
+function createCanvas(width: number, height: number): EncodableCanvas {
+	if (supportOffscreenCanvas()) {
+		return new OffscreenCanvas(width, height)
+	}
+	const canvas = document.createElement('canvas')
+	canvas.width = width
+	canvas.height = height
+	return canvas
+}
+
+/**
+ * Encodes the canvas contents
+ *
+ * @param canvas The canvas to encode
+ * @param type The requested output MIME type
+ * @param quality The encoder quality (between 0 and 1)
+ */
+async function encodeCanvas(canvas: EncodableCanvas, type: string, quality: number): Promise<Blob> {
+	if ('convertToBlob' in canvas) {
+		return await canvas.convertToBlob({ type, quality })
+	}
+
+	return await new Promise((resolve, reject) => {
+		canvas.toBlob(
+			(blob) => blob ? resolve(blob) : reject(new Error('[imageCompression] Failed to encode canvas')),
+			type,
+			quality,
+		)
+	})
+}
+
+/**
+ * Whether a file of the given MIME type can be re-encoded by compressImage.
+ *
+ * @param mimeType The MIME type of the file
+ */
+export function supportImageCompression(mimeType: string): boolean {
+	return COMPRESSIBLE_TYPES.includes(mimeType)
+}
+
+/**
+ * Scale dimensions down so neither side exceeds maxResolution, preserving aspect ratio.
+ *
+ * @param width The original width in pixels
+ * @param height The original height in pixels
+ * @param maxResolution The maximum allowed resolution in pixels
+ */
+function scaledDimensions(width: number, height: number, maxResolution: number): { width: number, height: number } {
+	if (width <= maxResolution && height <= maxResolution) {
+		return { width, height }
+	}
+	const ratio = Math.min(maxResolution / width, maxResolution / height)
+	return { width: Math.round(width * ratio), height: Math.round(height * ratio) }
+}
+
+/**
+ * Compresses an image file via the Canvas API.
+ * - preserve the EXIF orientation before drawing ('from-image'), while stripping EXIF tag;
+ * - outputs WebP (JPEG as fallback) file with adjusted extension;
+ * - scales down images larger than maxResolution on either axis;
+ * - returns null when the encode fails, or when re-encoding would not make the file smaller.
+ *
+ * @param file The image file to compress
+ * @param quality The encoder quality (between 0 and 1)
+ * @param maxResolution The maximum allowed resolution in pixels
+ */
+export async function compressImage(file: File, quality = COMPRESS_QUALITY, maxResolution = COMPRESS_MAX_RESOLUTION): Promise<File | null> {
+	const bitmap = await createImageBitmap(file, { imageOrientation: 'from-image' })
+	const dimensionsOriginal = `${bitmap.width}×${bitmap.height}`
+	const { width, height } = scaledDimensions(bitmap.width, bitmap.height, maxResolution)
+
+	const outputType = supportWebpEncoding() ? OUTPUT_TYPE : FALLBACK_TYPE
+	const canvas = createCanvas(width, height)
+	const ctx = canvas.getContext('2d') as OffscreenCanvasRenderingContext2D | CanvasRenderingContext2D | null
+	if (!ctx) {
+		bitmap.close()
+		console.warn('[imageCompression] Failed to get 2D canvas context')
+		return null
+	}
+
+	try {
+		ctx.imageSmoothingQuality = 'high'
+		if (outputType === FALLBACK_TYPE) {
+			// JPEG has no alpha channel, so composite onto white instead of black
+			ctx.fillStyle = '#ffffff'
+			ctx.fillRect(0, 0, width, height)
+		}
+		ctx.drawImage(bitmap, 0, 0, width, height)
+	} catch (e) {
+		console.warn('[imageCompression] Failed to draw image on canvas')
+		return null
+	} finally {
+		// Bitmap is no longer required, close both in case of success or exception
+		bitmap.close()
+	}
+
+	const blob = await encodeCanvas(canvas, outputType, quality)
+	// An unsupported type silently yields a PNG - trust the encoder to assign type
+	const type = blob.type as keyof typeof EXTENSIONS
+	const name = file.name.replace(/\.[^.]+$/, '') + (EXTENSIONS[type] ?? '')
+	const compressed = new File([blob], name, { type, lastModified: file.lastModified })
+
+	if (compressed.size >= file.size) {
+		console.debug('[DEBUG] spreed: imageCompression skipped - re-encoding did not reduce the size')
+		return null
+	}
+
+	console.debug(
+		'[DEBUG] spreed: image compressed with %s loss:\n<<< %s (%s, %s)\n>>> %s (%s, %s)',
+		// Loss
+		((1 - compressed.size / file.size) * 100).toFixed(1) + '%',
+		// Original
+		file.name,
+		dimensionsOriginal,
+		(file.size / 1024).toFixed(1) + ' KiB',
+		// Reduced
+		compressed.name,
+		`${width}×${height}`,
+		(compressed.size / 1024).toFixed(1) + ' KiB',
+	)
+
+	return compressed
+}


### PR DESCRIPTION
## ☑️ Resolves

* Allow to send images as compressed/stripped versions to reduce the stored file size
	* Opt-out (compress by default, skip compression on toggle -> UI is subject to change)
	* Limit dimensions to reasonable (atm 1280px)
	* Convert any image natively to WebP
		* support alpha channel, good compression rates, server core, browser support
	* Strip EXIF tag and metadata (retaining orientation)
		* Fix #5438

### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

Note: PR is for pure functionality-logic. Design changes come later

<img width="357" height="206" alt="image" src="https://github.com/user-attachments/assets/72de8a27-de1c-47dd-b0f0-1e4c7f9022cf" />
<img width="291" height="71" alt="image" src="https://github.com/user-attachments/assets/ac36ea25-7a7e-489b-84d2-d2b220db2153" />


### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required