### PR TITLE
Create a reference widget AKA Smart Picker widget

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -27,6 +27,7 @@ use OCA\Talk\Chat\Parser\UserMention;
 use OCA\Talk\Chat\SystemMessage\Listener as SystemMessageListener;
 use OCA\Talk\Collaboration\Collaborators\Listener as CollaboratorsListener;
 use OCA\Talk\Collaboration\Reference\ReferenceInvalidationListener;
+use OCA\Talk\Collaboration\Reference\RenderReferenceEventListener as TalkRenderReferenceEventListener;
 use OCA\Talk\Collaboration\Reference\TalkReferenceProvider;
 use OCA\Talk\Collaboration\Resources\ConversationProvider;
 use OCA\Talk\Collaboration\Resources\Listener as ResourceListener;
@@ -142,6 +143,7 @@ use OCP\AppFramework\Bootstrap\IRegistrationContext;
 use OCP\Calendar\Events\CalendarObjectCreatedEvent;
 use OCP\Calendar\Events\CalendarObjectUpdatedEvent;
 use OCP\Collaboration\AutoComplete\AutoCompleteFilterEvent;
+use OCP\Collaboration\Reference\RenderReferenceEvent;
 use OCP\Collaboration\Resources\IProviderManager;
 use OCP\Collaboration\Resources\LoadAdditionalScriptsEvent;
 use OCP\Config\BeforePreferenceSetEvent;
@@ -263,6 +265,7 @@ class Application extends App implements IBootstrap {
 		$context->registerEventListener(LobbyModifiedEvent::class, ReferenceInvalidationListener::class);
 		$context->registerEventListener(RoomDeletedEvent::class, ReferenceInvalidationListener::class);
 		$context->registerEventListener(RoomModifiedEvent::class, ReferenceInvalidationListener::class);
+		$context->registerEventListener(RenderReferenceEvent::class, TalkRenderReferenceEventListener::class);
 
 		// Resources listeners
 		$context->registerEventListener(AttendeesAddedEvent::class, ResourceListener::class);

--- a/lib/Collaboration/Reference/RenderReferenceEventListener.php
+++ b/lib/Collaboration/Reference/RenderReferenceEventListener.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Talk\Collaboration\Reference;
+
+use OCA\Talk\AppInfo\Application;
+use OCP\Collaboration\Reference\RenderReferenceEvent;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\Util;
+
+/**
+ * Loads the Talk reference widget bundle whenever a page might render
+ * references (e.g. link previews or Smart Picker widgets), so a Talk
+ * conversation link can be rendered with a richer, Talk-specific widget
+ * instead of the generic link preview.
+ *
+ * @template-implements IEventListener<Event>
+ */
+class RenderReferenceEventListener implements IEventListener {
+	#[\Override]
+	public function handle(Event $event): void {
+		if (!($event instanceof RenderReferenceEvent)) {
+			return;
+		}
+
+		Util::addScript(Application::APP_ID, 'talk-reference');
+	}
+}

--- a/rspack.config.js
+++ b/rspack.config.js
@@ -53,6 +53,7 @@ module.exports = defineConfig((env) => {
 			deck: path.join(__dirname, 'src', 'deck.js'),
 			maps: path.join(__dirname, 'src', 'maps.js'),
 			search: path.join(__dirname, 'src', 'search.js'),
+			reference: path.join(__dirname, 'src', 'reference.ts'),
 			icons: path.join(__dirname, 'src', 'icons.css'),
 		},
 

--- a/src/components/ConversationIcon.vue
+++ b/src/components/ConversationIcon.vue
@@ -6,7 +6,7 @@
 <template>
 	<div
 		class="conversation-icon"
-		:style="{ '--icon-size': `${size}px` }"
+		:style="{ '--icon-size': iconSize }"
 		:class="[themeClass, { offline: offline }]">
 		<template v-if="!isOneToOne">
 			<div
@@ -138,6 +138,11 @@ export default {
 			type: Number,
 			default: AVATAR.SIZE.DEFAULT,
 		},
+
+		cssSize: {
+			type: String,
+			default: null,
+		},
 	},
 
 	setup() {
@@ -160,6 +165,10 @@ export default {
 	},
 
 	computed: {
+		iconSize() {
+			return this.cssSize || `${this.size}px`
+		},
+
 		showCall() {
 			return !this.hideCall && this.item.hasCall
 		},

--- a/src/components/ConversationIcon.vue
+++ b/src/components/ConversationIcon.vue
@@ -6,7 +6,7 @@
 <template>
 	<div
 		class="conversation-icon"
-		:style="{ '--icon-size': iconSize }"
+		:style="{ '--icon-size': `${size}px` }"
 		:class="[themeClass, { offline: offline }]">
 		<template v-if="!isOneToOne">
 			<div
@@ -139,10 +139,6 @@ export default {
 			default: AVATAR.SIZE.DEFAULT,
 		},
 
-		cssSize: {
-			type: String,
-			default: null,
-		},
 	},
 
 	setup() {
@@ -165,10 +161,6 @@ export default {
 	},
 
 	computed: {
-		iconSize() {
-			return this.cssSize || `${this.size}px`
-		},
-
 		showCall() {
 			return !this.hideCall && this.item.hasCall
 		},

--- a/src/components/ReferenceWidgets/CallReferenceWidget.spec.ts
+++ b/src/components/ReferenceWidgets/CallReferenceWidget.spec.ts
@@ -1,0 +1,167 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { flushPromises, mount } from '@vue/test-utils'
+import { describe, expect, test, vi } from 'vitest'
+import ConversationIcon from '../ConversationIcon.vue'
+import { CONVERSATION, MESSAGE } from '../../constants.ts'
+import { fetchConversation } from '../../services/conversationsService.ts'
+import CallReferenceWidget from './CallReferenceWidget.vue'
+
+vi.mock('../../services/conversationsService.ts', () => ({
+	fetchConversation: vi.fn(),
+}))
+
+// ConversationIcon reads capabilities/cached conversations from BrowserStorage at import time
+vi.mock('../../services/CapabilitiesManager.ts', () => ({
+	hasTalkFeature: vi.fn(() => false),
+	getTalkConfig: vi.fn(),
+}))
+
+describe('CallReferenceWidget.vue', () => {
+	const richObject = {
+		id: 'XXTOKENXX',
+		name: 'Fallback conversation name',
+		link: 'https://nextcloud.local/call/XXTOKENXX',
+		'call-type': 'group',
+	}
+
+	/**
+	 * @param props additional props to merge on top of the defaults
+	 */
+	function mountWidget(props = {}) {
+		return mount(CallReferenceWidget, {
+			props: {
+				richObject,
+				accessible: true,
+				...props,
+			},
+		})
+	}
+
+	test('renders nothing when the reference is not accessible', async () => {
+		const wrapper = mountWidget({ accessible: false })
+		await flushPromises()
+
+		expect(wrapper.find('a').exists()).toBe(false)
+		expect(fetchConversation).not.toHaveBeenCalled()
+	})
+
+	test('renders the live conversation once loaded', async () => {
+		vi.mocked(fetchConversation).mockResolvedValueOnce({
+			data: {
+				ocs: {
+					data: {
+						token: 'XXTOKENXX',
+						displayName: 'Live conversation name',
+						type: CONVERSATION.TYPE.GROUP,
+					},
+				},
+			},
+		})
+
+		const wrapper = mountWidget()
+		await flushPromises()
+
+		expect(fetchConversation).toHaveBeenCalledWith('XXTOKENXX')
+		expect(wrapper.text()).toContain('Live conversation name')
+		expect(wrapper.findComponent(ConversationIcon).exists()).toBe(true)
+	})
+
+	test('falls back to the reference metadata when the live fetch fails', async () => {
+		vi.mocked(fetchConversation).mockRejectedValueOnce(new Error('403'))
+
+		const wrapper = mountWidget({ fallbackAvatarUrl: 'https://nextcloud.local/avatar.png' })
+		await flushPromises()
+
+		expect(wrapper.text()).toContain('Fallback conversation name')
+		expect(wrapper.findComponent(ConversationIcon).exists()).toBe(false)
+		expect(wrapper.find('img').attributes('src')).toBe('https://nextcloud.local/avatar.png')
+	})
+
+	test('does not show an expired last message', async () => {
+		vi.mocked(fetchConversation).mockResolvedValueOnce({
+			data: {
+				ocs: {
+					data: {
+						token: 'XXTOKENXX',
+						displayName: 'Live conversation name',
+						type: CONVERSATION.TYPE.GROUP,
+						lastMessage: {
+							actorDisplayName: 'Alice',
+							actorType: 'users',
+							message: 'hello',
+							messageParameters: {},
+							messageType: 'comment',
+							systemMessage: '',
+							expirationTimestamp: 1,
+						},
+					},
+				},
+			},
+		})
+
+		const wrapper = mountWidget()
+		await flushPromises()
+
+		expect(wrapper.text()).not.toContain('hello')
+	})
+
+	test('does not show a deleted last message', async () => {
+		vi.mocked(fetchConversation).mockResolvedValueOnce({
+			data: {
+				ocs: {
+					data: {
+						token: 'XXTOKENXX',
+						displayName: 'Live conversation name',
+						type: CONVERSATION.TYPE.GROUP,
+						lastMessage: {
+							actorDisplayName: 'Alice',
+							actorType: 'users',
+							message: 'hello',
+							messageParameters: {},
+							messageType: MESSAGE.TYPE.COMMENT_DELETED,
+							systemMessage: '',
+							expirationTimestamp: 0,
+						},
+					},
+				},
+			},
+		})
+
+		const wrapper = mountWidget()
+		await flushPromises()
+
+		expect(wrapper.text()).not.toContain('hello')
+	})
+
+	test('shows a non-expired last message with its actor', async () => {
+		vi.mocked(fetchConversation).mockResolvedValueOnce({
+			data: {
+				ocs: {
+					data: {
+						token: 'XXTOKENXX',
+						displayName: 'Live conversation name',
+						type: CONVERSATION.TYPE.GROUP,
+						lastMessage: {
+							actorDisplayName: 'Alice',
+							actorType: 'users',
+							message: 'hello',
+							messageParameters: {},
+							messageType: 'comment',
+							systemMessage: '',
+							expirationTimestamp: 0,
+						},
+					},
+				},
+			},
+		})
+
+		const wrapper = mountWidget()
+		await flushPromises()
+
+		expect(wrapper.text()).toContain('Alice: hello')
+	})
+})

--- a/src/components/ReferenceWidgets/CallReferenceWidget.spec.ts
+++ b/src/components/ReferenceWidgets/CallReferenceWidget.spec.ts
@@ -6,9 +6,9 @@
 import { flushPromises, mount } from '@vue/test-utils'
 import { describe, expect, test, vi } from 'vitest'
 import ConversationIcon from '../ConversationIcon.vue'
+import CallReferenceWidget from './CallReferenceWidget.vue'
 import { CONVERSATION, MESSAGE } from '../../constants.ts'
 import { fetchConversation } from '../../services/conversationsService.ts'
-import CallReferenceWidget from './CallReferenceWidget.vue'
 
 vi.mock('../../services/conversationsService.ts', () => ({
 	fetchConversation: vi.fn(),
@@ -57,6 +57,12 @@ describe('CallReferenceWidget.vue', () => {
 						token: 'XXTOKENXX',
 						displayName: 'Live conversation name',
 						type: CONVERSATION.TYPE.GROUP,
+						description: 'A useful room description',
+						unreadMessages: 2,
+						hasCall: true,
+						lastMessage: {
+							timestamp: 1710000000,
+						},
 					},
 				},
 			},
@@ -67,7 +73,46 @@ describe('CallReferenceWidget.vue', () => {
 
 		expect(fetchConversation).toHaveBeenCalledWith('XXTOKENXX')
 		expect(wrapper.text()).toContain('Live conversation name')
+		expect(wrapper.text()).toContain('Group conversation')
+		expect(wrapper.text()).toContain('A useful room description')
+		expect(wrapper.text()).toContain('2 unread messages')
+		expect(wrapper.text()).toContain('Call in progress')
 		expect(wrapper.findComponent(ConversationIcon).exists()).toBe(true)
+	})
+
+	test('renders a message reference using the provider metadata', async () => {
+		vi.mocked(fetchConversation).mockResolvedValueOnce({
+			data: {
+				ocs: {
+					data: {
+						token: 'XXTOKENXX',
+						displayName: 'Live conversation name',
+						type: CONVERSATION.TYPE.GROUP,
+						lastMessage: {
+							actorDisplayName: 'Latest actor',
+							actorType: 'users',
+							message: 'latest message',
+							messageParameters: {},
+							messageType: 'comment',
+							systemMessage: '',
+							expirationTimestamp: 0,
+						},
+					},
+				},
+			},
+		})
+
+		const wrapper = mountWidget({
+			richObject: { ...richObject, 'message-id': '42' },
+			referenceTitle: 'Alice in Project room',
+			referenceDescription: 'A message from Alice',
+		})
+		await flushPromises()
+
+		expect(wrapper.text()).toContain('Alice in Project room')
+		expect(wrapper.text()).toContain('A message from Alice')
+		expect(wrapper.text()).toContain('Message')
+		expect(wrapper.text()).not.toContain('Latest actor: latest message')
 	})
 
 	test('falls back to the reference metadata when the live fetch fails', async () => {

--- a/src/components/ReferenceWidgets/CallReferenceWidget.spec.ts
+++ b/src/components/ReferenceWidgets/CallReferenceWidget.spec.ts
@@ -61,12 +61,20 @@ describe('CallReferenceWidget.vue', () => {
 						unreadMessages: 2,
 						hasCall: true,
 						lastMessage: {
+							actorDisplayName: 'Alice',
+							actorId: 'alice',
+							actorType: 'users',
+							message: '',
+							messageParameters: {},
+							messageType: 'comment',
+							systemMessage: '',
+							expirationTimestamp: 0,
 							timestamp: 1710000000,
 						},
 					},
 				},
 			},
-		})
+		} as never)
 
 		const wrapper = mountWidget()
 		await flushPromises()
@@ -77,7 +85,10 @@ describe('CallReferenceWidget.vue', () => {
 		expect(wrapper.text()).toContain('A useful room description')
 		expect(wrapper.text()).toContain('2 unread messages')
 		expect(wrapper.text()).toContain('Call in progress')
-		expect(wrapper.findComponent(ConversationIcon).exists()).toBe(true)
+		const conversationIcon = wrapper.findComponent(ConversationIcon)
+		expect(conversationIcon.exists()).toBe(true)
+		expect(conversationIcon.props('cssSize')).toBe('min(100cqi, 100cqb)')
+		expect(wrapper.find('.talk-reference-call__avatar-frame').exists()).toBe(true)
 	})
 
 	test('renders a message reference using the provider metadata', async () => {
@@ -90,6 +101,7 @@ describe('CallReferenceWidget.vue', () => {
 						type: CONVERSATION.TYPE.GROUP,
 						lastMessage: {
 							actorDisplayName: 'Latest actor',
+							actorId: 'latest-actor',
 							actorType: 'users',
 							message: 'latest message',
 							messageParameters: {},
@@ -100,7 +112,7 @@ describe('CallReferenceWidget.vue', () => {
 					},
 				},
 			},
-		})
+		} as never)
 
 		const wrapper = mountWidget({
 			richObject: { ...richObject, 'message-id': '42' },
@@ -123,6 +135,7 @@ describe('CallReferenceWidget.vue', () => {
 
 		expect(wrapper.text()).toContain('Fallback conversation name')
 		expect(wrapper.findComponent(ConversationIcon).exists()).toBe(false)
+		expect(wrapper.find('.talk-reference-call__avatar-frame').exists()).toBe(true)
 		expect(wrapper.find('img').attributes('src')).toBe('https://nextcloud.local/avatar.png')
 	})
 
@@ -146,7 +159,7 @@ describe('CallReferenceWidget.vue', () => {
 					},
 				},
 			},
-		})
+		} as never)
 
 		const wrapper = mountWidget()
 		await flushPromises()
@@ -174,7 +187,7 @@ describe('CallReferenceWidget.vue', () => {
 					},
 				},
 			},
-		})
+		} as never)
 
 		const wrapper = mountWidget()
 		await flushPromises()
@@ -202,7 +215,7 @@ describe('CallReferenceWidget.vue', () => {
 					},
 				},
 			},
-		})
+		} as never)
 
 		const wrapper = mountWidget()
 		await flushPromises()

--- a/src/components/ReferenceWidgets/CallReferenceWidget.spec.ts
+++ b/src/components/ReferenceWidgets/CallReferenceWidget.spec.ts
@@ -87,7 +87,6 @@ describe('CallReferenceWidget.vue', () => {
 		expect(wrapper.text()).toContain('Call in progress')
 		const conversationIcon = wrapper.findComponent(ConversationIcon)
 		expect(conversationIcon.exists()).toBe(true)
-		expect(conversationIcon.props('cssSize')).toBe('min(100cqi, 100cqb)')
 		expect(wrapper.find('.talk-reference-call__avatar-frame').exists()).toBe(true)
 	})
 

--- a/src/components/ReferenceWidgets/CallReferenceWidget.vue
+++ b/src/components/ReferenceWidgets/CallReferenceWidget.vue
@@ -17,7 +17,8 @@
 				v-if="conversation"
 				:item="conversation"
 				:size="AVATAR.SIZE.DEFAULT"
-				hideUserStatus />
+				hideUserStatus
+				:hideCall="isMessageReference" />
 			<img
 				v-else-if="fallbackAvatarUrl"
 				:src="fallbackAvatarUrl"
@@ -25,8 +26,11 @@
 				class="talk-reference-call__fallback-avatar">
 
 			<span class="talk-reference-call__body">
-				<span class="talk-reference-call__title">{{ displayName }}</span>
-				<span v-if="lastMessagePreview" class="talk-reference-call__subtitle">{{ lastMessagePreview }}</span>
+				<span class="talk-reference-call__title">{{ title }}</span>
+				<span class="talk-reference-call__type">{{ referenceType }}</span>
+				<span v-if="subtitle" class="talk-reference-call__subtitle">{{ subtitle }}</span>
+				<span v-if="!isMessageReference && lastMessagePreview" class="talk-reference-call__preview">{{ lastMessagePreview }}</span>
+				<span v-if="roomMetadata" class="talk-reference-call__metadata">{{ roomMetadata }}</span>
 			</span>
 		</template>
 	</a>
@@ -35,17 +39,21 @@
 <script setup lang="ts">
 import type { Conversation, TalkReferenceRichObject } from '../../types/index.ts'
 
+import { n, t } from '@nextcloud/l10n'
 import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
 import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
 import ConversationIcon from '../ConversationIcon.vue'
 import { AVATAR, MESSAGE } from '../../constants.ts'
 import { fetchConversation } from '../../services/conversationsService.ts'
+import { formatDateTime } from '../../utils/formattedTime.ts'
 import { getDisplayNameWithFallback } from '../../utils/getDisplayName.ts'
 import { parseToSimpleMessage } from '../../utils/textParse.ts'
 
 const props = defineProps<{
 	richObject: TalkReferenceRichObject
 	accessible: boolean
+	referenceTitle?: string | null
+	referenceDescription?: string | null
 	/** Server-rendered fallback avatar (open graph thumbnail), used only until/if the live conversation loads */
 	fallbackAvatarUrl?: string | null
 }>()
@@ -80,6 +88,64 @@ onBeforeUnmount(() => {
 })
 
 const displayName = computed(() => conversation.value?.displayName || props.richObject.name)
+
+const isMessageReference = computed(() => Boolean(props.richObject['message-id']))
+
+const title = computed(() => {
+	if (isMessageReference.value) {
+		return props.referenceTitle || props.richObject.name
+	}
+
+	return displayName.value
+})
+
+const subtitle = computed(() => {
+	if (isMessageReference.value) {
+		return props.referenceDescription || ''
+	}
+
+	return conversation.value?.description || props.referenceDescription || ''
+})
+
+const referenceType = computed(() => {
+	if (isMessageReference.value) {
+		return t('spreed', 'Message')
+	}
+
+	switch (conversation.value?.type ?? props.richObject['call-type']) {
+		case 'one2one':
+		case 1:
+			return t('spreed', 'One-to-one conversation')
+		case 'public':
+		case 3:
+			return t('spreed', 'Public conversation')
+		case 'group':
+		case 2:
+			return t('spreed', 'Group conversation')
+		default:
+			return t('spreed', 'Conversation')
+	}
+})
+
+const roomMetadata = computed(() => {
+	if (isMessageReference.value || !conversation.value) {
+		return ''
+	}
+
+	const metadata = []
+	const timestamp = conversation.value.lastMessage?.timestamp
+	if (timestamp) {
+		metadata.push(formatDateTime(timestamp * 1000, 'shortDateWithTime'))
+	}
+	if (conversation.value.unreadMessages > 0) {
+		metadata.push(n('spreed', '{count} unread message', '{count} unread messages', conversation.value.unreadMessages, { count: conversation.value.unreadMessages }))
+	}
+	if (conversation.value.hasCall) {
+		metadata.push(t('spreed', 'Call in progress'))
+	}
+
+	return metadata.join(' · ')
+})
 
 const fallbackAvatarUrl = computed(() => props.fallbackAvatarUrl ?? null)
 
@@ -144,14 +210,29 @@ const lastMessagePreview = computed(() => {
 		font-weight: bold;
 		overflow: hidden;
 		text-overflow: ellipsis;
-		white-space: nowrap;
+		white-space: normal;
+	}
+
+	&__type {
+		color: var(--color-text-maxcontrast);
+		font-size: var(--font-size-small);
 	}
 
 	&__subtitle {
 		color: var(--color-text-maxcontrast);
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
+		white-space: normal;
+	}
+
+	&__preview {
+		margin-top: var(--default-grid-baseline);
+		white-space: normal;
+	}
+
+	&__metadata {
+		margin-top: var(--default-grid-baseline);
+		color: var(--color-text-maxcontrast);
+		font-size: var(--font-size-small);
+		white-space: normal;
 	}
 }
 </style>

--- a/src/components/ReferenceWidgets/CallReferenceWidget.vue
+++ b/src/components/ReferenceWidgets/CallReferenceWidget.vue
@@ -1,0 +1,157 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<a
+		v-if="accessible"
+		class="talk-reference-call"
+		:href="richObject.link"
+		target="_blank"
+		rel="noopener noreferrer">
+		<NcLoadingIcon v-if="loading" :size="32" />
+
+		<template v-else>
+			<ConversationIcon
+				v-if="conversation"
+				:item="conversation"
+				:size="AVATAR.SIZE.DEFAULT"
+				hideUserStatus />
+			<img
+				v-else-if="fallbackAvatarUrl"
+				:src="fallbackAvatarUrl"
+				:alt="displayName"
+				class="talk-reference-call__fallback-avatar">
+
+			<span class="talk-reference-call__body">
+				<span class="talk-reference-call__title">{{ displayName }}</span>
+				<span v-if="lastMessagePreview" class="talk-reference-call__subtitle">{{ lastMessagePreview }}</span>
+			</span>
+		</template>
+	</a>
+</template>
+
+<script setup lang="ts">
+import type { Conversation, TalkReferenceRichObject } from '../../types/index.ts'
+
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
+import ConversationIcon from '../ConversationIcon.vue'
+import { AVATAR, MESSAGE } from '../../constants.ts'
+import { fetchConversation } from '../../services/conversationsService.ts'
+import { getDisplayNameWithFallback } from '../../utils/getDisplayName.ts'
+import { parseToSimpleMessage } from '../../utils/textParse.ts'
+
+const props = defineProps<{
+	richObject: TalkReferenceRichObject
+	accessible: boolean
+	/** Server-rendered fallback avatar (open graph thumbnail), used only until/if the live conversation loads */
+	fallbackAvatarUrl?: string | null
+}>()
+
+const loading = ref(true)
+const conversation = ref<Conversation | null>(null)
+let cancelled = false
+
+onMounted(async () => {
+	if (!props.accessible) {
+		loading.value = false
+		return
+	}
+
+	try {
+		const response = await fetchConversation(props.richObject.id)
+		if (!cancelled) {
+			conversation.value = response.data.ocs.data
+		}
+	} catch (error) {
+		// Show less rather than showing something wrong: fall back to the reference metadata
+		console.debug('Could not load live Talk conversation data for reference widget', error)
+	} finally {
+		if (!cancelled) {
+			loading.value = false
+		}
+	}
+})
+
+onBeforeUnmount(() => {
+	cancelled = true
+})
+
+const displayName = computed(() => conversation.value?.displayName || props.richObject.name)
+
+const fallbackAvatarUrl = computed(() => props.fallbackAvatarUrl ?? null)
+
+/**
+ * A short "actor: message" preview of the conversation's last message.
+ * Only shown when the live conversation response demonstrably includes a non-expired,
+ * non-deleted, non-system message; otherwise omitted entirely.
+ */
+const lastMessagePreview = computed(() => {
+	const lastMessage = conversation.value?.lastMessage
+	if (!lastMessage) {
+		return ''
+	}
+
+	if (lastMessage.messageType === MESSAGE.TYPE.COMMENT_DELETED || lastMessage.systemMessage) {
+		return ''
+	}
+
+	if (lastMessage.expirationTimestamp !== 0 && lastMessage.expirationTimestamp * 1000 <= Date.now()) {
+		return ''
+	}
+
+	const text = parseToSimpleMessage(lastMessage.message, lastMessage.messageParameters)
+	if (!text) {
+		return ''
+	}
+
+	const actor = getDisplayNameWithFallback(lastMessage.actorDisplayName, lastMessage.actorType)
+	return actor ? `${actor}: ${text}` : text
+})
+</script>
+
+<style lang="scss" scoped>
+.talk-reference-call {
+	display: flex;
+	align-items: center;
+	gap: calc(var(--default-grid-baseline) * 2);
+	padding: calc(var(--default-grid-baseline) * 2);
+	color: var(--color-main-text);
+	text-decoration: none;
+
+	&:hover,
+	&:focus {
+		background-color: var(--color-background-hover);
+		border-radius: var(--border-radius-large);
+	}
+
+	&__fallback-avatar {
+		width: v-bind('`${AVATAR.SIZE.DEFAULT}px`');
+		height: v-bind('`${AVATAR.SIZE.DEFAULT}px`');
+		border-radius: 50%;
+		object-fit: cover;
+	}
+
+	&__body {
+		display: flex;
+		flex-direction: column;
+		min-width: 0;
+	}
+
+	&__title {
+		font-weight: bold;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	&__subtitle {
+		color: var(--color-text-maxcontrast);
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+}
+</style>

--- a/src/components/ReferenceWidgets/CallReferenceWidget.vue
+++ b/src/components/ReferenceWidgets/CallReferenceWidget.vue
@@ -18,7 +18,6 @@
 					v-if="conversation"
 					:item="conversation"
 					:size="AVATAR.SIZE.DEFAULT"
-					cssSize="min(100cqi, 100cqb)"
 					hideUserStatus
 					:hideCall="isMessageReference" />
 				<img
@@ -203,7 +202,6 @@ const lastMessagePreview = computed(() => {
 	}
 
 	&__avatar-frame {
-		container-type: size;
 		display: grid;
 		place-items: center;
 		flex: 0 0 20%;
@@ -211,10 +209,9 @@ const lastMessagePreview = computed(() => {
 	}
 
 	&__fallback-avatar {
-		width: min(100cqi, 100cqb) !important;
-		height: min(100cqi, 100cqb) !important;
-		max-width: min(100cqi, 100cqb) !important;
-		max-height: min(100cqi, 100cqb) !important;
+		width: 100% !important;
+		height: auto !important;
+		max-width: 100% !important;
 		aspect-ratio: 1;
 		border-radius: 50%;
 		object-fit: cover;
@@ -222,6 +219,9 @@ const lastMessagePreview = computed(() => {
 	}
 
 	&__avatar-frame :deep(.conversation-icon) {
+		width: 100%;
+		height: auto;
+		aspect-ratio: 1;
 		flex: none;
 		min-width: 0;
 		min-height: 0;
@@ -229,10 +229,10 @@ const lastMessagePreview = computed(() => {
 
 	&__avatar-frame :deep(.conversation-icon img.avatar.icon),
 	&__avatar-frame :deep(.conversation-icon .avatardiv) {
-		width: var(--icon-size) !important;
-		height: var(--icon-size) !important;
-		max-width: var(--icon-size) !important;
-		max-height: var(--icon-size) !important;
+		width: 100% !important;
+		height: 100% !important;
+		max-width: 100% !important;
+		max-height: 100% !important;
 		aspect-ratio: 1;
 	}
 

--- a/src/components/ReferenceWidgets/CallReferenceWidget.vue
+++ b/src/components/ReferenceWidgets/CallReferenceWidget.vue
@@ -13,17 +13,20 @@
 		<NcLoadingIcon v-if="loading" :size="32" />
 
 		<template v-else>
-			<ConversationIcon
-				v-if="conversation"
-				:item="conversation"
-				:size="AVATAR.SIZE.DEFAULT"
-				hideUserStatus
-				:hideCall="isMessageReference" />
-			<img
-				v-else-if="fallbackAvatarUrl"
-				:src="fallbackAvatarUrl"
-				:alt="displayName"
-				class="talk-reference-call__fallback-avatar">
+			<span class="talk-reference-call__avatar-frame">
+				<ConversationIcon
+					v-if="conversation"
+					:item="conversation"
+					:size="AVATAR.SIZE.DEFAULT"
+					cssSize="min(100cqi, 100cqb)"
+					hideUserStatus
+					:hideCall="isMessageReference" />
+				<img
+					v-else-if="fallbackAvatarUrl"
+					:src="fallbackAvatarUrl"
+					:alt="displayName"
+					class="talk-reference-call__fallback-avatar">
+			</span>
 
 			<span class="talk-reference-call__body">
 				<span class="talk-reference-call__title">{{ title }}</span>
@@ -133,7 +136,10 @@ const roomMetadata = computed(() => {
 	}
 
 	const metadata = []
-	const timestamp = conversation.value.lastMessage?.timestamp
+	const lastMessage = conversation.value.lastMessage
+	const timestamp = lastMessage && 'timestamp' in lastMessage
+		? lastMessage.timestamp
+		: conversation.value.lastActivity
 	if (timestamp) {
 		metadata.push(formatDateTime(timestamp * 1000, 'shortDateWithTime'))
 	}
@@ -180,8 +186,11 @@ const lastMessagePreview = computed(() => {
 
 <style lang="scss" scoped>
 .talk-reference-call {
+	box-sizing: border-box;
 	display: flex;
-	align-items: center;
+	width: 100%;
+	flex-grow: 1;
+	align-items: stretch;
 	gap: calc(var(--default-grid-baseline) * 2);
 	padding: calc(var(--default-grid-baseline) * 2);
 	color: var(--color-main-text);
@@ -193,15 +202,49 @@ const lastMessagePreview = computed(() => {
 		border-radius: var(--border-radius-large);
 	}
 
+	&__avatar-frame {
+		container-type: size;
+		display: grid;
+		place-items: center;
+		flex: 0 0 20%;
+		min-width: 0;
+	}
+
 	&__fallback-avatar {
-		width: v-bind('`${AVATAR.SIZE.DEFAULT}px`');
-		height: v-bind('`${AVATAR.SIZE.DEFAULT}px`');
+		width: min(100cqi, 100cqb) !important;
+		height: min(100cqi, 100cqb) !important;
+		max-width: min(100cqi, 100cqb) !important;
+		max-height: min(100cqi, 100cqb) !important;
+		aspect-ratio: 1;
 		border-radius: 50%;
 		object-fit: cover;
+		object-position: center;
+	}
+
+	&__avatar-frame :deep(.conversation-icon) {
+		flex: none;
+		min-width: 0;
+		min-height: 0;
+	}
+
+	&__avatar-frame :deep(.conversation-icon img.avatar.icon),
+	&__avatar-frame :deep(.conversation-icon .avatardiv) {
+		width: var(--icon-size) !important;
+		height: var(--icon-size) !important;
+		max-width: var(--icon-size) !important;
+		max-height: var(--icon-size) !important;
+		aspect-ratio: 1;
+	}
+
+	&__avatar-frame :deep(.conversation-icon img.avatar.icon),
+	&__avatar-frame :deep(.conversation-icon .avatardiv img) {
+		object-fit: cover;
+		object-position: center;
 	}
 
 	&__body {
 		display: flex;
+		flex: 1;
 		flex-direction: column;
 		min-width: 0;
 	}

--- a/src/reference.ts
+++ b/src/reference.ts
@@ -29,6 +29,8 @@ registerWidget('call', (el, { richObject, accessible, openGraphObject }) => {
 	const app = createApp(CallReferenceWidget, {
 		richObject: richObject as unknown as TalkReferenceRichObject,
 		accessible,
+		referenceTitle: openGraphObject?.name ?? null,
+		referenceDescription: openGraphObject?.description ?? null,
 		fallbackAvatarUrl: openGraphObject?.thumb ?? null,
 	})
 	widgetApps.set(el, app)

--- a/src/reference.ts
+++ b/src/reference.ts
@@ -1,0 +1,43 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { App } from 'vue'
+import type { TalkReferenceRichObject } from './types/index.ts'
+
+import { getCSPNonce } from '@nextcloud/auth'
+import { generateFilePath } from '@nextcloud/router'
+import { registerWidget } from '@nextcloud/vue/functions/reference'
+import { createApp, defineAsyncComponent } from 'vue'
+
+// CSP config for webpack dynamic chunk loading
+__webpack_nonce__ = getCSPNonce()
+
+// Correct the root of the app for chunk loading
+// OC.linkTo matches the apps folders
+// OC.generateUrl ensure the index.php (or not)
+// We do not want the index.php since we're loading files
+__webpack_public_path__ = generateFilePath('spreed', '', 'js/')
+
+const CallReferenceWidget = defineAsyncComponent(() => import('./components/ReferenceWidgets/CallReferenceWidget.vue'))
+
+// Track mounted widget instances per host element so the destroy callback can unmount them
+const widgetApps = new WeakMap<HTMLElement, App>()
+
+registerWidget('call', (el, { richObject, accessible, openGraphObject }) => {
+	const app = createApp(CallReferenceWidget, {
+		richObject: richObject as unknown as TalkReferenceRichObject,
+		accessible,
+		fallbackAvatarUrl: openGraphObject?.thumb ?? null,
+	})
+	widgetApps.set(el, app)
+	app.mount(el)
+}, (el) => {
+	widgetApps.get(el)?.unmount()
+	widgetApps.delete(el)
+}, {
+	hasInteractiveView: false,
+	fullWidth: false,
+	isResizable: false,
+})

--- a/src/services/conversationsService.ts
+++ b/src/services/conversationsService.ts
@@ -78,9 +78,10 @@ async function fetchConversations(params: getAllConversationsParams, options?: A
  * Fetches a conversation from the server.
  *
  * @param token The token of the conversation to be fetched.
+ * @param [options] Axios request options
  */
-async function fetchConversation(token: string): getSingleConversationResponse {
-	return axios.get(generateOcsUrl('apps/spreed/api/v4/room/{token}', { token }))
+async function fetchConversation(token: string, options?: AxiosRequestConfig): getSingleConversationResponse {
+	return axios.get(generateOcsUrl('apps/spreed/api/v4/room/{token}', { token }), options)
 }
 
 /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -387,6 +387,17 @@ export type importEmailsResponse = ApiResponse<operations['room-import-emails-as
 
 // Chats
 export type Mention = RichObject<'server' | 'call-type' | 'icon-url'> & { 'mention-id'?: string }
+
+// Collaboration reference (Smart Picker / link preview) payload for a Talk conversation link,
+// as produced by TalkReferenceProvider::fetchReference(). Not a RichObjectParameter: no 'type' key.
+export type TalkReferenceRichObject = {
+	id: string
+	name: string
+	link: string
+	'call-type': string
+	'message-id'?: string
+}
+
 export type File = RichObject<'size' | 'path' | 'link' | 'mimetype' | 'preview-available'> & {
 	etag: string
 	permissions: string

--- a/tests/php/Collaboration/Reference/RenderReferenceEventListenerTest.php
+++ b/tests/php/Collaboration/Reference/RenderReferenceEventListenerTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Talk\Tests\php\Collaboration\Reference;
+
+use OCA\Talk\Collaboration\Reference\RenderReferenceEventListener;
+use OCP\Collaboration\Reference\RenderReferenceEvent;
+use OCP\EventDispatcher\Event;
+use OCP\Util;
+use Test\TestCase;
+
+class RenderReferenceEventListenerTest extends TestCase {
+	protected RenderReferenceEventListener $listener;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->listener = new RenderReferenceEventListener();
+	}
+
+	public function testHandleIgnoresUnrelatedEvents(): void {
+		$scriptsBefore = Util::getScripts();
+
+		$this->listener->handle($this->createMock(Event::class));
+
+		self::assertSame($scriptsBefore, Util::getScripts());
+	}
+
+	public function testHandleLoadsTheReferenceScriptOnRenderReferenceEvent(): void {
+		$this->listener->handle(new RenderReferenceEvent());
+
+		self::assertContains('spreed/js/talk-reference', Util::getScripts());
+	}
+}


### PR DESCRIPTION
## ☑️ Resolves

* Fix #19087

# AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

Claude Sonnet 5 to be exact, plus Codex in other parts.

## Summary

Adds a real Talk widget for the Smart Picker (Reference Provider), replacing the generic open-graph card that a Talk conversation link now shows.

This means Talk conversation links render as a little conversation card: avatar, display name, conversation type, and the last message.

Still want to add room description too, as this got lost. And see what else we could show, making the widget a bit nicer. But first looking for some feedback.

This is read-only, and thus has no interactions like join a talk/chat. Maybe for a V2. But clicking of course opens the Talk room (link).

## What changed
(Claude-generated description):

- **`RenderReferenceEventListener`** (new, `lib/Collaboration/Reference/`, registered in `Application.php`): listens for `OCP\Collaboration\Reference\RenderReferenceEvent` and loads the new `talk-reference` script bundle wherever a reference is rendered (Text, comments, Collectives, etc.).
- **`src/reference.ts`** (new entry point, added to `rspack.config.js`): registers a `call` widget for the Smart Picker with `hasInteractiveView: false`, `fullWidth: false`, `isResizable: false`.
- **`CallReferenceWidget.vue`** (new): fetches the conversation via the existing authorized conversation endpoint and renders avatar/name/type/last-message. Falls back to metadata-only (title from the `Reference` payload) when the room isn't accessible or the fetch fails.
- Small additive `options` param on `fetchConversation()` in `conversationsService.ts` — no behavior change for existing callers.
- Frontend unit tests (`CallReferenceWidget.spec.ts`, 6 cases) and a PHP test for the event listener.

### Why client-side fetch, not a fatter `Reference`

`TalkReferenceProvider` caches resolved references by room (`getCachePrefix()`/`getCacheKey()`). Last message, participant state, etc. are volatile and have no sensible cache-invalidation story — putting them in the `Reference` payload would mean the widget serves stale data forever between cache refreshes. So the widget fetches live data itself, the same way the Talk UI does; `fetchReference()` is untouched.

### Access control

No new access checks were added or changed. The existing endpoint used by the widget enforces the same authorization as the rest of Talk (lobby, federation proxy-cache, room membership); the widget just renders what it's given and shows the inaccessible/fallback state when the fetch fails or `accessible === false` comes back from the provider.

### Scope

Out of scope: message history/list rendering, sending messages, reactions, polls, joining calls, live updates. None of `src/components/MessagesList/` is touched.

### Testing done

- `npm run ts:check`, `eslint`, `stylelint` — clean
- `npm run test` (vitest) — new + existing suites pass
- `php -l`, `composer cs:fix`, `composer psalm` — clean
- `npm run build` — succeeds
- PHP listener test (`RenderReferenceEventListenerTest.php`) — **not run**; this checkout isn't nested under a `server` install as `tests/php/bootstrap.php` requires. Needs to run in a proper dev environment before merge.

### Open point for review

* **Bundle size.** The new `reference` entry is ~617 KiB (JS+CSS) — smaller than `deck`/`maps` (~840 KiB) but still over rspack's size-warning threshold, consistent with Talk's other standalone bundles. Flagging in case reviewers want the `ConversationIcon` reuse traded for a lighter custom avatar to shrink it further.

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts
So I would like to make the widget higher - show a bit more of the image. Just not as crazy big as the original. And add a bit more info!

| 🏚️ Before | 🏡 After |
| -- | -- |
| Screenshot before | Screenshot after |
| <img width="1293" height="652" alt="Screenshot 2026-08-24 at 22 25 16" src="https://github.com/user-attachments/assets/b9f71990-bd5c-4844-8aaa-55bba46836a8" />  | <img width="1342" height="438" alt="Screenshot 2026-08-24 at 21 53 50" src="https://github.com/user-attachments/assets/8982490f-df9b-4b9a-9338-130d853362f5" /> | 
|  <img width="687" height="514" alt="Screenshot 2026-08-24 at 22 10 59" src="https://github.com/user-attachments/assets/6e2fc3cf-2b9a-434b-9863-f8fe8d43788e" /> | <img width="971" height="290" alt="Screenshot 2026-08-24 at 22 07 53" src="https://github.com/user-attachments/assets/78d1368c-b5fc-4b45-bb60-5b957f43e8b9" /> |
| <img width="959" height="907" alt="Screenshot 2026-08-24 at 22 11 41" src="https://github.com/user-attachments/assets/6204ebf2-15c7-49e2-b261-8abf9500aa83" /> | <img width="971" height="908" alt="Screenshot 2026-08-24 at 21 55 06" src="https://github.com/user-attachments/assets/80e75a6a-1bb9-49d8-8de4-42d2ec5f5a0c" />
| ☀️ Light theme | 🌑 Dark Theme |
| <img width="971" height="908" alt="Screenshot 2026-08-24 at 21 54 51" src="https://github.com/user-attachments/assets/0cf1cc0d-4d5d-4f79-93d3-957155081bfb" /> | <img width="1068" height="892" alt="Screenshot 2026-08-24 at 22 09 11" src="https://github.com/user-attachments/assets/43a31728-1360-4e83-a2cd-a054e365d532" /> | 

EDIT: check screenshots in [comment below](https://github.com/nextcloud/spreed/pull/19088#issuecomment-5560588284) with changes implemented after feedback from Joas. Main change is the addition of more information to the widgets, like type of conversation, unread count, date/time of last comment etc.

| 🏚️ Before | 🏡 After |
| -- | -- |
| Screenshot before | Screenshot after |
| <img width="971" height="290" alt="Screenshot 2026-08-24 at 22 07 53" src="https://github.com/user-attachments/assets/78d1368c-b5fc-4b45-bb60-5b957f43e8b9" /> |  <img width="766" height="722" alt="Screenshot 2026-09-06 at 17 44 56" src="https://github.com/user-attachments/assets/863c2e78-ae2c-4c7a-a8c2-f2443ff9b47d" />| 


### 🚧 Tasks

- [x] get general feedback
- [x] add description, increase avatar size and wrap the last message, add last message time and the type badge.
- [x] add unread count and call in progress. <- these have the issue that they are not live. Well, neither are the others, but it's something to at least be aware off ;-)
- [x] fix avatar size and aspect ratio in Talk

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is **not required**

---

<!--
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
░░░███████░░░█████████░░█████░
░░███░░░███░░░███░░░███░░███░░
░░█████████░░░████████░░░███░░
░░███░░░███░░░███░░░░░░░░███░░
░█████░█████░█████░░░░░░█████░
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching frontend/UI code
-->

## 🛠️ API Checklist

I don't think it does much in this space, right?

### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or **not needed**

Assisted-by: Claude Sonnet 5:claude-sonnet-5
