### PR TITLE
fix(tags): drop total unread counter

### DIFF
--- a/src/components/LeftSidebar/ConversationsList/ConversationTagHeader.vue
+++ b/src/components/LeftSidebar/ConversationsList/ConversationTagHeader.vue
@@ -13,7 +13,6 @@ import { useStore } from 'vuex'
 import NcActionButton from '@nextcloud/vue/components/NcActionButton'
 import NcActionSeparator from '@nextcloud/vue/components/NcActionSeparator'
 import NcAppNavigationItem from '@nextcloud/vue/components/NcAppNavigationItem'
-import NcCounterBubble from '@nextcloud/vue/components/NcCounterBubble'
 import NcIconSvgWrapper from '@nextcloud/vue/components/NcIconSvgWrapper'
 import IconArrowDown from 'vue-material-design-icons/ArrowDown.vue'
 import IconArrowUp from 'vue-material-design-icons/ArrowUp.vue'
@@ -27,8 +26,6 @@ import { useConversationTagsStore } from '../../../stores/conversationTags.ts'
 export type TagHeaderItem = ConversationTag & {
 	_type: 'tag-header'
 	unreadCount: number
-	unreadMention: boolean
-	unreadMentionDirect: boolean
 	isFirst?: boolean
 	isLast?: boolean
 }
@@ -42,15 +39,6 @@ const tagsStore = useConversationTagsStore()
 
 const isCustomTag = computed(() => props.item.type === 'custom')
 const isFavoritesTag = computed(() => props.item.type === 'favorites')
-const counterType = computed(() => {
-	if (props.item.unreadMentionDirect) {
-		return 'highlighted'
-	} else if (props.item.unreadMention) {
-		return 'outlined'
-	} else {
-		return ''
-	}
-})
 
 /**
  * Assign a new name to the tag via dialog
@@ -144,9 +132,6 @@ async function handleMarkReadTag() {
 		<template v-if="isFavoritesTag" #icon>
 			<!-- Filled for better indication -->
 			<IconStar :size="20" fillColor="var(--color-favorite)" />
-		</template>
-		<template #counter>
-			<NcCounterBubble v-if="item.unreadCount > 0" :count="item.unreadCount" :type="counterType" />
 		</template>
 		<template #actions>
 			<NcActionButton

--- a/src/components/LeftSidebar/ConversationsList/ConversationsListVirtual.vue
+++ b/src/components/LeftSidebar/ConversationsList/ConversationsListVirtual.vue
@@ -12,7 +12,7 @@ import { computed, watch } from 'vue'
 import LoadingPlaceholder from '../../UIShared/LoadingPlaceholder.vue'
 import ConversationItem from './ConversationItem.vue'
 import ConversationTagHeader from './ConversationTagHeader.vue'
-import { AVATAR, CONVERSATION } from '../../../constants.ts'
+import { AVATAR } from '../../../constants.ts'
 import { useConversationTagsStore } from '../../../stores/conversationTags.ts'
 import { hasCall, hasUnreadMessages } from '../../../utils/conversation.ts'
 
@@ -57,34 +57,21 @@ const listItems = computed<VirtualListItem[]>(() => {
 		hasTagged: boolean
 		favorites: Conversation[]
 		favoritesUnreadCount: number
-		favoritesUnreadMention: boolean
-		favoritesUnreadMentionDirect: boolean
 		tagged: Record<string, Conversation[]>
 		taggedUnreadCount: Record<string, number>
-		taggedUnreadMention: Record<string, boolean>
-		taggedUnreadMentionDirect: Record<string, boolean>
 		other: Conversation[]
 		otherUnreadCount: number
-		otherUnreadMention: boolean
-		otherUnreadMentionDirect: boolean
 	}>((acc, conversation) => {
-		// Count amount of unread conversations, highlight if any has a direct or group mention
+		// Count amount of unread conversations
 		const unreadCount = conversation.unreadMessages ? 1 : 0
-		const unreadMention = conversation.unreadMention
-		const unreadMentionDirect = conversation.unreadMentionDirect
-			|| (!!unreadCount && [CONVERSATION.TYPE.ONE_TO_ONE, CONVERSATION.TYPE.ONE_TO_ONE_FORMER].includes(conversation.type))
 		const isTagged = !!conversation.tagIds?.length
 
 		if (conversation.isFavorite) {
 			acc.favorites.push(conversation)
 			acc.favoritesUnreadCount += unreadCount
-			acc.favoritesUnreadMention ||= unreadMention
-			acc.favoritesUnreadMentionDirect ||= unreadMentionDirect
 		} else if (!isTagged) {
 			acc.other.push(conversation)
 			acc.otherUnreadCount += unreadCount
-			acc.otherUnreadMention ||= unreadMention
-			acc.otherUnreadMentionDirect ||= unreadMentionDirect
 		}
 
 		if (isTagged) {
@@ -97,24 +84,16 @@ const listItems = computed<VirtualListItem[]>(() => {
 			acc.tagged[tagId] ??= []
 			acc.tagged[tagId].push(conversation)
 			acc.taggedUnreadCount[tagId] = (acc.taggedUnreadCount[tagId] || 0) + unreadCount
-			acc.taggedUnreadMention[tagId] = acc.taggedUnreadMention[tagId] || unreadMention
-			acc.taggedUnreadMentionDirect[tagId] = acc.taggedUnreadMentionDirect[tagId] || unreadMentionDirect
 		}
 		return acc
 	}, {
 		hasTagged: false,
 		favorites: [],
 		favoritesUnreadCount: 0,
-		favoritesUnreadMention: false,
-		favoritesUnreadMentionDirect: false,
 		tagged: {},
 		taggedUnreadCount: {},
-		taggedUnreadMention: {},
-		taggedUnreadMentionDirect: {},
 		other: [],
 		otherUnreadCount: 0,
-		otherUnreadMention: false,
-		otherUnreadMentionDirect: false,
 	})
 
 	if (!groupedConversations.hasTagged && groupedConversations.favorites.length === 0) {
@@ -126,8 +105,6 @@ const listItems = computed<VirtualListItem[]>(() => {
 		tag: ConversationTag
 		conversations: Conversation[]
 		unreadCount: number
-		unreadMention: boolean
-		unreadMentionDirect: boolean
 	}>>((acc, tag) => {
 		const conversations = tag.type === 'favorites'
 			? groupedConversations.favorites
@@ -144,23 +121,11 @@ const listItems = computed<VirtualListItem[]>(() => {
 			: tag.type === 'other'
 				? groupedConversations.otherUnreadCount
 				: (groupedConversations.taggedUnreadCount[tag.id] ?? 0)
-		const unreadMention = tag.type === 'favorites'
-			? groupedConversations.favoritesUnreadMention
-			: tag.type === 'other'
-				? groupedConversations.otherUnreadMention
-				: (groupedConversations.taggedUnreadMention[tag.id] ?? false)
-		const unreadMentionDirect = tag.type === 'favorites'
-			? groupedConversations.favoritesUnreadMentionDirect
-			: tag.type === 'other'
-				? groupedConversations.otherUnreadMentionDirect
-				: (groupedConversations.taggedUnreadMentionDirect[tag.id] ?? false)
 
 		acc.push({
 			tag,
 			conversations,
 			unreadCount,
-			unreadMention,
-			unreadMentionDirect,
 		})
 		return acc
 	}, [])
@@ -170,8 +135,6 @@ const listItems = computed<VirtualListItem[]>(() => {
 			...section.tag,
 			_type: 'tag-header',
 			unreadCount: section.unreadCount,
-			unreadMention: section.unreadMention,
-			unreadMentionDirect: section.unreadMentionDirect,
 			isFirst: index === 0,
 			isLast: index === renderedSections.length - 1,
 		}


### PR DESCRIPTION
## ☑️ Resolves

* Partial revert of #18587 - causing confusion
	- unread conversations always show on collapse was implemented in #18677 after counter, making this redundant
	- this reverts commit 585d7fd1568e17991276b58f65cac859ca055681 and drops NcCounterBubble component
	- total unread still needed for 'mark all as read'

### AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="228" height="213" alt="2026-08-26_11h18_14" src="https://github.com/user-attachments/assets/ff7d6eb1-af7a-4191-a2b9-da8e688c04ab" /> | <img width="223" height="219" alt="2026-08-26_11h18_36" src="https://github.com/user-attachments/assets/64aaa9b8-96f5-483a-90fc-ff93de3e5b82" />

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required