### PR TITLE
fix(upload): construct referenceId for grouped uploads

### DIFF
--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -231,7 +231,7 @@ namespace OCA\Talk;
  *     reactions: array<string, integer>|\stdClass,
  *     // When the user reacted this is the list of emojis the user reacted with
  *     reactionsSelf?: list<string>,
- *     // A reference string that was given while posting the message to be able to identify a sent message again (only available with `chat-reference-id` capability)
+ *     // A reference string that was given while posting the message to be able to identify a sent message again (only available with `chat-reference-id` capability). For grouped file uploads support, expected format is `{sha256(uploadId)}-{order}`, matching /^[a-f0-9]{60}-[0-9]{3}$/
  *     referenceId: string,
  *     // Timestamp in seconds and UTC time zone
  *     timestamp: int,

--- a/openapi-backend-sipbridge.json
+++ b/openapi-backend-sipbridge.json
@@ -598,7 +598,7 @@
                             },
                             "referenceId": {
                                 "type": "string",
-                                "description": "A reference string that was given while posting the message to be able to identify a sent message again (only available with `chat-reference-id` capability)"
+                                "description": "A reference string that was given while posting the message to be able to identify a sent message again (only available with `chat-reference-id` capability). For grouped file uploads support, expected format is `{sha256(uploadId)}-{order}`, matching /^[a-f0-9]{60}-[0-9]{3}$/"
                             },
                             "timestamp": {
                                 "type": "integer",

--- a/openapi-federation.json
+++ b/openapi-federation.json
@@ -598,7 +598,7 @@
                             },
                             "referenceId": {
                                 "type": "string",
-                                "description": "A reference string that was given while posting the message to be able to identify a sent message again (only available with `chat-reference-id` capability)"
+                                "description": "A reference string that was given while posting the message to be able to identify a sent message again (only available with `chat-reference-id` capability). For grouped file uploads support, expected format is `{sha256(uploadId)}-{order}`, matching /^[a-f0-9]{60}-[0-9]{3}$/"
                             },
                             "timestamp": {
                                 "type": "integer",

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -845,7 +845,7 @@
                             },
                             "referenceId": {
                                 "type": "string",
-                                "description": "A reference string that was given while posting the message to be able to identify a sent message again (only available with `chat-reference-id` capability)"
+                                "description": "A reference string that was given while posting the message to be able to identify a sent message again (only available with `chat-reference-id` capability). For grouped file uploads support, expected format is `{sha256(uploadId)}-{order}`, matching /^[a-f0-9]{60}-[0-9]{3}$/"
                             },
                             "timestamp": {
                                 "type": "integer",

--- a/openapi.json
+++ b/openapi.json
@@ -785,7 +785,7 @@
                             },
                             "referenceId": {
                                 "type": "string",
-                                "description": "A reference string that was given while posting the message to be able to identify a sent message again (only available with `chat-reference-id` capability)"
+                                "description": "A reference string that was given while posting the message to be able to identify a sent message again (only available with `chat-reference-id` capability). For grouped file uploads support, expected format is `{sha256(uploadId)}-{order}`, matching /^[a-f0-9]{60}-[0-9]{3}$/"
                             },
                             "timestamp": {
                                 "type": "integer",

--- a/src/stores/upload.ts
+++ b/src/stores/upload.ts
@@ -325,6 +325,10 @@ export const useUploadStore = defineStore('upload', () => {
 	function initialiseUpload({ uploadId, token, threadId, files, rename = false, isVoiceMessage }: { uploadId: string, token: string, threadId?: number, files: File[], rename?: boolean, isVoiceMessage?: boolean }) {
 		// Set last upload id
 		currentUploadId.value = uploadId
+		const stagedFilesMaxIndex = Math.max(
+			0,
+			...getUploadsArray(uploadId).map(([index, _uploadedFile]) => Number(index.split('_').pop())),
+		)
 		for (let i = 0; i < files.length; i++) {
 			let file = files[i]
 
@@ -342,9 +346,9 @@ export const useUploadStore = defineStore('upload', () => {
 				? URL.createObjectURL(file)
 				: undefined
 
-			// Create a unique index for each file
-			const date = new Date()
-			const index = 'temp_' + date.getTime() + Math.random()
+			// Create a unique index for each file (append _1, _2, ... at the end to track file order)
+			const index = `temp_${uploadId}_${stagedFilesMaxIndex + 1 + i}`
+
 			// Create temporary message for the file and add it to the message list
 			const temporaryMessage = createTemporaryMessage({
 				message: '{file}',

--- a/src/types/openapi/openapi-backend-sipbridge.ts
+++ b/src/types/openapi/openapi-backend-sipbridge.ts
@@ -393,7 +393,7 @@ export type components = {
             };
             /** @description When the user reacted this is the list of emojis the user reacted with */
             reactionsSelf?: string[];
-            /** @description A reference string that was given while posting the message to be able to identify a sent message again (only available with `chat-reference-id` capability) */
+            /** @description A reference string that was given while posting the message to be able to identify a sent message again (only available with `chat-reference-id` capability). For grouped file uploads support, expected format is `{sha256(uploadId)}-{order}`, matching /^[a-f0-9]{60}-[0-9]{3}$/ */
             referenceId: string;
             /**
              * Format: int64

--- a/src/types/openapi/openapi-federation.ts
+++ b/src/types/openapi/openapi-federation.ts
@@ -404,7 +404,7 @@ export type components = {
             };
             /** @description When the user reacted this is the list of emojis the user reacted with */
             reactionsSelf?: string[];
-            /** @description A reference string that was given while posting the message to be able to identify a sent message again (only available with `chat-reference-id` capability) */
+            /** @description A reference string that was given while posting the message to be able to identify a sent message again (only available with `chat-reference-id` capability). For grouped file uploads support, expected format is `{sha256(uploadId)}-{order}`, matching /^[a-f0-9]{60}-[0-9]{3}$/ */
             referenceId: string;
             /**
              * Format: int64

--- a/src/types/openapi/openapi-full.ts
+++ b/src/types/openapi/openapi-full.ts
@@ -3040,7 +3040,7 @@ export type components = {
             };
             /** @description When the user reacted this is the list of emojis the user reacted with */
             reactionsSelf?: string[];
-            /** @description A reference string that was given while posting the message to be able to identify a sent message again (only available with `chat-reference-id` capability) */
+            /** @description A reference string that was given while posting the message to be able to identify a sent message again (only available with `chat-reference-id` capability). For grouped file uploads support, expected format is `{sha256(uploadId)}-{order}`, matching /^[a-f0-9]{60}-[0-9]{3}$/ */
             referenceId: string;
             /**
              * Format: int64

--- a/src/types/openapi/openapi.ts
+++ b/src/types/openapi/openapi.ts
@@ -2450,7 +2450,7 @@ export type components = {
             };
             /** @description When the user reacted this is the list of emojis the user reacted with */
             reactionsSelf?: string[];
-            /** @description A reference string that was given while posting the message to be able to identify a sent message again (only available with `chat-reference-id` capability) */
+            /** @description A reference string that was given while posting the message to be able to identify a sent message again (only available with `chat-reference-id` capability). For grouped file uploads support, expected format is `{sha256(uploadId)}-{order}`, matching /^[a-f0-9]{60}-[0-9]{3}$/ */
             referenceId: string;
             /**
              * Format: int64

--- a/src/utils/__tests__/prepareTemporaryMessage.spec.js
+++ b/src/utils/__tests__/prepareTemporaryMessage.spec.js
@@ -10,6 +10,7 @@ import { prepareTemporaryMessage } from '../prepareTemporaryMessage.ts'
 
 describe('prepareTemporaryMessage', () => {
 	const TOKEN = 'XXTOKENXX'
+	const UPLOAD_ID = String(new Date('2020-01-01T20:00:00').getTime())
 
 	beforeEach(() => {
 		vi.useFakeTimers().setSystemTime(new Date('2020-01-01T20:00:00'))
@@ -63,27 +64,28 @@ describe('prepareTemporaryMessage', () => {
 	const textFilePayload = {
 		...defaultPayload,
 		message: '{file}',
-		uploadId: 'upload-id-1',
-		index: 'upload-index-1',
+		uploadId: UPLOAD_ID,
+		index: `temp_${UPLOAD_ID}_1`,
 		file: textFile,
 		localUrl: 'local-url://original-name.txt',
 	}
 	const textFileResult = {
 		...defaultResult,
-		id: expect.stringMatching(/^temp-1577908800000-upload-id-1-0\.[0-9]*$/),
+		id: `temp-${UPLOAD_ID}-001`,
 		message: '{file}',
 		messageParameters: {
 			file: {
 				type: 'file',
 				file: textFile,
 				mimetype: 'text/plain',
-				id: expect.stringMatching(/^temp-1577908800000-upload-id-1-0\.[0-9]*$/),
+				id: `temp-${UPLOAD_ID}-001`,
 				name: 'new-name.txt',
-				uploadId: 'upload-id-1',
+				uploadId: UPLOAD_ID,
 				localUrl: 'local-url://original-name.txt',
-				index: 'upload-index-1',
+				index: `temp_${UPLOAD_ID}_1`,
 			},
 		},
+		referenceId: expect.stringMatching(/^[a-f0-9]{60}-[0-9]{3}$/),
 	}
 
 	const audioFile = {
@@ -94,14 +96,14 @@ describe('prepareTemporaryMessage', () => {
 		...defaultPayload,
 		message: '{file}',
 		messageType: MESSAGE.TYPE.VOICE_MESSAGE,
-		uploadId: 'upload-id-1',
-		index: 'upload-index-1',
+		uploadId: UPLOAD_ID,
+		index: `temp_${UPLOAD_ID}_1`,
 		file: audioFile,
 		localUrl: 'local-url://original-name.txt',
 	}
 	const audioFileResult = {
 		...defaultResult,
-		id: expect.stringMatching(/^temp-1577908800000-upload-id-1-0\.[0-9]*$/),
+		id: `temp-${UPLOAD_ID}-001`,
 		message: '{file}',
 		messageType: MESSAGE.TYPE.VOICE_MESSAGE,
 		messageParameters: {
@@ -109,13 +111,14 @@ describe('prepareTemporaryMessage', () => {
 				type: 'file',
 				file: audioFile,
 				mimetype: 'audio/wav',
-				id: expect.stringMatching(/^temp-1577908800000-upload-id-1-0\.[0-9]*$/),
+				id: `temp-${UPLOAD_ID}-001`,
 				name: 'Voice message 2020-01-01 20-00-00 (Note to self).wav',
-				uploadId: 'upload-id-1',
+				uploadId: UPLOAD_ID,
 				localUrl: 'local-url://original-name.txt',
-				index: 'upload-index-1',
+				index: `temp_${UPLOAD_ID}_1`,
 			},
 		},
+		referenceId: expect.stringMatching(/^[a-f0-9]{60}-[0-9]{3}$/),
 	}
 	const threadPayload = {
 		...defaultPayload,

--- a/src/utils/combineFileMessages.ts
+++ b/src/utils/combineFileMessages.ts
@@ -50,6 +50,22 @@ function isCombinableFileMessage(message: ChatMessage): boolean {
 }
 
 /**
+ * Checks whether file share message referenceId follows the group pattern
+ * (see prepareTemporaryMessage.ts for the format)
+ *
+ * @param id referenceId
+ * @return uploadHash (repeating part for single context upload) or original referenceId
+ */
+function getUploadHashFromReferenceId(id: string): string {
+	const [uploadHash, order] = id.split('-')
+	if (uploadHash.length === 60 && Number.isInteger(+order)) {
+		return uploadHash
+	} else {
+		return id
+	}
+}
+
+/**
  * Check whether two file shares belong to each other: they are replies to the same message
  * (or no replies at all) and they were shared together in a single context
  *
@@ -58,10 +74,8 @@ function isCombinableFileMessage(message: ChatMessage): boolean {
  */
 function canBeCombinedWith(message1: ChatMessage, message2: ChatMessage): boolean {
 	return message1.parent?.id === message2.parent?.id
-		// FIXME the timestamp is not a reliable indicator here, should instead
-		// create referenceId differently (e.g. as `${SHA(uploadId) + SHA(Math.random())}`)
-		// and base splitting on this (should be aligned with mobile clients as well)
-		&& message1.timestamp - message2.timestamp <= 30
+		&& !!message1.referenceId && !!message2.referenceId
+		&& getUploadHashFromReferenceId(message1.referenceId) === getUploadHashFromReferenceId(message2.referenceId)
 }
 
 /**

--- a/src/utils/prepareTemporaryMessage.ts
+++ b/src/utils/prepareTemporaryMessage.ts
@@ -65,7 +65,7 @@ export type TempChatMessageWithFile = Omit<ChatMessage, 'messageParameters'> & {
  * @param payload.message message string;
  * @param payload.token conversation token;
  * @param payload.uploadId upload id;
- * @param payload.index index;
+ * @param payload.index index of file. must be provided with file and uploadId;
  * @param payload.file file to upload;
  * @param payload.localUrl local URL of file to upload;
  * @param payload.messageType specify when the temporary file is a voice message
@@ -98,10 +98,25 @@ export function prepareTemporaryMessage({
 	isThread,
 }: PrepareTemporaryMessagePayload): ChatMessage | TempChatMessageWithFile {
 	const date = new Date()
-	let tempId = 'temp-' + date.getTime()
+	let tempId: string = 'temp-'
+	let referenceId: string
 	const messageParameters: ChatMessage['messageParameters'] = {}
 	if (file) {
-		tempId += '-' + uploadId + '-' + Math.random()
+		if (!index || !uploadId) {
+			throw new Error('[prepareTemporaryMessage]: index/uploadId is required for file messages')
+		}
+		const appendedIndex = index.split('_').pop()!.padStart(3, '0')
+		tempId += uploadId + '-' + appendedIndex
+
+		/**
+		 * Construct file share message referenceId in the following format:
+		 * /[a-f0-9]{60}-[0-9]{3}/, where:
+		 * /[a-f0-9]{60}/ - uploadId hashed with SHA-256 algorithm
+		 * /-/            - mandatory delimiter
+		 * /[0-9]{3}/     - order of file in given upload (natural integers, padded with zeroes)
+		 */
+		referenceId = Hex.stringify(SHA256(uploadId)).slice(0, 60) + '-' + appendedIndex
+
 		messageParameters.file = {
 			type: 'file',
 			// @ts-expect-error: 'file' does not exist in type RichObjectParameter
@@ -114,6 +129,9 @@ export function prepareTemporaryMessage({
 			localUrl,
 			index,
 		}
+	} else {
+		tempId += date.getTime()
+		referenceId = Hex.stringify(SHA256(tempId))
 	}
 
 	if (parent && 'token' in parent && parent.token !== token) {
@@ -140,7 +158,7 @@ export function prepareTemporaryMessage({
 		parent,
 		isReplyable: false,
 		reactions: {},
-		referenceId: Hex.stringify(SHA256(tempId)),
+		referenceId,
 		actorId,
 		actorType,
 		actorDisplayName,


### PR DESCRIPTION
## ☑️ Resolves

- Ref #11411
- construct referenceId in the following format:
  - `/[a-f0-9]{60}-[0-9]{3}/`, where:
  - `/[a-f0-9]{60}/` - uploadId hashed with SHA-256 algorithm
  - `/-/`            - mandatory delimiter
  - `/[0-9]{3}/`     - order of file in given upload (natural integers, padded with zeroes)

### AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI



## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

With applied grouping rules (two separate upload initiated within a minute):
🏚️ Before | 🏡 After
-- | --
<img width="482" height="95" alt="2026-08-20_15h29_00" src="https://github.com/user-attachments/assets/11c07115-9933-401b-a239-5c5d327d15d9" /> | <img width="483" height="245" alt="2026-08-20_15h28_34" src="https://github.com/user-attachments/assets/f493f426-53fa-4179-b7b0-04586a57c3df" />

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required