### PR TITLE
fix(message): improve support of messages with multiple files

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
@@ -475,6 +475,7 @@ import { generatePublicShareDownloadUrl, generateUserFileUrl, generateUserFolder
 import { convertToUnix, formatDateTime, ONE_DAY_IN_MS } from '../../../../../utils/formattedTime.ts'
 import { getCustomDateOptions } from '../../../../../utils/getCustomDateOptions.ts'
 import { copyConversationLinkToClipboard } from '../../../../../utils/handleUrl.ts'
+import { getFileKeys } from '../../../../../utils/message.ts'
 import { parseMentions } from '../../../../../utils/textParse.ts'
 
 const PIN_DURATION_OPTIONS = [
@@ -671,7 +672,7 @@ export default {
 		},
 
 		messageFile() {
-			const firstFileKey = (Object.keys(this.message.messageParameters).find((key) => key.startsWith('file')))
+			const firstFileKey = getFileKeys(this.message).at(0)
 			return this.message.messageParameters[firstFileKey]
 		},
 

--- a/src/components/MessagesList/MessagesGroup/Message/MessageItem.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageItem.vue
@@ -222,10 +222,6 @@ export default {
 			Object.keys(this.message.messageParameters).forEach(function(p) {
 				const type = this.message.messageParameters[p].type
 				const mimetype = this.message.messageParameters[p].mimetype
-				const itemType = getItemTypeFromMessage({
-					messageParameters: this.message.messageParameters,
-					messageType: this.message.messageType,
-				})
 				if (Object.values(MENTION.TYPE).includes(type)) {
 					richParameters[p] = {
 						component: MentionChip,
@@ -241,7 +237,7 @@ export default {
 							token: this.message.token,
 							messageId: this.message.id,
 							nextMessageId: this.nextMessageId,
-							itemType,
+							itemType: getItemTypeFromMessage(this.message, p),
 							referenceId: this.message.referenceId,
 							file: this.message.messageParameters[p],
 						},

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/MessageBody.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/MessageBody.vue
@@ -213,6 +213,7 @@ import { useChatExtrasStore } from '../../../../../stores/chatExtras.ts'
 import { usePollsStore } from '../../../../../stores/polls.ts'
 import { useUploadStore } from '../../../../../stores/upload.ts'
 import { formatDateTime } from '../../../../../utils/formattedTime.ts'
+import { getFileKeys } from '../../../../../utils/message.ts'
 import { parseMentions, parseSpecialSymbols } from '../../../../../utils/textParse.ts'
 
 // Regular expression to check for Unicode emojis in message text
@@ -292,6 +293,7 @@ export default {
 		const {
 			isEditable,
 			isFileShare,
+			isFileShareWithoutCaption,
 		} = useMessageInfo(message)
 		const threadId = useGetThreadId()
 		const isSidebar = inject('chatView:isSidebar', false)
@@ -305,6 +307,7 @@ export default {
 			threadId,
 			isEditable,
 			isFileShare,
+			isFileShareWithoutCaption,
 			isSidebar,
 			actorStore: useActorStore(),
 			isSplitViewEnabled,
@@ -324,9 +327,13 @@ export default {
 		},
 
 		renderedMessage() {
-			if (this.isFileShare && this.message.message !== '{file}') {
+			if (this.isFileShare) {
+				if (this.isFileShareWithoutCaption) {
+					return this.message.message
+				}
 				// Add a new line after file to split content into different paragraphs
-				return '{file}\n\n' + this.message.message
+				const filePlaceholdersString = getFileKeys(this.message).map((key) => `{${key}}`).join(' ')
+				return filePlaceholdersString + '\n\n' + this.message.message
 			} else if (this.isLocationMessageWithName) {
 				return this.message.message + '\n\n' + this.message.messageParameters.object.name
 			} {
@@ -526,7 +533,7 @@ export default {
 					this.uploadStore.retryUploadFiles({
 						token: this.message.token,
 						uploadId: this.$store.getters.message(this.message.token, this.message.id)?.uploadId,
-						caption: this.renderedMessage !== this.message.message ? this.message.message : undefined,
+						caption: this.isFileShareWithoutCaption ? undefined : this.message.message,
 					})
 				} else if (this.message.sendingFailure === 'failed-share') {
 					this.uploadStore.retryShareFiles({

--- a/src/composables/useMessageInfo.ts
+++ b/src/composables/useMessageInfo.ts
@@ -15,6 +15,7 @@ import { useActorStore } from '../stores/actor.ts'
 import { useGuestNameStore } from '../stores/guestName.ts'
 import { ONE_DAY_IN_MS, ONE_HOUR_IN_MS } from '../utils/formattedTime.ts'
 import { getDisplayNameWithFallback } from '../utils/getDisplayName.ts'
+import { hasOnlyFilePlaceholders } from '../utils/message.ts'
 import { useConversationInfo } from './useConversationInfo.ts'
 
 /**
@@ -113,7 +114,7 @@ export function useMessageInfo(item: MaybeRef<ChatMessage | undefined> = undefin
 
 	const hideDownloadOption = computed(() => Object.values(Object(message.value.messageParameters) as ChatMessage['messageParameters']).some((value) => value.type === 'file' && value['hide-download'] === 'yes'))
 
-	const isFileShareWithoutCaption = computed(() => message.value.message === '{file}' && isFileShare.value)
+	const isFileShareWithoutCaption = computed(() => isFileShare.value && hasOnlyFilePlaceholders(message.value.message))
 
 	const isDeleteable = computed(() => (hasTalkFeature(message.value.token, 'delete-messages-unlimited') || (Date.now() - message.value.timestamp * 1000 < 6 * ONE_HOUR_IN_MS))
 		&& [MESSAGE.TYPE.COMMENT, MESSAGE.TYPE.VOICE_MESSAGE, MESSAGE.TYPE.RECORD_AUDIO, MESSAGE.TYPE.RECORD_VIDEO].includes(message.value.messageType)

--- a/src/composables/useMessageInfo.ts
+++ b/src/composables/useMessageInfo.ts
@@ -15,7 +15,7 @@ import { useActorStore } from '../stores/actor.ts'
 import { useGuestNameStore } from '../stores/guestName.ts'
 import { ONE_DAY_IN_MS, ONE_HOUR_IN_MS } from '../utils/formattedTime.ts'
 import { getDisplayNameWithFallback } from '../utils/getDisplayName.ts'
-import { hasOnlyFilePlaceholders } from '../utils/message.ts'
+import { hasOnlyFilePlaceholders, isFileShareMessage } from '../utils/message.ts'
 import { useConversationInfo } from './useConversationInfo.ts'
 
 /**
@@ -110,7 +110,7 @@ export function useMessageInfo(item: MaybeRef<ChatMessage | undefined> = undefin
 		return (Date.now() - message.value.timestamp * 1000 < ONE_DAY_IN_MS)
 	})
 
-	const isFileShare = computed(() => Object.keys(Object(message.value.messageParameters)).some((key) => key.startsWith('file')))
+	const isFileShare = computed(() => isFileShareMessage(message.value))
 
 	const hideDownloadOption = computed(() => Object.values(Object(message.value.messageParameters) as ChatMessage['messageParameters']).some((value) => value.type === 'file' && value['hide-download'] === 'yes'))
 

--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -700,8 +700,6 @@ const actions = {
 				if (message.messageParameters?.object?.type === SHARED_ITEM.OBJECT_TYPE.POLL) {
 					EventBus.emit('talk:poll-added', { token, message })
 				}
-			} else if (Object.keys(message.messageParameters).some((key) => key.startsWith('file'))) {
-				// Handle shares with multiple files
 			}
 		}
 	},

--- a/src/stores/__tests__/chatExtras.spec.js
+++ b/src/stores/__tests__/chatExtras.spec.js
@@ -194,7 +194,7 @@ describe('chatExtrasStore', () => {
 				token: 'token-1',
 				id: 'id-1',
 				message: '{file}',
-				messageParameters: { file0: 'file-path' },
+				messageParameters: { file: 'file-path' },
 			}
 
 			// Act

--- a/src/stores/chatExtras.ts
+++ b/src/stores/chatExtras.ts
@@ -35,7 +35,7 @@ import {
 	setThreadNotificationLevel as setThreadNotificationLevelApi,
 	summarizeChat,
 } from '../services/messagesService.ts'
-import { hasOnlyFilePlaceholders } from '../utils/message.ts'
+import { hasOnlyFilePlaceholders, isFileShareMessage } from '../utils/message.ts'
 import { parseMentions, parseSpecialSymbols } from '../utils/textParse.ts'
 import { useActorStore } from './actor.ts'
 
@@ -618,7 +618,7 @@ export const useChatExtrasStore = defineStore('chatExtras', () => {
 	 */
 	function initiateEditingMessage({ token, id, message, messageParameters }: InitiateEditingMessagePayload) {
 		setMessageIdToEdit(token, id)
-		const isFileShareWithoutCaption = Object.keys(messageParameters ?? {}).some((key) => key.startsWith('file'))
+		const isFileShareWithoutCaption = isFileShareMessage({ messageParameters })
 			&& hasOnlyFilePlaceholders(message)
 		if (isFileShareWithoutCaption) {
 			setChatEditInput({ token, text: '' })

--- a/src/stores/chatExtras.ts
+++ b/src/stores/chatExtras.ts
@@ -35,6 +35,7 @@ import {
 	setThreadNotificationLevel as setThreadNotificationLevelApi,
 	summarizeChat,
 } from '../services/messagesService.ts'
+import { hasOnlyFilePlaceholders } from '../utils/message.ts'
 import { parseMentions, parseSpecialSymbols } from '../utils/textParse.ts'
 import { useActorStore } from './actor.ts'
 
@@ -617,9 +618,9 @@ export const useChatExtrasStore = defineStore('chatExtras', () => {
 	 */
 	function initiateEditingMessage({ token, id, message, messageParameters }: InitiateEditingMessagePayload) {
 		setMessageIdToEdit(token, id)
-		const isFileShareOnly = Object.keys(messageParameters ?? {}).some((key) => key.startsWith('file'))
-			&& message === '{file}'
-		if (isFileShareOnly) {
+		const isFileShareWithoutCaption = Object.keys(messageParameters ?? {}).some((key) => key.startsWith('file'))
+			&& hasOnlyFilePlaceholders(message)
+		if (isFileShareWithoutCaption) {
 			setChatEditInput({ token, text: '' })
 		} else {
 			setChatEditInput({

--- a/src/utils/getItemTypeFromMessage.ts
+++ b/src/utils/getItemTypeFromMessage.ts
@@ -6,6 +6,7 @@
 import type { ChatMessage, PinnedChatMessage } from '../types/index.ts'
 
 import { MESSAGE, SHARED_ITEM } from '../constants.ts'
+import { isFileShareMessage } from '../utils/message.ts'
 
 /**
  *
@@ -65,7 +66,7 @@ export function isValidSharedItem(type: string, message: ChatMessage | PinnedCha
 		return !!(message.messageParameters?.object)
 	}
 
-	// Items that require messageParameters.file
+	// Items that require at least one shared file
 	if ([
 		SHARED_ITEM.TYPES.FILE,
 		SHARED_ITEM.TYPES.AUDIO,
@@ -73,9 +74,9 @@ export function isValidSharedItem(type: string, message: ChatMessage | PinnedCha
 		SHARED_ITEM.TYPES.RECORDING,
 		SHARED_ITEM.TYPES.VOICE,
 	].includes(type)) {
-		return !!(message.messageParameters?.file)
+		return isFileShareMessage(message)
 	}
 
 	// At least one truthy property should be present
-	return !!(message.messageParameters?.object) || !!(message.messageParameters?.file)
+	return !!(message.messageParameters?.object) || isFileShareMessage(message)
 }

--- a/src/utils/getItemTypeFromMessage.ts
+++ b/src/utils/getItemTypeFromMessage.ts
@@ -9,23 +9,29 @@ import { MESSAGE, SHARED_ITEM } from '../constants.ts'
 import { isFileShareMessage } from '../utils/message.ts'
 
 /**
+ * Derives item type from message object for preview rendering
  *
- * @param message
+ * @param message message object
+ * @param [key] key of the message parameter to check ('object', 'file', 'file-1', …)
  */
-export function getItemTypeFromMessage(message: ChatMessage): string {
-	if (message.messageParameters?.object) {
-		if (message.messageParameters.object.type === SHARED_ITEM.OBJECT_TYPE.LOCATION) {
+export function getItemTypeFromMessage(message: ChatMessage, key?: string): typeof SHARED_ITEM.TYPES[keyof typeof SHARED_ITEM.TYPES] {
+	if (message.messageParameters?.object && (!key || key === 'object')) {
+		const objectType = message.messageParameters.object.type
+		if (objectType === SHARED_ITEM.OBJECT_TYPE.LOCATION) {
 			return SHARED_ITEM.TYPES.LOCATION
-		} else if (message.messageParameters.object.type === SHARED_ITEM.OBJECT_TYPE.DECK_CARD) {
+		} else if (objectType === SHARED_ITEM.OBJECT_TYPE.DECK_CARD) {
 			return SHARED_ITEM.TYPES.DECK_CARD
-		} else if (message.messageParameters.object.type === SHARED_ITEM.OBJECT_TYPE.POLL) {
+		} else if (objectType === SHARED_ITEM.OBJECT_TYPE.POLL) {
 			return SHARED_ITEM.TYPES.POLL
 		} else {
 			return SHARED_ITEM.TYPES.OTHER
 		}
-	} else if (message.messageParameters?.file) {
+	}
+
+	const fileKey = key ?? 'file'
+	if (message.messageParameters?.[fileKey]) {
 		const messageType = message.messageType
-		const mimetype = message.messageParameters.file.mimetype || ''
+		const mimetype = message.messageParameters[fileKey].mimetype || ''
 		if (messageType === MESSAGE.TYPE.RECORD_AUDIO || messageType === MESSAGE.TYPE.RECORD_VIDEO) {
 			return SHARED_ITEM.TYPES.RECORDING
 		} else if (messageType === MESSAGE.TYPE.VOICE_MESSAGE) {
@@ -37,9 +43,9 @@ export function getItemTypeFromMessage(message: ChatMessage): string {
 		} else {
 			return SHARED_ITEM.TYPES.FILE
 		}
-	} else {
-		return SHARED_ITEM.TYPES.OTHER
 	}
+
+	return SHARED_ITEM.TYPES.OTHER
 }
 
 /**

--- a/src/utils/message.ts
+++ b/src/utils/message.ts
@@ -177,17 +177,31 @@ function selfIsUser(message: ChatMessage, selfActorId: string, selfActorType: st
 }
 
 /**
+ * Matches a file-sharing rich object parameter key ('file', 'file-1', 'file-2', …)
+ */
+const FILE_KEY_REGEX = /^file(?:-\d+)?$/
+
+/**
  * Matches a file-sharing rich object parameter key ('{file}', '{file-1}', '{file-2}', …)
  */
 const FILE_PLACEHOLDERS_REGEX = /^\s*(?:\{file(?:-\d+)?\}\s*)+$/
 
 /**
+ * Returns all keys of files shared with the message ('file', 'file-1', …)
+ *
+ * @param message Chat message (or an object with messageParameters)
+ */
+export function getFileKeys(message: Pick<ChatMessage, 'messageParameters'>) {
+	return Object.keys(message.messageParameters ?? {}).filter((key) => FILE_KEY_REGEX.test(key))
+}
+
+/**
  * Returns whether the given message shares a file (has a rich object parameter with a key starting with 'file').
  *
- * @param message Chat message (or a parent message)
+ * @param message Chat message (or an object with messageParameters)
  */
-export function isFileShareMessage(message: ChatMessage): boolean {
-	return Object.keys(message.messageParameters ?? {}).some((key) => key.startsWith('file'))
+export function isFileShareMessage(message: Pick<ChatMessage, 'messageParameters'>): boolean {
+	return getFileKeys(message).length > 0
 }
 
 /**

--- a/src/utils/message.ts
+++ b/src/utils/message.ts
@@ -177,12 +177,26 @@ function selfIsUser(message: ChatMessage, selfActorId: string, selfActorType: st
 }
 
 /**
+ * Matches a file-sharing rich object parameter key ('{file}', '{file-1}', '{file-2}', …)
+ */
+const FILE_PLACEHOLDERS_REGEX = /^\s*(?:\{file(?:-\d+)?\}\s*)+$/
+
+/**
  * Returns whether the given message shares a file (has a rich object parameter with a key starting with 'file').
  *
  * @param message Chat message (or a parent message)
  */
 export function isFileShareMessage(message: ChatMessage): boolean {
 	return Object.keys(message.messageParameters ?? {}).some((key) => key.startsWith('file'))
+}
+
+/**
+ * Returns whether the given text consists of file placeholders only ('{file}', '{file-1} {file-2}', …), without caption
+ *
+ * @param text message text
+ */
+export function hasOnlyFilePlaceholders(text: string): boolean {
+	return FILE_PLACEHOLDERS_REGEX.test(text)
 }
 
 /**


### PR DESCRIPTION
## ☑️ Resolves

* Ref #11411 
	* As it was decided, that mutiple file messages should be done on client side, client itself needs to better handle it:
		* no direct uses of 'messageParameters.file', if it's not a server response
		* unified check of messageParameters via utils
		* make utils and components agnostic to 'file' objects amount

### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

No visual changes

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required