### PR TITLE
feat: pass talk meeting flag for summary tasks

### DIFF
--- a/lib/Service/RecordingService.php
+++ b/lib/Service/RecordingService.php
@@ -463,7 +463,10 @@ class RecordingService {
 
 		$task = new Task(
 			TextToTextSummary::ID,
-			['input' => $output],
+			[
+				'input' => $output,
+				'talk_meeting' => 1
+			],
 			Application::APP_ID,
 			$owner,
 			'call/summary/' . $room->getToken() . '/' . $recordingFileId,


### PR DESCRIPTION
## ☑️ Resolves

* Fix #…

### AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->


## 🛠️ API Checklist

### 🚧 Tasks

- [x] Pass `'talk_meeting'` flag when creating summary task for Talk meeting recording
- [x] this flag helps to distinguish summary for meetings (Talk meeting) vs regural summaries in `nextcloud/integration_openai`

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 

## Notes

This change depends on my PR in  `nextcloud/integration_openai` [Feat/configurable summary system prompts- #425](https://github.com/nextcloud/integration_openai/pull/425). The idea is having configurable promptsfor summary tasks. In the usecase of Talk meetings, Summary Provider will distinguish that it should summarize for Talk meeting. Why is that important? Because, there is a difference between summarizing an article and a meeting. For a meeting, an admin will be able to configure system prompt to recieve meeting specific output. For example, this might be required output:

```
1. Meeting purpose (sentence)
The purpose of a meeting ...
2. Time and place (sentence)
 ...
3. Participants (bullet points)
- Name Surname - works in IT department
- ...
4. Arrangements (bullet points)
- person X has to do Y
- ...
```

The command below will set system prompt for Talk meetining:
```
`php occ config:app:set integration_openai system_prompt_talk_summary --value="Configurable talk summary system prompt"`
```

Otherwise, the default behaviour (the same as before my changes) will be applied.

You can learn more in this PR [Feat/configurable summary system prompts- #425](https://github.com/nextcloud/integration_openai/pull/425)

### Draft PR

After review in `nextcloud/integration_openai` PR [Feat/configurable summary system prompts- #425](https://github.com/nextcloud/integration_openai/pull/425) I will change this Draft to PR


