### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -340,12 +340,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "ea6ca81337a2bf762a6bf4edff634b8f313a0dd3"
+                "reference": "75e04c37b52633c6601b63af3a33a71e0f48967e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/ea6ca81337a2bf762a6bf4edff634b8f313a0dd3",
-                "reference": "ea6ca81337a2bf762a6bf4edff634b8f313a0dd3",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/75e04c37b52633c6601b63af3a33a71e0f48967e",
+                "reference": "75e04c37b52633c6601b63af3a33a71e0f48967e",
                 "shasum": ""
             },
             "require": {
@@ -386,7 +386,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2026-08-20T13:01:12+00:00"
+            "time": "2026-08-24T17:09:03+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency