### PR TITLE
chore(release): Changelog for v24.0.4, v23.0.10, v22.0.17

### DIFF
--- a/docs/changelogs/changelog-22.md
+++ b/docs/changelogs/changelog-22.md
@@ -4,6 +4,17 @@
 -->
 # Changelog
 All notable changes to this project will be documented in this file.
+## 22.0.17 – 2026-08-13
+### Changed
+- Update dependencies
+- Update translations
+
+### Fixed
+- fix(external-call): Grant additional permissions to iframe
+  [#18922](https://github.com/nextcloud/spreed/pull/18922)
+- fix(external-call): Harden room creation checks
+  [#18847](https://github.com/nextcloud/spreed/pull/18847)
+  [#18841](https://github.com/nextcloud/spreed/pull/18841)
 
 ## 22.0.16 – 2026-07-24
 ### Changed

--- a/docs/changelogs/changelog-23.md
+++ b/docs/changelogs/changelog-23.md
@@ -4,6 +4,17 @@
 -->
 # Changelog
 All notable changes to this project will be documented in this file.
+## 23.0.10 – 2026-08-13
+### Changed
+- Update dependencies
+- Update translations
+
+### Fixed
+- fix(external-call): Grant additional permissions to iframe
+  [#18921](https://github.com/nextcloud/spreed/pull/18921)
+- fix(external-call): Harden room creation checks
+  [#18848](https://github.com/nextcloud/spreed/pull/18848)
+  [#18842](https://github.com/nextcloud/spreed/pull/18842)
 
 ## 23.0.9 – 2026-07-24
 ### Changed

--- a/docs/changelogs/changelog-24.md
+++ b/docs/changelogs/changelog-24.md
@@ -4,6 +4,23 @@
 -->
 # Changelog
 All notable changes to this project will be documented in this file.
+## 24.0.4 – 2026-08-13
+### Added
+- feat(bots): Allow bots to fetch their own enabled features
+  [#18834](https://github.com/nextcloud/spreed/pull/18834)
+
+### Changed
+- Update dependencies
+- Update translations
+
+### Fixed
+- fix(external-call): Grant additional permissions to iframe
+  [#18920](https://github.com/nextcloud/spreed/pull/18920)
+- fix(external-call): Harden room creation checks
+  [#18849](https://github.com/nextcloud/spreed/pull/18849)
+  [#18843](https://github.com/nextcloud/spreed/pull/18843)
+- fix(call): Prevent 'hall of mirrors' effect when sharing a screen
+  [#18836](https://github.com/nextcloud/spreed/pull/18836)
 
 ## 24.0.3 – 2026-07-24
 ### Added


### PR DESCRIPTION
## 22.0.17 – 2026-08-13
### Changed
- Update dependencies
- Update translations
### Fixed
- fix(external-call): Grant additional permissions to iframe
  [#18922](https://github.com/nextcloud/spreed/pull/18922)
- fix(external-call): Harden room creation checks
  [#18847](https://github.com/nextcloud/spreed/pull/18847)
  [#18841](https://github.com/nextcloud/spreed/pull/18841)
## 23.0.10 – 2026-08-13
### Changed
- Update dependencies
- Update translations
### Fixed
- fix(external-call): Grant additional permissions to iframe
  [#18921](https://github.com/nextcloud/spreed/pull/18921)
- fix(external-call): Harden room creation checks
  [#18848](https://github.com/nextcloud/spreed/pull/18848)
  [#18842](https://github.com/nextcloud/spreed/pull/18842)
## 24.0.4 – 2026-08-13
### Added
- feat(bots): Allow bots to fetch their own enabled features
  [#18834](https://github.com/nextcloud/spreed/pull/18834)
### Changed
- Update dependencies
- Update translations
### Fixed
- fix(external-call): Grant additional permissions to iframe
  [#18920](https://github.com/nextcloud/spreed/pull/18920)
- fix(external-call): Harden room creation checks
  [#18849](https://github.com/nextcloud/spreed/pull/18849)
  [#18843](https://github.com/nextcloud/spreed/pull/18843)
- fix(call): Prevent 'hall of mirrors' effect when sharing a screen
  [#18836](https://github.com/nextcloud/spreed/pull/18836)