### PR TITLE
fix(chat): render image previews for guests

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
@@ -440,8 +440,9 @@ export default {
 				// guest mode: grab token from the link URL
 				// FIXME: use a cleaner way...
 				const token = this.file.link.slice(this.file.link.lastIndexOf('/') + 1)
-				return generateUrl('/apps/files_sharing/publicpreview/{token}?x=-1&y={height}&a=1', {
+				return generateUrl('/apps/files_sharing/publicpreview/{token}?file={file}&x=-1&y={height}&a=1', {
 					token,
+					file: this.internalAbsolutePath,
 					height: previewSize,
 				})
 			} else {


### PR DESCRIPTION
## ☑️ Resolves

* Fix #19247
	- publicpreview API was hardened to request for file path, if the folder is shared
	- Talk does that kind of shares with subfolders feature support

### AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="444" height="465" alt="2026-09-03_11h22_32" src="https://github.com/user-attachments/assets/f20aa3ab-d61b-44d4-8c1f-995b0f4aa2c8" /> | <img width="448" height="391" alt="2026-09-03_11h22_21" src="https://github.com/user-attachments/assets/a2b26cc5-bd22-4a2c-a75e-d096156af7fb" />


### 🚧 Tasks

- [ ] Test against stable33 (desktop)

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required