### PR TITLE
refactor: split CallButton in two components

### DIFF
--- a/src/components/CallView/BottomBar.vue
+++ b/src/components/CallView/BottomBar.vue
@@ -8,7 +8,6 @@ import {
 	showError,
 } from '@nextcloud/dialogs'
 import { t } from '@nextcloud/l10n'
-import { useIsMobile } from '@nextcloud/vue/composables/useIsMobile'
 import { useResizeObserver } from '@vueuse/core'
 import debounce from 'debounce'
 import { computed, onMounted, onUnmounted, ref, toValue, useTemplateRef } from 'vue'
@@ -60,7 +59,6 @@ const settingsStore = useSettingsStore()
 const isLiveTranscriptionLoading = ref(false)
 const bottomBar = useTemplateRef('bottomBar')
 const callButtonWithActions = useTemplateRef('callButtonWithActions')
-const isMobile = useIsMobile()
 
 const conversation = computed(() => {
 	return store.getters.conversation(token.value) || store.getters.dummyConversation
@@ -647,7 +645,8 @@ function changeView() {
 			<CallEndLeaveButton
 				v-show="!(isVoiceRoom && isGuestActor)"
 				class="call-button"
-				:hideText="isSidebar || isMobile"
+				shrinkOnMobile
+				:hideText="isSidebar"
 				:isScreensharing="!!localMediaModel.attributes.localScreen" />
 		</div>
 	</div>

--- a/src/components/CallView/BottomBar.vue
+++ b/src/components/CallView/BottomBar.vue
@@ -25,9 +25,9 @@ import IconSubtitles from 'vue-material-design-icons/Subtitles.vue'
 import IconSubtitlesOutline from 'vue-material-design-icons/SubtitlesOutline.vue'
 import IconViewGalleryOutline from 'vue-material-design-icons/ViewGalleryOutline.vue'
 import IconViewGridOutline from 'vue-material-design-icons/ViewGridOutline.vue'
-import CallButton from '../TopBar/CallButton.vue'
 import ReactionMenu from '../TopBar/ReactionMenu.vue'
 import TopBarMediaControls from '../TopBar/TopBarMediaControls.vue'
+import CallEndLeaveButton from './CallEndLeaveButton.vue'
 import {
 	toggleFullscreen,
 	useDocumentFullscreen,
@@ -644,7 +644,7 @@ function changeView() {
 				</NcActionButton>
 			</NcActions>
 
-			<CallButton
+			<CallEndLeaveButton
 				v-show="!(isVoiceRoom && isGuestActor)"
 				class="call-button"
 				:hideText="isSidebar || isMobile"

--- a/src/components/CallView/CallEndLeaveButton.vue
+++ b/src/components/CallView/CallEndLeaveButton.vue
@@ -3,10 +3,13 @@
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
-<script>
+<script setup lang="ts">
 import { emit } from '@nextcloud/event-bus'
 import { t } from '@nextcloud/l10n'
 import { useIsMobile } from '@nextcloud/vue/composables/useIsMobile'
+import { computed, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { useStore } from 'vuex'
 import NcActionButton from '@nextcloud/vue/components/NcActionButton'
 import NcActions from '@nextcloud/vue/components/NcActions'
 import NcButton from '@nextcloud/vue/components/NcButton'
@@ -23,159 +26,89 @@ import { useBreakoutRoomsStore } from '../../stores/breakoutRooms.ts'
 import { useCallViewStore } from '../../stores/callView.ts'
 import { isConversationPhoneRoom } from '../../utils/conversation.ts'
 
-export default {
-	name: 'CallEndLeaveButton',
+const props = defineProps<{
+	/** Whether to render button as tertiary (to reduce drawn attention) */
+	isScreensharing?: boolean
+	/** Whether to use text on button (e.g. at sidebar) */
+	hideText?: boolean
+	/** Whether to use text on button at mobile view */
+	shrinkOnMobile?: boolean
+}>()
 
-	components: {
-		NcActions,
-		NcActionButton,
-		NcButton,
-		// Icons
-		IconArrowLeft,
-		IconChevronUp,
-		IconPhoneHangupOutline,
-		IconPhoneOffOutline,
-		NcLoadingIcon,
-	},
+const endCallLabel = t('spreed', 'End call')
+const leaveCallLabel = t('spreed', 'Leave call')
+const leaveCallActionsLabel = t('spreed', 'More actions')
+const backToMainRoomLabel = t('spreed', 'Back to main room')
 
-	props: {
-		/**
-		 * Whether to render button as tertiary (to reduce drawn attention)
-		 */
-		isScreensharing: {
-			type: Boolean,
-			default: false,
-		},
+const actorStore = useActorStore()
+const breakoutRoomsStore = useBreakoutRoomsStore()
+const callViewStore = useCallViewStore()
 
-		/**
-		 * Whether to use text on button (e.g. at sidebar)
-		 */
-		hideText: {
-			type: Boolean,
-			default: false,
-		},
+const router = useRouter()
+const vuexStore = useStore()
 
-		/**
-		 * Whether to use text on button at mobile view
-		 */
-		shrinkOnMobile: {
-			type: Boolean,
-			default: false,
-		},
-	},
+const token = useGetToken()
+const isMobile = useIsMobile()
 
-	setup() {
-		return {
-			actorStore: useActorStore(),
-			token: useGetToken(),
-			breakoutRoomsStore: useBreakoutRoomsStore(),
-			callViewStore: useCallViewStore(),
-			isMobile: useIsMobile(),
-		}
-	},
+const loading = ref(false)
 
-	data() {
-		return {
-			loading: false,
-		}
-	},
+const conversation = computed(() => vuexStore.getters.conversation(token.value) || vuexStore.getters.dummyConversation)
+const showButtonText = computed(() => !props.hideText && (!isMobile.value || !props.shrinkOnMobile))
+const canEndForAll = computed(() => !isBreakoutRoom.value
+	&& [PARTICIPANT.TYPE.OWNER, PARTICIPANT.TYPE.MODERATOR, PARTICIPANT.TYPE.GUEST_MODERATOR].includes(conversation.value.participantType))
+const isBreakoutRoom = computed(() => conversation.value.objectType === CONVERSATION.OBJECT_TYPE.BREAKOUT_ROOM)
+const isPhoneRoom = computed(() => isConversationPhoneRoom(conversation.value))
+const isVoiceRoom = computed(() => Boolean(conversation.value.attributes & CONVERSATION.ATTRIBUTE.VOICE_ROOM))
+const leaveCallButtonVariant = computed(() => {
+	if (props.isScreensharing) {
+		return 'tertiary'
+	}
+	return isBreakoutRoom.value ? 'primary' : 'error'
+})
 
-	computed: {
-		conversation() {
-			return this.$store.getters.conversation(this.token) || this.$store.getters.dummyConversation
-		},
+/**
+ * Leave or end the call
+ *
+ * @param endMeetingForAll - whether to kick all participants from the call
+ */
+async function leaveCall(endMeetingForAll = false) {
+	if (endMeetingForAll) {
+		console.info('End meeting for everyone')
+	} else {
+		console.info('Leaving call')
+	}
 
-		showButtonText() {
-			return !this.hideText && (!this.isMobile || !this.shrinkOnMobile)
-		},
+	if (isVoiceRoom.value) {
+		router.push({ name: 'root' })
+		// Call ending is handled in App.vue
+		return
+	}
 
-		participantType() {
-			return this.conversation.participantType
-		},
+	// Remove selected participant
+	callViewStore.setSelectedVideoPeerId(null)
+	loading.value = true
 
-		canEndForAll() {
-			return (this.participantType === PARTICIPANT.TYPE.OWNER
-				|| this.participantType === PARTICIPANT.TYPE.MODERATOR
-				|| this.participantType === PARTICIPANT.TYPE.GUEST_MODERATOR)
-			&& !this.isBreakoutRoom
-		},
+	// Open navigation
+	if (!isMobile.value) {
+		emit('toggle-navigation', {
+			open: true,
+		})
+	}
+	await vuexStore.dispatch('leaveCall', {
+		token: token.value,
+		participantIdentifier: actorStore.participantIdentifier,
+		all: endMeetingForAll,
+	})
+	loading.value = false
+}
 
-		leaveCallLabel() {
-			return t('spreed', 'Leave call')
-		},
-
-		backToMainRoomLabel() {
-			return t('spreed', 'Back to main room')
-		},
-
-		leaveCallActionsLabel() {
-			return t('spreed', 'More actions')
-		},
-
-		endCallLabel() {
-			return t('spreed', 'End call')
-		},
-
-		isBreakoutRoom() {
-			return this.conversation.objectType === CONVERSATION.OBJECT_TYPE.BREAKOUT_ROOM
-		},
-
-		isPhoneRoom() {
-			return isConversationPhoneRoom(this.conversation)
-		},
-
-		leaveCallButtonVariant() {
-			if (this.isScreensharing) {
-				return 'tertiary'
-			}
-			return this.isBreakoutRoom ? 'primary' : 'error'
-		},
-
-		isVoiceRoom() {
-			return Boolean(this.conversation.attributes & CONVERSATION.ATTRIBUTE.VOICE_ROOM)
-		},
-	},
-
-	methods: {
-		t,
-
-		async leaveCall(endMeetingForAll = false) {
-			if (endMeetingForAll) {
-				console.info('End meeting for everyone')
-			} else {
-				console.info('Leaving call')
-			}
-
-			if (this.isVoiceRoom) {
-				this.$router.push({ name: 'root' })
-				// Call ending is handled in App.vue
-				return
-			}
-
-			// Remove selected participant
-			this.callViewStore.setSelectedVideoPeerId(null)
-			this.loading = true
-
-			// Open navigation
-			if (!this.isMobile) {
-				emit('toggle-navigation', {
-					open: true,
-				})
-			}
-			await this.$store.dispatch('leaveCall', {
-				token: this.token,
-				participantIdentifier: this.actorStore.participantIdentifier,
-				all: endMeetingForAll,
-			})
-			this.loading = false
-		},
-
-		async switchToParentRoom() {
-			EventBus.emit('switch-to-conversation', {
-				token: this.breakoutRoomsStore.getParentRoomToken(this.token),
-			})
-		},
-	},
+/**
+ * Switch back from breakout room to main (parent) room
+ */
+function switchToParentRoom() {
+	EventBus.emit('switch-to-conversation', {
+		token: breakoutRoomsStore.getParentRoomToken(token.value)!,
+	})
 }
 </script>
 

--- a/src/components/CallView/CallEndLeaveButton.vue
+++ b/src/components/CallView/CallEndLeaveButton.vue
@@ -1,0 +1,284 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<script>
+import { emit } from '@nextcloud/event-bus'
+import { t } from '@nextcloud/l10n'
+import { useIsMobile } from '@nextcloud/vue/composables/useIsMobile'
+import NcActionButton from '@nextcloud/vue/components/NcActionButton'
+import NcActions from '@nextcloud/vue/components/NcActions'
+import NcButton from '@nextcloud/vue/components/NcButton'
+import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
+import IconArrowLeft from 'vue-material-design-icons/ArrowLeft.vue'
+import IconChevronUp from 'vue-material-design-icons/ChevronUp.vue'
+import IconPhoneHangupOutline from 'vue-material-design-icons/PhoneHangupOutline.vue'
+import IconPhoneOffOutline from 'vue-material-design-icons/PhoneOffOutline.vue'
+import { useGetToken } from '../../composables/useGetToken.ts'
+import { CONVERSATION, PARTICIPANT } from '../../constants.ts'
+import { EventBus } from '../../services/EventBus.ts'
+import { useActorStore } from '../../stores/actor.ts'
+import { useBreakoutRoomsStore } from '../../stores/breakoutRooms.ts'
+import { useCallViewStore } from '../../stores/callView.ts'
+import { isConversationPhoneRoom } from '../../utils/conversation.ts'
+
+export default {
+	name: 'CallEndLeaveButton',
+
+	components: {
+		NcActions,
+		NcActionButton,
+		NcButton,
+		// Icons
+		IconArrowLeft,
+		IconChevronUp,
+		IconPhoneHangupOutline,
+		IconPhoneOffOutline,
+		NcLoadingIcon,
+	},
+
+	props: {
+		/**
+		 * Whether to render button as tertiary (to reduce drawn attention)
+		 */
+		isScreensharing: {
+			type: Boolean,
+			default: false,
+		},
+
+		/**
+		 * Whether to use text on button (e.g. at sidebar)
+		 */
+		hideText: {
+			type: Boolean,
+			default: false,
+		},
+
+		/**
+		 * Whether to use text on button at mobile view
+		 */
+		shrinkOnMobile: {
+			type: Boolean,
+			default: false,
+		},
+	},
+
+	setup() {
+		return {
+			actorStore: useActorStore(),
+			token: useGetToken(),
+			breakoutRoomsStore: useBreakoutRoomsStore(),
+			callViewStore: useCallViewStore(),
+			isMobile: useIsMobile(),
+		}
+	},
+
+	data() {
+		return {
+			loading: false,
+		}
+	},
+
+	computed: {
+		conversation() {
+			return this.$store.getters.conversation(this.token) || this.$store.getters.dummyConversation
+		},
+
+		showButtonText() {
+			return !this.hideText && (!this.isMobile || !this.shrinkOnMobile)
+		},
+
+		participantType() {
+			return this.conversation.participantType
+		},
+
+		canEndForAll() {
+			return (this.participantType === PARTICIPANT.TYPE.OWNER
+				|| this.participantType === PARTICIPANT.TYPE.MODERATOR
+				|| this.participantType === PARTICIPANT.TYPE.GUEST_MODERATOR)
+			&& !this.isBreakoutRoom
+		},
+
+		leaveCallLabel() {
+			return t('spreed', 'Leave call')
+		},
+
+		backToMainRoomLabel() {
+			return t('spreed', 'Back to main room')
+		},
+
+		leaveCallActionsLabel() {
+			return t('spreed', 'More actions')
+		},
+
+		endCallLabel() {
+			return t('spreed', 'End call')
+		},
+
+		isBreakoutRoom() {
+			return this.conversation.objectType === CONVERSATION.OBJECT_TYPE.BREAKOUT_ROOM
+		},
+
+		isPhoneRoom() {
+			return isConversationPhoneRoom(this.conversation)
+		},
+
+		leaveCallButtonVariant() {
+			if (this.isScreensharing) {
+				return 'tertiary'
+			}
+			return this.isBreakoutRoom ? 'primary' : 'error'
+		},
+
+		isVoiceRoom() {
+			return Boolean(this.conversation.attributes & CONVERSATION.ATTRIBUTE.VOICE_ROOM)
+		},
+	},
+
+	methods: {
+		t,
+
+		async leaveCall(endMeetingForAll = false) {
+			if (endMeetingForAll) {
+				console.info('End meeting for everyone')
+			} else {
+				console.info('Leaving call')
+			}
+
+			if (this.isVoiceRoom) {
+				this.$router.push({ name: 'root' })
+				// Call ending is handled in App.vue
+				return
+			}
+
+			// Remove selected participant
+			this.callViewStore.setSelectedVideoPeerId(null)
+			this.loading = true
+
+			// Open navigation
+			if (!this.isMobile) {
+				emit('toggle-navigation', {
+					open: true,
+				})
+			}
+			await this.$store.dispatch('leaveCall', {
+				token: this.token,
+				participantIdentifier: this.actorStore.participantIdentifier,
+				all: endMeetingForAll,
+			})
+			this.loading = false
+		},
+
+		async switchToParentRoom() {
+			EventBus.emit('switch-to-conversation', {
+				token: this.breakoutRoomsStore.getParentRoomToken(this.token),
+			})
+		},
+	},
+}
+</script>
+
+<template>
+	<NcButton
+		v-if="canEndForAll && isPhoneRoom"
+		:aria-label="endCallLabel"
+		class="leave-call"
+		variant="error"
+		:disabled="loading"
+		@click="leaveCall(true)">
+		<template #icon>
+			<NcLoadingIcon v-if="loading" :size="20" />
+			<IconPhoneHangupOutline v-else :size="20" />
+		</template>
+		<template v-if="showButtonText" #default>
+			{{ endCallLabel }}
+		</template>
+	</NcButton>
+	<NcButton
+		v-else-if="(!canEndForAll || isVoiceRoom) && !isBreakoutRoom"
+		:aria-label="leaveCallLabel"
+		class="leave-call"
+		:variant="isScreensharing ? 'tertiary' : 'error'"
+		:disabled="loading"
+		@click="leaveCall(false)">
+		<template #icon>
+			<NcLoadingIcon v-if="loading" :size="20" />
+			<IconPhoneHangupOutline v-else :size="20" />
+		</template>
+		<template v-if="showButtonText" #default>
+			{{ leaveCallLabel }}
+		</template>
+	</NcButton>
+	<NcActions
+		v-else-if="(canEndForAll || isBreakoutRoom)"
+		class="leave-call leave-call-actions--split"
+		:disabled="loading"
+		:forceName="showButtonText"
+		placement="top-end"
+		:aria-label="leaveCallActionsLabel"
+		:inline="1"
+		:variant="leaveCallButtonVariant">
+		<template #icon>
+			<IconChevronUp :size="20" />
+		</template>
+		<NcActionButton
+			v-if="isBreakoutRoom"
+			:aria-label="backToMainRoomLabel"
+			@click="switchToParentRoom">
+			<template #icon>
+				<IconArrowLeft class="bidirectional-icon" :size="20" />
+			</template>
+			<template v-if="showButtonText" #default>
+				{{ backToMainRoomLabel }}
+			</template>
+		</NcActionButton>
+		<NcActionButton
+			class="leave-call-button--split"
+			:aria-label="leaveCallLabel"
+			@click="leaveCall(false)">
+			<template #icon>
+				<NcLoadingIcon v-if="loading" :size="20" />
+				<IconPhoneHangupOutline v-else :size="20" />
+			</template>
+			<template v-if="showButtonText || isBreakoutRoom" #default>
+				{{ leaveCallLabel }}
+			</template>
+		</NcActionButton>
+		<NcActionButton v-if="canEndForAll && !isVoiceRoom" @click="leaveCall(true)">
+			<template #icon>
+				<IconPhoneOffOutline :size="20" />
+			</template>
+			{{ t('spreed', 'End call for everyone') }}
+		</NcActionButton>
+	</NcActions>
+</template>
+
+<style lang="scss" scoped>
+.leave-call.button-vue--error,
+.leave-call :deep(.button-vue--error) {
+	// Overwrite default button colors for leaving call
+	background-color: #FF3333 !important; // Nextcloud 31 --color-error
+	color: var(--color-primary-text) !important;
+
+	&:hover:not(:disabled) {
+		background-color: var(--color-error-hover) !important;
+	}
+}
+
+.leave-call-actions--split {
+	gap: 1px !important;
+}
+
+.leave-call-actions--split :deep(.action-item--single) {
+	border-start-end-radius: 2px;
+	border-end-end-radius: 2px;
+}
+
+.leave-call-actions--split :deep(.action-item__menutoggle) {
+	--button-size: var(--clickable-area-small);
+	height: var(--default-clickable-area);
+	border-start-start-radius: 2px;
+	border-end-start-radius: 2px;
+}
+</style>

--- a/src/components/TopBar/CallButton.vue
+++ b/src/components/TopBar/CallButton.vue
@@ -3,13 +3,16 @@
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
-<script>
+<script setup lang="ts">
 import axios from '@nextcloud/axios'
 import { showError } from '@nextcloud/dialogs'
 import { emit } from '@nextcloud/event-bus'
 import { t } from '@nextcloud/l10n'
 import { generateOcsUrl } from '@nextcloud/router'
 import { useIsMobile } from '@nextcloud/vue/composables/useIsMobile'
+import { computed, ref, watch } from 'vue'
+import { useRouter } from 'vue-router'
+import { useStore } from 'vuex'
 import NcButton from '@nextcloud/vue/components/NcButton'
 import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
 import IconPhone from 'vue-material-design-icons/Phone.vue' // Filled used for non-silent calls
@@ -25,258 +28,177 @@ import { useSettingsStore } from '../../stores/settings.ts'
 import { useSoundsStore } from '../../stores/sounds.js'
 import { useTalkHashStore } from '../../stores/talkHash.js'
 import { useTokenStore } from '../../stores/token.ts'
+import { isAxiosErrorResponse } from '../../types/guards.ts'
 import { blockCalls, unsupportedWarning } from '../../utils/browserCheck.ts'
 import { hasExternalCallService, isConversationPhoneRoom } from '../../utils/conversation.ts'
 import { messagePleaseReload } from '../../utils/talkDesktopUtils.ts'
 
-export default {
-	name: 'CallButton',
+const props = defineProps<{
+	disabled?: boolean
+	/** Whether the component is used in MediaSettings or not (click directly starts a call) */
+	isMediaSettings?: boolean
+	/** Whether the call should trigger a notifications and sound for other participants or not */
+	silentCall?: boolean
+	/** Whether to trigger recording to start with the call */
+	isRecordingFromStart?: boolean
+	/** Pass through of recording consent */
+	recordingConsentGiven?: boolean
+	/** Whether to use text on button (e.g. at sidebar) */
+	hideText?: boolean
+	/** Whether to use text on button at mobile view */
+	shrinkOnMobile?: boolean
+}>()
 
-	components: {
-		NcButton,
-		// Icons
-		IconPhone,
-		IconPhoneDialOutline,
-		IconPhoneOutline,
-		NcLoadingIcon,
-	},
+const { joinCall } = useJoinCall()
 
-	props: {
-		disabled: {
-			type: Boolean,
-			default: false,
-		},
+const tokenStore = useTokenStore()
+const isInCall = useIsInCall()
+const callViewStore = useCallViewStore()
+const talkHashStore = useTalkHashStore()
+const settingsStore = useSettingsStore()
+const soundsStore = useSoundsStore()
 
-		/**
-		 * Whether the component is used in MediaSettings or not
-		 * (when click will directly start a call)
-		 */
-		isMediaSettings: {
-			type: Boolean,
-			default: false,
-		},
+const router = useRouter()
+const vuexStore = useStore()
 
-		/**
-		 * Whether the call should trigger a notifications and sound
-		 * for other participants or not
-		 */
-		silentCall: {
-			type: Boolean,
-			default: false,
-		},
+const token = useGetToken()
+const isMobile = useIsMobile()
 
-		isRecordingFromStart: {
-			type: Boolean,
-			default: false,
-		},
+const loading = ref(false)
 
-		recordingConsentGiven: {
-			type: Boolean,
-			default: false,
-		},
+const conversation = computed(() => vuexStore.getters.conversation(token.value) || vuexStore.getters.dummyConversation)
+const showButtonText = computed(() => !props.hideText && (!isMobile.value || !props.shrinkOnMobile))
+const hasCall = computed(() => conversation.value.hasCall)
+const isPhoneRoom = computed(() => isConversationPhoneRoom(conversation.value))
+const isInLobby = computed(() => vuexStore.getters.isInLobby)
+const isJoiningCall = computed(() => vuexStore.getters.isJoiningCall(token.value))
+const isNextcloudTalkHashDirty = computed(() => {
+	return talkHashStore.isNextcloudTalkHashDirty
+		// @ts-expect-error talkHashStore is js
+		|| talkHashStore.isNextcloudTalkProxyHashDirty[token.value]
+})
 
-		/**
-		 * Whether to use text on button (e.g. at sidebar)
-		 */
-		hideText: {
-			type: Boolean,
-			default: false,
-		},
+const showStartCallButton = computed(() => {
+	return (getTalkConfig(token.value, 'call', 'enabled') || hasExternalCallService(conversation.value))
+		&& conversation.value.type !== CONVERSATION.TYPE.NOTE_TO_SELF
+		&& conversation.value.readOnly === CONVERSATION.STATE.READ_WRITE
+		&& (!conversation.value.remoteServer || hasTalkFeature(token.value, 'federation-v2'))
+		&& !isInCall.value
+})
+const startCallButtonDisabled = computed(() => {
+	return props.disabled
+		|| (callViewStore.callHasJustEnded && !hasCall.value)
+		|| (!conversation.value.canStartCall && !hasExternalCallService(conversation.value) && !hasCall.value)
+		|| isInLobby.value
+		|| conversation.value.readOnly
+		|| isNextcloudTalkHashDirty.value
+		|| !tokenStore.currentConversationIsJoined
+		|| blockCalls
+})
+const showRecordingWarning = computed(() => {
+	return [
+		CALL.RECORDING.VIDEO_STARTING,
+		CALL.RECORDING.AUDIO_STARTING,
+		CALL.RECORDING.VIDEO,
+		CALL.RECORDING.AUDIO,
+	].includes(conversation.value.callRecording)
+	|| conversation.value.recordingConsent === CALL.RECORDING_CONSENT.ENABLED
+})
 
-		/**
-		 * Whether to use text on button at mobile view
-		 */
-		shrinkOnMobile: {
-			type: Boolean,
-			default: false,
-		},
-	},
+const startCallLabel = computed(() => {
+	if (hasCall.value && !isInLobby.value) {
+		return t('spreed', 'Join call')
+	}
+	if (isJoiningCall.value) {
+		return t('spreed', 'Connecting …')
+	}
+	return props.silentCall ? t('spreed', 'Start call silently') : t('spreed', 'Start call')
+})
+const startCallTitle = computed(() => {
+	if (isNextcloudTalkHashDirty.value) {
+		return t('spreed', 'The server was updated, you cannot start or join a call.') + ' ' + messagePleaseReload
+	}
+	if (callViewStore.callHasJustEnded) {
+		return t('spreed', 'This call has just ended')
+	}
+	if (blockCalls) {
+		return unsupportedWarning
+	}
+	if (!conversation.value.canStartCall && !hasCall.value) {
+		return t('spreed', 'You will be able to join the call only after a moderator starts it.')
+	}
+	return ''
+})
 
-	setup() {
-		const { joinCall } = useJoinCall()
-		return {
-			tokenStore: useTokenStore(),
-			token: useGetToken(),
-			isInCall: useIsInCall(),
-			callViewStore: useCallViewStore(),
-			talkHashStore: useTalkHashStore(),
-			settingsStore: useSettingsStore(),
-			soundsStore: useSoundsStore(),
-			isMobile: useIsMobile(),
-			joinCall,
+watch(token, (newValue, oldValue) => {
+	callViewStore.resetCallHasJustEnded()
+	talkHashStore.resetTalkProxyHashDirty(oldValue)
+})
+
+/**
+ * Start or join the call
+ */
+async function handleJoinCall() {
+	loading.value = true
+	await joinCall(token.value, {
+		silent: hasCall.value ? true : props.silentCall,
+		recordingConsent: props.recordingConsentGiven,
+		shouldStartRecording: props.isRecordingFromStart,
+	})
+	loading.value = false
+}
+
+/**
+ * Run pre-checks before starting/joining the call
+ */
+function handleClick() {
+	if (hasExternalCallService(conversation.value)) {
+		// Another service is in charge, trigger iframe rendering in MainView
+		handleExternalCall()
+		return
+	}
+
+	// Create audio objects as a result of a user interaction to allow playing sounds in Safari
+	soundsStore.initAudioObjects()
+
+	if (props.isMediaSettings || isPhoneRoom.value) {
+		handleJoinCall()
+		return
+	}
+
+	if (showRecordingWarning.value || settingsStore.showMediaSettings) {
+		emit('talk:media-settings:show')
+	} else {
+		handleJoinCall()
+	}
+}
+
+/**
+ * Initiate a call at external service (iframe embedded)
+ */
+async function handleExternalCall() {
+	try {
+		loading.value = true
+		const response = await axios.post(generateOcsUrl('apps/spreed/api/v4/room/{token}/external-call', { token: token.value }))
+
+		// Check for successful response (200, 302, 303)
+		if ([200, 302, 303].includes(response.status)) {
+			const callUrl = response.data.ocs.data.url
+			if (callUrl) {
+				callViewStore.setExternalCallServiceUrl(callUrl)
+			}
+			callViewStore.setForceCallView(true)
 		}
-	},
-
-	data() {
-		return {
-			loading: false,
+	} catch (error) {
+		if (isAxiosErrorResponse(error) && error.response?.status === 403) {
+			router.push({ name: 'forbidden' })
+			return
 		}
-	},
-
-	computed: {
-		isNextcloudTalkHashDirty() {
-			return this.talkHashStore.isNextcloudTalkHashDirty
-				|| this.talkHashStore.isNextcloudTalkProxyHashDirty[this.token]
-		},
-
-		conversation() {
-			return this.$store.getters.conversation(this.token) || this.$store.getters.dummyConversation
-		},
-
-		showButtonText() {
-			return !this.hideText && (!this.isMobile || !this.shrinkOnMobile)
-		},
-
-		showRecordingWarning() {
-			return [
-				CALL.RECORDING.VIDEO_STARTING,
-				CALL.RECORDING.AUDIO_STARTING,
-				CALL.RECORDING.VIDEO,
-				CALL.RECORDING.AUDIO,
-			].includes(this.conversation.callRecording)
-			|| this.conversation.recordingConsent === CALL.RECORDING_CONSENT.ENABLED
-		},
-
-		showMediaSettings() {
-			return this.settingsStore.showMediaSettings
-		},
-
-		hasCall() {
-			return this.conversation.hasCall
-		},
-
-		startCallButtonDisabled() {
-			return this.disabled
-				|| (this.callViewStore.callHasJustEnded && !this.hasCall)
-				|| (!this.conversation.canStartCall && !hasExternalCallService(this.conversation) && !this.hasCall)
-				|| this.isInLobby
-				|| this.conversation.readOnly
-				|| this.isNextcloudTalkHashDirty
-				|| !this.tokenStore.currentConversationIsJoined
-				|| blockCalls
-		},
-
-		startCallLabel() {
-			if (this.hasCall && !this.isInLobby) {
-				return t('spreed', 'Join call')
-			}
-
-			if (this.isJoiningCall) {
-				return t('spreed', 'Connecting …')
-			}
-
-			return this.silentCall ? t('spreed', 'Start call silently') : t('spreed', 'Start call')
-		},
-
-		startCallTitle() {
-			if (this.isNextcloudTalkHashDirty) {
-				return t('spreed', 'The server was updated, you cannot start or join a call.') + ' ' + messagePleaseReload
-			}
-
-			if (this.callViewStore.callHasJustEnded) {
-				return t('spreed', 'This call has just ended')
-			}
-
-			if (blockCalls) {
-				return unsupportedWarning
-			}
-
-			if (!this.conversation.canStartCall && !this.hasCall) {
-				return t('spreed', 'You will be able to join the call only after a moderator starts it.')
-			}
-
-			return ''
-		},
-
-		showStartCallButton() {
-			return (getTalkConfig(this.token, 'call', 'enabled') || hasExternalCallService(this.conversation))
-				&& this.conversation.type !== CONVERSATION.TYPE.NOTE_TO_SELF
-				&& this.conversation.readOnly === CONVERSATION.STATE.READ_WRITE
-				&& (!this.conversation.remoteServer || hasTalkFeature(this.token, 'federation-v2'))
-				&& !this.isInCall
-		},
-
-		isPhoneRoom() {
-			return isConversationPhoneRoom(this.conversation)
-		},
-
-		isInLobby() {
-			return this.$store.getters.isInLobby
-		},
-
-		isJoiningCall() {
-			return this.$store.getters.isJoiningCall(this.token)
-		},
-	},
-
-	watch: {
-		token(newValue, oldValue) {
-			this.callViewStore.resetCallHasJustEnded()
-			this.talkHashStore.resetTalkProxyHashDirty(oldValue)
-		},
-	},
-
-	methods: {
-		t,
-
-		async handleJoinCall() {
-			this.loading = true
-			await this.joinCall(this.token, {
-				silent: this.hasCall ? true : this.silentCall,
-				recordingConsent: this.recordingConsentGiven,
-				shouldStartRecording: this.isRecordingFromStart,
-			})
-			this.loading = false
-		},
-
-		handleClick() {
-			if (hasExternalCallService(this.conversation)) {
-				// Another service is in charge, trigger iframe rendering in MainView
-				this.handleExternalCall()
-				return
-			}
-
-			// Create audio objects as a result of a user interaction to allow playing sounds in Safari
-			this.soundsStore.initAudioObjects()
-
-			if (this.isMediaSettings || this.isPhoneRoom) {
-				this.handleJoinCall()
-				return
-			}
-
-			if (this.showRecordingWarning || this.showMediaSettings) {
-				emit('talk:media-settings:show')
-			} else {
-				this.handleJoinCall()
-			}
-		},
-
-		async handleExternalCall() {
-			try {
-				this.loading = true
-				const response = await axios.post(generateOcsUrl('apps/spreed/api/v4/room/{token}/external-call', { token: this.token }))
-
-				// Check for successful response (200, 302, 303)
-				if ([200, 302, 303].includes(response.status)) {
-					const callUrl = response.data.ocs.data.url
-					if (callUrl) {
-						this.callViewStore.setExternalCallServiceUrl(callUrl)
-					}
-					this.callViewStore.setForceCallView(true)
-				}
-			} catch (error) {
-				if (error.response?.status === 403) {
-					this.skipLeaveWarning = true
-					this.$router.push({ name: 'forbidden' })
-					return
-				}
-				console.error('Failed to initialize external call service:', error)
-				showError(t('spreed', 'Connection failed'))
-			} finally {
-				this.loading = false
-			}
-		},
-	},
+		console.error('Failed to initialize external call service:', error)
+		showError(t('spreed', 'Connection failed'))
+	} finally {
+		loading.value = false
+	}
 }
 </script>
 

--- a/src/components/TopBar/CallButton.vue
+++ b/src/components/TopBar/CallButton.vue
@@ -3,100 +3,6 @@
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
-<template>
-	<NcButton
-		v-if="showStartCallButton"
-		:title="startCallTitle"
-		:aria-label="startCallLabel"
-		:disabled="startCallButtonDisabled || loading || isJoiningCall"
-		class="join-call"
-		:variant="hasCall ? 'success' : 'primary'"
-		@click="handleClick">
-		<template #icon>
-			<NcLoadingIcon v-if="isJoiningCall || loading" :size="20" />
-			<IconPhoneDialOutline v-else-if="isPhoneRoom" :size="20" />
-			<IconPhoneOutline v-else-if="silentCall" :size="20" />
-			<IconPhone v-else :size="20" />
-		</template>
-		<template v-if="showButtonText" #default>
-			{{ startCallLabel }}
-		</template>
-	</NcButton>
-
-	<NcButton
-		v-else-if="showLeaveCallButton && canEndForAll && isPhoneRoom"
-		:aria-label="endCallLabel"
-		class="leave-call"
-		variant="error"
-		:disabled="loading"
-		@click="leaveCall(true)">
-		<template #icon>
-			<NcLoadingIcon v-if="loading" :size="20" />
-			<IconPhoneHangupOutline v-else :size="20" />
-		</template>
-		<template v-if="showButtonText" #default>
-			{{ endCallLabel }}
-		</template>
-	</NcButton>
-	<NcButton
-		v-else-if="showLeaveCallButton && (!canEndForAll || isVoiceRoom) && !isBreakoutRoom"
-		:aria-label="leaveCallLabel"
-		class="leave-call"
-		:variant="isScreensharing ? 'tertiary' : 'error'"
-		:disabled="loading"
-		@click="leaveCall(false)">
-		<template #icon>
-			<NcLoadingIcon v-if="loading" :size="20" />
-			<IconPhoneHangupOutline v-else :size="20" />
-		</template>
-		<template v-if="showButtonText" #default>
-			{{ leaveCallLabel }}
-		</template>
-	</NcButton>
-	<NcActions
-		v-else-if="showLeaveCallButton && (canEndForAll || isBreakoutRoom)"
-		class="leave-call leave-call-actions--split"
-		:disabled="loading"
-		:forceName="showButtonText"
-		placement="top-end"
-		:aria-label="leaveCallActionsLabel"
-		:inline="1"
-		:variant="leaveCallButtonVariant">
-		<template #icon>
-			<IconChevronUp :size="20" />
-		</template>
-		<NcActionButton
-			v-if="isBreakoutRoom"
-			:aria-label="backToMainRoomLabel"
-			@click="switchToParentRoom">
-			<template #icon>
-				<IconArrowLeft class="bidirectional-icon" :size="20" />
-			</template>
-			<template v-if="showButtonText" #default>
-				{{ backToMainRoomLabel }}
-			</template>
-		</NcActionButton>
-		<NcActionButton
-			class="leave-call-button--split"
-			:aria-label="leaveCallLabel"
-			@click="leaveCall(false)">
-			<template #icon>
-				<NcLoadingIcon v-if="loading" :size="20" />
-				<IconPhoneHangupOutline v-else :size="20" />
-			</template>
-			<template v-if="showButtonText || isBreakoutRoom" #default>
-				{{ leaveCallLabel }}
-			</template>
-		</NcActionButton>
-		<NcActionButton v-if="canEndForAll && !isVoiceRoom" @click="leaveCall(true)">
-			<template #icon>
-				<IconPhoneOffOutline :size="20" />
-			</template>
-			{{ t('spreed', 'End call for everyone') }}
-		</NcActionButton>
-	</NcActions>
-</template>
-
 <script>
 import axios from '@nextcloud/axios'
 import { showError } from '@nextcloud/dialogs'
@@ -104,25 +10,16 @@ import { emit } from '@nextcloud/event-bus'
 import { t } from '@nextcloud/l10n'
 import { generateOcsUrl } from '@nextcloud/router'
 import { useIsMobile } from '@nextcloud/vue/composables/useIsMobile'
-import NcActionButton from '@nextcloud/vue/components/NcActionButton'
-import NcActions from '@nextcloud/vue/components/NcActions'
 import NcButton from '@nextcloud/vue/components/NcButton'
 import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
-import IconArrowLeft from 'vue-material-design-icons/ArrowLeft.vue'
-import IconChevronUp from 'vue-material-design-icons/ChevronUp.vue'
 import IconPhone from 'vue-material-design-icons/Phone.vue' // Filled used for non-silent calls
 import IconPhoneDialOutline from 'vue-material-design-icons/PhoneDialOutline.vue'
-import IconPhoneHangupOutline from 'vue-material-design-icons/PhoneHangupOutline.vue'
-import IconPhoneOffOutline from 'vue-material-design-icons/PhoneOffOutline.vue'
 import IconPhoneOutline from 'vue-material-design-icons/PhoneOutline.vue'
 import { useGetToken } from '../../composables/useGetToken.ts'
 import { useIsInCall } from '../../composables/useIsInCall.js'
 import { useJoinCall } from '../../composables/useJoinCall.ts'
-import { CALL, CONVERSATION, PARTICIPANT } from '../../constants.ts'
+import { CALL, CONVERSATION } from '../../constants.ts'
 import { getTalkConfig, hasTalkFeature } from '../../services/CapabilitiesManager.ts'
-import { EventBus } from '../../services/EventBus.ts'
-import { useActorStore } from '../../stores/actor.ts'
-import { useBreakoutRoomsStore } from '../../stores/breakoutRooms.ts'
 import { useCallViewStore } from '../../stores/callView.ts'
 import { useSettingsStore } from '../../stores/settings.ts'
 import { useSoundsStore } from '../../stores/sounds.js'
@@ -136,16 +33,10 @@ export default {
 	name: 'CallButton',
 
 	components: {
-		NcActions,
-		NcActionButton,
 		NcButton,
 		// Icons
-		IconArrowLeft,
-		IconChevronUp,
 		IconPhone,
 		IconPhoneDialOutline,
-		IconPhoneHangupOutline,
-		IconPhoneOffOutline,
 		IconPhoneOutline,
 		NcLoadingIcon,
 	},
@@ -184,11 +75,6 @@ export default {
 			default: false,
 		},
 
-		isScreensharing: {
-			type: Boolean,
-			default: false,
-		},
-
 		/**
 		 * Whether to use text on button (e.g. at sidebar)
 		 */
@@ -209,11 +95,9 @@ export default {
 	setup() {
 		const { joinCall } = useJoinCall()
 		return {
-			actorStore: useActorStore(),
 			tokenStore: useTokenStore(),
 			token: useGetToken(),
 			isInCall: useIsInCall(),
-			breakoutRoomsStore: useBreakoutRoomsStore(),
 			callViewStore: useCallViewStore(),
 			talkHashStore: useTalkHashStore(),
 			settingsStore: useSettingsStore(),
@@ -257,17 +141,6 @@ export default {
 			return this.settingsStore.showMediaSettings
 		},
 
-		participantType() {
-			return this.conversation.participantType
-		},
-
-		canEndForAll() {
-			return (this.participantType === PARTICIPANT.TYPE.OWNER
-				|| this.participantType === PARTICIPANT.TYPE.MODERATOR
-				|| this.participantType === PARTICIPANT.TYPE.GUEST_MODERATOR)
-			&& !this.isBreakoutRoom
-		},
-
 		hasCall() {
 			return this.conversation.hasCall
 		},
@@ -283,18 +156,6 @@ export default {
 				|| blockCalls
 		},
 
-		leaveCallLabel() {
-			return t('spreed', 'Leave call')
-		},
-
-		backToMainRoomLabel() {
-			return t('spreed', 'Back to main room')
-		},
-
-		leaveCallActionsLabel() {
-			return t('spreed', 'More actions')
-		},
-
 		startCallLabel() {
 			if (this.hasCall && !this.isInLobby) {
 				return t('spreed', 'Join call')
@@ -305,10 +166,6 @@ export default {
 			}
 
 			return this.silentCall ? t('spreed', 'Start call silently') : t('spreed', 'Start call')
-		},
-
-		endCallLabel() {
-			return t('spreed', 'End call')
 		},
 
 		startCallTitle() {
@@ -339,15 +196,6 @@ export default {
 				&& !this.isInCall
 		},
 
-		showLeaveCallButton() {
-			return this.conversation.readOnly === CONVERSATION.STATE.READ_WRITE
-				&& this.isInCall
-		},
-
-		isBreakoutRoom() {
-			return this.conversation.objectType === CONVERSATION.OBJECT_TYPE.BREAKOUT_ROOM
-		},
-
 		isPhoneRoom() {
 			return isConversationPhoneRoom(this.conversation)
 		},
@@ -358,17 +206,6 @@ export default {
 
 		isJoiningCall() {
 			return this.$store.getters.isJoiningCall(this.token)
-		},
-
-		leaveCallButtonVariant() {
-			if (this.isScreensharing) {
-				return 'tertiary'
-			}
-			return this.isBreakoutRoom ? 'primary' : 'error'
-		},
-
-		isVoiceRoom() {
-			return Boolean(this.conversation.attributes & CONVERSATION.ATTRIBUTE.VOICE_ROOM)
 		},
 	},
 
@@ -388,37 +225,6 @@ export default {
 				silent: this.hasCall ? true : this.silentCall,
 				recordingConsent: this.recordingConsentGiven,
 				shouldStartRecording: this.isRecordingFromStart,
-			})
-			this.loading = false
-		},
-
-		async leaveCall(endMeetingForAll = false) {
-			if (endMeetingForAll) {
-				console.info('End meeting for everyone')
-			} else {
-				console.info('Leaving call')
-			}
-
-			if (this.isVoiceRoom) {
-				this.$router.push({ name: 'root' })
-				// Call ending is handled in App.vue
-				return
-			}
-
-			// Remove selected participant
-			this.callViewStore.setSelectedVideoPeerId(null)
-			this.loading = true
-
-			// Open navigation
-			if (!this.isMobile) {
-				emit('toggle-navigation', {
-					open: true,
-				})
-			}
-			await this.$store.dispatch('leaveCall', {
-				token: this.token,
-				participantIdentifier: this.actorStore.participantIdentifier,
-				all: endMeetingForAll,
 			})
 			this.loading = false
 		},
@@ -470,15 +276,30 @@ export default {
 				this.loading = false
 			}
 		},
-
-		async switchToParentRoom() {
-			EventBus.emit('switch-to-conversation', {
-				token: this.breakoutRoomsStore.getParentRoomToken(this.token),
-			})
-		},
 	},
 }
 </script>
+
+<template>
+	<NcButton
+		v-if="showStartCallButton"
+		:title="startCallTitle"
+		:aria-label="startCallLabel"
+		:disabled="startCallButtonDisabled || loading || isJoiningCall"
+		class="join-call"
+		:variant="hasCall ? 'success' : 'primary'"
+		@click="handleClick">
+		<template #icon>
+			<NcLoadingIcon v-if="isJoiningCall || loading" :size="20" />
+			<IconPhoneDialOutline v-else-if="isPhoneRoom" :size="20" />
+			<IconPhoneOutline v-else-if="silentCall" :size="20" />
+			<IconPhone v-else :size="20" />
+		</template>
+		<template v-if="showButtonText" #default>
+			{{ startCallLabel }}
+		</template>
+	</NcButton>
+</template>
 
 <style lang="scss" scoped>
 .join-call.button-vue--success {
@@ -503,32 +324,4 @@ export default {
 		background-color: var(--join-call-border-color);
 	}
 }
-
-.leave-call.button-vue--error,
-.leave-call :deep(.button-vue--error) {
-	// Overwrite default button colors for leaving call
-	background-color: #FF3333 !important; // Nextcloud 31 --color-error
-	color: var(--color-primary-text) !important;
-
-	&:hover:not(:disabled) {
-		background-color: var(--color-error-hover) !important;
-	}
-}
-
-.leave-call-actions--split {
-	gap: 1px !important;
-}
-
-.leave-call-actions--split :deep(.action-item--single) {
-	border-start-end-radius: 2px;
-	border-end-end-radius: 2px;
-}
-
-.leave-call-actions--split :deep(.action-item__menutoggle) {
-	--button-size: var(--clickable-area-small);
-	height: var(--default-clickable-area);
-	border-start-start-radius: 2px;
-	border-end-start-radius: 2px;
-}
-
 </style>


### PR DESCRIPTION
## ☑️ Resolves

- logic for 'End call' is only used in a single place and only when isInCall
- Split into separate component
- Refactor to script setup

### AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI

## 🖌️ UI Checklist

No behaviour change

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client