### PR TITLE
feat(call): multi speaker view

### DIFF
--- a/src/components/CallView/BottomBar.vue
+++ b/src/components/CallView/BottomBar.vue
@@ -23,6 +23,7 @@ import IconFullscreen from 'vue-material-design-icons/Fullscreen.vue'
 import IconFullscreenExit from 'vue-material-design-icons/FullscreenExit.vue'
 import IconSubtitles from 'vue-material-design-icons/Subtitles.vue'
 import IconSubtitlesOutline from 'vue-material-design-icons/SubtitlesOutline.vue'
+import IconViewDashboardOutline from 'vue-material-design-icons/ViewDashboardOutline.vue'
 import IconViewGalleryOutline from 'vue-material-design-icons/ViewGalleryOutline.vue'
 import IconViewGridOutline from 'vue-material-design-icons/ViewGridOutline.vue'
 import CallButton from '../TopBar/CallButton.vue'
@@ -159,14 +160,36 @@ const fullscreenLabel = computed(() => {
 		: t('spreed', 'Full screen (F)')
 })
 
-const changeViewLabel = computed(() => {
-	return isGrid.value
-		? t('spreed', 'Speaker view')
-		: t('spreed', 'Grid view')
-})
-
 const showCallLayoutSwitch = computed(() => !isSidebar && !callViewStore.isEmptyCallView)
 const isGrid = computed(() => callViewStore.isGrid)
+
+const CALL_LAYOUT = {
+	GRID: 'grid',
+	SPEAKER: 'speaker',
+	MULTI_SPEAKER: 'multi-speaker',
+} as const
+const CALL_LAYOUT_COMPONENT = {
+	[CALL_LAYOUT.GRID]: {
+		label: t('spreed', 'Grid view'),
+		icon: IconViewGridOutline,
+	},
+	[CALL_LAYOUT.SPEAKER]: {
+		label: t('spreed', 'Speaker view'),
+		icon: IconViewGalleryOutline,
+	},
+	[CALL_LAYOUT.MULTI_SPEAKER]: {
+		label: t('spreed', 'Multi-speaker view'),
+		icon: IconViewDashboardOutline,
+	},
+} as const
+type CallLayout = typeof CALL_LAYOUT[keyof typeof CALL_LAYOUT]
+const callLayouts = [CALL_LAYOUT.GRID, CALL_LAYOUT.SPEAKER, CALL_LAYOUT.MULTI_SPEAKER] as const
+const callLayout = computed(() => {
+	if (isGrid.value) {
+		return CALL_LAYOUT.GRID
+	}
+	return callViewStore.isMultiSpeaker ? CALL_LAYOUT.MULTI_SPEAKER : CALL_LAYOUT.SPEAKER
+})
 
 const COLLAPSIBLE_BUTTONS = ['virtualBackground', 'liveTranscription', 'callLayout', 'fullscreen'] as const
 type CollapsibleButtons = Record<typeof COLLAPSIBLE_BUTTONS[number], boolean>
@@ -423,10 +446,19 @@ async function disableLiveTranslation() {
 }
 
 /**
- * Switches the call view mode between grid and speaker view.
+ * Switches the call view to the given layout.
+ *
+ * @param layout the layout to switch to
  */
-function changeView() {
-	callViewStore.setCallViewMode({ token: token.value, isGrid: !isGrid.value, clearLast: false })
+function setCallLayout(layout: CallLayout) {
+	callViewStore.setCallViewMode({
+		token: token.value,
+		isGrid: layout === CALL_LAYOUT.GRID,
+		// Picking the grid says nothing about how speaker view should look, so
+		// the preference is kept for when it is picked again
+		isMultiSpeaker: layout === CALL_LAYOUT.GRID ? null : layout === CALL_LAYOUT.MULTI_SPEAKER,
+		clearLast: false,
+	})
 	callViewStore.setSelectedVideoPeerId(null)
 }
 </script>
@@ -447,17 +479,28 @@ function changeView() {
 				</template>
 			</NcButton>
 			<!-- Call layout switcher -->
-			<NcButton
+			<NcActions
 				v-if="showCallLayoutSwitch && !hidingList.callLayout"
 				variant="tertiary"
-				:aria-label="changeViewLabel"
-				:title="changeViewLabel"
-				@click="changeView">
+				:aria-label="CALL_LAYOUT_COMPONENT[callLayout].label"
+				:title="CALL_LAYOUT_COMPONENT[callLayout].label">
 				<template #icon>
-					<IconViewGridOutline v-if="!isGrid" :size="20" />
-					<IconViewGalleryOutline v-else :size="20" />
+					<component :is="CALL_LAYOUT_COMPONENT[callLayout].icon" :size="20" />
 				</template>
-			</NcButton>
+				<NcActionButton
+					v-for="layout in callLayouts"
+					:key="layout"
+					:modelValue="callLayout"
+					:value="layout"
+					type="radio"
+					closeAfterClick
+					@click="setCallLayout(layout)">
+					<template #icon>
+						<component :is="CALL_LAYOUT_COMPONENT[layout].icon" :size="20" />
+					</template>
+					{{ CALL_LAYOUT_COMPONENT[layout].label }}
+				</NcActionButton>
+			</NcActions>
 		</div>
 
 		<div class="bottom-bar-call-controls">
@@ -590,18 +633,21 @@ function changeView() {
 					{{ fullscreenLabel }}
 				</NcActionButton>
 				<!-- Call layout switcher -->
-				<NcActionButton
-					v-if="hidingList.callLayout && showCallLayoutSwitch"
-					variant="tertiary"
-					:aria-label="changeViewLabel"
-					:title="changeViewLabel"
-					@click="changeView">
-					<template #icon>
-						<IconViewGridOutline v-if="!isGrid" :size="20" />
-						<IconViewGalleryOutline v-else :size="20" />
-					</template>
-					{{ changeViewLabel }}
-				</NcActionButton>
+				<template v-if="hidingList.callLayout && showCallLayoutSwitch">
+					<NcActionButton
+						v-for="layout in callLayouts"
+						:key="layout"
+						:modelValue="callLayout"
+						:value="layout"
+						type="radio"
+						closeAfterClick
+						@click="setCallLayout(layout)">
+						<template #icon>
+							<component :is="CALL_LAYOUT_COMPONENT[layout].icon" :size="20" />
+						</template>
+						{{ CALL_LAYOUT_COMPONENT[layout].label }}
+					</NcActionButton>
+				</template>
 				<NcActionButton
 					v-if="isLiveTranscriptionSupported && hidingList.liveTranscription"
 					:title="liveTranscriptionButtonLabel"

--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -199,6 +199,7 @@ import { callParticipantCollection, localCallParticipantModel, localMediaModel }
 import RemoteVideoBlocker from '../../utils/webrtc/RemoteVideoBlocker.js'
 import { placeholderImage, placeholderModel, placeholderName, placeholderSharedData } from './Grid/gridPlaceholders.ts'
 import { animateTilePromotion } from './Grid/tilePromotionTransition.ts'
+import { setUpSpeakerSimulation, tearDownSpeakerSimulation } from './speakerSimulation.ts'
 import { useActiveSpeakers } from './useActiveSpeakers.ts'
 import { useWakeLock } from './useWakeLock.ts'
 
@@ -673,9 +674,17 @@ export default {
 		callParticipantCollection.on('remove', this._lowerHandWhenParticipantLeaves)
 
 		subscribe('switch-screen-to-id', this._switchScreenToId)
+
+		if (OC.debug) {
+			setUpSpeakerSimulation(this.token)
+		}
 	},
 
 	beforeUnmount() {
+		if (OC.debug) {
+			tearDownSpeakerSimulation()
+		}
+
 		this.debounceFetchPeers.clear?.()
 		this.debounceHandleMovement.clear?.()
 		this.callViewStore.setIsEmptyCallView(true)

--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -83,6 +83,7 @@
 					<VideoVue
 						v-else-if="promotedParticipantModel"
 						:key="`autopilot-${promotedParticipantModel.attributes.peerId}`"
+						:data-tile-session-id="showSpeakers ? promotedParticipantModel.attributes.nextcloudSessionId : undefined"
 						:token="token"
 						:model="promotedParticipantModel"
 						:sharedData="sharedDatas[promotedParticipantModel.attributes.peerId]"
@@ -196,6 +197,7 @@ import { useSettingsStore } from '../../stores/settings.ts'
 import { callParticipantCollection, localCallParticipantModel, localMediaModel } from '../../utils/webrtc/index.js'
 import RemoteVideoBlocker from '../../utils/webrtc/RemoteVideoBlocker.js'
 import { placeholderImage, placeholderModel, placeholderName, placeholderSharedData } from './Grid/gridPlaceholders.ts'
+import { animateTilePromotion } from './Grid/tilePromotionTransition.ts'
 import { useActiveSpeakers } from './useActiveSpeakers.ts'
 import { useWakeLock } from './useWakeLock.ts'
 
@@ -348,6 +350,16 @@ export default {
 			return this.showSpeakers && this.promotedSpeakerModels.length > 1
 		},
 
+		// Session ids of the tiles actually shown in the main area, empty when a
+		// single participant is promoted there as usual
+		promotedSpeakerSessionIds() {
+			if (!this.showSpeakersGrid) {
+				return []
+			}
+
+			return this.promotedSpeakerModels.map((model) => model.attributes.nextcloudSessionId)
+		},
+
 		// Peer ids of the speakers actually shown in the main area, which deserve
 		// the same video quality as a single promoted participant
 		promotedSpeakerPeerIds() {
@@ -365,7 +377,7 @@ export default {
 				return this.callParticipantModels
 			}
 
-			const promoted = new Set(this.promotedSpeakerModels.map((model) => model.attributes.nextcloudSessionId))
+			const promoted = new Set(this.promotedSpeakerSessionIds)
 			return this.callParticipantModels.filter((model) => !promoted.has(model.attributes.nextcloudSessionId))
 		},
 
@@ -551,6 +563,12 @@ export default {
 
 		isMultiSpeaker() {
 			this._setPromotedParticipant()
+		},
+
+		promotedSpeakerSessionIds(sessionIds, previousSessionIds) {
+			// Runs before the grids are re-rendered, while the tiles are still
+			// where they are about to move from
+			animateTilePromotion(sessionIds, previousSessionIds)
 		},
 
 		speakers: {

--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -70,6 +70,15 @@
 						:showVideoOverlay="showVideoOverlay"
 						:sharedData="sharedDatas[shownRemoteScreenPeerId]"
 						isBig />
+					<!-- Several active speakers sharing the main area -->
+					<SpeakersGrid
+						v-else-if="showSpeakersGrid"
+						:token="token"
+						:models="promotedSpeakerModels"
+						:sharedDatas="sharedDatas"
+						:showVideoOverlay="showVideoOverlay"
+						:isOneToOne="isOneToOne"
+						@selectVideo="handleSelectVideo" />
 					<!-- Promoted "autopilot" mode -->
 					<VideoVue
 						v-else-if="promotedParticipantModel"
@@ -116,7 +125,7 @@
 					:isRecording="isRecording"
 					:token="token"
 					:isOverlap="showFullPage"
-					:callParticipantModels="callParticipantModels"
+					:callParticipantModels="stripeParticipantModels"
 					:screens="screens"
 					:localMediaModel="localMediaModel"
 					:localCallParticipantModel="localCallParticipantModel"
@@ -164,8 +173,9 @@ import { subscribe, unsubscribe } from '@nextcloud/event-bus'
 import { loadState } from '@nextcloud/initial-state'
 import { t } from '@nextcloud/l10n'
 import debounce from 'debounce'
-import { provide, ref } from 'vue'
+import { computed, provide, ref } from 'vue'
 import BottomBar from './BottomBar.vue'
+import SpeakersGrid from './Grid/SpeakersGrid.vue'
 import VideosGrid from './Grid/VideosGrid.vue'
 import EmptyCallView from './shared/EmptyCallView.vue'
 import LiveTranscriptionRenderer from './shared/LiveTranscriptionRenderer.vue'
@@ -186,6 +196,7 @@ import { useSettingsStore } from '../../stores/settings.ts'
 import { callParticipantCollection, localCallParticipantModel, localMediaModel } from '../../utils/webrtc/index.js'
 import RemoteVideoBlocker from '../../utils/webrtc/RemoteVideoBlocker.js'
 import { placeholderImage, placeholderModel, placeholderName, placeholderSharedData } from './Grid/gridPlaceholders.ts'
+import { useActiveSpeakers } from './useActiveSpeakers.ts'
 import { useWakeLock } from './useWakeLock.ts'
 
 const serverVersion = loadState('core', 'config', {}).version ?? '29.0.0.0'
@@ -202,6 +213,7 @@ export default {
 		PresenterOverlay,
 		ReactionToaster,
 		ScreenShare,
+		SpeakersGrid,
 		VideoBottomBar,
 		VideoVue,
 		ViewerOverlayCallView,
@@ -226,7 +238,7 @@ export default {
 		},
 	},
 
-	setup() {
+	setup(props) {
 		// Prevent the screen from turning off
 		useWakeLock()
 
@@ -243,14 +255,34 @@ export default {
 		}
 
 		const participantActivityStore = useParticipantActivityStore()
+		const callViewStore = useCallViewStore()
+
+		const callParticipantModels = computed(() => {
+			return callParticipantCollection.callParticipantModels
+				.filter((callParticipantModel) => !callParticipantModel.attributes.internal || callParticipantModel.attributes.videoAvailable)
+		})
+
+		// Several speakers share the main area only in speaker view, and only
+		// when asked for. The sidebar has a layout of its own.
+		const isMultiSpeaker = computed(() => {
+			return callViewStore.isMultiSpeaker && !callViewStore.isGrid && !props.isSidebar
+		})
+
+		const { promotedSessionIds } = useActiveSpeakers({
+			callParticipantModels,
+			enabled: isMultiSpeaker,
+		})
 
 		return {
 			localMediaModel,
 			localCallParticipantModel,
 			callParticipantCollection,
+			callParticipantModels,
 			devMode,
-			callViewStore: useCallViewStore(),
+			callViewStore,
 			participantActivityStore,
+			isMultiSpeaker,
+			promotedSessionIds,
 		}
 	},
 
@@ -281,12 +313,60 @@ export default {
 		promotedParticipantModel() {
 			// Ensure at least one participant is always promoted to show in autopilot
 			return this.forcePromotedModel
+				// A single active speaker keeps the main area for itself, rather
+				// than being the only tile of the speakers grid
+				?? (this.showSpeakers ? this.promotedSpeakerModels[0] : undefined)
 				?? this.callParticipantModels.find((callParticipantModel) => this.sharedDatas[callParticipantModel.attributes.peerId].promoted)
 				?? this.callParticipantModels[0]
 		},
 
-		callParticipantModels() {
-			return callParticipantCollection.callParticipantModels.filter((callParticipantModel) => !callParticipantModel.attributes.internal || callParticipantModel.attributes.videoAvailable)
+		// The speakers currently sharing the main area, in the order they became
+		// active
+		promotedSpeakerModels() {
+			return this.promotedSessionIds
+				.map((sessionId) => this.callParticipantModels.find((model) => model.attributes.nextcloudSessionId === sessionId))
+				.filter((model) => model !== undefined)
+		},
+
+		// Whether the active speakers rule the main area. Until somebody has
+		// spoken there is none, and the single promoted participant is shown as
+		// usual.
+		showSpeakers() {
+			return this.isMultiSpeaker
+				&& !this.showSelectedVideo
+				&& !this.showLocalVideo
+				&& !this.showLocalScreen
+				&& !this.showRemoteScreen
+				&& !this.showSelectedScreen
+				&& this.promotedSpeakerModels.length > 0
+		},
+
+		// Whether the main area is shared between several speakers. A lone
+		// speaker is shown as the promoted participant instead, so that the
+		// speaker they already were is not moved around for nothing.
+		showSpeakersGrid() {
+			return this.showSpeakers && this.promotedSpeakerModels.length > 1
+		},
+
+		// Peer ids of the speakers actually shown in the main area, which deserve
+		// the same video quality as a single promoted participant
+		promotedSpeakerPeerIds() {
+			if (!this.showSpeakers) {
+				return new Set()
+			}
+
+			return new Set(this.promotedSpeakerModels.map((model) => model.attributes.peerId))
+		},
+
+		// The tiles of the stripe. Speakers shown in the main area are taken out
+		// of it, as they moved from the stripe into their slot.
+		stripeParticipantModels() {
+			if (!this.showSpeakersGrid) {
+				return this.callParticipantModels
+			}
+
+			const promoted = new Set(this.promotedSpeakerModels.map((model) => model.attributes.nextcloudSessionId))
+			return this.callParticipantModels.filter((model) => !promoted.has(model.attributes.nextcloudSessionId))
 		},
 
 		callParticipantModelsWithScreen() {
@@ -461,6 +541,16 @@ export default {
 
 		selectedVideoPeerId() {
 			this.adjustSimulcastQuality()
+		},
+
+		// A speaker entering or leaving the promoted area is what promotes them,
+		// so the flag is set from here rather than from `speakers`
+		promotedSpeakerPeerIds() {
+			this._setPromotedParticipant()
+		},
+
+		isMultiSpeaker() {
+			this._setPromotedParticipant()
 		},
 
 		speakers: {
@@ -709,20 +799,29 @@ export default {
 		},
 
 		_setPromotedParticipant() {
-			let promotedPeerId = null
+			let promotedPeerIds = []
 
-			if (!this.screenSharingActive && this.speakers.length) {
-				promotedPeerId = this.speakers[0].id
-			} else if (this.shownRemoteScreenPeerId && this.sharedDatas[this.shownRemoteScreenPeerId]) {
-				promotedPeerId = this.shownRemoteScreenPeerId
+			if (this.screenSharingActive) {
+				if (this.shownRemoteScreenPeerId) {
+					promotedPeerIds = [this.shownRemoteScreenPeerId]
+				}
+			} else if (this.isMultiSpeaker) {
+				// The promoted flag follows the promoted area rather than whoever
+				// speaks: a speaker only moves up once they spoke long enough, and
+				// promoting them as soon as they speak would mark a tile that is
+				// still in the stripe as promoted.
+				promotedPeerIds = this.promotedSpeakerModels.map((model) => model.attributes.peerId)
+			} else if (this.speakers.length) {
+				promotedPeerIds = [this.speakers[0].id]
 			}
 
+			promotedPeerIds = promotedPeerIds.filter((peerId) => this.sharedDatas[peerId])
+
 			// Ensure at least one participant is always promoted to show in autopilot
-			if (promotedPeerId && this.sharedDatas[promotedPeerId]) {
+			if (promotedPeerIds.length) {
 				Object.keys(this.sharedDatas).forEach((peerId) => {
-					this.sharedDatas[peerId].promoted = false
+					this.sharedDatas[peerId].promoted = promotedPeerIds.includes(peerId)
 				})
-				this.sharedDatas[promotedPeerId].promoted = true
 			}
 
 			this.adjustSimulcastQuality()
@@ -834,7 +933,9 @@ export default {
 			// bad specially with a low number of participants.
 			if (this.isGrid) {
 				callParticipantModel.setSimulcastVideoQuality(SIMULCAST.MEDIUM, SIMULCAST.HIGH)
-			} else if (this.sharedDatas[callParticipantModel.attributes.peerId].promoted || this.selectedVideoPeerId === callParticipantModel.attributes.peerId) {
+			} else if (this.sharedDatas[callParticipantModel.attributes.peerId].promoted
+				|| this.selectedVideoPeerId === callParticipantModel.attributes.peerId
+				|| this.promotedSpeakerPeerIds.has(callParticipantModel.attributes.peerId)) {
 				callParticipantModel.setSimulcastVideoQuality(SIMULCAST.HIGH, SIMULCAST.HIGH)
 			} else {
 				callParticipantModel.setSimulcastVideoQuality(SIMULCAST.LOW, SIMULCAST.HIGH)

--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -22,13 +22,14 @@
 
 			<div id="videos" :class="{ 'is-sidebar': isSidebar }">
 				<div
-					v-if="devMode ? !isGrid : (!isGrid || !callParticipantModels.length)"
+					v-if="showPromotedArea"
 					class="video__promoted"
 					:class="{ 'full-page': showFullPage }">
 					<!-- Selected video override mode -->
 					<VideoVue
 						v-if="showSelectedVideo && selectedCallParticipantModel"
 						:key="`promoted-${selectedVideoPeerId}`"
+						:data-tile-session-id="selectedCallParticipantModel.attributes.nextcloudSessionId"
 						:token="token"
 						:model="selectedCallParticipantModel"
 						:sharedData="sharedDatas[selectedVideoPeerId]"
@@ -83,7 +84,7 @@
 					<VideoVue
 						v-else-if="promotedParticipantModel"
 						:key="`autopilot-${promotedParticipantModel.attributes.peerId}`"
-						:data-tile-session-id="showSpeakers ? promotedParticipantModel.attributes.nextcloudSessionId : undefined"
+						:data-tile-session-id="promotedParticipantModel.attributes.nextcloudSessionId"
 						:token="token"
 						:model="promotedParticipantModel"
 						:sharedData="sharedDatas[promotedParticipantModel.attributes.peerId]"
@@ -122,7 +123,7 @@
 				<!-- Stripe or fullscreen grid depending on `isGrid` -->
 				<VideosGrid
 					v-if="!isSidebar"
-					:isStripe="devMode ? !isGrid : (!isGrid || !callParticipantModels.length)"
+					:isStripe="showPromotedArea"
 					:isRecording="isRecording"
 					:token="token"
 					:isOverlap="showFullPage"
@@ -350,14 +351,39 @@ export default {
 			return this.showSpeakers && this.promotedSpeakerModels.length > 1
 		},
 
-		// Session ids of the tiles actually shown in the main area, empty when a
-		// single participant is promoted there as usual
-		promotedSpeakerSessionIds() {
-			if (!this.showSpeakersGrid) {
+		// Whether the promoted area is shown next to the stripe, rather than the
+		// grid taking the whole view
+		showPromotedArea() {
+			return this.devMode ? !this.isGrid : (!this.isGrid || !this.callParticipantModels.length)
+		},
+
+		// Session ids of the participant tiles shown in the promoted area, be it
+		// the active speakers, a selected video or the promoted participant.
+		//
+		// A screen share holds no participant tile: the camera of whoever shares
+		// it is only shown in the stripe, so nothing is taken out of it.
+		promotedAreaSessionIds() {
+			if (!this.showPromotedArea
+				|| this.showLocalVideo
+				|| this.showLocalScreen
+				|| this.showRemoteScreen
+				|| this.showSelectedScreen) {
 				return []
 			}
 
-			return this.promotedSpeakerModels.map((model) => model.attributes.nextcloudSessionId)
+			if (this.showSelectedVideo) {
+				return this.selectedCallParticipantModel
+					? [this.selectedCallParticipantModel.attributes.nextcloudSessionId]
+					: []
+			}
+
+			if (this.showSpeakersGrid) {
+				return this.promotedSpeakerModels.map((model) => model.attributes.nextcloudSessionId)
+			}
+
+			return this.promotedParticipantModel
+				? [this.promotedParticipantModel.attributes.nextcloudSessionId]
+				: []
 		},
 
 		// Peer ids of the speakers actually shown in the main area, which deserve
@@ -370,14 +396,15 @@ export default {
 			return new Set(this.promotedSpeakerModels.map((model) => model.attributes.peerId))
 		},
 
-		// The tiles of the stripe. Speakers shown in the main area are taken out
-		// of it, as they moved from the stripe into their slot.
+		// The tiles of the stripe. Whoever is shown in the promoted area is taken
+		// out of it, as they moved from the stripe into their slot rather than
+		// being shown twice.
 		stripeParticipantModels() {
-			if (!this.showSpeakersGrid) {
+			if (!this.promotedAreaSessionIds.length) {
 				return this.callParticipantModels
 			}
 
-			const promoted = new Set(this.promotedSpeakerSessionIds)
+			const promoted = new Set(this.promotedAreaSessionIds)
 			return this.callParticipantModels.filter((model) => !promoted.has(model.attributes.nextcloudSessionId))
 		},
 
@@ -565,7 +592,7 @@ export default {
 			this._setPromotedParticipant()
 		},
 
-		promotedSpeakerSessionIds(sessionIds, previousSessionIds) {
+		promotedAreaSessionIds(sessionIds, previousSessionIds) {
 			// Runs before the grids are re-rendered, while the tiles are still
 			// where they are about to move from
 			animateTilePromotion(sessionIds, previousSessionIds)

--- a/src/components/CallView/Grid/SpeakersGrid.vue
+++ b/src/components/CallView/Grid/SpeakersGrid.vue
@@ -96,6 +96,7 @@ function tileStyle(index: number) {
 				:key="model.attributes.peerId"
 				class="speakers-grid__tile"
 				:style="tileStyle(index)"
+				:data-tile-session-id="model.attributes.nextcloudSessionId"
 				:token="token"
 				:model="model"
 				:sharedData="sharedDatas[model.attributes.peerId]"

--- a/src/components/CallView/Grid/SpeakersGrid.vue
+++ b/src/components/CallView/Grid/SpeakersGrid.vue
@@ -1,0 +1,133 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<script setup lang="ts">
+import { computed, ref, useTemplateRef } from 'vue'
+import VideoVue from '../shared/VideoVue.vue'
+import {
+	computeTilePlacements,
+	getHalfColumnCount,
+	getHalfColumnMinWidth,
+	TILE_COLUMN_SPAN,
+} from './gridLayout.ts'
+import { useGridDimensions } from './useGridDimensions.ts'
+
+const props = defineProps<{
+	/** Token of the conversation the call belongs to */
+	token: string
+	/** The promoted participant models, in the order they became active */
+	models: { attributes: { peerId: string, nextcloudSessionId: string } }[]
+	/** Per participant shared state, keyed by peer id */
+	sharedDatas: Record<string, object>
+	/** Whether the video overlay is currently shown */
+	showVideoOverlay?: boolean
+	/** Whether the call is a one to one conversation */
+	isOneToOne?: boolean
+}>()
+
+const emit = defineEmits<{
+	selectVideo: [peerId: string]
+}>()
+
+const wrapper = useTemplateRef('wrapper')
+const grid = useTemplateRef('grid')
+
+const videoCount = computed(() => props.models.length)
+
+// This grid only ever holds promoted speakers, the local video lives in the
+// stripe below it.
+const noLocalVideoReserve = ref(true)
+
+const {
+	columns,
+	rows,
+	dpiAwareMinWidth,
+	dpiAwareMinHeight,
+} = useGridDimensions({
+	wrapper,
+	grid,
+	isStripe: ref(false),
+	isSidebar: ref(false),
+	noLocalVideoReserve,
+	videoCount,
+	stripeOpen: ref(false),
+})
+
+// Placement of every tile, so that a row leaving an odd number of columns
+// empty is centered rather than left-aligned (three speakers give one
+// centered tile below two).
+const tilePlacements = computed(() => computeTilePlacements({
+	totalTiles: videoCount.value,
+	rows: rows.value,
+	columns: columns.value,
+}))
+
+const gridStyle = computed(() => ({
+	gridTemplateColumns: `repeat(${getHalfColumnCount(columns.value)}, minmax(${getHalfColumnMinWidth(dpiAwareMinWidth.value)}px, 1fr))`,
+	gridTemplateRows: `repeat(${rows.value}, minmax(${dpiAwareMinHeight.value}px, 1fr))`,
+}))
+
+/**
+ * Explicit placement of a tile in the grid. Columns are counted in half
+ * columns, which the grid flips on its own in RTL layouts.
+ *
+ * @param index - rendering position of the tile
+ */
+function tileStyle(index: number) {
+	const placement = tilePlacements.value[index]
+	if (!placement) {
+		return undefined
+	}
+
+	return {
+		gridRow: placement.row,
+		gridColumn: `${placement.column} / span ${TILE_COLUMN_SPAN}`,
+	}
+}
+</script>
+
+<template>
+	<div ref="wrapper" class="speakers-grid-wrapper">
+		<div ref="grid" class="speakers-grid" :style="gridStyle">
+			<VideoVue
+				v-for="(model, index) in models"
+				:key="model.attributes.peerId"
+				class="speakers-grid__tile"
+				:style="tileStyle(index)"
+				:token="token"
+				:model="model"
+				:sharedData="sharedDatas[model.attributes.peerId]"
+				:showVideoOverlay="showVideoOverlay"
+				:isOneToOne="isOneToOne"
+				isGrid
+				fitVideo
+				@clickVideo="emit('selectVideo', model.attributes.peerId)" />
+		</div>
+	</div>
+</template>
+
+<style lang="scss" scoped>
+.speakers-grid-wrapper {
+	width: 100%;
+	height: 100%;
+	min-width: 0;
+}
+
+.speakers-grid {
+	display: grid;
+	width: 100%;
+	height: 100%;
+
+	row-gap: var(--grid-gap);
+	column-gap: var(--grid-gap);
+
+	// The grid is laid out in half columns, so a tile takes two of them by
+	// default. Explicitly placed tiles set their own start line but keep that
+	// span (see `TILE_COLUMN_SPAN`).
+	> * {
+		grid-column: span 2;
+	}
+}
+</style>

--- a/src/components/CallView/Grid/VideosGrid.vue
+++ b/src/components/CallView/Grid/VideosGrid.vue
@@ -299,12 +299,16 @@ export default {
 			return videosCap ? Math.min(videosCap, count) : count
 		})
 
+		// The full grid reserves one slot for the local video, unless it is not
+		// shown (stripe or recording mode).
+		const noLocalVideoReserve = computed(() => props.isStripe || props.isRecording)
+
 		const gridDimensions = useGridDimensions({
 			wrapper: gridWrapper,
 			grid,
 			isStripe: toRef(() => props.isStripe),
 			isSidebar: toRef(() => props.isSidebar),
-			isRecording: toRef(() => props.isRecording),
+			noLocalVideoReserve,
 			videoCount: cappedVideosCount,
 			stripeOpen,
 		})
@@ -318,7 +322,7 @@ export default {
 		// consistent even before the layout has been recomputed.
 		const slots = computed(() => {
 			const gridSlots = gridDimensions.rows.value * gridDimensions.columns.value
-			const slots = gridDimensions.noLocalVideoReserve.value ? gridSlots : gridSlots - 1
+			const slots = noLocalVideoReserve.value ? gridSlots : gridSlots - 1
 			return videosCap ? Math.min(videosCap, slots) : slots
 		})
 
@@ -380,6 +384,7 @@ export default {
 			gridWrapper,
 			grid,
 			stripeOpen,
+			noLocalVideoReserve,
 			...gridDimensions,
 		}
 	},

--- a/src/components/CallView/Grid/VideosGrid.vue
+++ b/src/components/CallView/Grid/VideosGrid.vue
@@ -52,6 +52,7 @@
 								:key="callParticipantModel.attributes.peerId"
 								:class="{ video: !isStripe }"
 								:style="tileStyle(index)"
+								:data-tile-session-id="callParticipantModel.attributes.nextcloudSessionId"
 								:showVideoOverlay="showVideoOverlay"
 								:token="token"
 								:model="callParticipantModel"

--- a/src/components/CallView/Grid/tilePromotionTransition.ts
+++ b/src/components/CallView/Grid/tilePromotionTransition.ts
@@ -1,0 +1,149 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { nextTick } from 'vue'
+
+/** Duration (in ms) of the travel of a tile between the stripe and its slot. */
+const TRANSITION_DURATION = 300
+
+/**
+ * Data attribute the animated tiles are looked up by. Both the stripe and the
+ * speakers grid tag their tiles with it.
+ */
+export const TILE_SESSION_ATTRIBUTE = 'data-tile-session-id'
+
+/**
+ * @param sessionId - session id of the tile to look up
+ */
+function findTile(sessionId: string): HTMLElement | null {
+	return document.querySelector(`[${TILE_SESSION_ATTRIBUTE}="${CSS.escape(sessionId)}"]`)
+}
+
+/**
+ * Kept around rather than queried again every time, as its `matches` already
+ * follows the setting when the user changes it mid-call. Only built on the
+ * first animation, so that importing this module does not require a document.
+ */
+let reducedMotionQuery: MediaQueryList | undefined
+
+/**
+ * Whether the user asked not to be shown motion.
+ */
+function prefersReducedMotion(): boolean {
+	reducedMotionQuery ??= window.matchMedia('(prefers-reduced-motion: reduce)')
+	return reducedMotionQuery.matches
+}
+
+/**
+ * Move a tile from where it was to where it now is.
+ *
+ * The tile is rendered by a different grid before and after the change, so it
+ * cannot simply be transitioned: it is a new element in a new place. It is
+ * instead put back over the old one with a transform and then released, which
+ * reads as a single tile travelling to its new spot.
+ *
+ * @param sessionId - session id of the tile to animate
+ * @param from - bounding rectangle the tile had before the change
+ */
+function animateTile(sessionId: string, from: DOMRect) {
+	const tile = findTile(sessionId)
+	if (!tile) {
+		return
+	}
+
+	const to = tile.getBoundingClientRect()
+	if (!from.width || !from.height || !to.width || !to.height) {
+		// One of the two grids was not laid out, there is nothing to travel
+		// between
+		return
+	}
+
+	if (from.left === to.left && from.top === to.top
+		&& from.width === to.width && from.height === to.height) {
+		// The tile did not move, so no transition would start and the styles
+		// applied below would never be handed back
+		return
+	}
+
+	/**
+	 * Hand the tile back to the layout.
+	 *
+	 * @param event - the transition that ended, when called as a listener
+	 */
+	function reset(event?: TransitionEvent) {
+		// Tiles hold overlays and buttons transitioning on their own, and those
+		// events bubble up to here
+		if (event && (event.target !== tile || event.propertyName !== 'transform')) {
+			return
+		}
+
+		tile!.style.transition = ''
+		tile!.style.transform = ''
+		tile!.style.transformOrigin = ''
+		tile!.style.pointerEvents = ''
+		tile!.removeEventListener('transitionend', reset)
+		tile!.removeEventListener('transitioncancel', reset)
+	}
+
+	tile.style.transition = 'none'
+	tile.style.transformOrigin = 'top left'
+	tile.style.transform = `translate(${from.left - to.left}px, ${from.top - to.top}px)`
+		+ ` scale(${from.width / to.width}, ${from.height / to.height})`
+	// A tile on its way is not a target: it would be hovered where it is only
+	// passing by, and clicked while no longer under the cursor
+	tile.style.pointerEvents = 'none'
+
+	// Apply the offset before transitioning it away, otherwise the tile is
+	// simply painted at its new place
+	tile.offsetWidth
+
+	tile.addEventListener('transitionend', reset)
+	// Nothing else ends the transition when it is taken over, for instance by
+	// another change moving the tile again
+	tile.addEventListener('transitioncancel', reset)
+	tile.style.transition = `transform ${TRANSITION_DURATION}ms ease-in-out`
+	tile.style.transform = ''
+}
+
+/**
+ * Animates the tiles entering or leaving the main area, so that a promoted
+ * speaker is seen travelling from the stripe into its slot rather than
+ * appearing there, and the other way around once it is demoted.
+ *
+ * The speakers that keep their spot travel as well: they make room for the
+ * newcomer, or take back the space of whoever left, at the same time and pace,
+ * so the main area is seen rearranging itself as a whole.
+ *
+ * Must be called while the tiles are still in their old place, that is from a
+ * watcher with the default `pre` flush, before the grids are re-rendered.
+ *
+ * @param sessionIds - session ids of the tiles of the main area
+ * @param previousSessionIds - the same, before the change
+ */
+export function animateTilePromotion(sessionIds: string[], previousSessionIds: string[]) {
+	if (prefersReducedMotion()) {
+		return
+	}
+
+	// Everyone in the main area before or after the change: those coming in,
+	// those going out, and those simply resized by the new layout
+	const involved = new Set([...previousSessionIds, ...sessionIds])
+
+	const origins = new Map<string, DOMRect>()
+	involved.forEach((sessionId) => {
+		const rect = findTile(sessionId)?.getBoundingClientRect()
+		if (rect) {
+			origins.set(sessionId, rect)
+		}
+	})
+
+	if (!origins.size) {
+		return
+	}
+
+	nextTick(() => {
+		origins.forEach((rect, sessionId) => animateTile(sessionId, rect))
+	})
+}

--- a/src/components/CallView/Grid/useGridDimensions.ts
+++ b/src/components/CallView/Grid/useGridDimensions.ts
@@ -18,8 +18,8 @@ type UseGridDimensionsOptions = {
 	isStripe: Readonly<Ref<boolean>>
 	/** Whether the grid is shown inside the sidebar */
 	isSidebar: Readonly<Ref<boolean>>
-	/** Whether the call is being recorded (the local video is then not shown) */
-	isRecording: Readonly<Ref<boolean>>
+	/** Whether no slot must be reserved for the local video */
+	noLocalVideoReserve: Readonly<Ref<boolean>>
 	/** Number of tiles to lay out (already clamped to any cap) */
 	videoCount: Readonly<Ref<number>>
 	/** Whether the stripe is expanded (only relevant in stripe mode) */
@@ -37,7 +37,7 @@ type UseGridDimensionsOptions = {
  * @param options.grid - grid element whose client size drives the layout
  * @param options.isStripe - whether the grid is shown as a stripe
  * @param options.isSidebar - whether the grid is shown inside the sidebar
- * @param options.isRecording - whether the call is being recorded
+ * @param options.noLocalVideoReserve - whether no slot must be reserved for the local video
  * @param options.videoCount - number of tiles to lay out (already clamped to any cap)
  * @param options.stripeOpen - whether the stripe is expanded
  */
@@ -46,7 +46,7 @@ export function useGridDimensions({
 	grid,
 	isStripe,
 	isSidebar,
-	isRecording,
+	noLocalVideoReserve,
 	videoCount,
 	stripeOpen,
 }: UseGridDimensionsOptions) {
@@ -81,10 +81,6 @@ export function useGridDimensions({
 	const dpiAwareMinHeight = computed(() => minHeight.value / dpiFactor.value)
 	const targetAspectRatio = computed(() => getTargetAspectRatio(isStripe.value))
 	const gridAspectRatio = computed(() => (gridWidth.value / gridHeight.value).toPrecision(2))
-
-	// The full grid reserves one slot for the local video, unless it is not shown
-	// (stripe or recording mode).
-	const noLocalVideoReserve = computed(() => isStripe.value || isRecording.value)
 
 	/**
 	 * Measure the grid element and recompute the number of columns and rows.
@@ -135,11 +131,11 @@ export function useGridDimensions({
 	// The number of tiles changed: the available size is unchanged, recompute now.
 	watch(videoCount, recompute)
 
-	// Switching mode, (un)collapsing the stripe or toggling recording changes the
-	// element visibility and size (and whether a local-video slot is reserved), so
-	// recompute on the next tick once the DOM has settled. When the grid is hidden
-	// the element is unmounted and `recompute` is a no-op.
-	watch([isStripe, stripeOpen, isRecording], () => nextTick(recompute))
+	// Switching mode, (un)collapsing the stripe or reserving a slot for the local
+	// video changes the element visibility and size, so recompute on the next tick
+	// once the DOM has settled. When the grid is hidden the element is unmounted
+	// and `recompute` is a no-op.
+	watch([isStripe, stripeOpen, noLocalVideoReserve], () => nextTick(recompute))
 
 	return {
 		gridWidth,
@@ -153,7 +149,6 @@ export function useGridDimensions({
 		dpiAwareMinHeight,
 		targetAspectRatio,
 		gridAspectRatio,
-		noLocalVideoReserve,
 		/** Force a re-measure and recompute (e.g. for debugging) */
 		recompute,
 	}

--- a/src/components/CallView/speakerSimulation.ts
+++ b/src/components/CallView/speakerSimulation.ts
@@ -1,0 +1,211 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * Development helper: fakes a conversation between six participants so the
+ * multi-speaker layout can be exercised without a room full of people.
+ *
+ * Only active in debug mode: the call view sets it up and tears it down only
+ * when `OC.debug` is truthy.
+ *
+ * Automatically starts when joining the call of `SIMULATION_TOKEN`, and can be
+ * driven by hand from the console:
+ *
+ *     OCA.Talk.speakerSimulation.start()      // (re)start the timeline
+ *     OCA.Talk.speakerSimulation.start(2)     // 2x faster, see `start()`
+ *     OCA.Talk.speakerSimulation.stop()
+ *     OCA.Talk.speakerSimulation.speak(2, 5)  // make participant 2 speak 5s
+ */
+
+import { reactive } from 'vue'
+import { callParticipantCollection } from '../../utils/webrtc/index.js'
+import { ConnectionState } from '../../utils/webrtc/models/CallParticipantModel.js'
+import { placeholderName } from './Grid/gridPlaceholders.ts'
+
+/** Conversation the simulation starts in on its own. */
+export const SIMULATION_TOKEN = 'mmhc6xg4'
+
+const PARTICIPANT_COUNT = 6
+
+/**
+ * One turn of speech: who speaks, when they start (in seconds from the
+ * beginning of the timeline) and for how long.
+ *
+ * The timeline is built to exercise every rule of the layout, and loops.
+ */
+const TIMELINE: { speaker: number, at: number, duration: number }[] = [
+	// A holds the floor: promoted at 3s, alone in the main area
+	{ speaker: 0, at: 0, duration: 20 },
+	// B asks a question: the main area splits in two at 9s
+	{ speaker: 1, at: 6, duration: 6 },
+	// Too short to count, the layout must not move
+	{ speaker: 2, at: 14, duration: 2 },
+	// C answers properly: three tiles at 21s, the last one centered
+	{ speaker: 2, at: 18, duration: 8 },
+	// D joins in at 27s with every spot taken, so B (silent since 12s) makes
+	// room for it
+	{ speaker: 3, at: 24, duration: 10 },
+	// E likewise takes over from A at 41s, F from C at 51s
+	{ speaker: 4, at: 38, duration: 8 },
+	{ speaker: 5, at: 48, duration: 6 },
+	// Nobody says anything for a while, so the spots are given up one by one
+	// after 30s of silence: D at 64s, E at 76s, F at 84s, and the main area
+	// falls back to a single participant
+	{ speaker: 1, at: 100, duration: 6 },
+	{ speaker: 4, at: 108, duration: 10 },
+]
+
+/**
+ * Length of a full run, in seconds.
+ *
+ * The last turn ends at 118s and takes 30s of silence to be demoted, so the
+ * run has to be longer than 148s for the next one to start from an empty main
+ * area. Restarting any earlier leaves speakers of the previous run promoted,
+ * and they are then demoted in the middle of the next one.
+ */
+const TIMELINE_DURATION = 155
+
+type SimulatedModel = ReturnType<typeof createModel>
+
+/**
+ * Build an object with the surface of a `CallParticipantModel` that the call
+ * view actually reads. No peer connection is involved, so the tiles show the
+ * participant name over an avatar rather than a video.
+ *
+ * @param index - position of the participant in the simulation
+ */
+function createModel(index: number) {
+	return {
+		attributes: reactive({
+			peerId: `simulated-peer-${index}`,
+			nextcloudSessionId: `simulated-session-${index}`,
+			peer: null,
+			screenPeer: null,
+			actorType: 'users',
+			actorId: `${index}-simulated-user-${index}`,
+			userId: `${index}-simulated-user-${index}`,
+			name: placeholderName(index),
+			internal: false,
+			connectionState: ConnectionState.CONNECTED,
+			negotiating: false,
+			connecting: false,
+			initialConnection: false,
+			connectedAtLeastOnce: true,
+			stream: null,
+			audioAvailable: true,
+			speaking: false,
+			videoBlocked: false,
+			videoAvailable: false,
+			screen: null,
+			raisedHand: { state: false, timestamp: null },
+		}),
+		// Methods the call view calls on a participant model
+		on: () => {},
+		off: () => {},
+		forceMute: () => {},
+		setVideoBlocked: () => {},
+		setSimulcastVideoQuality: () => {},
+		getWebRtc: () => ({ connection: { getSendVideoIfAvailable: () => {} } }),
+		destroy: () => {},
+	}
+}
+
+let models: SimulatedModel[] = []
+let timers: ReturnType<typeof setTimeout>[] = []
+
+/**
+ * Remove the simulated participants and cancel the timeline.
+ */
+function stop() {
+	timers.forEach((timer) => clearTimeout(timer))
+	timers = []
+
+	models.forEach((model) => {
+		const index = callParticipantCollection.callParticipantModels.indexOf(model as never)
+		if (index !== -1) {
+			callParticipantCollection.callParticipantModels.splice(index, 1)
+		}
+	})
+	models = []
+
+	console.info('[speaker simulation] stopped')
+}
+
+/**
+ * Make one of the simulated participants speak.
+ *
+ * @param index - position of the participant in the simulation
+ * @param duration - how long they speak, in seconds
+ */
+function speak(index: number, duration: number) {
+	const model = models[index]
+	if (!model) {
+		console.warn('[speaker simulation] no participant', index)
+		return
+	}
+
+	model.attributes.speaking = true
+	const timer = setTimeout(() => {
+		timers.splice(timers.indexOf(timer), 1)
+		model.attributes.speaking = false
+	}, duration * 1000)
+	timers.push(timer)
+}
+
+/**
+ * Add the simulated participants and play the timeline in a loop.
+ *
+ * @param speed - how much faster than real time to play, 1 by default. The
+ *   promotion and demotion delays are NOT scaled, so the turns get shorter
+ *   while the 3s needed to be promoted does not: past 2x almost nothing is
+ *   promoted any more, which is only useful to check that brief exchanges
+ *   leave the layout alone. Use `speak()` by hand to make people talk over
+ *   each other.
+ */
+function start(speed = 1) {
+	stop()
+
+	models = Array.from({ length: PARTICIPANT_COUNT }, (_, index) => createModel(index))
+	callParticipantCollection.callParticipantModels.push(...(models as never[]))
+
+	const scheduleRun = () => {
+		TIMELINE.forEach(({ speaker, at, duration }) => {
+			timers.push(setTimeout(() => speak(speaker, duration / speed), (at / speed) * 1000))
+		})
+		timers.push(setTimeout(scheduleRun, (TIMELINE_DURATION / speed) * 1000))
+	}
+	scheduleRun()
+
+	console.info(`[speaker simulation] started with ${PARTICIPANT_COUNT} participants at ${speed}x`)
+}
+
+/**
+ * Expose the controls and start the simulation if the call is the one it was
+ * written for.
+ *
+ * Only called by the call view when `OC.debug` is truthy.
+ *
+ * @param token - token of the conversation being joined
+ */
+export function setUpSpeakerSimulation(token: string) {
+	if (window.OCA?.Talk) {
+		// @ts-expect-error: OCA is not typed
+		window.OCA.Talk.speakerSimulation = { start, stop, speak }
+	}
+
+	if (token === SIMULATION_TOKEN) {
+		start()
+	}
+}
+
+/**
+ * Counterpart of {@link setUpSpeakerSimulation}, to be called when the call
+ * view goes away.
+ */
+export function tearDownSpeakerSimulation() {
+	stop()
+	// @ts-expect-error: OCA is not typed
+	delete window.OCA?.Talk?.speakerSimulation
+}

--- a/src/components/CallView/useActiveSpeakers.spec.ts
+++ b/src/components/CallView/useActiveSpeakers.spec.ts
@@ -1,0 +1,278 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { SpeakerModel } from './useActiveSpeakers.ts'
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { effectScope, nextTick, reactive, ref } from 'vue'
+import { DEMOTE_DELAY, MAX_PROMOTED_SPEAKERS, PROMOTE_DELAY, useActiveSpeakers } from './useActiveSpeakers.ts'
+
+let sessionCounter = 0
+
+/**
+ * Build a call participant model with the reactive attributes the speaker
+ * tracking reads.
+ *
+ * @param speaking - whether the participant starts out speaking
+ */
+function makeModel(speaking = false): SpeakerModel {
+	return {
+		attributes: reactive({
+			nextcloudSessionId: `session-${sessionCounter++}`,
+			speaking,
+		}),
+	}
+}
+
+/**
+ * Instantiate the composable inside an effect scope, so its watchers and its
+ * `onScopeDispose` cleanup behave as they would in a component.
+ *
+ * @param models - the call participant models
+ */
+function createSpeakers(models: SpeakerModel[] = []) {
+	const callParticipantModels = ref(models)
+	const enabled = ref(true)
+
+	const scope = effectScope()
+	const { promotedSessionIds } = scope.run(() => useActiveSpeakers({
+		callParticipantModels,
+		enabled,
+	}))!
+
+	return { callParticipantModels, enabled, promotedSessionIds, scope }
+}
+
+/**
+ * Let the watchers run, fire the timers due within the given time, then let the
+ * watchers run again.
+ *
+ * @param ms - time to advance the fake clock by
+ */
+async function advance(ms: number) {
+	await nextTick()
+	vi.advanceTimersByTime(ms)
+	await nextTick()
+}
+
+describe('useActiveSpeakers', () => {
+	beforeEach(() => {
+		sessionCounter = 0
+		vi.useFakeTimers()
+	})
+
+	afterEach(() => {
+		vi.useRealTimers()
+	})
+
+	describe('promotion', () => {
+		test('promotes a participant that spoke long enough', async () => {
+			const model = makeModel()
+			const { promotedSessionIds } = createSpeakers([model])
+
+			model.attributes.speaking = true
+
+			await advance(PROMOTE_DELAY - 1)
+			expect(promotedSessionIds.value).toEqual([])
+
+			await advance(1)
+			expect(promotedSessionIds.value).toEqual(['session-0'])
+		})
+
+		test('ignores a short interjection', async () => {
+			const model = makeModel()
+			const { promotedSessionIds } = createSpeakers([model])
+
+			model.attributes.speaking = true
+			await advance(PROMOTE_DELAY - 500)
+			model.attributes.speaking = false
+
+			await advance(PROMOTE_DELAY)
+			expect(promotedSessionIds.value).toEqual([])
+		})
+
+		test('requires uninterrupted speech to promote', async () => {
+			const model = makeModel()
+			const { promotedSessionIds } = createSpeakers([model])
+
+			// Two bursts adding up to more than the delay, but neither long enough
+			for (let burst = 0; burst < 2; burst++) {
+				model.attributes.speaking = true
+				await advance(PROMOTE_DELAY - 500)
+				model.attributes.speaking = false
+				await advance(100)
+			}
+			expect(promotedSessionIds.value).toEqual([])
+
+			model.attributes.speaking = true
+			await advance(PROMOTE_DELAY)
+			expect(promotedSessionIds.value).toEqual(['session-0'])
+		})
+
+		test('keeps the speakers in the order they became active', async () => {
+			const models = [makeModel(), makeModel()]
+			const { promotedSessionIds } = createSpeakers(models)
+
+			models[1].attributes.speaking = true
+			await advance(PROMOTE_DELAY)
+			models[0].attributes.speaking = true
+			await advance(PROMOTE_DELAY)
+
+			expect(promotedSessionIds.value).toEqual(['session-1', 'session-0'])
+		})
+	})
+
+	describe('demotion', () => {
+		test('demotes a participant that stayed silent', async () => {
+			const model = makeModel()
+			const { promotedSessionIds } = createSpeakers([model])
+
+			model.attributes.speaking = true
+			await advance(PROMOTE_DELAY)
+			model.attributes.speaking = false
+
+			await advance(DEMOTE_DELAY - 1)
+			expect(promotedSessionIds.value).toEqual(['session-0'])
+
+			await advance(1)
+			expect(promotedSessionIds.value).toEqual([])
+		})
+
+		test('cancels the demotion when the participant speaks again', async () => {
+			const model = makeModel()
+			const { promotedSessionIds } = createSpeakers([model])
+
+			model.attributes.speaking = true
+			await advance(PROMOTE_DELAY)
+			model.attributes.speaking = false
+			await advance(DEMOTE_DELAY - 1000)
+			model.attributes.speaking = true
+
+			await advance(DEMOTE_DELAY)
+			expect(promotedSessionIds.value).toEqual(['session-0'])
+		})
+
+		test('demotes a participant that left the call right away', async () => {
+			const models = [makeModel(), makeModel()]
+			const { callParticipantModels, promotedSessionIds } = createSpeakers(models)
+
+			models.forEach((model) => {
+				model.attributes.speaking = true
+			})
+			await advance(PROMOTE_DELAY)
+			expect(promotedSessionIds.value).toEqual(['session-0', 'session-1'])
+
+			// Left while still flagged as speaking
+			callParticipantModels.value = [models[1]]
+			await nextTick()
+			expect(promotedSessionIds.value).toEqual(['session-1'])
+		})
+	})
+
+	describe('slots', () => {
+		/**
+		 * Promote the given models one after the other, each of them speaking
+		 * long enough and then falling silent.
+		 *
+		 * @param models - the models to promote, in order
+		 */
+		async function promoteInTurn(models: SpeakerModel[]) {
+			for (const model of models) {
+				model.attributes.speaking = true
+				await advance(PROMOTE_DELAY)
+				model.attributes.speaking = false
+				await advance(100)
+			}
+		}
+
+		test('promotes no more than three speakers at once', async () => {
+			const models = Array.from({ length: 4 }, () => makeModel())
+			const { promotedSessionIds } = createSpeakers(models)
+
+			await promoteInTurn(models)
+
+			expect(promotedSessionIds.value).toHaveLength(MAX_PROMOTED_SPEAKERS)
+		})
+
+		test('gives the spot of the least recent speaker to a new one', async () => {
+			const models = Array.from({ length: 4 }, () => makeModel())
+			const { promotedSessionIds } = createSpeakers(models)
+
+			await promoteInTurn(models.slice(0, 3))
+			expect(promotedSessionIds.value).toEqual(['session-0', 'session-1', 'session-2'])
+
+			// The first one spoke longest ago, so it makes room
+			await promoteInTurn([models[3]])
+			expect(promotedSessionIds.value).toEqual(['session-1', 'session-2', 'session-3'])
+		})
+
+		test('keeps a speaker that spoke recently over one that did not', async () => {
+			const models = Array.from({ length: 4 }, () => makeModel())
+			const { promotedSessionIds } = createSpeakers(models)
+
+			await promoteInTurn(models.slice(0, 3))
+			// The first one chimes in again, so the second is now the stalest
+			await promoteInTurn([models[0]])
+			await promoteInTurn([models[3]])
+
+			// Speaking again keeps a promoted speaker in place rather than
+			// moving its tile around
+			expect(promotedSessionIds.value).toEqual(['session-0', 'session-2', 'session-3'])
+		})
+
+		test('does not evict a speaker that is still talking', async () => {
+			const models = Array.from({ length: 4 }, () => makeModel())
+			const { promotedSessionIds } = createSpeakers(models)
+
+			// The first one never stops talking, the others take turns
+			models[0].attributes.speaking = true
+			await advance(PROMOTE_DELAY)
+			await promoteInTurn(models.slice(1, 3))
+			await promoteInTurn([models[3]])
+
+			expect(promotedSessionIds.value).toContain('session-0')
+			expect(promotedSessionIds.value).not.toContain('session-1')
+		})
+	})
+
+	describe('lifecycle', () => {
+		test('forgets the speakers when disabled', async () => {
+			const model = makeModel()
+			const { enabled, promotedSessionIds } = createSpeakers([model])
+
+			model.attributes.speaking = true
+			await advance(PROMOTE_DELAY)
+			expect(promotedSessionIds.value).toEqual(['session-0'])
+
+			enabled.value = false
+			await nextTick()
+			expect(promotedSessionIds.value).toEqual([])
+		})
+
+		test('does not track speakers while disabled', async () => {
+			const model = makeModel()
+			const { enabled, promotedSessionIds } = createSpeakers([model])
+
+			enabled.value = false
+			await nextTick()
+			model.attributes.speaking = true
+
+			await advance(PROMOTE_DELAY)
+			expect(promotedSessionIds.value).toEqual([])
+		})
+
+		test('cancels pending timers when the scope is disposed', async () => {
+			const model = makeModel()
+			const { promotedSessionIds, scope } = createSpeakers([model])
+
+			model.attributes.speaking = true
+			await nextTick()
+			scope.stop()
+
+			await advance(PROMOTE_DELAY)
+			expect(promotedSessionIds.value).toEqual([])
+		})
+	})
+})

--- a/src/components/CallView/useActiveSpeakers.ts
+++ b/src/components/CallView/useActiveSpeakers.ts
@@ -1,0 +1,209 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { Ref } from 'vue'
+
+import { computed, onScopeDispose, ref, watch } from 'vue'
+
+/** Time (in ms) a participant has to speak without interruption to be promoted. */
+export const PROMOTE_DELAY = 3_000
+
+/** Time (in ms) a promoted participant stays silent before being demoted again. */
+export const DEMOTE_DELAY = 30_000
+
+/** Maximum number of speakers promoted at the same time. */
+export const MAX_PROMOTED_SPEAKERS = 3
+
+/**
+ * Minimal shape of a call participant model the speaker tracking relies on.
+ * The real models expose many more attributes, but only these are read here.
+ */
+export type SpeakerModel = {
+	attributes: {
+		nextcloudSessionId: string
+		speaking?: boolean
+	}
+}
+
+type UseActiveSpeakersOptions = {
+	/** All call participant models, in their source order */
+	callParticipantModels: Readonly<Ref<SpeakerModel[]>>
+	/** Whether speakers should be tracked at all */
+	enabled: Readonly<Ref<boolean>>
+}
+
+/**
+ * Tracks which participants are active enough to deserve a spot in the main
+ * area of the call view.
+ *
+ * A participant that speaks for {@link PROMOTE_DELAY} without interruption
+ * becomes active, and stops being active once it has been silent for
+ * {@link DEMOTE_DELAY}. Short interjections therefore never disturb the view,
+ * and someone who only listens for a while makes room again on their own.
+ *
+ * At most {@link MAX_PROMOTED_SPEAKERS} speakers are promoted at a time. Once
+ * they are all taken, a new speaker takes the spot of whoever spoke least
+ * recently, so that the main area always follows the conversation rather than
+ * making a new speaker wait for a spot to be given up.
+ *
+ * @param options - the reactive inputs driving the tracking
+ * @param options.callParticipantModels - all call participant models
+ * @param options.enabled - whether speakers should be tracked at all
+ */
+export function useActiveSpeakers({
+	callParticipantModels,
+	enabled,
+}: UseActiveSpeakersOptions) {
+	// Session ids of the participants that are currently promoted, in the order
+	// they were promoted. Only ids are kept, so no participant model is
+	// referenced here.
+	const activeSessionIds = ref<string[]>([])
+
+	// When each participant last took part in the conversation, used to pick who
+	// makes room when a new speaker comes in.
+	const lastSpokeAt: Record<string, number> = {}
+
+	const promoteTimers: Record<string, ReturnType<typeof setTimeout>> = {}
+	const demoteTimers: Record<string, ReturnType<typeof setTimeout>> = {}
+
+	/**
+	 * @param timers the timer map to clear the entry from
+	 * @param sessionId session id of the participant
+	 */
+	function clearTimer(timers: Record<string, ReturnType<typeof setTimeout>>, sessionId: string) {
+		clearTimeout(timers[sessionId])
+		delete timers[sessionId]
+	}
+
+	/**
+	 * @param sessionId session id of the participant to drop
+	 */
+	function deactivate(sessionId: string) {
+		const index = activeSessionIds.value.indexOf(sessionId)
+		if (index !== -1) {
+			activeSessionIds.value.splice(index, 1)
+		}
+	}
+
+	/**
+	 * Promote a participant, taking the spot of whoever spoke least recently if
+	 * they are all taken.
+	 *
+	 * A participant that is speaking right now counts as speaking at this very
+	 * moment, so somebody in the middle of a sentence is only ever replaced when
+	 * everyone promoted is talking at once.
+	 *
+	 * @param sessionId - session id of the participant to promote
+	 * @param speaking - session ids of the participants speaking right now
+	 */
+	function activate(sessionId: string, speaking: Set<string>) {
+		if (activeSessionIds.value.includes(sessionId)) {
+			return
+		}
+
+		if (activeSessionIds.value.length >= MAX_PROMOTED_SPEAKERS) {
+			const now = Date.now()
+			const recencyOf = (id: string) => (speaking.has(id) ? now : (lastSpokeAt[id] ?? 0))
+			const leastRecent = activeSessionIds.value
+				.reduce((least, id) => (recencyOf(id) < recencyOf(least) ? id : least))
+
+			clearTimer(demoteTimers, leastRecent)
+			deactivate(leastRecent)
+		}
+
+		activeSessionIds.value.push(sessionId)
+	}
+
+	/**
+	 * Forget every speaker and cancel all pending changes.
+	 */
+	function reset() {
+		Object.keys(promoteTimers).forEach((sessionId) => clearTimer(promoteTimers, sessionId))
+		Object.keys(demoteTimers).forEach((sessionId) => clearTimer(demoteTimers, sessionId))
+		Object.keys(lastSpokeAt).forEach((sessionId) => delete lastSpokeAt[sessionId])
+		activeSessionIds.value = []
+	}
+
+	const speakingSessionIds = computed(() => {
+		if (!enabled.value) {
+			return []
+		}
+
+		return callParticipantModels.value
+			.filter((model) => model.attributes.speaking)
+			.map((model) => model.attributes.nextcloudSessionId)
+	})
+
+	// TODO: extract one session-keyed set to be used by tile ordering too
+	watch(speakingSessionIds, (sessionIds, previousSessionIds) => {
+		const speaking = new Set(sessionIds)
+
+		sessionIds.forEach((sessionId) => {
+			// Speaking again: whatever was pending for this participant is moot
+			clearTimer(demoteTimers, sessionId)
+			lastSpokeAt[sessionId] = Date.now()
+
+			if (activeSessionIds.value.includes(sessionId) || promoteTimers[sessionId]) {
+				return
+			}
+
+			promoteTimers[sessionId] = setTimeout(() => {
+				delete promoteTimers[sessionId]
+				activate(sessionId, new Set(speakingSessionIds.value))
+			}, PROMOTE_DELAY)
+		})
+
+		previousSessionIds.filter((sessionId) => !speaking.has(sessionId)).forEach((sessionId) => {
+			// Stopped speaking before being promoted, so it never gets promoted
+			clearTimer(promoteTimers, sessionId)
+			// They took part in the conversation up to this very moment
+			lastSpokeAt[sessionId] = Date.now()
+
+			if (!activeSessionIds.value.includes(sessionId) || demoteTimers[sessionId]) {
+				return
+			}
+
+			demoteTimers[sessionId] = setTimeout(() => {
+				delete demoteTimers[sessionId]
+				deactivate(sessionId)
+			}, DEMOTE_DELAY)
+		})
+	})
+
+	// A participant that left frees its spot right away: `speaking` is not
+	// guaranteed to be reset on disconnection, so waiting for the silence timer
+	// would keep an empty tile around.
+	watch(() => callParticipantModels.value.map((model) => model.attributes.nextcloudSessionId), (sessionIds) => {
+		const present = new Set(sessionIds)
+		const known = new Set([
+			...activeSessionIds.value,
+			...Object.keys(promoteTimers),
+			...Object.keys(demoteTimers),
+		])
+
+		known.forEach((sessionId) => {
+			if (present.has(sessionId)) {
+				return
+			}
+			clearTimer(promoteTimers, sessionId)
+			clearTimer(demoteTimers, sessionId)
+			delete lastSpokeAt[sessionId]
+			deactivate(sessionId)
+		})
+	})
+
+	watch(enabled, (value) => {
+		if (!value) {
+			reset()
+		}
+	})
+
+	onScopeDispose(reset)
+
+	return {
+		/** Session ids of the speakers to show in the main area, most senior first */
+		promotedSessionIds: computed(() => [...activeSessionIds.value]),
+	}
+}

--- a/src/stores/__tests__/callView.spec.js
+++ b/src/stores/__tests__/callView.spec.js
@@ -20,6 +20,7 @@ vi.mock('../../services/BrowserStorage.js', () => ({
 describe('callViewStore', () => {
 	const TOKEN = 'XXTOKENXX'
 	const BROWSER_STORAGE_KEY = 'callprefs-XXTOKENXX-isgrid'
+	const BROWSER_STORAGE_KEY_MULTISPEAKER = 'callprefs-XXTOKENXX-multispeaker'
 	const PEER_ID = 'peer-id'
 	let callViewStore
 
@@ -100,6 +101,37 @@ describe('callViewStore', () => {
 			expect(callViewStore.isGrid).toBeFalsy()
 			expect(callViewStore.isStripeOpen).toBeTruthy()
 			expect(BrowserStorage.setItem).toHaveBeenCalledWith(BROWSER_STORAGE_KEY, 'false')
+		})
+
+		it('switching multi-speaker mode saves in local storage', () => {
+			callViewStore.setCallViewMode({ token: TOKEN, isMultiSpeaker: true })
+			expect(callViewStore.isMultiSpeaker).toBeTruthy()
+			expect(BrowserStorage.setItem).toHaveBeenCalledWith(BROWSER_STORAGE_KEY_MULTISPEAKER, 'true')
+
+			callViewStore.setCallViewMode({ token: TOKEN, isMultiSpeaker: false })
+			expect(callViewStore.isMultiSpeaker).toBeFalsy()
+			expect(BrowserStorage.setItem).toHaveBeenCalledWith(BROWSER_STORAGE_KEY_MULTISPEAKER, 'false')
+		})
+
+		it('does not touch multi-speaker mode when switching between grid and speaker view', () => {
+			callViewStore.setCallViewMode({ token: TOKEN, isMultiSpeaker: true })
+			callViewStore.setCallViewMode({ token: TOKEN, isGrid: true })
+			expect(callViewStore.isMultiSpeaker).toBeTruthy()
+		})
+
+		it('restores multi-speaker state from BrowserStorage when joining call', () => {
+			// Arrange
+			const conversation = { token: TOKEN, type: CONVERSATION.TYPE.GROUP }
+			vuexStore.commit('addConversation', conversation)
+			// The grid preference is read first, the multi-speaker one right after
+			BrowserStorage.getItem.mockReturnValueOnce(null).mockReturnValueOnce('true')
+
+			// Act
+			callViewStore.handleJoinCall(conversation)
+
+			// Assert
+			expect(BrowserStorage.getItem).toHaveBeenCalledWith(BROWSER_STORAGE_KEY_MULTISPEAKER)
+			expect(callViewStore.isMultiSpeaker).toBeTruthy()
 		})
 
 		it('start presentation switches off grid view and restores when it ends', () => {

--- a/src/stores/callView.ts
+++ b/src/stores/callView.ts
@@ -18,6 +18,7 @@ type State = {
 	forceCallView: boolean
 	isViewerOverlay: boolean
 	isGrid: boolean
+	isMultiSpeaker: boolean
 	isStripeOpen: boolean
 	isEmptyCallView: boolean
 	lastIsGrid: boolean | null
@@ -32,6 +33,7 @@ type State = {
 type CallViewModePayload = {
 	token: string
 	isGrid?: boolean | null
+	isMultiSpeaker?: boolean | null
 	isStripeOpen?: boolean | null
 	clearLast?: boolean
 }
@@ -41,6 +43,7 @@ export const useCallViewStore = defineStore('callView', {
 		forceCallView: false,
 		isViewerOverlay: false,
 		isGrid: false,
+		isMultiSpeaker: false,
 		isStripeOpen: true,
 		isEmptyCallView: true,
 		lastIsGrid: null,
@@ -94,7 +97,9 @@ export const useCallViewStore = defineStore('callView', {
 				// not defined yet, default to grid view for group/public calls, otherwise speaker view
 				? [CONVERSATION.TYPE.GROUP, CONVERSATION.TYPE.PUBLIC].includes(conversation.type)
 				: gridPreference === 'true'
-			this.setCallViewMode({ token: conversation.token, isGrid, isStripeOpen: true })
+			// Speaker view shows a single speaker unless multi-speaker was picked before
+			const isMultiSpeaker = BrowserStorage.getItem(`callprefs-${conversation.token}-multispeaker`) === 'true'
+			this.setCallViewMode({ token: conversation.token, isGrid, isMultiSpeaker, isStripeOpen: true })
 		},
 
 		/**
@@ -104,10 +109,11 @@ export const useCallViewStore = defineStore('callView', {
 		 * @param data the wrapping object;
 		 * @param data.token current conversation token;
 		 * @param data.isGrid true for enabled grid mode, false for speaker view;
+		 * @param data.isMultiSpeaker true to promote several speakers at once in speaker view;
 		 * @param data.isStripeOpen true for visible striped mode, false for speaker view;
 		 * @param data.clearLast set false to not reset last temporary remembered state;
 		 */
-		setCallViewMode({ token, isGrid = null, isStripeOpen = null, clearLast = true }: CallViewModePayload) {
+		setCallViewMode({ token, isGrid = null, isMultiSpeaker = null, isStripeOpen = null, clearLast = true }: CallViewModePayload) {
 			if (clearLast) {
 				this.lastIsGrid = null
 				this.lastIsStripeOpen = null
@@ -121,6 +127,11 @@ export const useCallViewStore = defineStore('callView', {
 				if (isGrid) {
 					this.setSelectedVideoPeerId(null)
 				}
+			}
+
+			if (isMultiSpeaker !== null && isMultiSpeaker !== undefined) {
+				BrowserStorage.setItem(`callprefs-${token}-multispeaker`, isMultiSpeaker.toString())
+				this.isMultiSpeaker = isMultiSpeaker
 			}
 
 			if (isStripeOpen !== null && isStripeOpen !== undefined) {


### PR DESCRIPTION
## ☑️ Resolves

* Part of #18905

It is a big PR bc it is a giant feature. The logic behind multi speaker is to use automation based on speaking. The demotion happens after 1 min of silence. It is max 4 speakers. 

### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

I prepared a simulation in the last commit to help test, you can alter it to test edge cases of course (I included the case of 5 to 6 speakers).


<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts


https://github.com/user-attachments/assets/5709f239-0f1a-4dea-9632-c82871f1e829




<!-- ☀️ Light theme | 🌑 Dark Theme -->


### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
