### PR TITLE
feat(conversations): show time of last message in the chat

### DIFF
--- a/src/components/LeftSidebar/ConversationsList/Conversation.spec.js
+++ b/src/components/LeftSidebar/ConversationsList/Conversation.spec.js
@@ -6,7 +6,7 @@
 import { showError, showSuccess } from '@nextcloud/dialogs'
 import { flushPromises, mount } from '@vue/test-utils'
 import { cloneDeep } from 'es-toolkit'
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, test, vi } from 'vitest'
 import { createStore } from 'vuex'
 import NcListItem from '@nextcloud/vue/components/NcListItem'
 import IconFileOutline from 'vue-material-design-icons/FileOutline.vue'
@@ -35,6 +35,7 @@ describe('ConversationItem.vue', () => {
 	let store
 	let testStoreConfig
 	let item
+	let compact
 	let messagesMock
 
 	/**
@@ -53,6 +54,7 @@ describe('ConversationItem.vue', () => {
 			props: {
 				isSearchResult,
 				item,
+				compact,
 			},
 		})
 	}
@@ -206,6 +208,53 @@ describe('ConversationItem.vue', () => {
 
 			const el = wrapper.find('.conversation__subname')
 			expect(el.exists()).toBe(false)
+		})
+	})
+
+	describe('last message timestamp', () => {
+		beforeEach(() => {
+			const mockDate = new Date('2026-08-01T12:00:00')
+			vi.useFakeTimers().setSystemTime(mockDate)
+		})
+
+		afterEach(() => {
+			vi.useRealTimers()
+			compact = undefined
+		})
+
+		const TEST_CASES = [
+			['2026-08-01T11:00:00', '2026-08-01T11:00:00', '11:00 AM'],
+			['2026-07-31T12:00:00', '2026-07-31T12:00:00', 'Fri'],
+			['2026-07-24T12:00:00', '2026-07-24T12:00:00', 'Jul 24'],
+			['2025-12-24T12:00:00', '2025-12-24T12:00:00', 'Dec 24, 2025'],
+			// Federated conversations - check activity
+			[undefined, '2026-07-30T12:00:00', 'Thu'],
+			// Fallback
+			[0, 0, ''],
+			[undefined, undefined, ''],
+		]
+
+		it.each(TEST_CASES)(
+			'should render correct timestamp for %s',
+			(message, activity, output) => {
+				item.lastMessage.timestamp = message && new Date(message).valueOf() / 1000
+				item.lastActivity = activity && new Date(activity).valueOf() / 1000
+
+				const wrapper = mountConversation(false)
+
+				const el = wrapper.findComponent(NcListItem)
+				expect(el.exists()).toBe(true)
+				expect(el.props('details')).toBe(output)
+			},
+		)
+
+		test('does not render timestamp in compact mode', () => {
+			compact = true
+			const wrapper = mountConversation(false)
+
+			const el = wrapper.findComponent(NcListItem)
+			expect(el.exists()).toBe(true)
+			expect(el.props('details')).toBe('')
 		})
 	})
 

--- a/src/components/LeftSidebar/ConversationsList/ConversationItem.vue
+++ b/src/components/LeftSidebar/ConversationsList/ConversationItem.vue
@@ -20,6 +20,7 @@
 		:bold="!!item.unreadMessages"
 		:counterNumber="item.unreadMessages"
 		:counterType="counterType"
+		:details="compact ? '' : lastActivityTimeString"
 		forceMenu
 		:compact="compact"
 		@click="onClick"
@@ -334,6 +335,7 @@ import { AVATAR, CONVERSATION, PARTICIPANT } from '../../../constants.ts'
 import { getTalkConfig, hasTalkFeature } from '../../../services/CapabilitiesManager.ts'
 import { useConversationTagsStore } from '../../../stores/conversationTags.ts'
 import { isClassifiedConversation } from '../../../utils/conversation.ts'
+import { formatDateTime, getDiffInDays } from '../../../utils/formattedTime.ts'
 import { copyConversationLinkToClipboard } from '../../../utils/handleUrl.ts'
 
 const supportsArchive = hasTalkFeature('local', 'archived-conversations-v2')
@@ -490,6 +492,25 @@ export default {
 		showCallNotificationSettings() {
 			return getTalkConfig(this.item.token, 'call', 'enabled')
 				&& (!this.item.remoteServer || hasTalkFeature(this.item.token, 'federation-v2'))
+		},
+
+		lastActivityTimeString() {
+			const timestampInMs = (this.item.lastMessage?.timestamp ?? this.item.lastActivity ?? 0) * 1_000
+			if (timestampInMs === 0) {
+				return ''
+			}
+
+			const diffInDays = Math.abs(getDiffInDays(timestampInMs))
+			if (diffInDays === 0) {
+				// Today
+				return formatDateTime(timestampInMs, 'shortTime')
+			} else if (diffInDays < 7) {
+				// Within a week
+				return formatDateTime(timestampInMs, 'shortWeekday')
+			}
+
+			const isSameYear = new Date(timestampInMs).getFullYear() === new Date().getFullYear()
+			return formatDateTime(timestampInMs, isSameYear ? 'shortDateSameYear' : 'shortDate')
 		},
 
 		isVoiceRoom() {
@@ -750,6 +771,18 @@ export default {
 	& :deep(.list-item:hover .conversation-icon__type) {
 		background-color: var(--color-background-hover);
 		border-color: var(--color-background-hover);
+	}
+
+	// Overwrite NcListItem styles to reduce timestamp size and fit two lines in 40px height limit
+	& :deep(.list-item .list-item-content__details) {
+		justify-content: flex-start;
+		font-size: var(--font-size-small);
+	}
+	& :deep(.list-item .list-item-details__extra) {
+		margin-block-start: 0;
+	}
+	& :deep(.list-item .counter-bubble__counter) {
+		--counter-bubble-height: 20px !important;
 	}
 
 	&--active {

--- a/src/utils/__tests__/formattedTime.spec.js
+++ b/src/utils/__tests__/formattedTime.spec.js
@@ -112,6 +112,7 @@ describe('formatDateTime', () => {
 		['shortDateNumeric', '02/15/2025'], // 'MM/DD/YYYY'
 		['shortDateWithTime', 'Feb 15, 2025, 8:30 PM'], // 'MMM D, YYYY h:mm A'
 		['shortDateWithTimeSeconds', 'Feb 15, 2025, 8:30:00 PM'], // 'MMM D, YYYY h:mm:ss A'
+		['shortWeekday', 'Sat'], // 'ddd'
 		['shortWeekdayWithTime', 'Sat 8:30 PM'], // 'ddd h:mm A'
 	]
 

--- a/src/utils/formattedTime.ts
+++ b/src/utils/formattedTime.ts
@@ -20,6 +20,7 @@ const absoluteTimeFormat = {
 	shortDateNumeric: new Intl.DateTimeFormat(locale, { year: 'numeric', month: '2-digit', day: '2-digit' }), // '02/15/2025'
 	shortDateWithTime: new Intl.DateTimeFormat(locale, { year: 'numeric', month: 'short', day: 'numeric', hour: 'numeric', minute: 'numeric' }), // 'Feb 15, 2025, 8:30 PM'
 	shortDateWithTimeSeconds: new Intl.DateTimeFormat(locale, { year: 'numeric', month: 'short', day: 'numeric', hour: 'numeric', minute: 'numeric', second: 'numeric' }), // 'Feb 15, 2025, 8:30:00 PM'
+	shortWeekday: new Intl.DateTimeFormat(locale, { weekday: 'short' }), // 'Sat'
 	shortWeekdayWithTime: new Intl.DateTimeFormat(locale, { weekday: 'short', hour: 'numeric', minute: 'numeric' }), // 'Sat 8:30 PM'
 } as const
 


### PR DESCRIPTION
## ☑️ Resolves

* Ref #13175
	* render last message timestamp in LeftSidebar
	* fallback to last activity
	* copy rendering logic from upcoming events
	* do not show time if not from today
	* do not show time in compact mode

### AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="182" height="234" alt="image" src="https://github.com/user-attachments/assets/66623455-2feb-4644-8c8c-2ef89ddbc89d" /> | <img width="183" height="233" alt="image" src="https://github.com/user-attachments/assets/39f36a9c-2d52-40bd-8bc5-eb397c5f7615" />
Older entries | <img width="287" height="133" alt="image" src="https://github.com/user-attachments/assets/9115d939-9402-44d5-8333-76295171474c" />

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [x] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required