### PR TITLE
fix(participants): Only count real participants in the tab header

### DIFF
--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -164,7 +164,7 @@ import ThreadsTab from './Threads/ThreadsTab.vue'
 import IconPermMediaOutline from '../../../img/material-icons/perm-media-outline.svg?raw'
 import { useGetParticipants } from '../../composables/useGetParticipants.ts'
 import { useGetToken } from '../../composables/useGetToken.ts'
-import { CONVERSATION, PARTICIPANT, WEBINAR } from '../../constants.ts'
+import { ATTENDEE, CONVERSATION, PARTICIPANT, WEBINAR } from '../../constants.ts'
 import { getTalkConfig, hasTalkFeature } from '../../services/CapabilitiesManager.ts'
 import { useActorStore } from '../../stores/actor.ts'
 import { useSidebarStore } from '../../stores/sidebar.ts'
@@ -351,7 +351,13 @@ export default {
 		},
 
 		participantsText() {
-			const participants = this.$store.getters.participantsList(this.token)
+			const participants = this.$store.getters.participantsList(this.token).filter((participant) => {
+				return participant.actorType !== ATTENDEE.ACTOR_TYPE.GROUPS
+					&& participant.actorType !== ATTENDEE.ACTOR_TYPE.CIRCLES
+					&& participant.actorType !== ATTENDEE.ACTOR_TYPE.TEAMS
+					&& participant.actorType !== ATTENDEE.ACTOR_TYPE.BOTS
+					&& participant.actorType !== ATTENDEE.ACTOR_TYPE.BRIDGED
+			})
 			return t('spreed', 'Participants ({count})', { count: participants.length })
 		},
 


### PR DESCRIPTION
## ☑️ Resolves

* Only count real participants (skipping groups, teams, bots, …)

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="370" height="436" alt="Bildschirmfoto vom 2026-08-26 15-47-15" src="https://github.com/user-attachments/assets/8d9a2a69-0733-44e3-8cc2-865b99bfca06" /> | <img width="370" height="436" alt="Bildschirmfoto vom 2026-08-26 15-45-46" src="https://github.com/user-attachments/assets/b4dc0fa9-8993-4dde-8bae-c5b15adbe712" /> 

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
