### PR TITLE
docs: Update license to SPDX compliant license identifier

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -19,7 +19,7 @@
 ]]></description>
 
 	<version>25.0.0-dev.0</version>
-	<licence>agpl</licence>
+	<licence>AGPL-3.0-or-later</licence>
 
 	<author>Christian Lorang</author>
 	<author>Daniel Calviño Sánchez</author>

--- a/openapi-administration.json
+++ b/openapi-administration.json
@@ -5,7 +5,7 @@
         "version": "0.0.1",
         "description": "Chat, video & audio-conferencing using WebRTC",
         "license": {
-            "name": "agpl"
+            "name": "AGPL-3.0-or-later"
         }
     },
     "components": {

--- a/openapi-backend-recording.json
+++ b/openapi-backend-recording.json
@@ -5,7 +5,7 @@
         "version": "0.0.1",
         "description": "Chat, video & audio-conferencing using WebRTC",
         "license": {
-            "name": "agpl"
+            "name": "AGPL-3.0-or-later"
         }
     },
     "components": {

--- a/openapi-backend-signaling.json
+++ b/openapi-backend-signaling.json
@@ -5,7 +5,7 @@
         "version": "0.0.1",
         "description": "Chat, video & audio-conferencing using WebRTC",
         "license": {
-            "name": "agpl"
+            "name": "AGPL-3.0-or-later"
         }
     },
     "components": {

--- a/openapi-backend-sipbridge.json
+++ b/openapi-backend-sipbridge.json
@@ -5,7 +5,7 @@
         "version": "0.0.1",
         "description": "Chat, video & audio-conferencing using WebRTC",
         "license": {
-            "name": "agpl"
+            "name": "AGPL-3.0-or-later"
         }
     },
     "components": {

--- a/openapi-bots.json
+++ b/openapi-bots.json
@@ -5,7 +5,7 @@
         "version": "0.0.1",
         "description": "Chat, video & audio-conferencing using WebRTC",
         "license": {
-            "name": "agpl"
+            "name": "AGPL-3.0-or-later"
         }
     },
     "components": {

--- a/openapi-federation.json
+++ b/openapi-federation.json
@@ -5,7 +5,7 @@
         "version": "0.0.1",
         "description": "Chat, video & audio-conferencing using WebRTC",
         "license": {
-            "name": "agpl"
+            "name": "AGPL-3.0-or-later"
         }
     },
     "components": {

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -5,7 +5,7 @@
         "version": "0.0.1",
         "description": "Chat, video & audio-conferencing using WebRTC",
         "license": {
-            "name": "agpl"
+            "name": "AGPL-3.0-or-later"
         }
     },
     "components": {

--- a/openapi.json
+++ b/openapi.json
@@ -5,7 +5,7 @@
         "version": "0.0.1",
         "description": "Chat, video & audio-conferencing using WebRTC",
         "license": {
-            "name": "agpl"
+            "name": "AGPL-3.0-or-later"
         }
     },
     "components": {


### PR DESCRIPTION
## ☑️ Resolves

* use of modern SPDX compliant license IDs in meta data

current versions of Nextcloud support all/most licenses that are compliant to the server, so we can move to such IDs given the current amin is v35 as a min version.

### AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI

### 🚧 Tasks

- [ ] review'n'merge