### PR TITLE
fix(classified): Fix interaction between classified and recording consent

### DIFF
--- a/lib/Controller/CallController.php
+++ b/lib/Controller/CallController.php
@@ -303,6 +303,9 @@ class CallController extends AEnvironmentAwareOCSController {
 	 *                                   not given
 	 */
 	protected function validateRecordingConsent(bool $recordingConsent): void {
+		if ($this->room->isClassified()) {
+			return;
+		}
 		if (!$recordingConsent && $this->talkConfig->recordingConsentRequired() !== RecordingService::CONSENT_REQUIRED_NO) {
 			if ($this->talkConfig->recordingConsentRequired() === RecordingService::CONSENT_REQUIRED_YES) {
 				throw new \InvalidArgumentException();

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -3193,7 +3193,7 @@ class RoomController extends AEnvironmentAwareOCSController {
 	 * @param int $recordingConsent New consent setting for the conversation
 	 *                              (Only {@see RecordingService::CONSENT_REQUIRED_NO} and {@see RecordingService::CONSENT_REQUIRED_YES} are allowed here.)
 	 * @psalm-param RecordingService::CONSENT_REQUIRED_NO|RecordingService::CONSENT_REQUIRED_YES $recordingConsent
-	 * @return DataResponse<Http::STATUS_OK, TalkRoom, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array{error: 'breakout-room'|'call'|'value'}, array{}>|DataResponse<Http::STATUS_PRECONDITION_FAILED, array{error: 'config'}, array{}>
+	 * @return DataResponse<Http::STATUS_OK, TalkRoom, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array{error: 'breakout-room'|'call'|'classified'|'value'}, array{}>|DataResponse<Http::STATUS_PRECONDITION_FAILED, array{error: 'config'}, array{}>
 	 *
 	 * 200: Recording consent requirement set successfully
 	 * 400: Setting recording consent requirement is not possible

--- a/lib/Exceptions/RoomProperty/RecordingConsentException.php
+++ b/lib/Exceptions/RoomProperty/RecordingConsentException.php
@@ -12,6 +12,7 @@ class RecordingConsentException extends \InvalidArgumentException {
 	public const REASON_BREAKOUT_ROOM = 'breakout-room';
 	public const REASON_CALL = 'call';
 	public const REASON_VALUE = 'value';
+	public const REASON_CLASSIFIED = 'classified';
 
 	/**
 	 * @param self::REASON_* $reason

--- a/lib/Service/RoomFormatter.php
+++ b/lib/Service/RoomFormatter.php
@@ -165,7 +165,10 @@ class RoomFormatter {
 			'attributes' => 0,
 		];
 
-		if ($room->isFederatedConversation()) {
+		if ($room->isClassified()) {
+			// No recording, no consent, ever
+			$roomData['recordingConsent'] = RecordingService::CONSENT_REQUIRED_NO;
+		} elseif ($room->isFederatedConversation()) {
 			$roomData['recordingConsent'] = $room->getRecordingConsent();
 		}
 
@@ -228,7 +231,6 @@ class RoomFormatter {
 			'hasCall' => $room->getActiveSince() instanceof \DateTimeInterface,
 			'callStartTime' => $room->getActiveSince() instanceof \DateTimeInterface ? $room->getActiveSince()->getTimestamp() : 0,
 			'callRecording' => $room->getCallRecording(),
-			'recordingConsent' => $this->talkConfig->recordingConsentRequired() === RecordingService::CONSENT_REQUIRED_OPTIONAL ? $room->getRecordingConsent() : $this->talkConfig->recordingConsentRequired(),
 			'lastActivity' => $lastActivity,
 			'callFlag' => $room->getCallFlag(),
 			'isFavorite' => $attendee->isFavorite(),
@@ -258,10 +260,6 @@ class RoomFormatter {
 			'hiddenPinnedId' => $attendee->getHiddenPinnedId(),
 			'attributes' => $room->getAttributes(),
 		]);
-
-		if ($room->isFederatedConversation()) {
-			$roomData['recordingConsent'] = $room->getRecordingConsent();
-		}
 
 		if ($currentParticipant->getAttendee()->getReadPrivacy() === Participant::PRIVACY_PUBLIC) {
 			if (isset($commonReadMessages[$room->getId()])) {

--- a/lib/Service/RoomService.php
+++ b/lib/Service/RoomService.php
@@ -479,6 +479,10 @@ class RoomService {
 			return;
 		}
 
+		if ($room->isClassified()) {
+			throw new RecordingConsentException(RecordingConsentException::REASON_CLASSIFIED);
+		}
+
 		if (!in_array($recordingConsent, [RecordingService::CONSENT_REQUIRED_NO, RecordingService::CONSENT_REQUIRED_YES], true)) {
 			throw new RecordingConsentException(RecordingConsentException::REASON_VALUE);
 		}

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -26570,6 +26570,7 @@
                                                             "enum": [
                                                                 "breakout-room",
                                                                 "call",
+                                                                "classified",
                                                                 "value"
                                                             ]
                                                         }

--- a/openapi.json
+++ b/openapi.json
@@ -26445,6 +26445,7 @@
                                                             "enum": [
                                                                 "breakout-room",
                                                                 "call",
+                                                                "classified",
                                                                 "value"
                                                             ]
                                                         }

--- a/src/types/openapi/openapi-full.ts
+++ b/src/types/openapi/openapi-full.ts
@@ -13554,7 +13554,7 @@ export interface operations {
                             meta: components["schemas"]["OCSMeta"];
                             data: {
                                 /** @enum {string} */
-                                error: "breakout-room" | "call" | "value";
+                                error: "breakout-room" | "call" | "classified" | "value";
                             };
                         };
                     };

--- a/src/types/openapi/openapi.ts
+++ b/src/types/openapi/openapi.ts
@@ -12931,7 +12931,7 @@ export interface operations {
                             meta: components["schemas"]["OCSMeta"];
                             data: {
                                 /** @enum {string} */
-                                error: "breakout-room" | "call" | "value";
+                                error: "breakout-room" | "call" | "classified" | "value";
                             };
                         };
                     };

--- a/tests/integration/features/conversation-4/classified.feature
+++ b/tests/integration/features/conversation-4/classified.feature
@@ -43,6 +43,108 @@ Feature: conversation-4/classified
     And user "participant1" sends message "Message 1" to room "classified" with 201
     And user "participant1" can not request summary for "classified" starting from "Message 1" with 400 (v1)
 
+  Scenario: A classified conversation never requires recording consent
+    # Classified conversations can not be recorded at all, so there is nothing to
+    # consent to and the administrator setting must not leak into them.
+    Given recording server is started
+    And the following "spreed" app config is set
+      | recording_consent | 1 |
+    And user "participant1" creates room "classified" (v4)
+      | roomType | 2 |
+      | roomName | classified |
+      | preset   | classified |
+    And user "participant1" creates room "regular" (v4)
+      | roomType | 2 |
+      | roomName | regular |
+    # The administrator setting applies to a regular conversation …
+    Then user "participant1" is participant of room "regular" (v4)
+      | id      | type | recordingConsent |
+      | regular | 2    | 1                |
+    And user "participant1" gets room "regular" with 200 (v4)
+      | recordingConsent | 1 |
+    # … but never to a classified one
+    And user "participant1" is participant of room "classified" (v4)
+      | id         | type | recordingConsent |
+      | classified | 2    | 0                |
+    And user "participant1" gets room "classified" with 200 (v4)
+      | recordingConsent | 0 |
+
+  Scenario: A moderator can not enable recording consent in a classified conversation
+    # With the optional setting a moderator can turn the consent on per
+    # conversation, but a classified conversation can not be recorded at all.
+    Given recording server is started
+    And the following "spreed" app config is set
+      | recording_consent | 2 |
+    And user "participant1" creates room "classified" (v4)
+      | roomType | 2 |
+      | roomName | classified |
+      | preset   | classified |
+    And user "participant1" creates room "regular" (v4)
+      | roomType | 2 |
+      | roomName | regular |
+    # Enabling the consent works in a regular conversation …
+    When user "participant1" sets the recording consent to 1 for room "regular" with 200 (v4)
+    Then user "participant1" is participant of room "regular" (v4)
+      | id      | type | recordingConsent |
+      | regular | 2    | 1                |
+    # … but is rejected in a classified one
+    When user "participant1" sets the recording consent to 1 for room "classified" with 400 (v4)
+    Then user "participant1" is participant of room "classified" (v4)
+      | id         | type | recordingConsent |
+      | classified | 2    | 0                |
+    And user "participant1" gets room "classified" with 200 (v4)
+      | recordingConsent | 0 |
+    # Requesting the value it already has stays a no-op
+    And user "participant1" sets the recording consent to 0 for room "classified" with 200 (v4)
+
+  Scenario: Recording consent requested during creation is never required in a classified conversation
+    Given recording server is started
+    And the following "spreed" app config is set
+      | recording_consent | 2 |
+    And user "participant1" creates room "classified" (v4)
+      | roomType         | 2 |
+      | roomName         | classified |
+      | preset           | classified |
+      | recordingConsent | 1 |
+    Then user "participant1" is participant of room "classified" (v4)
+      | id         | type | recordingConsent |
+      | classified | 2    | 0                |
+    And user "participant1" gets room "classified" with 200 (v4)
+      | recordingConsent | 0 |
+
+  Scenario: Joining a call in a classified conversation never requires consent
+    # The administrator requires the consent for all conversations, so joining a
+    # regular call without agreeing is rejected, while the classified call can be
+    # joined right away as it can not be recorded.
+    Given recording server is started
+    And the following "spreed" app config is set
+      | recording_consent | 1 |
+    And user "participant1" creates room "classified" (v4)
+      | roomType | 2 |
+      | roomName | classified |
+      | preset   | classified |
+    And user "participant1" creates room "regular" (v4)
+      | roomType | 2 |
+      | roomName | regular |
+    And user "participant1" joins room "regular" with 200 (v4)
+    When user "participant1" joins call "regular" with 400 (v4)
+    And user "participant1" joins call "regular" with 200 (v4)
+      | recordingConsent | 1 |
+    And user "participant1" leaves call "regular" with 200 (v4)
+    And user "participant1" leaves room "regular" with 200 (v4)
+    And user "participant1" joins room "classified" with 200 (v4)
+    Then user "participant1" joins call "classified" with 200 (v4)
+    And user "participant1" leaves call "classified" with 200 (v4)
+    # Agreeing anyway does not record a consent for the classified conversation,
+    # so only the consent of the regular conversation is listed
+    And user "participant1" joins call "classified" with 200 (v4)
+      | recordingConsent | 1 |
+    And user "participant1" leaves call "classified" with 200 (v4)
+    And user "participant1" leaves room "classified" with 200 (v4)
+    And the following recording consent is recorded for user "participant1"
+      | token   | actorType | actorId      |
+      | regular | users     | participant1 |
+
   Scenario: Phone numbers can not be added to a classified conversation
     # SIP dial-out is fully configured and allowed for the user here, so the
     # rejection can only come from the conversation being classified. Without a


### PR DESCRIPTION
## 🛠️ API Checklist

- Recording consent is always off and can not be enabled
- Even when enforced via config

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
