### PR TITLE
fix(CallView): solve undefined array watcher error

### DIFF
--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -320,7 +320,10 @@ export default {
 				// A single active speaker keeps the main area for itself, rather
 				// than being the only tile of the speakers grid
 				?? (this.showSpeakers ? this.promotedSpeakerModels[0] : undefined)
-				?? this.callParticipantModels.find((callParticipantModel) => this.sharedDatas[callParticipantModel.attributes.peerId].promoted)
+				// The shared data of a model is set from a watcher, so it may not
+				// be there yet when this is evaluated right after the model was
+				// added
+				?? this.callParticipantModels.find((callParticipantModel) => this.sharedDatas[callParticipantModel.attributes.peerId]?.promoted)
 				?? this.callParticipantModels[0]
 		},
 
@@ -596,7 +599,7 @@ export default {
 		promotedAreaSessionIds(sessionIds, previousSessionIds) {
 			// Runs before the grids are re-rendered, while the tiles are still
 			// where they are about to move from
-			animateTilePromotion(sessionIds, previousSessionIds)
+			animateTilePromotion(sessionIds, previousSessionIds ?? [])
 		},
 
 		speakers: {
@@ -987,7 +990,7 @@ export default {
 			// bad specially with a low number of participants.
 			if (this.isGrid) {
 				callParticipantModel.setSimulcastVideoQuality(SIMULCAST.MEDIUM, SIMULCAST.HIGH)
-			} else if (this.sharedDatas[callParticipantModel.attributes.peerId].promoted
+			} else if (this.sharedDatas[callParticipantModel.attributes.peerId]?.promoted
 				|| this.selectedVideoPeerId === callParticipantModel.attributes.peerId
 				|| this.promotedSpeakerPeerIds.has(callParticipantModel.attributes.peerId)) {
 				callParticipantModel.setSimulcastVideoQuality(SIMULCAST.HIGH, SIMULCAST.HIGH)


### PR DESCRIPTION
## ☑️ Resolves

* Based in debugging:
`promotedAreaSessionIds` -> `promotedParticipantModel` -> `this.sharedDatas[peerId].promoted` with `sharedDatas` still `{}` while `callParticipantModels` already has entries -> Cannot read properties of undefined (reading 'promoted').

### AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="955" height="751" alt="image" src="https://github.com/user-attachments/assets/9077a302-30ed-4c6c-ab72-e70a571a7daa" /> | Screenshot after

<!-- ☀️ Light theme | 🌑 Dark Theme -->

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required

