### PR TITLE
fix(chat): do not separate edited messages from the group

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/MessageBody.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/MessageBody.vue
@@ -503,9 +503,8 @@ export default {
 
 		isEditorDifferentThenAuthor() {
 			return this.message.lastEditActorId
-				&& this.message.lastEditActorId !== this.message.actorId
-				&& this.message.lastEditActorDisplayName !== this.message.actorDisplayName
-				&& this.message.lastEditActorType !== this.message.actorType
+				&& !(this.message.lastEditActorId === this.message.actorId
+					&& this.message.lastEditActorType === this.message.actorType)
 		},
 
 		isMessagePinned() {

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/MessageBody.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/MessageBody.vue
@@ -84,7 +84,11 @@
 		<div
 			v-if="!isDeletedMessage"
 			class="message-main__info">
-			<span v-if="isSplitViewEnabled && isOwnMessage && message.lastEditTimestamp" class="editor">
+			<span
+				v-if="message.lastEditTimestamp"
+				class="editor"
+				:aria-label="lastEditor"
+				:title="lastEditor">
 				<IconPencilOutline :size="14" />
 				<AvatarWrapper
 					v-if="isEditorDifferentThenAuthor"
@@ -295,6 +299,7 @@ export default {
 			isEditable,
 			isFileShare,
 			isFileShareWithoutCaption,
+			lastEditor,
 		} = useMessageInfo(message)
 		const threadId = useGetThreadId()
 		const isSidebar = inject('chatView:isSidebar', false)
@@ -309,6 +314,7 @@ export default {
 			isEditable,
 			isFileShare,
 			isFileShareWithoutCaption,
+			lastEditor,
 			isSidebar,
 			actorStore: useActorStore(),
 			isSplitViewEnabled,
@@ -616,7 +622,8 @@ export default {
 	min-height: var(--clickable-area-small);
 	min-width: 100%;
 	// Layout 1 (standard view): text and info in two columns
-	grid-template-columns: minmax(0, $messages-text-max-width) $messages-info-width;
+	// Info column grows past its minimum to fit the edited-message icon, so it never overlaps the text column
+	grid-template-columns: minmax(0, $messages-text-max-width) minmax($messages-info-width, max-content);
 	row-gap: var(--default-grid-baseline);
 
 	& .message-main__thread-title,
@@ -669,6 +676,7 @@ export default {
 		.message-main__info {
 			opacity: 0;
 			width: auto;
+			min-width: 0;
 			font-size: var(--font-size-small);
 
 			&::before {
@@ -688,13 +696,10 @@ export default {
 			align-items: end;
 			font-size: var(--font-size-small);
 			width: auto;
+			min-width: 0;
 
 			.editor {
-				display: inline-flex;
-				align-items: center;
 				margin-inline-end: var(--default-grid-baseline);
-				gap: calc(var(--default-grid-baseline) / 2);
-				height: 1lh;
 			}
 		}
 
@@ -804,12 +809,24 @@ export default {
 		position: relative;
 		user-select: none;
 		display: flex;
+		align-items: center;
 		justify-content: flex-end;
 		color: var(--color-text-maxcontrast);
 		font-size: var(--default-font-size);
-		width: $messages-info-width;
+		min-width: $messages-info-width;
 		gap: calc(var(--default-grid-baseline) / 2);
 		padding-inline: calc(2 * var(--default-grid-baseline));
+
+		.editor {
+			display: inline-flex;
+			align-items: center;
+			gap: calc(var(--default-grid-baseline) / 2);
+			height: 1lh;
+
+			:deep(.avatar-wrapper) {
+				line-height: 0;
+			}
+		}
 
 		.date {
 			width: 8ch;

--- a/src/components/MessagesList/MessagesGroup/MessagesGroup.vue
+++ b/src/components/MessagesList/MessagesGroup/MessagesGroup.vue
@@ -101,14 +101,13 @@ export default {
 		const firstMessage = computed(() => messages.value[0])
 		const {
 			remoteServer,
-			lastEditor,
 			actorDisplayName,
 			actorDisplayNameWithFallback,
 		} = useMessageInfo(firstMessage)
 		const isSidebar = inject('chatView:isSidebar', false)
 
 		const actorInfo = computed(() => {
-			return [actorDisplayNameWithFallback.value, remoteServer.value, lastEditor.value]
+			return [actorDisplayNameWithFallback.value, remoteServer.value]
 				.filter((value) => value).join(' ')
 		})
 

--- a/src/components/MessagesList/MessagesList.spec.js
+++ b/src/components/MessagesList/MessagesList.spec.js
@@ -201,6 +201,16 @@ describe('MessagesList.vue', () => {
 		/**
 		 * @param {Array} messagesGroups List of messages that should be grouped
 		 */
+		/**
+		 * Merge MessagesGroup and MessagesSystemGroup instances, sorted by DOM order.
+		 *
+		 * @param {object} wrapper The mounted MessagesList wrapper
+		 */
+		function findAllGroups(wrapper) {
+			return [...wrapper.findAllComponents(MessagesGroup), ...wrapper.findAllComponents(MessagesSystemGroup)]
+				.sort((a, b) => (a.element.compareDocumentPosition(b.element) & Node.DOCUMENT_POSITION_FOLLOWING ? -1 : 1))
+		}
+
 		function testGrouped(...messagesGroups) {
 			store.commit('addConversation', {
 				token: TOKEN,
@@ -212,7 +222,7 @@ describe('MessagesList.vue', () => {
 
 			const wrapper = mountMessagesList()
 
-			const groups = wrapper.findAllComponents('li.wrapper')
+			const groups = findAllGroups(wrapper)
 			groups.forEach((group, index) => {
 				expect(group.props('messages')).toStrictEqual(messagesGroups[index])
 			})
@@ -234,7 +244,7 @@ describe('MessagesList.vue', () => {
 
 			const wrapper = mountMessagesList()
 
-			const groups = wrapper.findAll('.messages-group')
+			const groups = findAllGroups(wrapper)
 			groups.forEach((group, index) => {
 				expect(group.props('messages')).toStrictEqual([messages[index]])
 			})
@@ -426,8 +436,8 @@ describe('MessagesList.vue', () => {
 			}])
 		})
 
-		test('does not group edited messages', () => {
-			testNotGrouped([{
+		test('groups edited messages', () => {
+			testGrouped([{
 				id: 100,
 				token: TOKEN,
 				actorId: 'alice',

--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -592,10 +592,6 @@ export default {
 				return false
 			}
 
-			if (!!message1.lastEditTimestamp || !!message2.lastEditTimestamp) {
-				return false // Edited messages are not grouped
-			}
-
 			if (message1.actorType === ATTENDEE.ACTOR_TYPE.BOTS // Don't group messages of bots
 				&& message1.actorId !== ATTENDEE.CHANGELOG_BOT_ID // Apart from the changelog bot
 				&& message1.actorId !== ATTENDEE.SAMPLE_BOT_ID) { // Apart from the sample message


### PR DESCRIPTION
## ☑️ Resolves

* Behaviour change for edited messages:
	* Edit marker is unified (pencil icon + avatar if differs from author, details in message actions menu) 
	* Messages no longer ungrouped, if edited

### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
Edited caption is ungrouped, all edited messages ungrouped, foreign edits are not visible | Edited caption part of combined message, all edited messages are part of respective group, foreign edits highlighted with avatar
<img width="723" height="779" alt="image" src="https://github.com/user-attachments/assets/dcde81ac-df52-426b-ae0a-4569d90ac44b" /> | <img width="725" height="715" alt="image" src="https://github.com/user-attachments/assets/d0fe34a3-cc5e-4674-a07e-47865bb3fb1a" />
<img width="725" height="767" alt="image" src="https://github.com/user-attachments/assets/f64482ed-9935-47af-8cd8-e72669903011" /> | <img width="725" height="730" alt="image" src="https://github.com/user-attachments/assets/ba9b7095-a411-4c2f-83c4-439b43f7c5f2" />

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
