### PR TITLE
fix(FilePreview): sanitize file name

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/AudioPlayer.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/AudioPlayer.vue
@@ -13,8 +13,8 @@
 			@ended="handleEnded">
 			{{ t('spreed', 'Your browser does not support playing audio files') }}
 		</audio>
-		<span v-if="showFileName" class="audio-player__name" :title="name">
-			{{ name }}
+		<span v-if="showFileName" class="audio-player__name" :title="sanitizedFileName">
+			<span class="audio-player__basename">{{ fileNameWithoutExtension }}</span><span v-if="fileExtension">{{ fileExtension }}</span>
 		</span>
 	</div>
 </template>
@@ -26,6 +26,7 @@ import { generateRemoteUrl } from '@nextcloud/router'
 import { inject } from 'vue'
 import { EventBus } from '../../../../../services/EventBus.ts'
 import { useActorStore } from '../../../../../stores/actor.ts'
+import { getFileExtension, sanitizeFileName } from '../../../../../utils/fileUpload.ts'
 
 export default {
 	name: 'AudioPlayer',
@@ -84,6 +85,18 @@ export default {
 	},
 
 	computed: {
+		sanitizedFileName() {
+			return sanitizeFileName(this.name)
+		},
+
+		fileNameWithoutExtension() {
+			return this.name.slice(0, this.name.length - getFileExtension(this.name).length)
+		},
+
+		fileExtension() {
+			return getFileExtension(this.name)
+		},
+
 		internalAbsolutePath() {
 			if (this.path.startsWith('/')) {
 				return this.path
@@ -153,6 +166,10 @@ export default {
 		white-space: nowrap;
 		text-overflow: ellipsis;
 		font-weight: bold;
+	}
+
+	&__basename {
+		unicode-bidi: isolate;
 	}
 
 	&__audio {

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.spec.js
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.spec.js
@@ -136,16 +136,17 @@ describe('FilePreview.vue', () => {
 			expect(imageUrl.searchParams.get('y')).toBe('576')
 		})
 
-		test('renders small previews when requested', async () => {
-			props.smallPreview = true
+		test('renders a mime icon instead of a scaled preview in row layout', async () => {
+			props.rowLayout = true
+			OC.MimeType.getIconUrl.mockReturnValueOnce(imagePath('core', 'image/jpeg'))
 
 			const wrapper = mountFilePreview()
 
 			await wrapper.find('img').trigger('load')
 
 			expect(wrapper.element.tagName).toBe('A')
-			const imageUrl = parseRelativeUrl(wrapper.find('img').attributes('src'))
-			expect(imageUrl.searchParams.get('y')).toBe('24')
+			const imageUrl = wrapper.find('img').attributes('src')
+			expect(imageUrl).toBe(imagePath('core', 'image/jpeg'))
 		})
 
 		describe('uploading', () => {
@@ -412,8 +413,8 @@ describe('FilePreview.vue', () => {
 					await testPlayButtonVisible(true)
 				})
 
-				test('does not render play icon for small previews', async () => {
-					props.smallPreview = true
+				test('does not render play icon in row layout', async () => {
+					props.rowLayout = true
 					await testPlayButtonVisible(false)
 				})
 

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
@@ -95,7 +95,8 @@
 			</template>
 		</NcButton>
 		<div v-if="shouldShowFileDetail" class="name-container">
-			<span class="name-container__basename">{{ fileNameWithoutExtension }}</span><span v-if="fileExtension">{{ fileExtension }}</span>
+			<span class="name-container__basename">{{ fileNameWithoutExtension }}</span>
+			<span v-if="fileExtension" class="name-container__extension">{{ fileExtension }}</span>
 		</div>
 	</component>
 </template>
@@ -796,10 +797,18 @@ export default {
 		width: 100%;
 		overflow: hidden;
 		white-space: nowrap;
-		text-overflow: ellipsis;
+		display: inline-flex;
 
 		&__basename {
 			unicode-bidi: isolate;
+			overflow: hidden;
+			white-space: nowrap;
+			text-overflow: ellipsis;
+		}
+
+		&__extension {
+			color: var(--color-text-maxcontrast);
+			overflow: visible;
 		}
 	}
 

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
@@ -39,7 +39,7 @@
 					:alt="file.name"
 					:src="defaultIconUrl">
 				<!-- Indicator that preview is intentionally hidden, not failed -->
-				<span v-if="!smallPreview" class="classified-preview-button">
+				<span v-if="!rowLayout" class="classified-preview-button">
 					<IconEyeOutline :size="20" fillColor="#ffffff" />
 				</span>
 			</template>
@@ -52,7 +52,7 @@
 					@load="onLoad"
 					@error="onError">
 				<template v-if="!isLoading || fallbackLocalUrl">
-					<span v-if="isPlayable && !smallPreview" class="play-video-button">
+					<span v-if="isPlayable && !rowLayout" class="play-video-button">
 						<IconPlayCircleOutline
 							:size="48"
 							fillColor="#ffffff" />
@@ -170,14 +170,6 @@ export default {
 		referenceId: {
 			type: String,
 			default: '',
-		},
-
-		/**
-		 * Whether to render a small preview to embed in replies
-		 */
-		smallPreview: {
-			type: Boolean,
-			default: false,
 		},
 
 		/**
@@ -306,7 +298,7 @@ export default {
 
 		previewImageClass() {
 			let classes = ''
-			if (this.smallPreview) {
+			if (this.rowLayout) {
 				classes += 'preview-small '
 			} else if (this.mediumPreview) {
 				classes += 'preview-medium '
@@ -335,16 +327,21 @@ export default {
 				return {}
 			}
 
+			// Row layout always shows a small fixed-size icon, never a medium/full preview
+			if (this.rowLayout) {
+				return { width: '24px', height: '24px' }
+			}
+
 			// Fallback for loading mimeicons (preview for audio files is not provided)
 			if (this.file['preview-available'] !== 'yes' || this.file.mimetype.startsWith('audio/') || this.failed) {
 				return {
-					width: this.smallPreview ? '24px' : '128px',
-					height: this.smallPreview ? '24px' : '128px',
+					width: '128px',
+					height: '128px',
 				}
 			}
 
-			const widthConstraint = this.smallPreview ? 24 : (this.mediumPreview ? 192 : 600)
-			const heightConstraint = this.smallPreview ? 24 : (this.mediumPreview ? 192 : 384)
+			const widthConstraint = this.mediumPreview ? 192 : 600
+			const heightConstraint = this.mediumPreview ? 192 : 384
 
 			// Actual size when no metadata available
 			if (!this.file.width || !this.file.height) {
@@ -426,11 +423,7 @@ export default {
 			}
 
 			// use preview provider URL to render a smaller preview
-			let previewSize = 384
-			if (this.smallPreview) {
-				previewSize = 24
-			}
-			previewSize = Math.ceil(previewSize * window.devicePixelRatio)
+			const previewSize = Math.ceil(384 * window.devicePixelRatio)
 			if (userId === null) {
 				// guest mode: grab token from the link URL
 				// FIXME: use a cleaner way...

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
@@ -19,7 +19,7 @@
 		@click.exact="handleClick"
 		@keydown.enter="handleClick">
 		<span
-			:title="file.name"
+			:title="sanitizedFileName"
 			class="image-container"
 			:class="{ playable: isPlayable }"
 			:style="imageContainerStyle">
@@ -36,7 +36,7 @@
 					v-else
 					class="file-preview__image"
 					:class="previewImageClass"
-					:alt="file.name"
+					:alt="sanitizedFileName"
 					:src="defaultIconUrl">
 				<!-- Indicator that preview is intentionally hidden, not failed -->
 				<span v-if="!rowLayout" class="classified-preview-button">
@@ -47,7 +47,7 @@
 				<img
 					class="file-preview__image"
 					:class="previewImageClass"
-					:alt="file.name"
+					:alt="sanitizedFileName"
 					:src="failed ? defaultIconUrl : previewUrl"
 					@load="onLoad"
 					@error="onError">
@@ -95,7 +95,7 @@
 			</template>
 		</NcButton>
 		<div v-if="shouldShowFileDetail" class="name-container">
-			{{ fileDetail }}
+			<span class="name-container__basename">{{ fileNameWithoutExtension }}</span><span v-if="fileExtension">{{ fileExtension }}</span>
 		</div>
 	</component>
 </template>
@@ -122,6 +122,7 @@ import { useActorStore } from '../../../../../stores/actor.ts'
 import { useSharedItemsStore } from '../../../../../stores/sharedItems.ts'
 import { useUploadStore } from '../../../../../stores/upload.ts'
 import { isClassifiedConversation } from '../../../../../utils/conversation.ts'
+import { getFileExtension, sanitizeFileName } from '../../../../../utils/fileUpload.ts'
 import { canPlayAudio } from '../../../../../utils/sounds.js'
 
 const PREVIEW_TYPE = {
@@ -239,8 +240,18 @@ export default {
 			)
 		},
 
-		fileDetail() {
-			return this.file.name
+		// file.name with bidi control chars replaced by '_', for title/alt/aria-label text
+		sanitizedFileName() {
+			return sanitizeFileName(this.file.name)
+		},
+
+		fileNameWithoutExtension() {
+			return this.file.name.slice(0, this.file.name.length - getFileExtension(this.file.name).length)
+		},
+
+		// Dot included, original case
+		fileExtension() {
+			return getFileExtension(this.file.name)
 		},
 
 		fileSizeLabel() {
@@ -528,7 +539,7 @@ export default {
 		},
 
 		removeAriaLabel() {
-			return t('spreed', 'Remove {fileName}', { fileName: this.file.name })
+			return t('spreed', 'Remove {fileName}', { fileName: this.sanitizedFileName })
 		},
 	},
 
@@ -786,6 +797,10 @@ export default {
 		overflow: hidden;
 		white-space: nowrap;
 		text-overflow: ellipsis;
+
+		&__basename {
+			unicode-bidi: isolate;
+		}
 	}
 
 	&:not(.file-preview--viewer-available) {

--- a/src/components/RightSidebar/SharedItems/SharedItems.vue
+++ b/src/components/RightSidebar/SharedItems/SharedItems.vue
@@ -46,7 +46,6 @@
 			<FilePreview
 				v-else
 				:token="token"
-				:smallPreview="!isMedia"
 				:rowLayout="!isMedia"
 				:itemType="type"
 				isSharedItems

--- a/src/test-setup.js
+++ b/src/test-setup.js
@@ -28,6 +28,7 @@ vi.mock('@nextcloud/dialogs', () => ({
 
 vi.mock('@nextcloud/files', () => ({
 	validateFileName: vi.fn(),
+	formatFileSize: vi.fn((size) => `${size} B`),
 }))
 
 vi.mock('@nextcloud/files/dav', () => ({

--- a/src/utils/fileUpload.ts
+++ b/src/utils/fileUpload.ts
@@ -8,6 +8,7 @@ import type { UploadEntry } from '../types/index.ts'
 
 const extensionRegex = /\.[0-9a-z]+$/i
 const suffixRegex = / \(\d+\)$/
+const bidiControlRegex = /[\u202A-\u202E\u2066-\u2069]/g
 
 /**
  * Returns the file extension for the given path
@@ -17,6 +18,16 @@ const suffixRegex = / \(\d+\)$/
  */
 export function getFileExtension(path: string): string {
 	return path.match(extensionRegex)?.[0] ?? ''
+}
+
+/**
+ * Returns name with bidi control characters replaced by '_'
+ *
+ * @param name file name
+ * @return sanitized file name
+ */
+export function sanitizeFileName(name: string): string {
+	return name.replace(bidiControlRegex, '_')
 }
 
 /**

--- a/src/utils/textParse.ts
+++ b/src/utils/textParse.ts
@@ -8,6 +8,8 @@ import type { ChatMessage, Mention } from '../types/index.ts'
 import { getBaseUrl } from '@nextcloud/router'
 import { decodeHTML } from 'entities'
 import { MENTION } from '../constants.ts'
+import { sanitizeFileName } from './fileUpload.ts'
+import { getFileKeys } from './message.ts'
 
 /**
  * Parse message text to return proper formatting for mentions
@@ -61,8 +63,10 @@ function parseToSimpleMessage(text: string, parameters: ChatMessage['messagePara
 		return text.trim()
 	}
 
+	const fileKeys = getFileKeys({ messageParameters: parameters })
 	Object.entries(parameters).forEach(([key, value]) => {
-		text = text.replaceAll('{' + key + '}', value.name)
+		const name = fileKeys.includes(key) ? sanitizeFileName(value.name) : value.name
+		text = text.replaceAll('{' + key + '}', name)
 	})
 	return text.trim()
 }


### PR DESCRIPTION
## ☑️ Resolves

* Refactor + Hardening for FilePreview
	* drop redundant prop `smallPreview` - always used in pair with `rowLayout`
	* sanitize filename on rendering - keep file extension a static append to the file name (aligned with Files app)
	* highlight extension

### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="204" height="24" alt="image" src="https://github.com/user-attachments/assets/d069e0f2-ecaa-4db3-bbbc-da87e4632463" />| <img width="208" height="60" alt="image" src="https://github.com/user-attachments/assets/38c18cea-b526-4e14-bf8d-eb88c1f80a62" />
<img width="111" height="171" alt="image" src="https://github.com/user-attachments/assets/291d5bd0-bfb9-40a2-bc73-02874bfba5dd" /> | <img width="135" height="172" alt="image" src="https://github.com/user-attachments/assets/f9b911c1-9935-49b8-9431-f29247f1f8c6" />
<img width="151" height="126" alt="image" src="https://github.com/user-attachments/assets/81014580-1e14-47dc-a83b-d6ae17dc6ed8" /> | <img width="146" height="133" alt="image" src="https://github.com/user-attachments/assets/8328e9ef-0ba9-4042-b748-08ff7262fe0c" />
b | <img width="150" height="68" alt="image" src="https://github.com/user-attachments/assets/66ae98b2-a907-44c8-907f-25cfc78c3b3f" />
bb | <img width="333" height="75" alt="image" src="https://github.com/user-attachments/assets/0d5e58e4-6e32-4c45-8b69-8cf4e462cd0f" />

### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [ ] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required