### PR TITLE
fix(TalkSession): fall back to known tabId for requests without header

### DIFF
--- a/lib/TalkSession.php
+++ b/lib/TalkSession.php
@@ -113,9 +113,23 @@ class TalkSession {
 	}
 
 	protected function getValue(string $key, string $token, bool $useTabId = true): ?string {
-		$token .= $useTabId ? $this->getTabId() : '';
 		$values = $this->getValues($key);
-		return $values[$token] ?? null;
+		$tabId = $useTabId ? $this->getTabId() : '';
+
+		if ($tabId !== '') {
+			return $values[$token . $tabId] ?? null;
+		}
+
+		// Requests without the tab id header (e.g. an <img> tag) can not tell the
+		// tabs apart, so fall back to any value stored for the token
+		foreach ($values as $tokenKey => $value) {
+			$tokenKey = (string)$tokenKey;
+			if ($tokenKey === $token || str_starts_with($tokenKey, $token . self::TAB_ID_SEPARATOR)) {
+				return $value;
+			}
+		}
+
+		return null;
 	}
 
 	protected function setValue(string $key, string $token, string $value, bool $useTabId = true): void {
@@ -142,7 +156,7 @@ class TalkSession {
 			// This request does not support tabId, so we need to destroy all related data
 			foreach ($values as $tokenKey => $value) {
 				$tokenKey = (string)$tokenKey;
-				if (str_starts_with($tokenKey, $token)) {
+				if ($tokenKey === $token || str_starts_with($tokenKey, $token . self::TAB_ID_SEPARATOR)) {
 					unset($values[$tokenKey]);
 				}
 			}


### PR DESCRIPTION
## ☑️ Resolves

* Fix #19160 
* Follow-up to #17230
	- img GET requests can't set the header, so they fail on that middleware if e.g. guest tabId can't be identified - avatar endpoint locked for guests
	- harden checks for matching `$token . '$' . $tabId` key

To test:
- open public conversation from incognito

### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="228" height="40" alt="2026-08-27_14h31_231" src="https://github.com/user-attachments/assets/4699cf8c-30e1-40a6-8bef-fd9d78cfd3b6" /> | <img width="231" height="70" alt="2026-08-27_14h31_001" src="https://github.com/user-attachments/assets/2bfa6001-d7bf-4d45-abca-43b53f2b9702" />


---

<!--
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
░░░███████░░░█████████░░█████░
░░███░░░███░░░███░░░███░░███░░
░░█████████░░░████████░░░███░░
░░███░░░███░░░███░░░░░░░░███░░
░█████░█████░█████░░░░░░█████░
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching frontend/UI code
-->

## 🛠️ API Checklist

### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not possible
- [ ] 📘 API documentation in `docs/` has been updated or is not required
- [ ] 🔖 Capability is added or not needed 
