### PR TITLE
feat(call): center the tiles of an incomplete last row in the grid

### DIFF
--- a/src/components/CallView/Grid/VideosGrid.vue
+++ b/src/components/CallView/Grid/VideosGrid.vue
@@ -48,9 +48,10 @@
 						<template v-if="!devMode && !(isLessThanTwoVideos && isStripe)">
 							<EmptyCallView v-if="orderedVideos.length === 0 && !isStripe" class="video" :isGrid="true" />
 							<VideoVue
-								v-for="callParticipantModel in displayedVideos"
+								v-for="(callParticipantModel, index) in displayedVideos"
 								:key="callParticipantModel.attributes.peerId"
 								:class="{ video: !isStripe }"
+								:style="tileStyle(index)"
 								:showVideoOverlay="showVideoOverlay"
 								:token="token"
 								:model="callParticipantModel"
@@ -65,10 +66,11 @@
 						<!-- VideosGrid developer mode -->
 						<template v-if="devMode">
 							<div
-								v-for="key in displayedVideos"
+								v-for="(key, index) in displayedVideos"
 								:key="key"
 								class="dev-mode-video video"
-								:class="{ 'dev-mode-screenshot': screenshotMode }">
+								:class="{ 'dev-mode-screenshot': screenshotMode }"
+								:style="tileStyle(index)">
 								<img :alt="placeholderName(key)" :src="placeholderImage(key)">
 								<VideoBottomBar
 									:hasShadow="false"
@@ -82,9 +84,10 @@
 							</h1>
 						</template>
 						<LocalVideo
-							v-if="!isStripe && !isRecording"
+							v-if="!noLocalVideoReserve"
 							ref="localVideo"
 							class="video"
+							:style="tileStyle(displayedVideos.length)"
 							isGrid
 							:fitVideo="false"
 							:token="token"
@@ -177,7 +180,13 @@ import VideoBottomBar from '../shared/VideoBottomBar.vue'
 import VideoVue from '../shared/VideoVue.vue'
 import { getTalkConfig } from '../../../services/CapabilitiesManager.ts'
 import { useCallViewStore } from '../../../stores/callView.ts'
-import { GRID_GAP } from './gridLayout.ts'
+import {
+	computeTilePlacements,
+	getHalfColumnCount,
+	getHalfColumnMinWidth,
+	GRID_GAP,
+	TILE_COLUMN_SPAN,
+} from './gridLayout.ts'
 import { placeholderImage, placeholderModel, placeholderName, placeholderSharedData } from './gridPlaceholders.ts'
 import { useGridDimensions } from './useGridDimensions.ts'
 import { usePagination } from './usePagination.ts'
@@ -308,9 +317,8 @@ export default {
 		// `computeGridDimensions`); this clamp keeps the "videos per page" math
 		// consistent even before the layout has been recomputed.
 		const slots = computed(() => {
-			const noLocalVideoReserve = props.isStripe || props.isRecording
 			const gridSlots = gridDimensions.rows.value * gridDimensions.columns.value
-			const slots = noLocalVideoReserve ? gridSlots : gridSlots - 1
+			const slots = gridDimensions.noLocalVideoReserve.value ? gridSlots : gridSlots - 1
 			return videosCap ? Math.min(videosCap, slots) : slots
 		})
 
@@ -409,6 +417,27 @@ export default {
 			return (this.gridHeight - GRID_GAP * (this.rows - 1)) / this.rows
 		},
 
+		// Number of tiles rendered on the current page. The local video takes a
+		// tile of the grid, unless no slot is reserved for it.
+		totalTiles() {
+			return this.displayedVideos.length + (this.noLocalVideoReserve ? 0 : 1)
+		},
+
+		// Placement of every tile of the grid, in the order they are rendered.
+		// The stripe is a single scrollable row, and the empty call view has a
+		// layout of its own, so their tiles keep the default placement.
+		tilePlacements() {
+			if (this.isStripe || this.orderedVideos.length === 0) {
+				return []
+			}
+
+			return computeTilePlacements({
+				totalTiles: this.totalTiles,
+				rows: this.rows,
+				columns: this.columns,
+			})
+		},
+
 		isLessThanTwoVideos() {
 			// without screen share, we don't want to duplicate videos if we were to show them in the stripe
 			// however, if a screen share is in progress, it means the video of the presenting user is not visible,
@@ -428,8 +457,14 @@ export default {
 				rows = 2
 			}
 
+			// The grid is always laid out in half columns and every tile spans two
+			// of them, so that a row leaving an odd number of columns empty can be
+			// centered by starting it half a column further (see
+			// `computeTilePlacements`). A tile keeps the exact same width either
+			// way, as it also takes the gap between its two half columns, so the
+			// tiles do not jump around when the placement changes.
 			return {
-				gridTemplateColumns: `repeat(${columns}, minmax(${this.dpiAwareMinWidth}px, 1fr))`,
+				gridTemplateColumns: `repeat(${getHalfColumnCount(columns)}, minmax(${getHalfColumnMinWidth(this.dpiAwareMinWidth)}px, 1fr))`,
 				gridTemplateRows: `repeat(${rows}, minmax(${this.dpiAwareMinHeight}px, 1fr))`,
 			}
 		},
@@ -538,6 +573,20 @@ export default {
 			this.$emit('clickLocalVideo')
 		},
 
+		// Explicit placement of a tile in the grid. Columns are counted in half
+		// columns, which the grid flips on its own in RTL layouts.
+		tileStyle(index) {
+			const placement = this.tilePlacements[index]
+			if (!placement) {
+				return undefined
+			}
+
+			return {
+				gridRow: placement.row,
+				gridColumn: `${placement.column} / span ${TILE_COLUMN_SPAN}`,
+			}
+		},
+
 		isSelected(callParticipantModel) {
 			return callParticipantModel.attributes.peerId === this.callViewStore.selectedVideoPeerId
 		},
@@ -572,6 +621,13 @@ export default {
 
 	row-gap: var(--grid-gap);
 	column-gap: var(--grid-gap);
+
+	// The grid is laid out in half columns, so a tile takes two of them by
+	// default. Explicitly placed tiles set their own start line but keep that
+	// span (see `TILE_COLUMN_SPAN`).
+	> * {
+		grid-column: span 2;
+	}
 
 	&.stripe {
 		padding: var(--grid-gap) var(--grid-gap) 0 0;
@@ -659,10 +715,6 @@ export default {
 		min-height: unset;
 		margin: 0;
 	}
-}
-
-.video:last-child {
-	grid-column-end: -1;
 }
 
 .grid-navigation {

--- a/src/components/CallView/Grid/VideosGrid.vue
+++ b/src/components/CallView/Grid/VideosGrid.vue
@@ -48,9 +48,10 @@
 						<template v-if="!devMode && !(isLessThanTwoVideos && isStripe)">
 							<EmptyCallView v-if="orderedVideos.length === 0 && !isStripe" class="video" :isGrid="true" />
 							<VideoVue
-								v-for="callParticipantModel in displayedVideos"
+								v-for="(callParticipantModel, index) in displayedVideos"
 								:key="callParticipantModel.attributes.peerId"
 								:class="{ video: !isStripe }"
+								:style="tileStyle(index)"
 								:showVideoOverlay="showVideoOverlay"
 								:token="token"
 								:model="callParticipantModel"
@@ -65,10 +66,11 @@
 						<!-- VideosGrid developer mode -->
 						<template v-if="devMode">
 							<div
-								v-for="key in displayedVideos"
+								v-for="(key, index) in displayedVideos"
 								:key="key"
 								class="dev-mode-video video"
-								:class="{ 'dev-mode-screenshot': screenshotMode }">
+								:class="{ 'dev-mode-screenshot': screenshotMode }"
+								:style="tileStyle(index)">
 								<img :alt="placeholderName(key)" :src="placeholderImage(key)">
 								<VideoBottomBar
 									:hasShadow="false"
@@ -82,9 +84,10 @@
 							</h1>
 						</template>
 						<LocalVideo
-							v-if="!isStripe && !isRecording"
+							v-if="!noLocalVideoReserve"
 							ref="localVideo"
 							class="video"
+							:style="tileStyle(displayedVideos.length)"
 							isGrid
 							:fitVideo="false"
 							:token="token"
@@ -177,7 +180,13 @@ import VideoBottomBar from '../shared/VideoBottomBar.vue'
 import VideoVue from '../shared/VideoVue.vue'
 import { getTalkConfig } from '../../../services/CapabilitiesManager.ts'
 import { useCallViewStore } from '../../../stores/callView.ts'
-import { GRID_GAP } from './gridLayout.ts'
+import {
+	computeTilePlacements,
+	getHalfColumnCount,
+	getHalfColumnMinWidth,
+	GRID_GAP,
+	TILE_COLUMN_SPAN,
+} from './gridLayout.ts'
 import { placeholderImage, placeholderModel, placeholderName, placeholderSharedData } from './gridPlaceholders.ts'
 import { useGridDimensions } from './useGridDimensions.ts'
 import { usePagination } from './usePagination.ts'
@@ -308,9 +317,8 @@ export default {
 		// `computeGridDimensions`); this clamp keeps the "videos per page" math
 		// consistent even before the layout has been recomputed.
 		const slots = computed(() => {
-			const noLocalVideoReserve = props.isStripe || props.isRecording
 			const gridSlots = gridDimensions.rows.value * gridDimensions.columns.value
-			const slots = noLocalVideoReserve ? gridSlots : gridSlots - 1
+			const slots = gridDimensions.noLocalVideoReserve.value ? gridSlots : gridSlots - 1
 			return videosCap ? Math.min(videosCap, slots) : slots
 		})
 
@@ -409,11 +417,39 @@ export default {
 			return (this.gridHeight - GRID_GAP * (this.rows - 1)) / this.rows
 		},
 
+		// Number of tiles rendered on the current page. The local video takes a
+		// tile of the grid, unless no slot is reserved for it.
+		totalTiles() {
+			return this.displayedVideos.length + (this.noLocalVideoReserve ? 0 : 1)
+		},
+
+		// Placement of every tile of the grid, in the order they are rendered.
+		// The stripe is a single scrollable row, and the empty call view has a
+		// layout of its own, so their tiles keep the default placement.
+		tilePlacements() {
+			if (this.isStripe || this.orderedVideos.length === 0) {
+				return []
+			}
+
+			return computeTilePlacements({
+				totalTiles: this.totalTiles,
+				rows: this.rows,
+				columns: this.columns,
+			})
+		},
+
 		isLessThanTwoVideos() {
 			// without screen share, we don't want to duplicate videos if we were to show them in the stripe
 			// however, if a screen share is in progress, it means the video of the presenting user is not visible,
 			// so we can show it in the stripe
 			return this.orderedVideos.length <= 1 && !this.screens.length
+		},
+
+		// Whether the tiles are explicitly placed in a grid of half columns. The
+		// stripe and the empty call view keep the default placement, and so a
+		// column per tile.
+		usesHalfColumns() {
+			return this.tilePlacements.length > 0
 		},
 
 		// Computed css to reactively style the grid
@@ -428,8 +464,15 @@ export default {
 				rows = 2
 			}
 
+			// Explicitly placed tiles span two half columns each, so that a row
+			// leaving an odd number of columns empty can be centered by starting it
+			// half a column further (see `computeTilePlacements`)
+			const [columnCount, columnMinWidth] = this.usesHalfColumns
+				? [getHalfColumnCount(columns), getHalfColumnMinWidth(this.dpiAwareMinWidth)]
+				: [columns, this.dpiAwareMinWidth]
+
 			return {
-				gridTemplateColumns: `repeat(${columns}, minmax(${this.dpiAwareMinWidth}px, 1fr))`,
+				gridTemplateColumns: `repeat(${columnCount}, minmax(${columnMinWidth}px, 1fr))`,
 				gridTemplateRows: `repeat(${rows}, minmax(${this.dpiAwareMinHeight}px, 1fr))`,
 			}
 		},
@@ -536,6 +579,20 @@ export default {
 
 		handleClickLocalVideo() {
 			this.$emit('clickLocalVideo')
+		},
+
+		// Explicit placement of a tile in the grid. Columns are counted in half
+		// columns, which the grid flips on its own in RTL layouts.
+		tileStyle(index) {
+			const placement = this.tilePlacements[index]
+			if (!placement) {
+				return undefined
+			}
+
+			return {
+				gridRow: placement.row,
+				gridColumn: `${placement.column} / span ${TILE_COLUMN_SPAN}`,
+			}
 		},
 
 		isSelected(callParticipantModel) {
@@ -659,10 +716,6 @@ export default {
 		min-height: unset;
 		margin: 0;
 	}
-}
-
-.video:last-child {
-	grid-column-end: -1;
 }
 
 .grid-navigation {

--- a/src/components/CallView/Grid/gridLayout.spec.ts
+++ b/src/components/CallView/Grid/gridLayout.spec.ts
@@ -6,9 +6,15 @@
 import { describe, expect, test } from 'vitest'
 import {
 	computeGridDimensions,
+	computeRowDistribution,
+	computeTilePlacements,
+	getHalfColumnCount,
+	getHalfColumnMinWidth,
 	getMinTileHeight,
 	getMinTileWidth,
 	getTargetAspectRatio,
+	GRID_GAP,
+	TILE_COLUMN_SPAN,
 } from './gridLayout.ts'
 
 /**
@@ -152,6 +158,148 @@ describe('gridLayout', () => {
 								// Overflowing tiles are paginated on the maximum grid
 								expect({ columns, rows }).toEqual(max)
 							}
+						}
+					}
+				}
+			}
+		})
+	})
+
+	describe('computeRowDistribution', () => {
+		test('spreads the tiles evenly across the rows', () => {
+			expect(computeRowDistribution({ totalTiles: 7, rows: 3 })).toEqual([2, 3, 2])
+			expect(computeRowDistribution({ totalTiles: 9, rows: 3 })).toEqual([3, 3, 3])
+			expect(computeRowDistribution({ totalTiles: 13, rows: 4 })).toEqual([3, 4, 3, 3])
+			expect(computeRowDistribution({ totalTiles: 14, rows: 4 })).toEqual([3, 4, 4, 3])
+		})
+
+		test('keeps a single row untouched', () => {
+			expect(computeRowDistribution({ totalTiles: 4, rows: 1 })).toEqual([4])
+		})
+
+		test('never leaves a row empty', () => {
+			expect(computeRowDistribution({ totalTiles: 2, rows: 4 })).toEqual([1, 1])
+			expect(computeRowDistribution({ totalTiles: 0, rows: 3 })).toEqual([])
+			expect(computeRowDistribution({ totalTiles: 3, rows: 0 })).toEqual([])
+		})
+
+		test('lays out every tile in rows of an even size', () => {
+			for (let rows = 1; rows <= 6; rows++) {
+				for (let totalTiles = 1; totalTiles <= 30; totalTiles++) {
+					const distribution = computeRowDistribution({ totalTiles, rows })
+
+					// Every tile is laid out, and no row is left empty
+					expect(distribution.reduce((sum, size) => sum + size, 0)).toBe(totalTiles)
+					expect(distribution.length).toBe(Math.min(rows, totalTiles))
+					// The rows differ by at most one tile
+					expect(Math.max(...distribution) - Math.min(...distribution)).toBeLessThanOrEqual(1)
+					// The first row is the last one to receive an extra tile, so the
+					// fuller rows sit below it
+					if (totalTiles % distribution.length !== 0) {
+						expect(distribution[0]).toBe(Math.min(...distribution))
+					}
+				}
+			}
+		})
+	})
+
+	describe('half column helpers', () => {
+		test('splits every tile column in two', () => {
+			expect(TILE_COLUMN_SPAN).toBe(2)
+			expect(getHalfColumnCount(4)).toBe(8)
+			expect(getHalfColumnCount(0)).toBe(0)
+		})
+
+		test('sizes a half column so that a tile spanning two keeps its minimum width', () => {
+			// A tile spans two half columns and the gap between them
+			expect(getHalfColumnMinWidth(320) * 2 + GRID_GAP).toBe(320)
+		})
+
+		test('never returns a negative half column width', () => {
+			expect(getHalfColumnMinWidth(0)).toBe(0)
+		})
+	})
+
+	describe('computeTilePlacements', () => {
+		// A 4 columns grid, laid out as 8 half columns
+		const grid = { columns: 4 }
+
+		test('fills a complete grid from the first half column', () => {
+			expect(computeTilePlacements({ ...grid, rows: 2, totalTiles: 8 })).toEqual([
+				{ row: 1, column: 1 },
+				{ row: 1, column: 3 },
+				{ row: 1, column: 5 },
+				{ row: 1, column: 7 },
+				{ row: 2, column: 1 },
+				{ row: 2, column: 3 },
+				{ row: 2, column: 5 },
+				{ row: 2, column: 7 },
+			])
+		})
+
+		test('shifts a row by a half column when it leaves an odd number of columns empty', () => {
+			// 7 tiles over 2 rows of a 4 columns grid: 3 and 4 tiles
+			expect(computeTilePlacements({ ...grid, rows: 2, totalTiles: 7 })).toEqual([
+				{ row: 1, column: 2 },
+				{ row: 1, column: 4 },
+				{ row: 1, column: 6 },
+				{ row: 2, column: 1 },
+				{ row: 2, column: 3 },
+				{ row: 2, column: 5 },
+				{ row: 2, column: 7 },
+			])
+		})
+
+		test('centers a row leaving an even number of columns empty', () => {
+			// 7 tiles over 3 rows of a 4 columns grid: 2, 3 and 2 tiles
+			expect(computeTilePlacements({ ...grid, rows: 3, totalTiles: 7 })).toEqual([
+				{ row: 1, column: 3 },
+				{ row: 1, column: 5 },
+				{ row: 2, column: 2 },
+				{ row: 2, column: 4 },
+				{ row: 2, column: 6 },
+				{ row: 3, column: 3 },
+				{ row: 3, column: 5 },
+			])
+		})
+
+		test('falls back to the default placement when there is nothing to lay out', () => {
+			expect(computeTilePlacements({ ...grid, rows: 2, totalTiles: 0 })).toEqual([])
+			expect(computeTilePlacements({ ...grid, rows: 0, totalTiles: 4 })).toEqual([])
+			expect(computeTilePlacements({ columns: 0, rows: 0, totalTiles: 4 })).toEqual([])
+		})
+
+		test('falls back to the default placement when the grid is too small', () => {
+			expect(computeTilePlacements({ ...grid, rows: 2, totalTiles: 9 })).toEqual([])
+		})
+
+		test('keeps every row inside the grid and centered', () => {
+			for (let columns = 1; columns <= 5; columns++) {
+				const halfColumns = getHalfColumnCount(columns)
+
+				for (let rows = 1; rows <= 5; rows++) {
+					for (let totalTiles = 1; totalTiles <= columns * rows; totalTiles++) {
+						const placements = computeTilePlacements({ columns, rows, totalTiles })
+						expect(placements.length).toBe(totalTiles)
+
+						const distribution = computeRowDistribution({ totalTiles, rows })
+						for (const [index, rowSize] of distribution.entries()) {
+							const row = placements.filter((placement) => placement.row === index + 1)
+							expect(row.length).toBe(rowSize)
+
+							// The tiles of the row are laid out one after the other, every
+							// tile spanning TILE_COLUMN_SPAN half columns
+							const columnsOfRow = row.map((placement) => placement.column)
+							expect(columnsOfRow).toEqual(Array.from({ length: rowSize }, (_, i) => columnsOfRow[0] + i * TILE_COLUMN_SPAN))
+
+							// The row stays within the half columns of the grid
+							const firstLine = columnsOfRow[0]
+							const lastLine = columnsOfRow[rowSize - 1] + TILE_COLUMN_SPAN
+							expect(firstLine).toBeGreaterThanOrEqual(1)
+							expect(lastLine).toBeLessThanOrEqual(halfColumns + 1)
+
+							// The half columns left empty are split evenly on both sides
+							expect(firstLine - 1).toBe(halfColumns + 1 - lastLine)
 						}
 					}
 				}

--- a/src/components/CallView/Grid/gridLayout.ts
+++ b/src/components/CallView/Grid/gridLayout.ts
@@ -217,3 +217,142 @@ export function computeGridDimensions({
 
 	return { columns, rows }
 }
+
+type RowDistributionOptions = {
+	/** Number of tiles laid out on the page, including the local video tile */
+	totalTiles: number
+	/** Number of rows of the grid */
+	rows: number
+}
+
+/**
+ * Number of tiles of each row of the grid, from the first row to the last one.
+ *
+ * The tiles are spread as evenly as possible: every row holds
+ * `floor(totalTiles / rows)` tiles and the `totalTiles % rows` remaining tiles
+ * are handed out one by one. Filling the rows one after the other instead would
+ * leave every extra tile in the last row, so 7 tiles over 3 rows would be laid
+ * out as 3-3-1 rather than 2-3-2.
+ *
+ * The extra tiles are handed out from the second row onwards, the first row
+ * being served last, so that the fuller rows sit towards the middle of the grid
+ * and its silhouette stays symmetric: 7 tiles give 2-3-2 and 13 tiles give
+ * 3-4-3-3. This ordering is purely cosmetic, the number of tiles per row is
+ * decided above.
+ *
+ * @param options - the layout inputs
+ * @param options.totalTiles - number of tiles on the page, including the local video tile
+ * @param options.rows - number of rows of the grid
+ * @return the number of tiles of each row. Rows that would be left empty are
+ *   dropped, so the result may be shorter than `rows`.
+ */
+export function computeRowDistribution({ totalTiles, rows }: RowDistributionOptions): number[] {
+	// Never spread the tiles over more rows than there are tiles
+	const usedRows = Math.min(rows, totalTiles)
+	if (usedRows <= 0) {
+		return []
+	}
+
+	const base = Math.floor(totalTiles / usedRows)
+	const remainder = totalTiles % usedRows
+
+	const distribution = new Array<number>(usedRows)
+	for (let index = 0; index < usedRows; index++) {
+		// Rows in the order they receive one of the `remainder` extra tiles: from
+		// the second row of the grid down to the last one, and the first row last
+		const row = (index + 1) % usedRows
+		distribution[row] = index < remainder ? base + 1 : base
+	}
+
+	return distribution
+}
+
+/**
+ * Number of grid columns a single tile spans.
+ *
+ * Every column of the grid is laid out as two half columns, so that a row
+ * holding an odd number of empty columns can be centered by starting it half a
+ * column further, on a grid line rather than with a pixel offset.
+ */
+export const TILE_COLUMN_SPAN = 2
+
+/**
+ * Number of half columns the grid template needs for the given number of tile
+ * columns.
+ *
+ * @param columns - number of tile columns of the grid
+ */
+export function getHalfColumnCount(columns: number): number {
+	return columns * TILE_COLUMN_SPAN
+}
+
+/**
+ * Minimum width of a half column, in px, for the given minimum tile width.
+ *
+ * A tile spans two half columns and the gap between them, so each half column
+ * only has to hold half of the tile minus that gap.
+ *
+ * @param minTileWidth - minimum width of a whole tile in px
+ */
+export function getHalfColumnMinWidth(minTileWidth: number): number {
+	return Math.max((minTileWidth - GRID_GAP) / TILE_COLUMN_SPAN, 0)
+}
+
+type TilePlacementOptions = {
+	/** Number of tiles laid out on the page, including the local video tile */
+	totalTiles: number
+	/** Number of rows of the grid */
+	rows: number
+	/** Number of columns of the grid */
+	columns: number
+}
+
+/** Placement of a single tile in the CSS grid */
+export type TilePlacement = {
+	/** 1-based index of the row the tile belongs to */
+	row: number
+	/** 1-based index of the half column the tile starts at */
+	column: number
+}
+
+/**
+ * Placement of each tile of the grid, in the order the tiles are rendered.
+ *
+ * The tiles are spread across the rows by {@link computeRowDistribution} and
+ * each row is then centered horizontally: the columns left empty by that row are
+ * split evenly on both sides. A row leaving an odd number of columns empty has
+ * to be shifted by half a column, which is why the grid is laid out in half
+ * columns: the shift is then just another grid line, and every placement stays a
+ * whole number handled by the grid itself.
+ *
+ * @param options - the layout inputs
+ * @param options.totalTiles - number of tiles on the page, including the local video tile
+ * @param options.rows - number of rows of the grid
+ * @param options.columns - number of columns of the grid
+ * @return the placement of each tile, indexed by its rendering order. Empty if
+ *   the grid has not been measured yet or cannot hold every tile.
+ */
+export function computeTilePlacements({
+	totalTiles,
+	rows,
+	columns,
+}: TilePlacementOptions): TilePlacement[] {
+	// Nothing to place yet, or a grid too small to hold every tile: fall back to
+	// the default placement of the browser
+	if (totalTiles <= 0 || rows <= 0 || columns <= 0 || totalTiles > rows * columns) {
+		return []
+	}
+
+	const placements: TilePlacement[] = []
+
+	for (const [index, rowSize] of computeRowDistribution({ totalTiles, rows }).entries()) {
+		// The half columns left empty by the row, split evenly on both of its sides
+		const column = columns - rowSize + 1
+
+		for (let tile = 0; tile < rowSize; tile++) {
+			placements.push({ row: index + 1, column: column + tile * TILE_COLUMN_SPAN })
+		}
+	}
+
+	return placements
+}

--- a/src/components/CallView/Grid/useGridDimensions.ts
+++ b/src/components/CallView/Grid/useGridDimensions.ts
@@ -153,6 +153,7 @@ export function useGridDimensions({
 		dpiAwareMinHeight,
 		targetAspectRatio,
 		gridAspectRatio,
+		noLocalVideoReserve,
 		/** Force a re-measure and recompute (e.g. for debugging) */
 		recompute,
 	}

--- a/src/components/CallView/shared/LocalVideo.vue
+++ b/src/components/CallView/shared/LocalVideo.vue
@@ -377,9 +377,7 @@ export default {
 	}
 }
 
-// Always display the local video in the last row
 .localVideoContainer {
-	grid-row-end: -1;
 	border-radius: var(--border-radius-element, calc(var(--default-clickable-area) / 2));
 	overflow: hidden;
 	z-index: 1;


### PR DESCRIPTION
## ☑️ Resolves

* Part of #18905

### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="1059" height="710" alt="image" src="https://github.com/user-attachments/assets/f069f0d1-cdc5-4502-912b-1773a590ae64" /> | <img width="1055" height="718" alt="image" src="https://github.com/user-attachments/assets/70c849a6-47d9-4381-bf1e-51a30c91668e" />

<!-- ☀️ Light theme | 🌑 Dark Theme -->

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
