### PR TITLE
chore(release): Changelog for v25.0.0-alpha.1

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -18,7 +18,7 @@
 * 🌉 **Sync with other chat solutions** With [Matterbridge](https://github.com/42wim/matterbridge/) being integrated in Talk, you can easily sync a lot of other chat solutions to Nextcloud Talk and vice-versa.
 ]]></description>
 
-	<version>25.0.0-dev.0</version>
+	<version>25.0.0-alpha.1</version>
 	<licence>AGPL-3.0-or-later</licence>
 
 	<author>Christian Lorang</author>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- [Talk 25 for Nextcloud 35 / Hub 26 Summer](changelogs/changelog-25.md)
 - [Talk 24 for Nextcloud 34 / Hub 26 Spring](changelogs/changelog-24.md)
 - [Talk 23 for Nextcloud 33 / Hub 26 Winter](changelogs/changelog-23.md)
 - [Talk 22 for Nextcloud 32](changelogs/changelog-22.md)

--- a/docs/changelogs/changelog-25.md
+++ b/docs/changelogs/changelog-25.md
@@ -1,0 +1,36 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: CC0-1.0
+-->
+# Changelog
+All notable changes to this project will be documented in this file.
+
+## 25.0.0-alpha.1 – 2026-08-13
+### Added
+- Classified conversations, announcements and channels
+  [#18680](https://github.com/nextcloud/spreed/pull/18680)
+  [#18685](https://github.com/nextcloud/spreed/pull/18685)
+- Owner role: promote and demote users to and from owners
+  [#18924](https://github.com/nextcloud/spreed/pull/18924)
+- Global message search in the conversation list
+  [#16344](https://github.com/nextcloud/spreed/pull/16344)
+- Preserve conversations to restrict deletion, purging and visibility changes
+  [#18351](https://github.com/nextcloud/spreed/pull/18351)
+- Setting to limit the start of calls to specific groups
+  [#18647](https://github.com/nextcloud/spreed/pull/18647)
+- Upload editor in the message composer with image compression
+  [#18984](https://github.com/nextcloud/spreed/pull/18984)
+  [#18906](https://github.com/nextcloud/spreed/pull/18906)
+- Combine file shares into a single message in the chat
+  [#18989](https://github.com/nextcloud/spreed/pull/18989)
+- Introduce multi-speaker view in calls
+  [#18966](https://github.com/nextcloud/spreed/pull/18966)
+- Show the time of the last message in the conversation list
+  [#18987](https://github.com/nextcloud/spreed/pull/18987)
+
+### Changed
+- Update dependencies
+- Update translations
+- Require Nextcloud 35 / Hub 26 Summer
+- New design of the Talk dashboard panel
+  [#18980](https://github.com/nextcloud/spreed/pull/18980)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "talk",
-  "version": "25.0.0-dev.0",
+  "version": "25.0.0-alpha.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "talk",
-      "version": "25.0.0-dev.0",
+      "version": "25.0.0-alpha.1",
       "license": "agpl",
       "dependencies": {
         "@matrix-org/olm": "^3.2.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "talk",
-  "version": "25.0.0-dev.0",
+  "version": "25.0.0-alpha.1",
   "private": true,
   "description": "",
   "license": "agpl",


### PR DESCRIPTION
### Changelog


## 💺 Preparation

- [x] Create a test package and check if a new development file needs to be added to the packaging exclude list in `Makefile`
```sh
make appstore
```

## 🚀 v25.0.0-alpha.1

- [x] Remove changelog entries in  `CHANGELOG.md` of higher versions
- [x] Bump the version in `appinfo/info.xml`
- [x] Bump the version in `package.json`.  The following command will return a new version name, make sure it matches what you expect:
```sh
# Make sure the printed version matches the info.xml version
npm version --no-git-tag-version $(xmllint --xpath '/info/version/text()' appinfo/info.xml)
```

- [x] Make sure you pull the latest stable branch:
    ```sh
    git checkout main
    git pull origin main
    ```
- [x] Clean the dev instance and update all dependencies with the lock file versions and build the production javascript:
    ```sh
    make production-setup
    # On 24 and older versions run:
    # make dev-setup build-js-production
    ```
- [x] Do a quick smoke test by starting a call with:
    - [x] Chrome
    - [ ] Edge
    - [x] Firefox
    - [ ] Safari
    - [ ] Desktop client (Talk 16+)
    - [ ] Android app
    - [ ] iOS app
- [x] Create tag (note that the leading `v` in `v25.0.0-alpha.1` will be automatically added to the tag)
    ```sh
    make create-tag version=$(xmllint --xpath '/info/version/text()' appinfo/info.xml)
    ```
- [x] Push the git tag to https://github.com/nextcloud-releases/spreed
    ```sh
    git push releases v$(xmllint --xpath '/info/version/text()' appinfo/info.xml)
    ```
    Make sure you have access rights to the remote repository, and it is set up on your machine:
    ```sh
    git remote add releases git@github.com:nextcloud-releases/spreed.git
    ```
- [x] Prepare a (pre-)release in https://github.com/nextcloud/spreed/releases/new?tag=v25.0.0-alpha.1
    - [x] Make sure that chosen tag is v25.0.0-alpha.1, target is main, and previous tag is v25.0.0-dev.0
    - [x] Add the respective `CHANGELOG.md` section from merged PR
    - [x] Use the **Generate release notes** button and wrap the output result into
        ```
        ## What's Changed

        <details>
        	<!-- insert the output here -->
        </details>
        ```
    - [x] Set as a pre-release / as the latest release
    - [x] Publish release
- [x] Prepare a (pre-)release in https://github.com/nextcloud-releases/spreed/releases/new?tag=v25.0.0-alpha.1
    - [x] Copy the full content from the release description of the previous step
    - [x] Set as a pre-release / as the latest release
    - [x] Publish release
- [x] Check that the GitHub Action started: https://github.com/nextcloud-releases/spreed/actions
- [x] Rename milestone `💚 Next Patch (35)` to `v25.0.0-alpha.1` in https://github.com/nextcloud/spreed/milestones

    Unless last release of the stable branch:
    - [x] Create a follow-up milestone for `💚 Next Patch (35)` (Due date in ~4 weeks, ~1 week for beta/RC)

    - [x] Move all open issues from milestone `v25.0.0-alpha.1` to `💚 Next Patch (35)`: https://github.com/nextcloud/spreed/issues?q=is%3Aissue%20state%3Aopen%20milestone%3Av25.0.0-alpha.1

    - [x] Move all open PRs from milestone `v25.0.0-alpha.1` to `💚 Next Patch (35)`: https://github.com/nextcloud/spreed/pulls?q=is%3Apr%20state%3Aopen%20milestone%3Av25.0.0-alpha.1

- [x] Close the `v25.0.0-alpha.1` milestone
```
gh api 'repos/nextcloud/spreed/milestones?state=open&per_page=100' --paginate \
    --jq '.[] | select(.title | endswith("(35)")) | "\(.number)\t\(.title)"'

363     ⛅ Next Major (35)

gh api --method PATCH repos/nextcloud/spreed/milestones/363 \
    -f title="v25.0.0-alpha.1" --jq .title

v25.0.0-alpha.1

# For a beta/RC use '+1 week' instead of '+4 weeks'
gh api --method POST repos/nextcloud/spreed/milestones \
    -f title="⛅ Next Beta/RC (35)" \
    -f due_on="$(date -u -d '+1 weeks' +%Y-%m-%dT00:00:00Z)" \
    --jq '"\(.number)\t\(.title)\t\(.due_on)"'

383     ⛅ Next Beta/RC (35)    2026-08-19T00:00:00Z

gh api 'repos/nextcloud/spreed/issues?milestone=363&state=open&per_page=100' \
    --paginate --jq '.[].number' \
    | xargs -r -I{} gh api --method PATCH repos/nextcloud/spreed/issues/{} \
        -F milestone=383 --jq .number

gh api --method PATCH repos/nextcloud/spreed/milestones/363 \
    -f state=closed --jq .state

closed
```
- [x] Ensure that the GitHub Action finished successfully: https://github.com/nextcloud-releases/spreed/actions