### PR TITLE
fix(call): set the right size for stripe mode avatars

### DIFF
--- a/src/components/CallView/shared/LocalVideo.vue
+++ b/src/components/CallView/shared/LocalVideo.vue
@@ -218,7 +218,7 @@ export default {
 		},
 
 		avatarSize() {
-			if (this.isStripe || (!this.isBig && !this.isGrid)) {
+			if (!this.isBig && !this.isGrid) {
 				return AVATAR.SIZE.LARGE
 			} else if (!this.containerAspectRatio) {
 				return AVATAR.SIZE.FULL

--- a/src/components/CallView/shared/VideoVue.vue
+++ b/src/components/CallView/shared/VideoVue.vue
@@ -335,7 +335,7 @@ export default {
 		},
 
 		avatarSize() {
-			if (this.isStripe || (!this.isBig && !this.isGrid)) {
+			if (!this.isBig && !this.isGrid) {
 				return AVATAR.SIZE.LARGE
 			} else if (!this.containerAspectRatio) {
 				return AVATAR.SIZE.FULL


### PR DESCRIPTION
## ☑️ Resolves


### AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="848" height="113" alt="image" src="https://github.com/user-attachments/assets/cf63ea28-38e8-4872-8db5-21d6e10de01e" /> | <img width="1323" height="195" alt="image" src="https://github.com/user-attachments/assets/5945fcec-9fc5-4472-ad25-0c25834958ca" />

<!-- ☀️ Light theme | 🌑 Dark Theme -->

### 🚧 Tasks


### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
