### PR TITLE
fix(call): stop conversation-joined watcher on immediate match

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -615,7 +615,7 @@ export default {
 				unwatchJoinedConversation = watchJoinedConversation(targetToken, () => {
 					stopWatchingJoinedConversation()
 					this._joinCallHandler({ token: targetToken })
-				}, { immediate: true })
+				})
 			}
 		},
 	},

--- a/src/composables/useJoinedConversation.ts
+++ b/src/composables/useJoinedConversation.ts
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import type { MaybeRefOrGetter, WatchCallback, WatchOptions, WatchStopHandle } from 'vue'
+import type { MaybeRefOrGetter, WatchCallback, WatchStopHandle } from 'vue'
 
-import { createSharedComposable } from '@vueuse/core'
-import { onBeforeMount, onBeforeUnmount, readonly, ref, toValue, watch } from 'vue'
+import { createSharedComposable, whenever } from '@vueuse/core'
+import { onBeforeMount, onBeforeUnmount, readonly, ref, toValue } from 'vue'
 import { EventBus } from '../services/EventBus.ts'
 import SessionStorage from '../services/SessionStorage.js'
 
@@ -39,24 +39,24 @@ export const useJoinedConversation = createSharedComposable(useJoinedConversatio
 
 /**
  * Watch for the current joined conversation matching the provided token.
+ * Fires immediately if already matching, and stops after the first match
  *
  * @param token token to match against the joined conversation
  * @param callback callback triggered when the joined conversation matches the token
- * @param options watch options
  */
 export function watchJoinedConversation(
 	token: MaybeRefOrGetter<string | null>,
-	callback: WatchCallback<string, string | null | undefined>,
-	options?: WatchOptions,
+	callback: WatchCallback<string, string | undefined>,
 ): WatchStopHandle {
 	const currentJoinedConversation = useJoinedConversation()
 
-	return watch(currentJoinedConversation, (newToken, oldToken, onCleanup) => {
+	// Getter resolves to the matching token / undefined
+	// `whenever()` only invokes the callback and stops watching on a truthy value.
+	return whenever<string | undefined>(() => {
 		const targetToken = toValue(token)
-		if (!targetToken || newToken !== targetToken) {
+		if (!targetToken || currentJoinedConversation.value !== targetToken) {
 			return
 		}
-
-		callback(newToken, oldToken, onCleanup)
-	}, options)
+		return targetToken
+	}, callback, { immediate: true, once: true })
 }

--- a/src/views/MainView.vue
+++ b/src/views/MainView.vue
@@ -126,7 +126,7 @@ function handleDirectCall(routeToken: string) {
 	unwatchJoinedConversation = watchJoinedConversation(routeToken, () => {
 		stopWatchingJoinedConversation()
 		void joinCall(routeToken, { directCall: true })
-	}, { immediate: true })
+	})
 }
 </script>
 


### PR DESCRIPTION
## ☑️ Resolves

* Fix https://github.com/nextcloud/talk-desktop/issues/1777
	* Watcher runs a callback on a match, but doesn't stop it - this was delegated to consumer components
	* On default behaviour, callback ran after stopWatch is returned
	* With `{ immediate: true }`, callback ran before stopWatch was returned
		* That left the stray watcher in components, what can't stop it anymore
	* switch to `@vueuse` library implementation of `whenever()` - immediate + once matches how we use it (alternative is to keep current implementation and stopWatch before/after the callback)

To test:
- Set 'Skip device preview before joining a call' option to true
- Open Talk with URL like `.../index.php/call/{token}#direct-call`, join call
- Leave call, navigate to another conversation
- Navigate back, see call joined (before PR) or not joined (after PR)

### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist


### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required