### PR TITLE
fix(navigation): Register navigation entry via event

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -30,7 +30,6 @@ use OCA\Talk\Collaboration\Reference\ReferenceInvalidationListener;
 use OCA\Talk\Collaboration\Reference\TalkReferenceProvider;
 use OCA\Talk\Collaboration\Resources\ConversationProvider;
 use OCA\Talk\Collaboration\Resources\Listener as ResourceListener;
-use OCA\Talk\Config;
 use OCA\Talk\ConfigLexicon;
 use OCA\Talk\Dashboard\TalkWidget;
 use OCA\Talk\Deck\DeckPluginLoader;
@@ -98,6 +97,7 @@ use OCA\Talk\Listener\DisplayNameListener;
 use OCA\Talk\Listener\FeaturePolicyListener;
 use OCA\Talk\Listener\GroupDeletedListener;
 use OCA\Talk\Listener\GroupMembershipListener;
+use OCA\Talk\Listener\LoadNavigationEntryListener;
 use OCA\Talk\Listener\NoteToSelfListener;
 use OCA\Talk\Listener\RestrictStartingCalls as RestrictStartingCallsListener;
 use OCA\Talk\Listener\SampleConversationsListener;
@@ -154,11 +154,7 @@ use OCP\Group\Events\GroupDeletedEvent;
 use OCP\Group\Events\UserAddedEvent;
 use OCP\Group\Events\UserRemovedEvent;
 use OCP\IConfig;
-use OCP\INavigationManager;
-use OCP\IURLGenerator;
-use OCP\IUser;
-use OCP\IUserSession;
-use OCP\L10N\IFactory;
+use OCP\Navigation\Events\LoadAdditionalEntriesEvent;
 use OCP\OCM\Events\ResourceTypeRegisterEvent;
 use OCP\Security\CSP\AddContentSecurityPolicyEvent;
 use OCP\Security\FeaturePolicy\AddFeaturePolicyEvent;
@@ -203,6 +199,7 @@ class Application extends App implements IBootstrap {
 		$context->registerEventListener(BeforeTemplateRenderedEvent::class, PublicShareAuthTemplateLoader::class);
 		$context->registerEventListener(LoadSidebar::class, FilesTemplateLoader::class);
 		$context->registerEventListener(BeforePreferenceSetEvent::class, BeforePreferenceSetEventListener::class);
+		$context->registerEventListener(LoadAdditionalEntriesEvent::class, LoadNavigationEntryListener::class);
 
 		// Activity listeners
 		$context->registerEventListener(AttendeesAddedEvent::class, ActivityListener::class);
@@ -402,7 +399,6 @@ class Application extends App implements IBootstrap {
 	public function boot(IBootContext $context): void {
 		$context->injectFn($this->registerCollaborationResourceProvider(...));
 		$context->injectFn($this->registerClientLinks(...));
-		$context->injectFn($this->registerNavigationLink(...));
 		$context->injectFn($this->registerCloudFederationProviderManager(...));
 	}
 
@@ -417,24 +413,6 @@ class Application extends App implements IBootstrap {
 		if ($appManager->isEnabledForUser('firstrunwizard')) {
 			$settingManager->registerSetting('personal', Personal::class);
 		}
-	}
-
-	public function registerNavigationLink(INavigationManager $navigationManager): void {
-		$navigationManager->add(static function () {
-			$config = Server::get(Config::class);
-			$userSession = Server::get(IUserSession::class);
-			$urlGenerator = Server::get(IURLGenerator::class);
-			$l = Server::get(IFactory::class)->get(self::APP_ID);
-			$user = $userSession->getUser();
-			return [
-				'id' => self::APP_ID,
-				'name' => $l->t('Talk'),
-				'href' => $urlGenerator->linkToRouteAbsolute('spreed.Page.index'),
-				'icon' => $urlGenerator->imagePath(self::APP_ID, 'app.svg'),
-				'order' => -5,
-				'type' => $user instanceof IUser && !$config->isDisabledForUser($user) ? 'link' : 'hidden',
-			];
-		});
 	}
 
 	public function registerCloudFederationProviderManager(

--- a/lib/Listener/LoadNavigationEntryListener.php
+++ b/lib/Listener/LoadNavigationEntryListener.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Talk\Listener;
+
+use OCA\Talk\AppInfo\Application;
+use OCA\Talk\Config;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\IL10N;
+use OCP\INavigationManager;
+use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\IUserSession;
+use OCP\Navigation\Events\LoadAdditionalEntriesEvent;
+
+/**
+ * @template-implements IEventListener<LoadAdditionalEntriesEvent>
+ */
+class LoadNavigationEntryListener implements IEventListener {
+
+	public function __construct(
+		private readonly INavigationManager $navigationManager,
+		private readonly IURLGenerator $urlGenerator,
+		private readonly IUserSession $userSession,
+		private readonly Config $config,
+		private readonly IL10N $l,
+	) {
+	}
+
+	#[\Override]
+	public function handle(Event $event): void {
+		if (!$event instanceof LoadAdditionalEntriesEvent) {
+			// Unrelated
+			return;
+		}
+
+		$this->navigationManager->add(function (): ?array {
+			$user = $this->userSession->getUser();
+			if (!$user instanceof IUser || $this->config->isDisabledForUser($user)) {
+				return null;
+			}
+
+			return [
+				'id' => Application::APP_ID,
+				'name' => $this->l->t('Talk'),
+				'href' => $this->urlGenerator->linkToRouteAbsolute('spreed.Page.index'),
+				'icon' => $this->urlGenerator->imagePath(Application::APP_ID, 'app.svg'),
+				'order' => -5,
+				'type' => INavigationManager::TYPE_APPS,
+			];
+		});
+	}
+}

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -2796,6 +2796,40 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 		return $expected;
 	}
 
+	#[Then('/^user "([^"]*)" (has|does not have) the "([^"]*)" navigation entry$/')]
+	public function userHasNavigationEntry(string $user, string $hasEntry, string $entryId, ?TableNode $formData = null): void {
+		$this->setCurrentUser($user);
+		$this->sendRequest('GET', '/core/navigation/apps');
+		$this->assertStatusCode($this->response, 200);
+
+		$entries = array_column($this->getDataFromResponse($this->response), null, 'id');
+
+		if ($hasEntry === 'does not have') {
+			Assert::assertArrayNotHasKey($entryId, $entries, 'Navigation entry "' . $entryId . '" should not be listed');
+			return;
+		}
+
+		Assert::assertArrayHasKey($entryId, $entries, 'Navigation entry "' . $entryId . '" is missing');
+
+		if ($formData === null) {
+			return;
+		}
+
+		$expected = $formData->getRowsHash();
+		$actual = $entries[$entryId];
+
+		if (isset($expected['icon'])) {
+			Assert::assertStringEndsWith($expected['icon'], $actual['icon'], 'Mismatch of icon for navigation entry "' . $entryId . '"');
+			unset($expected['icon'], $actual['icon']);
+		}
+
+		if (isset($expected['href'])) {
+			$expected['href'] = str_replace('{$BASE_URL}', $this->baseUrl, $expected['href']);
+		}
+
+		Assert::assertEquals($expected, array_intersect_key($actual, $expected), 'Mismatch of data for navigation entry "' . $entryId . '"');
+	}
+
 	#[Then('/^user "([^"]*)" sees the following entry when loading the list of dashboard widgets(?: \((v1)\))$/')]
 	public function userGetsDashboardWidgets(string $user, string $apiVersion = 'v1', ?TableNode $formData = null): void {
 		$this->setCurrentUser($user);

--- a/tests/integration/features/integration/navigation.feature
+++ b/tests/integration/features/integration/navigation.feature
@@ -1,0 +1,22 @@
+Feature: integration/navigation
+  Background:
+    Given user "participant1" exists
+    Given group "group1" exists
+
+  Scenario: Talk is listed in the navigation when the user is allowed to use Talk
+    Then user "participant1" has the "spreed" navigation entry
+      | name | Talk                              |
+      | href | {$BASE_URL}index.php/apps/spreed/ |
+      | icon | spreed/img/app.svg                |
+      | type | link                              |
+
+  Scenario: Talk is not listed in the navigation when the user is not allowed to use Talk
+    Given the following "spreed" app config is set
+      | allowed_groups | ["group1"] |
+    Then user "participant1" does not have the "spreed" navigation entry
+    Given user "participant1" is member of group "group1"
+    Then user "participant1" has the "spreed" navigation entry
+      | name | Talk                              |
+      | href | {$BASE_URL}index.php/apps/spreed/ |
+      | icon | spreed/img/app.svg                |
+      | type | link                              |


### PR DESCRIPTION
## ☑️ Resolves

* Fix red CI in #19076 and #19074
* Requires https://github.com/nextcloud/server/pull/63524 for CI to pass
* Fix #19082

### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

## 🛠️ API Checklist
### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
