### PR TITLE
fix(conversation): adjust scroll to unread mentions

### DIFF
--- a/src/components/LeftSidebar/ConversationsList/ConversationsListVirtual.vue
+++ b/src/components/LeftSidebar/ConversationsList/ConversationsListVirtual.vue
@@ -14,7 +14,7 @@ import ConversationItem from './ConversationItem.vue'
 import ConversationTagHeader from './ConversationTagHeader.vue'
 import { AVATAR, CONVERSATION } from '../../../constants.ts'
 import { useConversationTagsStore } from '../../../stores/conversationTags.ts'
-import { hasCall, hasUnreadMessages } from '../../../utils/conversation.ts'
+import { hasCall, hasUnreadMentions, hasUnreadMessages } from '../../../utils/conversation.ts'
 
 export type VirtualListItem = (Conversation | TagHeaderItem) & { _key?: string }
 
@@ -349,11 +349,35 @@ function scrollToConversation(token: string) {
 	}
 }
 
+/**
+ * Get the indices (in the flattened virtual-list, i.e. tag-header- and
+ * collapsed-section-aware) of conversations with unread mentions.
+ */
+function getUnreadMentionIndices(): number[] {
+	const indices: number[] = []
+	listItems.value.forEach((item, index) => {
+		if (!isTagHeader(item) && hasUnreadMentions(item)) {
+			indices.push(index)
+		}
+	})
+	return indices
+}
+
+/**
+ * Get the index (in the flattened virtual-list) of the last unread-mention
+ * conversation currently below the viewport, or null if there is none.
+ */
+function getLastUnreadMentionBelowViewportIndex(): number | null {
+	const lastInViewport = getLastItemInViewportIndex()
+	return getUnreadMentionIndices().findLast((idx) => idx > lastInViewport) ?? null
+}
+
 defineExpose({
 	getFirstItemInViewportIndex,
 	getLastItemInViewportIndex,
 	scrollToItem,
 	scrollToConversation,
+	getLastUnreadMentionBelowViewportIndex,
 })
 </script>
 

--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -696,14 +696,8 @@ export default {
 			return sortConversationsList(this.filteredConversationsList, this.groupMode, this.sortOrder)
 		},
 
-		unreadMentionIndices() {
-			const indices = []
-			for (const i in this.sortedConversationsList) {
-				if (hasUnreadMentions(this.sortedConversationsList[i])) {
-					indices.push(i)
-				}
-			}
-			return indices
+		hasUnreadMentionsInList() {
+			return this.sortedConversationsList.filter(hasUnreadMentions).length
 		},
 
 		emptyContentLabel() {
@@ -816,7 +810,7 @@ export default {
 			}
 		},
 
-		unreadMentionIndices() {
+		hasUnreadMentionsInList() {
 			this.debounceHandleScroll()
 		},
 	},
@@ -1143,22 +1137,12 @@ export default {
 		},
 
 		handleScroll() {
-			this.computeLastUnreadMention()
-		},
-
-		/**
-		 * Find position of the last unread conversation below viewport.
-		 * Iterates only over indices with unread mentions (cached via the
-		 * unreadMentionIndices computed) instead of the full list.
-		 */
-		computeLastUnreadMention() {
-			if (!this.$refs.scroller) {
-				this.lastUnreadMentionBelowViewportIndex = null
-				return
-			}
-			const lastInViewport = this.$refs.scroller.getLastItemInViewportIndex()
-			this.lastUnreadMentionBelowViewportIndex = this.unreadMentionIndices
-				.findLast((idx) => idx > lastInViewport) ?? null
+			/**
+			 * Find position of the last unread conversation below viewport.
+			 * Delegates to the scroller, which owns the flattened list (tag
+			 * headers and sections) and its indexes.
+			 */
+			this.lastUnreadMentionBelowViewportIndex = this.$refs.scroller?.getLastUnreadMentionBelowViewportIndex() ?? null
 		},
 
 		async scrollToConversation(token) {


### PR DESCRIPTION
## ☑️ Resolves

* Fix scroll to unread mention
	* previous 'unreadMentionIndices' was accounting only for sortedConversationsList, but we render ConversationsListVirtual#listItems and should compute indexes directly from it


### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before 

https://github.com/user-attachments/assets/bf3fcd5f-ec6d-4be0-852d-5b4ad7f4aa2a 

🏡 After

https://github.com/user-attachments/assets/cc0b85db-60d7-4184-996a-21c3537e4bbd


<!-- ☀️ Light theme | 🌑 Dark Theme -->

### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [x] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required