### PR TITLE
fix(changelog): Add changelog chat entry for Talk 25

### DIFF
--- a/lib/Chat/Changelog/Manager.php
+++ b/lib/Chat/Changelog/Manager.php
@@ -161,6 +161,10 @@ class Manager {
 			. $this->l->t('- Voice-rooms to connect spontaneously') . "\n"
 			. $this->l->t('- Presets for quick conversation configuration during creation') . "\n"
 			. $this->l->t('- Direct calls from profile menus for calls within other apps') . "\n",
+			$this->l->t('## New in Talk %s', ['25']) . "\n"
+			. $this->l->t('- Classified conversations for better discussions around sensitive topics') . "\n"
+			. $this->l->t('- Channels and announcements to broadcast information to a broader audiance') . "\n"
+			. $this->l->t('- Owners can preserve a conversation, preventing deletion and chat purging') . "\n",
 		];
 	}
 }


### PR DESCRIPTION
## ☑️ Resolves

> ## New in Talk 25
> - Classified conversations for better discussions around sensitive topics
> - Channels and announcements to broadcast information to a broader audiance
> - Owners can preserve a conversation, preventing deletion and chat purging

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
