### PR TITLE
fix(upload): drop file.newName property

### DIFF
--- a/src/stores/__tests__/upload.spec.js
+++ b/src/stores/__tests__/upload.spec.js
@@ -559,8 +559,9 @@ describe('fileUploadStore', () => {
 				rename: true,
 			})
 
-			expect(files[0].newName).toBe('20210427_153000.png')
-			expect(files[1].newName).toBe('20210425_153000.txt')
+			const uploads = uploadStore.getInitialisedUploads('upload-id1')
+			expect(uploads[0][1].file.name).toBe('20210427_153000.png')
+			expect(uploads[1][1].file.name).toBe('20210425_153000.txt')
 		})
 	})
 })

--- a/src/stores/upload.ts
+++ b/src/stores/upload.ts
@@ -307,15 +307,15 @@ export const useUploadStore = defineStore('upload', () => {
 		// Set last upload id
 		currentUploadId.value = uploadId
 		for (let i = 0; i < files.length; i++) {
-			const file = files[i]
+			let file = files[i]
 
 			if (rename) {
-				// note: can't overwrite the original read-only name attribute
 				// 'YYYY-MM-DDTHH:mm:ss.sssZ' -> 'YYYYMMDD_HHmmss.ext'
-				// @ts-expect-error: property does not exist on type File
-				file.newName = new Date(file.lastModified ?? file.lastModifiedDate)
+				const newName = new Date(file.lastModified)
 					.toISOString().replace('T', '_').replace(/[:-]/g, '').split('.')[0]
 					+ getFileExtension(file.name)
+				// The name attribute is read-only, so a new File has to be created instead
+				file = new File([file], newName, { type: file.type, lastModified: file.lastModified })
 			}
 
 			// Get localUrl for allowed image previews and voice messages uploads
@@ -399,7 +399,7 @@ export const useUploadStore = defineStore('upload', () => {
 		if (getTalkConfig(token, 'attachments', 'conversation-subfolders') === true) {
 			const initialisedUploads = getInitialisedUploads(uploadId)
 			const fileNames = initialisedUploads
-				.map(([, uploadedFile]) => uploadedFile.file.newName || uploadedFile.file.name)
+				.map(([, uploadedFile]) => uploadedFile.file.name)
 			try {
 				const response = await probeAttachmentFolder({ token, fileNames, allowUpdate })
 				uploads[uploadId].draftFolderPath = response.data.ocs.data.folder
@@ -484,7 +484,7 @@ export const useUploadStore = defineStore('upload', () => {
 
 		const performPropFind = async (uploadEntry: UploadEntry) => {
 			const [index, uploadedFile] = uploadEntry
-			const fileName = (uploadedFile.file.newName || uploadedFile.file.name)
+			const fileName = uploadedFile.file.name
 			const path = settingsStore.attachmentFolder + '/' + fileName
 
 			try {
@@ -540,7 +540,7 @@ export const useUploadStore = defineStore('upload', () => {
 		const performUpload = async (uploadEntry: UploadEntry) => {
 			const [index, uploadedFile] = uploadEntry
 			const currentFile = uploadedFile.file
-			const fileName = (currentFile.newName || currentFile.name)
+			const fileName = currentFile.name
 
 			try {
 				markFileAsUploading({ uploadId, index })
@@ -606,7 +606,7 @@ export const useUploadStore = defineStore('upload', () => {
 			// Persist talkMetaData on the file so retryShareFiles can reuse it
 			uploads[uploadId].files[index].talkMetaData = talkMetaData
 
-			const fileName = shareableFile.file.newName || shareableFile.file.name
+			const fileName = shareableFile.file.name
 			await performShare({ token, path: shareableFile.sharePath!, index, uploadId, id, referenceId, talkMetaData, fileName, allowUpdate })
 		}
 	}
@@ -726,7 +726,7 @@ export const useUploadStore = defineStore('upload', () => {
 
 			const { id, referenceId } = shareableFile.temporaryMessage || {}
 			const talkMetaData = shareableFile.talkMetaData || '{}'
-			const fileName = shareableFile.file.newName || shareableFile.file.name
+			const fileName = shareableFile.file.name
 
 			await performShare({ token, path: shareableFile.sharePath!, index, uploadId, id, referenceId, talkMetaData, fileName, allowUpdate })
 		}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -682,11 +682,9 @@ export type {
 export type UploadFile = {
 	file: File & {
 		name: string
-		newName?: string
 		type: string
 		size: number
 		lastModified?: number
-		lastModifiedDate?: Date
 		webkitRelativePath?: string
 	}
 	sharePath?: string

--- a/src/utils/__tests__/fileUpload.spec.js
+++ b/src/utils/__tests__/fileUpload.spec.js
@@ -147,7 +147,7 @@ describe('hasDuplicateUploadNames', () => {
 		const uploads = [
 			[1, { file: { name: 'file.txt' } }],
 			[2, { file: { name: 'file (1).txt' } }],
-			[3, { file: { name: 'file (copy).txt', newName: 'file (2).txt' } }],
+			[3, { file: { name: 'file (2).txt' } }],
 		]
 
 		expect(hasDuplicateUploadNames(uploads)).toBe(true)
@@ -157,7 +157,7 @@ describe('hasDuplicateUploadNames', () => {
 		const uploads = [
 			[1, { file: { name: 'file.txt' } }],
 			[2, { file: { name: 'file 2.txt' } }],
-			[3, { file: { name: 'file.txt', newName: 'file (copy).txt' } }],
+			[3, { file: { name: 'file (copy).txt' } }],
 		]
 
 		expect(hasDuplicateUploadNames(uploads)).toBe(false)
@@ -168,7 +168,7 @@ describe('hasDuplicateUploadNames', () => {
 			const uploads = [
 				[1, { file: { name: 'file.txt' } }],
 				[2, { file: { name: 'file (1).jpeg' } }],
-				[3, { file: { name: 'file (copy).txt', newName: 'file (2).txt' } }],
+				[3, { file: { name: 'file (2).txt' } }],
 				[4, { file: { name: 'file (unique).txt' } }],
 			]
 
@@ -181,7 +181,7 @@ describe('hasDuplicateUploadNames', () => {
 			])
 
 			expect(duplicates).toEqual([
-				[3, { file: { name: 'file (copy).txt', newName: 'file (2).txt' } }],
+				[3, { file: { name: 'file (2).txt' } }],
 			])
 		})
 	})

--- a/src/utils/__tests__/prepareTemporaryMessage.spec.js
+++ b/src/utils/__tests__/prepareTemporaryMessage.spec.js
@@ -57,8 +57,7 @@ describe('prepareTemporaryMessage', () => {
 
 	const textFile = {
 		type: 'text/plain',
-		name: 'original-name.txt',
-		newName: 'new-name.txt',
+		name: 'new-name.txt',
 	}
 	const textFilePayload = {
 		...defaultPayload,

--- a/src/utils/fileUpload.ts
+++ b/src/utils/fileUpload.ts
@@ -94,7 +94,7 @@ export async function findUniquePath(client: WebDAVClient, userRoot: string, pat
  */
 export function hasDuplicateUploadNames(uploads: UploadEntry[]): boolean {
 	const uploadNames = uploads.map(([_index, { file }]) => {
-		return getFileNamePrompt(file.newName || file.name)
+		return getFileNamePrompt(file.name)
 	})
 	const uploadNamesSet = new Set(uploadNames)
 
@@ -114,7 +114,7 @@ export function separateDuplicateUploads(uploads: UploadEntry[]): { uniques: Upl
 
 	// Count the occurrences of each name
 	for (const upload of uploads) {
-		const name = getFileNamePrompt(upload[1].file.newName || upload[1].file.name)
+		const name = getFileNamePrompt(upload[1].file.name)
 
 		if (nameCount.has(name)) {
 			duplicates.push(upload)

--- a/src/utils/prepareTemporaryMessage.ts
+++ b/src/utils/prepareTemporaryMessage.ts
@@ -22,7 +22,7 @@ export type RawTemporaryMessagePayload = Pick<ChatMessage, | 'message'
 	| 'parent'>> & {
 		uploadId?: string
 		index?: string
-		file?: File & { newName?: string }
+		file?: File
 		localUrl?: string
 		messageType?: typeof MESSAGE.TYPE['VOICE_MESSAGE' | 'COMMENT']
 	}
@@ -40,7 +40,7 @@ export type PrepareTemporaryMessagePayload = Pick<ChatMessage, | 'message'
 	| 'parent'> & {
 		uploadId?: string
 		index?: string
-		file?: File & { newName?: string }
+		file?: File
 		localUrl?: string
 		messageType?: typeof MESSAGE.TYPE['VOICE_MESSAGE' | 'COMMENT']
 	}
@@ -48,7 +48,7 @@ export type PrepareTemporaryMessagePayload = Pick<ChatMessage, | 'message'
 export type TempChatMessageWithFile = Omit<ChatMessage, 'messageParameters'> & {
 	messageParameters: ChatMessage['messageParameters'] & {
 		file: ChatMessage['messageParameters'][string] & {
-			file: File & { newName?: string }
+			file: File
 			uploadId: string
 			index: number
 			localUrl?: string
@@ -107,7 +107,7 @@ export function prepareTemporaryMessage({
 			file,
 			mimetype: file.type,
 			id: tempId,
-			name: file.newName || file.name,
+			name: file.name,
 			// index, will be the id from now on
 			uploadId,
 			localUrl,


### PR DESCRIPTION
## ☑️ Resolves

- Ref from review of #18906
	- fictional property was added due to limitations (file.name is readOnly)
	- passing original file via File() constructor retains metadata and mtime, but sets a new name
	- dropped from all used places

To review: paste a file from the clipboard (Ctrl+V), then it gets renamed to 'YYYYMMDD_HHmmss.ext'

### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

<img width="505" height="377" alt="2026-08-03_18h38_35" src="https://github.com/user-attachments/assets/ac70b914-3d15-4cf5-bd31-920e94016923" />

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required