### PR TITLE
feat(upload): show file size on upload

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
@@ -62,6 +62,12 @@
 						class="file-preview__progress"
 						type="circular"
 						:value="uploadProgress" />
+					<span
+						v-if="fileSizeLabel"
+						class="file-preview__size"
+						data-theme-dark>
+						{{ fileSizeLabel }}
+					</span>
 				</template>
 				<TransitionWrapper v-else-if="isLoading" name="fade">
 					<canvas
@@ -94,6 +100,7 @@
 </template>
 
 <script>
+import { formatFileSize } from '@nextcloud/files'
 import { t } from '@nextcloud/l10n'
 import { encodePath } from '@nextcloud/paths'
 import { generateRemoteUrl, generateUrl, imagePath } from '@nextcloud/router'
@@ -241,6 +248,15 @@ export default {
 
 		fileDetail() {
 			return this.file.name
+		},
+
+		fileSizeLabel() {
+			if (!this.isUploadEditor || !this.uploadFile) {
+				return ''
+			}
+
+			const size = this.uploadFile.totalSize
+			return size ? formatFileSize(size, true) : ''
 		},
 
 		fallbackLocalUrl() {
@@ -634,6 +650,19 @@ export default {
 		top: 50%;
 		inset-inline-end: calc(var(--progress-bar-height) * -1);
 		transform: translateY(-50%);
+	}
+
+	&__size {
+		position: absolute;
+		inset-block-end: var(--default-grid-baseline);
+		inset-inline-end: var(--default-grid-baseline);
+		padding: calc(0.5 * var(--default-grid-baseline)) var(--default-grid-baseline);
+		border-radius: var(--border-radius);
+		background-color: rgba(var(--color-main-background-rgb), 0.7);
+		color: var(--color-main-text);
+		font-size: var(--font-size-small);
+		line-height: 1;
+		z-index: 1;
 	}
 
 	.mimeicon {

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
@@ -255,7 +255,9 @@ export default {
 				return ''
 			}
 
-			const size = this.uploadFile.totalSize
+			const size = this.uploadStore.skipCompression
+				? this.uploadFile.totalSize
+				: this.uploadStore.compressedFileSizes[this.referenceId] ?? this.uploadFile.totalSize
 			return size ? formatFileSize(size, true) : ''
 		},
 

--- a/src/components/NewMessage/NewMessageUploadEditor.vue
+++ b/src/components/NewMessage/NewMessageUploadEditor.vue
@@ -94,6 +94,7 @@
 				:token="token"
 				isUploadEditor
 				:file="file[1].temporaryMessage.messageParameters.file"
+				:referenceId="file[1].temporaryMessage.referenceId"
 				@removeFile="removeFile" />
 		</TransitionWrapper>
 		<div v-else class="upload-editor__voice-message">

--- a/src/stores/__tests__/upload.spec.js
+++ b/src/stores/__tests__/upload.spec.js
@@ -608,13 +608,14 @@ describe('fileUploadStore', () => {
 				getTalkConfig.mockReturnValue(true)
 			})
 
-			test('does not compress anything when not requested', async () => {
+			test('starts eager compression on upload', async () => {
 				const file = makeImage()
+				compressImage.mockResolvedValue(makeCompressed())
 				uploadStore.initialiseUpload({ uploadId: 'upload-id1', token: TOKEN, files: [file] })
 
 				await uploadStore.uploadFiles({ token: TOKEN, uploadId: 'upload-id1', options: null })
 
-				expect(compressImage).not.toHaveBeenCalled()
+				expect(compressImage).toHaveBeenCalled()
 				expect(uploadMock).toHaveBeenCalledWith(expect.anything(), file)
 			})
 

--- a/src/stores/upload.ts
+++ b/src/stores/upload.ts
@@ -85,6 +85,8 @@ export const useUploadStore = defineStore('upload', () => {
 	const uploads = reactive<UploadsState>({})
 	const currentUploadId = ref<string | undefined>(undefined)
 	const localUrls = reactive<Record<string, string>>({})
+	const compressionJobs: Record<string, Promise<File | null> | undefined> = {}
+	const compressedFileSizes = reactive<Record<string, number>>({})
 
 	/**
 	 * The user's choices for the current upload. They are only valid until it
@@ -168,7 +170,7 @@ export const useUploadStore = defineStore('upload', () => {
 	/**
 	 * Returns the local URL of uploaded image
 	 *
-	 * @param referenceId
+	 * @param referenceId the temporary message's reference id
 	 */
 	function getLocalUrl(referenceId: string): string | undefined {
 		return localUrls[referenceId]
@@ -212,6 +214,9 @@ export const useUploadStore = defineStore('upload', () => {
 		}
 		if (localUrl) {
 			localUrls[temporaryMessage.referenceId] = localUrl
+		}
+		if (supportImageCompression(file.type) && file.size > 0) {
+			void initCompressImage(temporaryMessage.referenceId, file)
 		}
 	}
 
@@ -306,6 +311,7 @@ export const useUploadStore = defineStore('upload', () => {
 		const uploadId = currentUploadId.value!
 		for (const index in uploads[uploadId].files) {
 			if (uploads[uploadId].files[index].temporaryMessage!.id === temporaryMessageId) {
+				dismissCompressImage(uploads[uploadId].files[index].temporaryMessage!.referenceId)
 				delete uploads[uploadId].files[index]
 			}
 		}
@@ -378,7 +384,48 @@ export const useUploadStore = defineStore('upload', () => {
 		}
 		EventBus.emit('upload-discard')
 
+		for (const [_index, uploadedFile] of getUploadsArray(uploadId)) {
+			dismissCompressImage(uploadedFile.temporaryMessage.referenceId)
+		}
+
 		delete uploads[uploadId]
+	}
+
+	/**
+	 * Compresses a staged image eagerly, exposing resulting preview size.
+	 * The job output is kept, so compressUploadedImage() can reuse it.
+	 * Starts a job only once per file, and returns the pending or finished one.
+	 *
+	 * @param referenceId the temporary message's reference id
+	 * @param file the staged file
+	 */
+	function initCompressImage(referenceId: string, file: File): Promise<File | null> {
+		const startedJob = compressionJobs[referenceId]
+		if (startedJob) {
+			return startedJob
+		}
+		const newJob = async () => {
+			try {
+				const compressed = await compressImage(file)
+				compressedFileSizes[referenceId] = compressed?.size ?? file.size
+				return compressed
+			} catch (error) {
+				console.error('Failed to compress image, uploading original: ', error)
+				return null
+			}
+		}
+		compressionJobs[referenceId] = newJob()
+		return compressionJobs[referenceId]
+	}
+
+	/**
+	 * Drops the job and size preview, release resources
+	 *
+	 * @param referenceId the temporary message's reference id
+	 */
+	function dismissCompressImage(referenceId: string) {
+		delete compressionJobs[referenceId]
+		delete compressedFileSizes[referenceId]
 	}
 
 	/**
@@ -399,9 +446,10 @@ export const useUploadStore = defineStore('upload', () => {
 			return null
 		}
 
+		const referenceId = uploadedFile.temporaryMessage.referenceId
 		try {
 			// @ts-expect-error: UploadFile.file is a custom type, not a File
-			const compressed = await compressImage(currentFile)
+			const compressed = await initCompressImage(referenceId, currentFile)
 			if (!compressed) {
 				// Compression was not beneficial, the original file is kept
 				return null
@@ -411,7 +459,6 @@ export const useUploadStore = defineStore('upload', () => {
 			uploads[uploadId].files[index].file = compressed
 			uploads[uploadId].files[index].totalSize = compressed.size
 
-			const referenceId = uploadedFile.temporaryMessage.referenceId
 			if (localUrls[referenceId]) {
 				URL.revokeObjectURL(localUrls[referenceId])
 			}
@@ -453,6 +500,7 @@ export const useUploadStore = defineStore('upload', () => {
 			const compressed = compressImages
 				? await compressUploadedImage(uploadId, index)
 				: null
+			dismissCompressImage(uploadedFile.temporaryMessage.referenceId)
 
 			// Store the previously created temporary message
 			const message = {
@@ -827,6 +875,7 @@ export const useUploadStore = defineStore('upload', () => {
 		uploads,
 		currentUploadId,
 		localUrls,
+		compressedFileSizes,
 		allowUpdate,
 		skipCompression,
 


### PR DESCRIPTION
## ☑️ Resolves

* Follow-up to #18906
	* Perform compression eagerly, not delay submit itself
	* Show resulted file size on staging area

### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

☀️ Light theme | 🌑 Dark Theme
-- | --
<img width="546" height="144" alt="2026-08-21_11h36_05" src="https://github.com/user-attachments/assets/a7878805-d14e-4f7c-89fa-557e3b4e962a" /> | <img width="547" height="149" alt="2026-08-21_11h36_38" src="https://github.com/user-attachments/assets/a37e76f8-ac51-47ec-b464-129ba94c55f2" />
<img width="553" height="151" alt="2026-08-21_11h36_16" src="https://github.com/user-attachments/assets/27c568ee-edc0-4eb6-8b49-01a8098dc2dd" /> | <img width="551" height="153" alt="2026-08-21_11h36_28" src="https://github.com/user-attachments/assets/5feba147-aaab-4ba6-a0de-14dfd599b05f" />

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required