### PR TITLE
fix(AvatarWrapper): fix unreachable CSS rules

### DIFF
--- a/src/components/AvatarWrapper/AvatarWrapper.vue
+++ b/src/components/AvatarWrapper/AvatarWrapper.vue
@@ -296,7 +296,7 @@ export default {
 		font-size: calc(var(--avatar-size) / 2);
 		background-color: var(--color-text-maxcontrast-default);
 
-		&.icon {
+		& :deep(.avatar-class-icon) {
 			background-size: calc(var(--avatar-size) / 2);
 			&.icon-changelog {
 				background-size: cover !important;
@@ -323,9 +323,7 @@ export default {
 		margin-inline-start: calc(var(--condensed-overlap) * -1px);
 		display: flex;
 
-		& > .icon,
-		& > .guest,
-		:deep(img) {
+		& :deep(.avatardiv) {
 			outline: 2px solid var(--color-main-background);
 		}
 	}
@@ -369,9 +367,4 @@ export default {
 		background-color: var(--color-text-maxcontrast-default);
 	}
 }
-
-:deep(.icon-user) {
-	background-size: calc(var(--avatar-size) / 2);
-}
-
 </style>


### PR DESCRIPTION
## ☑️ Resolves

* Fix #16774
	* NcAvatar template was changed in the meantime, and .icon class is gone

### AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="198" height="41" alt="2026-08-18_17h33_16" src="https://github.com/user-attachments/assets/9a8771c2-16de-47ac-aae8-b7ed1329f5b4" /> | <img width="200" height="41" alt="2026-08-18_17h32_58" src="https://github.com/user-attachments/assets/cbb1c47f-9736-4a15-8876-4c9d2550cb03" />
<img width="281" height="58" alt="2026-08-18_17h33_59" src="https://github.com/user-attachments/assets/18d33926-6d86-4d02-8a65-b8098f7521f5" /> | <img width="286" height="61" alt="2026-08-18_17h33_36" src="https://github.com/user-attachments/assets/870ae2da-5d00-4d5e-ac09-e4c11603a604" />
Unchanged | --
<img width="145" height="85" alt="image" src="https://github.com/user-attachments/assets/ab702817-3144-4a45-928d-0d1ec4330d19" /> | <img width="145" height="85" alt="image" src="https://github.com/user-attachments/assets/ab702817-3144-4a45-928d-0d1ec4330d19" />

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [x] ⛑️ Tests are included or not possible