### PR TITLE
fix(chat): place temporary message after date separator

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessageItem.spec.js
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageItem.spec.js
@@ -483,7 +483,7 @@ describe('MessageItem.vue', () => {
 		})
 
 		test('does not render actions for temporary messages', async () => {
-			messageProps.message.timestamp = 0
+			messageProps.message.id = 'temp-123'
 
 			const wrapper = mountMessage(messageProps)
 
@@ -594,7 +594,7 @@ describe('MessageItem.vue', () => {
 		})
 
 		test('displays the message already with a spinner while sending it', () => {
-			messageProps.message.timestamp = 0
+			messageProps.message.id = 'temp-123'
 			const wrapper = mountMessage(messageProps)
 			const message = wrapper.findComponent(NcRichText)
 			expect(message.text()).toBe('test message')

--- a/src/components/MessagesList/MessagesGroup/Message/MessageItem.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageItem.vue
@@ -187,7 +187,7 @@ export default {
 		},
 
 		isTemporary() {
-			return !this.isScheduledMessage && this.message.timestamp === 0
+			return !this.isScheduledMessage && String(this.message.id).startsWith('temp-')
 		},
 
 		isDeletedMessage() {

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/MessageBody.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/MessageBody.vue
@@ -418,7 +418,7 @@ export default {
 		},
 
 		isTemporary() {
-			return !this.isScheduledMessage && this.message.timestamp === 0
+			return !this.isScheduledMessage && String(this.message.id).startsWith('temp-')
 		},
 
 		isScheduledSendingFailure() {
@@ -430,11 +430,11 @@ export default {
 		},
 
 		messageTime() {
-			return formatDateTime(this.isTemporary ? Date.now() : this.message.timestamp * 1000, 'shortTime')
+			return formatDateTime(this.message.timestamp * 1000, 'shortTime')
 		},
 
 		messageDate() {
-			return formatDateTime(this.isTemporary ? Date.now() : this.message.timestamp * 1000, 'longDate')
+			return formatDateTime(this.message.timestamp * 1000, 'longDate')
 		},
 
 		lastCallStartedMessageId() {

--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -476,7 +476,7 @@ export default {
 				if (!this.messagesShouldBeGrouped(message, lastMessage)) {
 					groupId = message.id
 					if (message.timestamp === 0) {
-						// This is a temporary message, the timestamp is today
+						// This is a scheduled message that failed to be scheduled, show it as today
 						dateTimestamp = this.currentDay
 					} else {
 						dateTimestamp = convertToUnix(new Date(message.timestamp * 1000).setHours(0, 0, 0, 0))
@@ -639,9 +639,6 @@ export default {
 		 * @return {object} Date object
 		 */
 		getDateOfMessage(message) {
-			if (message.id.toString().startsWith('temp-')) {
-				return new Date()
-			}
 			return new Date(message.timestamp * 1000)
 		},
 

--- a/src/components/NewMessage/NewMessage.vue
+++ b/src/components/NewMessage/NewMessage.vue
@@ -1349,7 +1349,7 @@ export default {
 			const lastMessageByCurrentUser = messagesList.findLast((message) => {
 				return this.actorStore.checkIfSelfIsActor(message) // From same actor
 					&& message.messageType !== MESSAGE.TYPE.COMMENT_DELETED // Not deleted
-					&& message.timestamp !== 0 // Not temporary
+					&& !String(message.id).startsWith('temp-') // Not temporary
 					&& !message.systemMessage // Not system message
 					&& (Date.now() - message.timestamp * 1000 < ONE_DAY_IN_MS)
 			})

--- a/src/utils/__tests__/prepareTemporaryMessage.spec.js
+++ b/src/utils/__tests__/prepareTemporaryMessage.spec.js
@@ -40,7 +40,7 @@ describe('prepareTemporaryMessage', () => {
 		reactions: {},
 		referenceId: expect.stringMatching(/^[a-zA-Z0-9]{64}$/),
 		systemMessage: '',
-		timestamp: 0,
+		timestamp: 1577908800,
 		token: TOKEN,
 		silent: false,
 		threadId: undefined,

--- a/src/utils/prepareTemporaryMessage.ts
+++ b/src/utils/prepareTemporaryMessage.ts
@@ -9,6 +9,7 @@ import Hex from 'crypto-js/enc-hex.js'
 import SHA256 from 'crypto-js/sha256.js'
 import { MESSAGE } from '../constants.ts'
 import { hasTalkFeature } from '../services/CapabilitiesManager.ts'
+import { convertToUnix } from './formattedTime.ts'
 
 export type RawTemporaryMessagePayload = Pick<ChatMessage, | 'message'
 	| 'token'
@@ -129,7 +130,7 @@ export function prepareTemporaryMessage({
 		// @ts-expect-error: type 'string' is not assignable to type 'number'
 		id: tempId,
 		token,
-		timestamp: 0,
+		timestamp: convertToUnix(date),
 		expirationTimestamp: 0,
 		systemMessage: '',
 		markdown: hasTalkFeature(token, 'markdown-messages'),


### PR DESCRIPTION
Avoid inserting temporary messages before the date separator.

Fixes #13777

## Test plan
- [ ] Review diff against issue
- [ ] Run project lint/tests if applicable
