### PR TITLE
fix(recording): allow chunked upload keys for longer tokens

### DIFF
--- a/lib/Service/RecordingService.php
+++ b/lib/Service/RecordingService.php
@@ -314,7 +314,10 @@ class RecordingService {
 	}
 
 	private function getUploadShareConfigKey(Room $room, string $fileName): string {
-		return self::APPCONFIG_UPLOAD_PREFIX . $room->getToken() . '/' . sha1(basename($fileName));
+		// Room tokens can be up to 30 characters long, so the token and file
+		// name are hashed together to keep the config key within the 64
+		// character limit regardless of the token length.
+		return self::APPCONFIG_UPLOAD_PREFIX . sha1($room->getToken() . '/' . basename($fileName));
 	}
 
 	/**

--- a/tests/php/Service/RecordingServiceTest.php
+++ b/tests/php/Service/RecordingServiceTest.php
@@ -257,7 +257,7 @@ class RecordingServiceTest extends TestCase {
 
 		$this->appConfig->expects($this->once())
 			->method('setAppValueString')
-			->with(RecordingService::APPCONFIG_UPLOAD_PREFIX . 'token123/' . sha1('recording.mp4'), 'shareToken', true, true);
+			->with(RecordingService::APPCONFIG_UPLOAD_PREFIX . sha1('token123/recording.mp4'), 'shareToken', true, true);
 
 		// The active-recording marker is cleared once the upload share is created,
 		// so a new recording can start while this one is still being uploaded.
@@ -335,7 +335,7 @@ class RecordingServiceTest extends TestCase {
 		// Only the temporary upload share's tracking value is cleared here; the
 		// active-recording marker was already removed in requestUpload().
 		$this->appConfig->expects($this->once())->method('deleteAppValue')
-			->with(RecordingService::APPCONFIG_UPLOAD_PREFIX . 'token123/' . sha1('name.ogg'));
+			->with(RecordingService::APPCONFIG_UPLOAD_PREFIX . sha1('token123/name.ogg'));
 
 		$this->notificationManager->expects($this->once())->method('notify');
 


### PR DESCRIPTION
Fix chunked recording upload when talk token length > 13.

Fixes #18458

## Test plan
- [ ] Review diff against issue
- [ ] Run project lint/tests if applicable
