### PR TITLE
fix(sounds): fall back when the server has no play-sounds capability

### DIFF
--- a/src/stores/__tests__/sounds.spec.js
+++ b/src/stores/__tests__/sounds.spec.js
@@ -4,14 +4,20 @@
  */
 
 import { getCurrentUser } from '@nextcloud/auth'
+import axios from '@nextcloud/axios'
+import { generateOcsUrl } from '@nextcloud/router'
 import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import BrowserStorage from '../../services/BrowserStorage.js'
 import { getTalkConfig } from '../../services/CapabilitiesManager.ts'
-import { setPlaySounds } from '../../services/settingsService.ts'
 
 vi.mock('@nextcloud/auth', () => ({
 	getCurrentUser: vi.fn(),
+}))
+vi.mock('@nextcloud/axios', () => ({
+	default: {
+		post: vi.fn(() => Promise.resolve()),
+	},
 }))
 vi.mock('../../services/BrowserStorage.js', () => ({
 	default: {
@@ -21,9 +27,6 @@ vi.mock('../../services/BrowserStorage.js', () => ({
 }))
 vi.mock('../../services/CapabilitiesManager.ts', () => ({
 	getTalkConfig: vi.fn(),
-}))
-vi.mock('../../services/settingsService.ts', () => ({
-	setPlaySounds: vi.fn(() => Promise.resolve()),
 }))
 
 /**
@@ -100,25 +103,28 @@ describe('soundsStore', () => {
 			getTalkConfig.mockReturnValue(true)
 			const store = await loadSoundsStore()
 			await store.setShouldPlaySounds(false)
-			expect(setPlaySounds).toHaveBeenCalledWith(true, 'no')
+			expect(axios.post).toHaveBeenCalledWith(
+				generateOcsUrl('apps/spreed/api/v1/settings/user'),
+				{ key: 'play_sounds', value: 'no' },
+			)
 			expect(BrowserStorage.setItem).not.toHaveBeenCalled()
 			expect(store.shouldPlaySounds).toBe(false)
 		})
 
-		it('leaves the value to browser storage when the server has no capability', async () => {
+		it('saves to browser storage instead on older servers, since they cannot hand it back', async () => {
 			const store = await loadSoundsStore()
 			await store.setShouldPlaySounds(false)
-			expect(setPlaySounds).toHaveBeenCalledWith(false, 'no')
-			expect(BrowserStorage.setItem).not.toHaveBeenCalled()
+			expect(axios.post).not.toHaveBeenCalled()
+			expect(BrowserStorage.setItem).toHaveBeenCalledWith('play_sounds', 'no')
 			expect(store.shouldPlaySounds).toBe(false)
 		})
 
-		it('saves guests to browser storage through the settings service only', async () => {
+		it('saves guests to browser storage', async () => {
 			getCurrentUser.mockReturnValue(null)
 			const store = await loadSoundsStore()
 			await store.setShouldPlaySounds(true)
-			expect(setPlaySounds).toHaveBeenCalledWith(false, 'yes')
-			expect(BrowserStorage.setItem).not.toHaveBeenCalled()
+			expect(axios.post).not.toHaveBeenCalled()
+			expect(BrowserStorage.setItem).toHaveBeenCalledWith('play_sounds', 'yes')
 		})
 	})
 })

--- a/src/stores/__tests__/sounds.spec.js
+++ b/src/stores/__tests__/sounds.spec.js
@@ -1,0 +1,124 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { getCurrentUser } from '@nextcloud/auth'
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import BrowserStorage from '../../services/BrowserStorage.js'
+import { getTalkConfig } from '../../services/CapabilitiesManager.ts'
+import { setPlaySounds } from '../../services/settingsService.ts'
+
+vi.mock('@nextcloud/auth', () => ({
+	getCurrentUser: vi.fn(),
+}))
+vi.mock('../../services/BrowserStorage.js', () => ({
+	default: {
+		getItem: vi.fn(),
+		setItem: vi.fn(),
+	},
+}))
+vi.mock('../../services/CapabilitiesManager.ts', () => ({
+	getTalkConfig: vi.fn(),
+}))
+vi.mock('../../services/settingsService.ts', () => ({
+	setPlaySounds: vi.fn(() => Promise.resolve()),
+}))
+
+/**
+ * The initial value is computed when the module is loaded, so load it fresh for every test
+ */
+async function loadSoundsStore() {
+	vi.resetModules()
+	const { useSoundsStore } = await import('../sounds.js')
+	setActivePinia(createPinia())
+	return useSoundsStore()
+}
+
+describe('soundsStore', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		getCurrentUser.mockReturnValue({ uid: 'alice' })
+		getTalkConfig.mockReturnValue(undefined)
+		BrowserStorage.getItem.mockReturnValue(null)
+	})
+
+	describe('initial value for users', () => {
+		it('takes the value from the capabilities on Talk 24+', async () => {
+			getTalkConfig.mockReturnValue(false)
+			const store = await loadSoundsStore()
+			expect(store.shouldPlaySounds).toBe(false)
+			expect(getTalkConfig).toHaveBeenCalledWith('local', 'call', 'play-sounds')
+		})
+
+		it('prefers the capabilities over browser storage', async () => {
+			getTalkConfig.mockReturnValue(true)
+			BrowserStorage.getItem.mockReturnValue('no')
+			const store = await loadSoundsStore()
+			expect(store.shouldPlaySounds).toBe(true)
+		})
+
+		it('falls back to browser storage when the server has no capability', async () => {
+			BrowserStorage.getItem.mockReturnValue('no')
+			const store = await loadSoundsStore()
+			expect(store.shouldPlaySounds).toBe(false)
+		})
+
+		it('defaults to enabled without capability or storage', async () => {
+			const store = await loadSoundsStore()
+			expect(store.shouldPlaySounds).toBe(true)
+		})
+	})
+
+	describe('initial value for guests', () => {
+		beforeEach(() => {
+			getCurrentUser.mockReturnValue(null)
+		})
+
+		it('prefers browser storage over the capabilities', async () => {
+			getTalkConfig.mockReturnValue(true)
+			BrowserStorage.getItem.mockReturnValue('no')
+			const store = await loadSoundsStore()
+			expect(store.shouldPlaySounds).toBe(false)
+		})
+
+		it('takes the value from the capabilities without storage', async () => {
+			getTalkConfig.mockReturnValue(false)
+			const store = await loadSoundsStore()
+			expect(store.shouldPlaySounds).toBe(false)
+		})
+
+		it('defaults to enabled on older servers', async () => {
+			const store = await loadSoundsStore()
+			expect(store.shouldPlaySounds).toBe(true)
+		})
+	})
+
+	describe('setShouldPlaySounds', () => {
+		it('saves on the server only when the capability exists', async () => {
+			getTalkConfig.mockReturnValue(true)
+			const store = await loadSoundsStore()
+			await store.setShouldPlaySounds(false)
+			expect(setPlaySounds).toHaveBeenCalledWith(true, 'no')
+			expect(BrowserStorage.setItem).not.toHaveBeenCalled()
+			expect(store.shouldPlaySounds).toBe(false)
+		})
+
+		it('leaves the value to browser storage when the server has no capability', async () => {
+			const store = await loadSoundsStore()
+			await store.setShouldPlaySounds(false)
+			expect(setPlaySounds).toHaveBeenCalledWith(false, 'no')
+			expect(BrowserStorage.setItem).not.toHaveBeenCalled()
+			expect(store.shouldPlaySounds).toBe(false)
+		})
+
+		it('saves guests to browser storage through the settings service only', async () => {
+			getCurrentUser.mockReturnValue(null)
+			const store = await loadSoundsStore()
+			await store.setShouldPlaySounds(true)
+			expect(setPlaySounds).toHaveBeenCalledWith(false, 'yes')
+			expect(BrowserStorage.setItem).not.toHaveBeenCalled()
+		})
+	})
+})

--- a/src/stores/sounds.js
+++ b/src/stores/sounds.js
@@ -11,19 +11,31 @@ import { getTalkConfig } from '../services/CapabilitiesManager.ts'
 import { setPlaySounds } from '../services/settingsService.ts'
 
 const hasUserAccount = Boolean(getCurrentUser()?.uid)
+const playSoundsCapability = getTalkConfig('local', 'call', 'play-sounds')
+const hasPlaySoundsCapability = playSoundsCapability !== undefined
+
 /**
- * Get play sounds option (from server for user or from browser storage for guest)
+ * Get play sounds option. A guest keeps whatever this browser remembered, otherwise the
+ * capability decides. Servers before Talk 24 don't hand the value out at all, so fall back
+ * to the browser and then to enabled.
+ *
+ * @return {boolean}
  */
-let shouldPlaySounds = false
-if (hasUserAccount) {
-	shouldPlaySounds = getTalkConfig('local', 'call', 'play-sounds')
-} else {
-	if (BrowserStorage.getItem('play_sounds')) {
-		shouldPlaySounds = BrowserStorage.getItem('play_sounds') !== 'no'
-	} else {
-		shouldPlaySounds = getTalkConfig('local', 'call', 'play-sounds')
+function getInitialShouldPlaySounds() {
+	const fromStorage = BrowserStorage.getItem('play_sounds')
+
+	if (!hasUserAccount && fromStorage) {
+		return fromStorage !== 'no'
 	}
+
+	if (hasPlaySoundsCapability) {
+		return playSoundsCapability
+	}
+
+	return fromStorage ? fromStorage !== 'no' : true
 }
+
+const shouldPlaySounds = getInitialShouldPlaySounds()
 
 /**
  * Preferred version is the .ogg, with .flac fallback if .ogg is not supported (Safari)
@@ -55,7 +67,7 @@ export const useSoundsStore = defineStore('sounds', {
 		 * @param {boolean} value whether sounds should be played
 		 */
 		async setShouldPlaySounds(value) {
-			await setPlaySounds(hasUserAccount, value ? 'yes' : 'no')
+			await setPlaySounds(hasUserAccount && hasPlaySoundsCapability, value ? 'yes' : 'no')
 			this.shouldPlaySounds = value
 		},
 


### PR DESCRIPTION
### ☑️ Resolves

* Ref nextcloud/talk-desktop#1087 (sound setting not saved across restarts)

Since Talk 24 the sounds store reads the user's "play sounds" setting from the capabilities (`config.call.play-sounds`). That works against a Talk 24+ server, but servers before Talk 24 don't have that capability at all, so `getTalkConfig('local', 'call', 'play-sounds')` returns `undefined` there: sounds are off after every start and the toggle in the settings dialog doesn't stick, which is the talk-desktop issue above again (the 2.2.x desktop client bundles the Talk 24 frontend and still supports NC 32/33 servers), just with the default flipped to silent.

The capability is read once at module level and stays the first source for users; for older servers there are two fallbacks:

1. capability (Talk 24+)
2. value remembered in browser storage
3. enabled, as before Talk 24

Guests are unchanged: browser storage first, then the capability (`guests_play_sounds`), then enabled. On change, `setPlaySounds()` gets `hasUserAccount && hasPlaySoundsCapability`, so a server that can't hand the value back isn't written to either and the setting stays in the browser. Against Talk 24+ nothing changes.

Known limitation on older servers: a change made in another browser/device isn't picked up until the toggle is used locally, since there is no way to read the value back. That's the same trade-off @Antreesy described in the linked issue.

Added a small spec for the store's initial value and the action; the store computes its initial value at import time, so the tests reload the module.

### 🖼️ Screenshots

n/a

### 🚧 Tasks

- [x] Code
- [x] Tests

### 🏁 Checklist

- [x] ⛑️ Tests are included or not possible
- [ ] 📘 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk is updated or not required
- [ ] 📗 Admin documentation in https://github.com/nextcloud/documentation/tree/master/admin_manual/talk is updated or not required
- [ ] 📕 Developer documentation in `docs/` is updated or not required
- [ ] 🔖 Capability is added or not needed
