### PR TITLE
refactor(upload): extract reusable logic, prepare to redesign

### DIFF
--- a/src/components/ChatView.vue
+++ b/src/components/ChatView.vue
@@ -80,13 +80,13 @@ import TransitionWrapper from './UIShared/TransitionWrapper.vue'
 import IconFileUpload from '../../img/material-icons/file-upload.svg?raw'
 import { useGetThreadId } from '../composables/useGetThreadId.ts'
 import { useGetToken } from '../composables/useGetToken.ts'
+import { useUploadFiles } from '../composables/useUploadFiles.ts'
 import { CONVERSATION, PARTICIPANT } from '../constants.ts'
 import { getTalkConfig } from '../services/CapabilitiesManager.ts'
 import { EventBus } from '../services/EventBus.ts'
 import { useActorStore } from '../stores/actor.ts'
 import { useChatExtrasStore } from '../stores/chatExtras.ts'
 import { useSettingsStore } from '../stores/settings.ts'
-import { useUploadStore } from '../stores/upload.ts'
 
 export default {
 
@@ -122,14 +122,18 @@ export default {
 
 	setup(props) {
 		provide('chatView:isSidebar', props.isSidebar)
+
+		const token = useGetToken()
+		const { addFiles } = useUploadFiles(token)
+
 		return {
 			IconFileUpload,
-			token: useGetToken(),
+			token,
 			threadId: useGetThreadId(),
 			chatExtrasStore: useChatExtrasStore(),
 			actorStore: useActorStore(),
 			settingsStore: useSettingsStore(),
-			uploadStore: useUploadStore(),
+			addFiles,
 		}
 	},
 
@@ -219,12 +223,8 @@ export default {
 			if (this.isGuest || this.isReadOnly) {
 				return
 			}
-			// Get the files from the event
-			const files = Object.values(event.dataTransfer.files)
-			// Create a unique id for the upload operation
-			const uploadId = new Date().getTime()
-			// Uploads and shares the files
-			this.uploadStore.initialiseUpload({ files, token: this.token, threadId: this.threadId, uploadId })
+			// Stage the files, they are uploaded and shared on submit
+			this.addFiles(Object.values(event.dataTransfer.files))
 		},
 
 		scrollToBottom() {

--- a/src/components/NewMessage/NewMessage.vue
+++ b/src/components/NewMessage/NewMessage.vue
@@ -360,6 +360,7 @@ import NewMessageTypingIndicator from './NewMessageTypingIndicator.vue'
 import { useChatMentions } from '../../composables/useChatMentions.ts'
 import { useGetThreadId } from '../../composables/useGetThreadId.ts'
 import { useTemporaryMessage } from '../../composables/useTemporaryMessage.ts'
+import { useUploadFiles } from '../../composables/useUploadFiles.ts'
 import { CONVERSATION, MESSAGE, PARTICIPANT, PRIVACY } from '../../constants.ts'
 import BrowserStorage from '../../services/BrowserStorage.js'
 import { getTalkConfig, hasTalkFeature } from '../../services/CapabilitiesManager.ts'
@@ -485,6 +486,10 @@ export default {
 
 		const isSidebar = inject('chatView:isSidebar', false)
 
+		const {
+			addFiles,
+		} = useUploadFiles(token)
+
 		return {
 			actorStore: useActorStore(),
 			chatExtrasStore: useChatExtrasStore(),
@@ -502,6 +507,7 @@ export default {
 			createTemporaryMessage,
 			convertToUnix,
 			isSidebar,
+			addFiles,
 		}
 	},
 
@@ -1279,10 +1285,8 @@ export default {
 				showWarning(t('spreed', 'File upload is not available in this conversation'))
 				return
 			}
-			// Create a unique id for the upload operation
-			const uploadId = this.currentUploadId ?? new Date().getTime()
-			// Uploads and shares the files
-			this.uploadStore.initialiseUpload({ files, token: this.token, threadId: this.threadId, uploadId, rename, isVoiceMessage })
+			// Stage the files, they are uploaded and shared on submit
+			this.addFiles(files, { rename, isVoiceMessage })
 		},
 
 		preserveSelectionRange() {

--- a/src/components/NewMessage/NewMessageUploadEditor.vue
+++ b/src/components/NewMessage/NewMessageUploadEditor.vue
@@ -61,13 +61,13 @@
 
 			<NcCheckboxRadioSwitch
 				v-if="!isVoiceMessage && supportConversationSubfolders"
-				v-model="allowUpdate"
+				v-model="uploadStore.allowUpdate"
 				type="switch">
 				{{ t('spreed', 'Allow editing of uploaded files') }}
 			</NcCheckboxRadioSwitch>
 			<NcCheckboxRadioSwitch
 				v-if="hasImages"
-				v-model="skipCompression"
+				v-model="uploadStore.skipCompression"
 				type="switch">
 				{{ t('spreed', 'Send images without compression') }}
 			</NcCheckboxRadioSwitch>
@@ -130,8 +130,6 @@ export default {
 
 	setup() {
 		const isDraggingOver = ref(false)
-		const allowUpdate = ref(false)
-		const skipCompression = ref(false)
 		const dialogMaskId = `new-message-upload-${useId()}`
 		const dialogHeaderId = `new-message-upload-header-${useId()}`
 		const modalContainerId = '#' + dialogMaskId
@@ -139,8 +137,6 @@ export default {
 		return {
 			modalContainerId,
 			isDraggingOver,
-			allowUpdate,
-			skipCompression,
 			dialogMaskId,
 			dialogHeaderId,
 			token: useGetToken(),
@@ -212,10 +208,6 @@ export default {
 				} else {
 					this.$refs.submitButton.$el.focus()
 				}
-			} else {
-				// Reset user's choices at closing
-				this.allowUpdate = false
-				this.skipCompression = false
 			}
 		},
 	},
@@ -233,8 +225,8 @@ export default {
 				uploadId: this.currentUploadId,
 				caption: null,
 				options: null,
-				allowUpdate: this.supportConversationSubfolders ? this.allowUpdate : undefined,
-				compressImages: this.hasImages ? !this.skipCompression : undefined,
+				allowUpdate: this.supportConversationSubfolders ? this.uploadStore.allowUpdate : undefined,
+				compressImages: this.hasImages ? !this.uploadStore.skipCompression : undefined,
 			})
 		},
 
@@ -251,8 +243,8 @@ export default {
 						silent: temporaryMessage.silent,
 						parent: temporaryMessage.parent,
 					},
-					allowUpdate: this.supportConversationSubfolders ? this.allowUpdate : undefined,
-					compressImages: this.hasImages ? !this.skipCompression : undefined,
+					allowUpdate: this.supportConversationSubfolders ? this.uploadStore.allowUpdate : undefined,
+					compressImages: this.hasImages ? !this.uploadStore.skipCompression : undefined,
 				})
 			} else {
 				this.uploadStore.discardUpload(this.currentUploadId)

--- a/src/components/NewMessage/NewMessageUploadEditor.vue
+++ b/src/components/NewMessage/NewMessageUploadEditor.vue
@@ -40,7 +40,7 @@
 						:token="token"
 						isUploadEditor
 						:file="file[1].temporaryMessage.messageParameters.file"
-						@removeFile="handleRemoveFileFromSelection" />
+						@removeFile="removeFile" />
 					<NcButton
 						:aria-label="addMoreAriaLabel"
 						variant="tertiary"
@@ -109,10 +109,8 @@ import TransitionWrapper from '../UIShared/TransitionWrapper.vue'
 import NewMessage from './NewMessage.vue'
 import { useGetThreadId } from '../../composables/useGetThreadId.ts'
 import { useGetToken } from '../../composables/useGetToken.ts'
-import { MESSAGE } from '../../constants.ts'
-import { getTalkConfig, hasTalkFeature } from '../../services/CapabilitiesManager.ts'
+import { useUploadFiles } from '../../composables/useUploadFiles.ts'
 import { useUploadStore } from '../../stores/upload.ts'
-import { supportImageCompression } from '../../utils/imageCompression.ts'
 
 export default {
 	name: 'NewMessageUploadEditor',
@@ -134,56 +132,47 @@ export default {
 		const dialogHeaderId = `new-message-upload-header-${useId()}`
 		const modalContainerId = '#' + dialogMaskId
 
+		const token = useGetToken()
+
+		const {
+			currentUploadId,
+			files,
+			hasFiles,
+			firstFile,
+			isVoiceMessage,
+			hasImages,
+			supportMediaCaption,
+			supportConversationSubfolders,
+			removeFile,
+		} = useUploadFiles(token)
+
 		return {
 			modalContainerId,
 			isDraggingOver,
 			dialogMaskId,
 			dialogHeaderId,
-			token: useGetToken(),
+			token,
 			threadId: useGetThreadId(),
 			uploadStore: useUploadStore(),
+			currentUploadId,
+			files,
+			hasFiles,
+			firstFile,
+			isVoiceMessage,
+			hasImages,
+			supportMediaCaption,
+			supportConversationSubfolders,
+			removeFile,
 		}
 	},
 
 	computed: {
-		supportMediaCaption() {
-			return hasTalkFeature(this.token, 'media-caption')
-		},
-
-		supportConversationSubfolders() {
-			return getTalkConfig(this.token, 'attachments', 'conversation-subfolders') === true
-		},
-
-		hasImages() {
-			return this.files.some(([, f]) => supportImageCompression(f.file.type))
-		},
-
-		currentUploadId() {
-			return this.uploadStore.currentUploadId
-		},
-
-		files() {
-			return this.uploadStore.getInitialisedUploads(this.currentUploadId)
-		},
-
 		showModal() {
 			return !!this.currentUploadId
 		},
 
 		addMoreAriaLabel() {
 			return t('spreed', 'Add more files')
-		},
-
-		firstFile() {
-			return this.files?.at(0)?.at(1)
-		},
-
-		// Hide the plus button in case this editor is used while sending a voice message
-		isVoiceMessage() {
-			if (!this.firstFile) {
-				return false
-			}
-			return this.firstFile.temporaryMessage.messageType === MESSAGE.TYPE.VOICE_MESSAGE
 		},
 
 		voiceMessageName() {
@@ -231,7 +220,7 @@ export default {
 		},
 
 		async handleUpload({ token, temporaryMessage }) {
-			if (this.files.length) {
+			if (this.hasFiles) {
 				// Create a share with optional caption
 				await this.uploadStore.uploadFiles({
 					token,
@@ -271,10 +260,6 @@ export default {
 			const files = Object.values(event.target.files)
 			this.uploadStore.initialiseUpload({ files, token: this.token, threadId: this.threadId, uploadId: this.currentUploadId })
 			this.$refs.fileUploadInput.value = null
-		},
-
-		handleRemoveFileFromSelection(id) {
-			this.uploadStore.removeFileFromSelection(id)
 		},
 
 		handleDragOver(event) {

--- a/src/composables/useUploadFiles.ts
+++ b/src/composables/useUploadFiles.ts
@@ -1,0 +1,96 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { MaybeRefOrGetter } from 'vue'
+import type { UploadEntry, UploadFile } from '../types/index.ts'
+
+import { computed, toValue } from 'vue'
+import { MESSAGE } from '../constants.ts'
+import { getTalkConfig, hasTalkFeature } from '../services/CapabilitiesManager.ts'
+import { useUploadStore } from '../stores/upload.ts'
+import { supportImageCompression } from '../utils/imageCompression.ts'
+import { useGetThreadId } from './useGetThreadId.ts'
+
+/**
+ * Composable to initialise and track files staged for an upload.
+ *
+ * Covers the intake (adding and removing files) and derives the state of the
+ * current upload from the store. Sending it is left to the caller, which
+ * builds the message around it, see uploadStore.uploadFiles().
+ *
+ * @param token the conversation token to upload to
+ */
+export function useUploadFiles(token: MaybeRefOrGetter<string>) {
+	const threadId = useGetThreadId()
+	const uploadStore = useUploadStore()
+
+	const currentUploadId = computed(() => uploadStore.currentUploadId)
+
+	const files = computed<UploadEntry[]>(() => currentUploadId.value
+		? uploadStore.getInitialisedUploads(currentUploadId.value)
+		: [])
+
+	const hasFiles = computed(() => files.value.length > 0)
+
+	const firstFile = computed<UploadFile | undefined>(() => files.value.at(0)?.[1])
+
+	const isVoiceMessage = computed(() => {
+		return firstFile.value?.temporaryMessage.messageType === MESSAGE.TYPE.VOICE_MESSAGE
+	})
+
+	const hasImages = computed(() => {
+		return files.value.some(([, uploadedFile]) => supportImageCompression(uploadedFile.file.type))
+	})
+
+	// TODO not supported in Nextcloud 27 and older, EOL in 06-2024
+	const supportMediaCaption = computed(() => hasTalkFeature(toValue(token), 'media-caption'))
+
+	const supportConversationSubfolders = computed(() => {
+		return getTalkConfig(toValue(token), 'attachments', 'conversation-subfolders') === true
+	})
+
+	/**
+	 * Stages files for upload, appending to the current upload if there is one
+	 *
+	 * @param newFiles the files to stage
+	 * @param [options] the wrapping object
+	 * @param [options.rename] whether to rename the files (usually after pasting)
+	 * @param [options.isVoiceMessage] whether the file is a voice recording
+	 */
+	function addFiles(newFiles: File[], { rename, isVoiceMessage }: { rename?: boolean, isVoiceMessage?: boolean } = {}) {
+		uploadStore.initialiseUpload({
+			files: newFiles,
+			token: toValue(token),
+			threadId: threadId.value,
+			// Create a unique id for the upload operation, unless one is ongoing
+			uploadId: currentUploadId.value ?? String(new Date().getTime()),
+			rename,
+			isVoiceMessage,
+		})
+	}
+
+	/**
+	 * Removes a staged file from the current upload
+	 *
+	 * @param temporaryMessageId message id of the temporary message associated to the file
+	 */
+	function removeFile(temporaryMessageId: number) {
+		uploadStore.removeFileFromSelection(temporaryMessageId)
+	}
+
+	return {
+		currentUploadId,
+		files,
+		hasFiles,
+		firstFile,
+		isVoiceMessage,
+		hasImages,
+		supportMediaCaption,
+		supportConversationSubfolders,
+
+		addFiles,
+		removeFile,
+	}
+}

--- a/src/stores/upload.ts
+++ b/src/stores/upload.ts
@@ -86,6 +86,22 @@ export const useUploadStore = defineStore('upload', () => {
 	const localUrls = reactive<Record<string, string>>({})
 
 	/**
+	 * The user's choices for the current upload. They are only valid until it
+	 * is sent or discarded, see resetCurrentUpload()
+	 */
+	const allowUpdate = ref(false)
+	const skipCompression = ref(false)
+
+	/**
+	 * Closes the current upload, clearing the user's choices made for it
+	 */
+	function resetCurrentUpload() {
+		currentUploadId.value = undefined
+		allowUpdate.value = false
+		skipCompression.value = false
+	}
+
+	/**
 	 * Returns an array of uploads for a given upload id
 	 *
 	 * @param uploadId unique identifier
@@ -353,7 +369,7 @@ export const useUploadStore = defineStore('upload', () => {
 	 */
 	function discardUpload(uploadId: string) {
 		if (currentUploadId.value === uploadId) {
-			currentUploadId.value = undefined
+			resetCurrentUpload()
 		}
 		EventBus.emit('upload-discard')
 
@@ -416,7 +432,8 @@ export const useUploadStore = defineStore('upload', () => {
 	 */
 	async function uploadFiles({ token, uploadId, caption, options, allowUpdate, compressImages }: UploadFilesPayload) {
 		if (currentUploadId.value === uploadId) {
-			currentUploadId.value = undefined
+			// The caller has read the user's choices into the payload already
+			resetCurrentUpload()
 		}
 
 		EventBus.emit('upload-start')
@@ -803,6 +820,8 @@ export const useUploadStore = defineStore('upload', () => {
 		uploads,
 		currentUploadId,
 		localUrls,
+		allowUpdate,
+		skipCompression,
 
 		getUploadsArray,
 		getInitialisedUploads,


### PR DESCRIPTION
## ☑️ Resolves

Pre-requisite to further component redesign and refactor
* move allowUpdate+skipCompression to the store
* ChatView drag-n-drop should add to current upload
	* blocked when NcModal for upload is open, so not a breaking change atm
* extract reusable code from NewMessageUplaodEditor to useUploadFiles

### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

No visual changes, no behaviour changes

### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [x] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required