### PR TITLE
fix: workaround for broken styles by BOM chars with postcss >=8.5.24

### DIFF
--- a/rspack.config.js
+++ b/rspack.config.js
@@ -144,7 +144,19 @@ module.exports = defineConfig((env) => {
 							loader: CssExtractRspackPlugin.loader,
 						},
 						'css-loader',
-						'sass-loader',
+						{
+							loader: 'sass-loader',
+							options: {
+								sassOptions: {
+									// Sass emits BOM for CSS files with non-ASCII characters in production build by default
+									// PostCSS (used in css-loader and Vue SFC compiler) starting from v8.5.24 stops removing BOM
+									// Merging these styles keeps BOM in the middle of the file, breaking the first selector of each merged stylesheet
+									// Disabling charset prevents breaking styles (a workaround until css-loader is fixed for the new PostCSS)
+									// This is safe since the document has "<meta charset="utf-8">" anyway
+									charset: false,
+								},
+							},
+						},
 					],
 				},
 				{


### PR DESCRIPTION
## ☑️ Resolves

* Fix regresion from #18916
* Sass emits BOM for CSS files with non-ASCII characters in production build by default
* PostCSS (used in css-loader and Vue SFC compiler) starting from v8.5.24 stops removing BOM
* Merging these styles keeps BOM in the middle of the file, breaking the first selector of each merged stylesheet
* Disabling charset prevents breaking styles (a workaround until css-loader is fixed for the new PostCSS)
* This is safe since the document has "<meta charset="utf-8">" anyway

### AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="218" height="239" alt="image" src="https://github.com/user-attachments/assets/b87a5844-685a-4796-99b9-641fa3e16f48" /> | <img width="241" height="211" alt="image" src="https://github.com/user-attachments/assets/dd2b33c2-ca1c-4dab-a4ee-9a6a9d31f499" />

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client