### PR TITLE
fix(external-call): grant additional permissions

### DIFF
--- a/src/components/ExternalCallView.vue
+++ b/src/components/ExternalCallView.vue
@@ -13,6 +13,25 @@ const { token } = defineProps<{
 	token: string
 }>()
 
+/** Allowed content within iframe sandbox */
+const sandbox = [
+	'allow-same-origin',
+	'allow-scripts',
+	'allow-forms',
+	'allow-popups',
+	'allow-presentation',
+	'allow-downloads',
+].join(' ')
+
+/** Allowed permissions within iframe */
+const allow = [
+	'camera',
+	'microphone',
+	'display-capture',
+	'fullscreen',
+	'clipboard-write',
+].join('; ')
+
 const actorStore = useActorStore()
 const callViewStore = useCallViewStore()
 
@@ -104,8 +123,8 @@ function onIframeRemoved() {
 			:src="externalCallServiceUrl"
 			title="External Call Service"
 			class="external-call-view__iframe"
-			sandbox="allow-same-origin allow-scripts allow-forms allow-popups allow-presentation"
-			allow="camera; microphone; display-capture; fullscreen"
+			:sandbox
+			:allow
 			loading="eager"
 			referrerpolicy="no-referrer"
 			crossorigin="anonymous" />


### PR DESCRIPTION
## ☑️ Resolves

Grant additional permissions for iframe with external call
- `allow-downloads`
- `clipboard-write`

### AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required