### PR TITLE
feat(dashboard): Show triggered reminders instead of upcoming ones

### DIFF
--- a/src/components/Dashboard/TalkDashboard.vue
+++ b/src/components/Dashboard/TalkDashboard.vue
@@ -34,12 +34,13 @@ import { CONVERSATION } from '../../constants.ts'
 import { getTalkConfig, hasTalkFeature, localCapabilities } from '../../services/CapabilitiesManager.ts'
 import { EventBus } from '../../services/EventBus.ts'
 import { useActorStore } from '../../stores/actor.ts'
-import { useDashboardStore } from '../../stores/dashboard.ts'
+import { supportsTriggeredReminders, useDashboardStore } from '../../stores/dashboard.ts'
 import { hasUnreadMentions } from '../../utils/conversation.ts'
 import { convertToUnix } from '../../utils/formattedTime.ts'
 import { copyConversationLinkToClipboard } from '../../utils/handleUrl.ts'
 
-const supportsUpcomingReminders = hasTalkFeature('local', 'upcoming-reminders')
+const supportsReminders = hasTalkFeature('local', 'upcoming-reminders') || supportsTriggeredReminders
+const remindersTitle = supportsTriggeredReminders ? t('spreed', 'Reminders') : t('spreed', 'Upcoming reminders')
 const canModerateSipDialOut = hasTalkFeature('local', 'sip-support-dialout')
 	&& getTalkConfig('local', 'call', 'sip-enabled')
 	&& getTalkConfig('local', 'call', 'sip-dialout-enabled')
@@ -71,9 +72,9 @@ const forwardScrollable = ref(false)
 const backwardScrollable = ref(false)
 const eventCardsWrapper = ref<HTMLDivElement | null>(null)
 const eventRooms = computed(() => dashboardStore.eventRooms || [])
-const upcomingReminders = computed(() => dashboardStore.upcomingReminders || [])
+const reminders = computed(() => dashboardStore.reminders || [])
 const eventsInitialised = computed(() => dashboardStore.eventRoomsInitialised)
-const remindersInitialised = computed(() => dashboardStore.upcomingRemindersInitialised)
+const remindersInitialised = computed(() => dashboardStore.remindersInitialised)
 const conversationName = ref('')
 let actualizeDataInterval: ReturnType<typeof setInterval> | null = null
 
@@ -85,7 +86,7 @@ let actualizeDataInterval: ReturnType<typeof setInterval> | null = null
 async function actualizeData() {
 	await Promise.all([
 		dashboardStore.fetchDashboardEventRooms(),
-		dashboardStore.fetchUpcomingReminders(),
+		dashboardStore.fetchReminders(),
 	])
 }
 
@@ -378,18 +379,19 @@ function scrollEventCards({ direction }: { direction: 'backward' | 'forward' }) 
 						:backgroundImage="illustration('mentions')" />
 				</div>
 				<div
-					v-if="supportsUpcomingReminders"
+					v-if="supportsReminders"
 					class="talk-dashboard__upcoming-reminders">
 					<DashboardSection
-						v-if="upcomingReminders.length > 0 || !remindersInitialised"
-						:title="t('spreed', 'Upcoming reminders')"
+						v-if="reminders.length > 0 || !remindersInitialised"
+						:title="remindersTitle"
 						:backgroundImage="illustration('reminders')">
 						<template #list>
 							<ul v-if="remindersInitialised" class="upcoming-reminders-list">
 								<SearchMessageItem
-									v-for="reminder in upcomingReminders"
-									:key="reminder.messageId"
+									v-for="reminder in reminders"
+									:key="reminder.notificationId ?? reminder.messageId"
 									:messageId="reminder.messageId"
+									:notificationId="reminder.notificationId"
 									:title="reminder.actorDisplayName"
 									:subline="reminder.message"
 									:messageParameters="reminder.messageParameters"
@@ -397,7 +399,7 @@ function scrollEventCards({ direction }: { direction: 'backward' | 'forward' }) 
 									:to="{
 										name: 'conversation',
 										params: { token: reminder.roomToken },
-										hash: `#message_${reminder.messageId}`,
+										hash: reminder.messageId ? `#message_${reminder.messageId}` : undefined,
 									}"
 									:actorId="reminder.actorId"
 									:actorType="reminder.actorType"

--- a/src/components/RightSidebar/SearchMessages/SearchMessageItem.vue
+++ b/src/components/RightSidebar/SearchMessages/SearchMessageItem.vue
@@ -34,10 +34,12 @@ const props = withDefaults(defineProps<{
 	timestamp: number
 	messageParameters?: ChatMessage['messageParameters']
 	isReminder?: boolean
+	notificationId?: number | null
 	compact?: boolean
 }>(), {
 	messageParameters: () => ({}),
 	isReminder: false,
+	notificationId: null,
 })
 
 const router = useRouter()
@@ -117,7 +119,7 @@ function handleResultClick() {
 		<template v-if="isReminder" #actions>
 			<NcActionButton
 				closeAfterClick
-				@click.stop="dashboardStore.removeReminder(token, messageId)">
+				@click.stop="dashboardStore.removeReminder(token, messageId, notificationId)">
 				<template #icon>
 					<CloseCircleOutline :size="20" />
 				</template>

--- a/src/services/CapabilitiesManager.ts
+++ b/src/services/CapabilitiesManager.ts
@@ -77,6 +77,15 @@ export function hasTalkFeature(token: string = 'local', feature: string): boolea
 }
 
 /**
+ * Check whether the notifications app of the local server offers the given OCS endpoint feature
+ *
+ * @param feature endpoint capability in string format
+ */
+export function hasNotificationsFeature(feature: string): boolean {
+	return localCapabilities?.notifications?.['ocs-endpoints']?.includes(feature) ?? false
+}
+
+/**
  * Get an according config value from local or remote capabilities
  *
  * @param token conversation token

--- a/src/services/notificationsService.ts
+++ b/src/services/notificationsService.ts
@@ -1,0 +1,38 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { getReminderNotificationsResponse } from '../types/index.ts'
+
+import axios from '@nextcloud/axios'
+import { generateOcsUrl } from '@nextcloud/router'
+
+/**
+ * Fetches the reminder notifications of the user, that is the reminders which already triggered
+ * and were not dismissed yet. Requires the `list-filter` capability of the notifications app.
+ */
+async function getReminderNotifications(): getReminderNotificationsResponse {
+	return axios.get(generateOcsUrl('apps/notifications/api/v2/notifications'), {
+		params: {
+			app: 'spreed',
+			objectType: 'reminder',
+		},
+	})
+}
+
+/**
+ * Dismisses a single notification of the user
+ *
+ * @param notificationId The id of the notification
+ */
+async function dismissNotification(notificationId: number) {
+	return axios.delete(generateOcsUrl('apps/notifications/api/v2/notifications/{notificationId}', {
+		notificationId,
+	}))
+}
+
+export {
+	dismissNotification,
+	getReminderNotifications,
+}

--- a/src/stores/__tests__/dashboard.spec.js
+++ b/src/stores/__tests__/dashboard.spec.js
@@ -1,0 +1,220 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { createPinia, setActivePinia } from 'pinia'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ATTENDEE } from '../../constants.ts'
+import { generateOCSErrorResponse, generateOCSResponse } from '../../test-helpers.js'
+
+vi.mock('../../services/CapabilitiesManager.ts', () => ({
+	hasNotificationsFeature: vi.fn(),
+	hasTalkFeature: vi.fn(),
+}))
+vi.mock('../../services/notificationsService.ts', () => ({
+	dismissNotification: vi.fn(),
+	getReminderNotifications: vi.fn(),
+}))
+vi.mock('../../services/remindersService.js', () => ({
+	getUpcomingReminders: vi.fn(),
+	removeMessageReminder: vi.fn(),
+}))
+vi.mock('../../services/dashboardService.ts', () => ({
+	getDashboardEventRooms: vi.fn(),
+}))
+
+/**
+ * Load a fresh dashboard store, as the supported reminder source is read from the capabilities
+ * once when the module is evaluated.
+ *
+ * @param {boolean} supportsListFilter Whether the notifications app can filter by app and object
+ */
+async function setupStore(supportsListFilter) {
+	vi.resetModules()
+	const { hasNotificationsFeature, hasTalkFeature } = await import('../../services/CapabilitiesManager.ts')
+	hasTalkFeature.mockReturnValue(true)
+	hasNotificationsFeature.mockReturnValue(supportsListFilter)
+
+	const notificationsService = await import('../../services/notificationsService.ts')
+	const remindersService = await import('../../services/remindersService.js')
+	const { useDashboardStore } = await import('../dashboard.ts')
+
+	setActivePinia(createPinia())
+	return { store: useDashboardStore(), notificationsService, remindersService }
+}
+
+describe('dashboardStore', () => {
+	const reminderNotification = {
+		notification_id: 9,
+		app: 'spreed',
+		user: 'remindertester',
+		datetime: '2026-09-03T15:39:03+00:00',
+		object_type: 'reminder',
+		object_id: 'u8u7if2f/3',
+		subject: 'Reminder: Other Person in private conversation',
+		message: 'Hello there, remember this one',
+		link: 'http://localhost/index.php/call/u8u7if2f#message_3',
+		subjectRichParameters: {
+			user: { type: 'user', id: 'reminderother', name: 'Other Person' },
+			call: { type: 'call', id: '1', name: 'Other Person' },
+		},
+		messageRich: 'Hello there, remember this one',
+		messageRichParameters: [],
+	}
+
+	const upcomingReminder = {
+		messageId: 3,
+		roomToken: 'u8u7if2f',
+		actorId: 'reminderother',
+		actorType: ATTENDEE.ACTOR_TYPE.USERS,
+		actorDisplayName: 'Other Person',
+		message: 'Hello there, remember this one',
+		messageParameters: {},
+		reminderTimestamp: 1788449943,
+	}
+
+	beforeEach(() => {
+		setActivePinia(createPinia())
+	})
+
+	afterEach(() => {
+		vi.clearAllMocks()
+	})
+
+	describe('fetching reminders', () => {
+		it('parses triggered reminders out of the notifications of the user', async () => {
+			// Arrange
+			const { store, notificationsService } = await setupStore(true)
+			notificationsService.getReminderNotifications.mockResolvedValueOnce(generateOCSResponse({ payload: [reminderNotification] }))
+
+			// Act
+			await store.fetchReminders()
+
+			// Assert
+			expect(notificationsService.getReminderNotifications).toHaveBeenCalled()
+			expect(store.remindersInitialised).toBe(true)
+			expect(store.reminders).toEqual([{
+				notificationId: 9,
+				roomToken: 'u8u7if2f',
+				messageId: 3,
+				actorId: 'reminderother',
+				actorType: ATTENDEE.ACTOR_TYPE.USERS,
+				actorDisplayName: 'Other Person',
+				message: 'Hello there, remember this one',
+				messageParameters: {},
+				reminderTimestamp: 1788449943,
+			}])
+		})
+
+		it('reads the message id and thread id out of the object id', async () => {
+			// Arrange
+			const { store, notificationsService } = await setupStore(true)
+			notificationsService.getReminderNotifications.mockResolvedValueOnce(generateOCSResponse({ payload: [{ ...reminderNotification, object_id: 'u8u7if2f/3/2' }] }))
+
+			// Act
+			await store.fetchReminders()
+
+			// Assert
+			expect(store.reminders[0].roomToken).toBe('u8u7if2f')
+			expect(store.reminders[0].messageId).toBe(3)
+		})
+
+		it('falls back to the subject when a sensitive conversation hides the message', async () => {
+			// Arrange
+			const { store, notificationsService } = await setupStore(true)
+			notificationsService.getReminderNotifications.mockResolvedValueOnce(generateOCSResponse({
+				payload: [{
+					...reminderNotification,
+					object_id: 'u8u7if2f',
+					subject: 'Reminder in a private conversation',
+					subjectRichParameters: [],
+					messageRich: '',
+					messageRichParameters: [],
+				}],
+			}))
+
+			// Act
+			await store.fetchReminders()
+
+			// Assert
+			expect(store.reminders[0].messageId).toBe(0)
+			expect(store.reminders[0].actorDisplayName).toBe('Reminder in a private conversation')
+			expect(store.reminders[0].messageParameters).toEqual({})
+		})
+
+		it('shows nothing when no app registered a notifier and the endpoint answers 204', async () => {
+			// Arrange
+			const { store, notificationsService } = await setupStore(true)
+			notificationsService.getReminderNotifications.mockResolvedValueOnce({ status: 204, data: '' })
+
+			// Act
+			await store.fetchReminders()
+
+			// Assert
+			expect(store.reminders).toEqual([])
+			expect(store.remindersInitialised).toBe(true)
+		})
+
+		it('falls back to upcoming reminders without the notifications capability', async () => {
+			// Arrange
+			const { store, notificationsService, remindersService } = await setupStore(false)
+			remindersService.getUpcomingReminders.mockResolvedValueOnce(generateOCSResponse({ payload: [upcomingReminder] }))
+
+			// Act
+			await store.fetchReminders()
+
+			// Assert
+			expect(notificationsService.getReminderNotifications).not.toHaveBeenCalled()
+			expect(store.reminders).toEqual([{ ...upcomingReminder, notificationId: null }])
+		})
+	})
+
+	describe('removing reminders', () => {
+		it('dismisses the notification of a reminder that already triggered', async () => {
+			// Arrange
+			const { store, notificationsService, remindersService } = await setupStore(true)
+			notificationsService.getReminderNotifications.mockResolvedValueOnce(generateOCSResponse({ payload: [reminderNotification] }))
+			await store.fetchReminders()
+
+			// Act
+			await store.removeReminder('u8u7if2f', 3, 9)
+
+			// Assert
+			expect(notificationsService.dismissNotification).toHaveBeenCalledWith(9)
+			expect(remindersService.removeMessageReminder).not.toHaveBeenCalled()
+			expect(store.reminders).toEqual([])
+		})
+
+		it('deletes the reminder itself when it did not trigger yet', async () => {
+			// Arrange
+			const { store, notificationsService, remindersService } = await setupStore(false)
+			remindersService.getUpcomingReminders.mockResolvedValueOnce(generateOCSResponse({ payload: [upcomingReminder] }))
+			await store.fetchReminders()
+
+			// Act
+			await store.removeReminder('u8u7if2f', 3)
+
+			// Assert
+			expect(remindersService.removeMessageReminder).toHaveBeenCalledWith('u8u7if2f', 3)
+			expect(notificationsService.dismissNotification).not.toHaveBeenCalled()
+			expect(store.reminders).toEqual([])
+		})
+
+		it('keeps the list untouched when dismissing fails', async () => {
+			// Arrange
+			const { store, notificationsService } = await setupStore(true)
+			notificationsService.getReminderNotifications.mockResolvedValueOnce(generateOCSResponse({ payload: [reminderNotification] }))
+			await store.fetchReminders()
+			const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+			notificationsService.dismissNotification.mockRejectedValueOnce(generateOCSErrorResponse({ payload: null, status: 404 }))
+
+			// Act
+			await store.removeReminder('u8u7if2f', 3, 9)
+
+			// Assert
+			expect(store.reminders).toHaveLength(1)
+			consoleErrorSpy.mockRestore()
+		})
+	})
+})

--- a/src/stores/dashboard.ts
+++ b/src/stores/dashboard.ts
@@ -3,29 +3,61 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import type { DashboardEventRoom, UpcomingReminder } from '../types/index.ts'
+import type { DashboardEventRoom, DashboardReminder, NotificationsNotification, UpcomingReminder } from '../types/index.ts'
 
 import { showError, showSuccess } from '@nextcloud/dialogs'
 import { t } from '@nextcloud/l10n'
 import { defineStore } from 'pinia'
-import { hasTalkFeature } from '../services/CapabilitiesManager.ts'
+import { ATTENDEE } from '../constants.ts'
+import { hasNotificationsFeature, hasTalkFeature } from '../services/CapabilitiesManager.ts'
 import { getDashboardEventRooms } from '../services/dashboardService.ts'
+import { dismissNotification, getReminderNotifications } from '../services/notificationsService.ts'
 import { getUpcomingReminders, removeMessageReminder } from '../services/remindersService.js'
+import { convertToUnix } from '../utils/formattedTime.ts'
 
 const supportsUpcomingReminders = hasTalkFeature('local', 'upcoming-reminders')
+// Reminders that already triggered are shown instead of upcoming ones, which the user delayed on purpose
+export const supportsTriggeredReminders = hasNotificationsFeature('list-filter')
+
+/**
+ * Convert a reminder notification into the shape the upcoming reminders endpoint returns.
+ *
+ * The object id of a parsed Talk notification is `token/messageId` (and `token/messageId/threadId`
+ * for threads), except in sensitive conversations, where neither the message id nor a preview of
+ * the message is handed to the client.
+ *
+ * @param notification A notification with the object type `reminder`
+ */
+function parseReminderNotification(notification: NotificationsNotification): DashboardReminder {
+	const [roomToken, messageId] = notification.object_id.split('/')
+	const parameters = Array.isArray(notification.subjectRichParameters) ? {} : notification.subjectRichParameters
+	const actor = parameters.user ?? parameters.guest
+
+	return {
+		notificationId: notification.notification_id,
+		roomToken,
+		messageId: Number(messageId ?? 0),
+		actorId: actor?.id ?? '',
+		actorType: actor?.type === 'guest' ? ATTENDEE.ACTOR_TYPE.GUESTS : ATTENDEE.ACTOR_TYPE.USERS,
+		actorDisplayName: actor?.name ?? notification.subject,
+		message: notification.messageRich,
+		messageParameters: Array.isArray(notification.messageRichParameters) ? {} : notification.messageRichParameters,
+		reminderTimestamp: convertToUnix(new Date(notification.datetime)),
+	}
+}
 
 type State = {
 	eventRooms: DashboardEventRoom[]
-	upcomingReminders: UpcomingReminder[]
+	reminders: DashboardReminder[]
 	eventRoomsInitialised: boolean
-	upcomingRemindersInitialised: boolean
+	remindersInitialised: boolean
 }
 export const useDashboardStore = defineStore('dashboard', {
 	state: (): State => ({
 		eventRooms: [],
-		upcomingReminders: [],
+		reminders: [],
 		eventRoomsInitialised: false,
-		upcomingRemindersInitialised: false,
+		remindersInitialised: false,
 	}),
 
 	actions: {
@@ -40,26 +72,62 @@ export const useDashboardStore = defineStore('dashboard', {
 			}
 		},
 
+		async fetchReminders() {
+			if (supportsTriggeredReminders) {
+				await this.fetchTriggeredReminders()
+			} else {
+				await this.fetchUpcomingReminders()
+			}
+		},
+
+		async fetchTriggeredReminders() {
+			try {
+				const response = await getReminderNotifications()
+				// The endpoint answers 204 without a body when no app registered a notifier
+				const notifications = response.data ? response.data.ocs.data : []
+				this.reminders = notifications.map(parseReminderNotification)
+				this.remindersInitialised = true
+			} catch (error) {
+				console.error('Error fetching reminder notifications:', error)
+				showError(t('spreed', 'Error fetching reminders'))
+			}
+		},
+
 		async fetchUpcomingReminders() {
 			try {
 				if (!supportsUpcomingReminders) {
 					return
 				}
 				const response = await getUpcomingReminders()
-				this.upcomingReminders = response.data.ocs.data
-				this.upcomingRemindersInitialised = true
+				this.reminders = response.data.ocs.data.map((reminder: UpcomingReminder) => ({ ...reminder, notificationId: null }))
+				this.remindersInitialised = true
 			} catch (error) {
 				console.error('Error fetching upcoming reminders:', error)
 				showError(t('spreed', 'Error fetching upcoming reminders'))
 			}
 		},
 
-		async removeReminder(token: string, messageId: number) {
+		/**
+		 * Clear a reminder shown on the dashboard. A reminder that already triggered is not stored
+		 * as a reminder anymore, so its notification is dismissed instead.
+		 *
+		 * @param token The conversation token
+		 * @param messageId The id of the message the reminder is set on
+		 * @param notificationId The id of the notification, when the reminder already triggered
+		 */
+		async removeReminder(token: string, messageId: number, notificationId: number | null = null) {
 			try {
-				await removeMessageReminder(token, messageId)
-				this.upcomingReminders = this.upcomingReminders.filter((reminder) => {
-					return reminder.messageId !== messageId
-				})
+				if (notificationId !== null) {
+					await dismissNotification(notificationId)
+					this.reminders = this.reminders.filter((reminder) => {
+						return reminder.notificationId !== notificationId
+					})
+				} else {
+					await removeMessageReminder(token, messageId)
+					this.reminders = this.reminders.filter((reminder) => {
+						return reminder.messageId !== messageId
+					})
+				}
 				showSuccess(t('spreed', 'A reminder was successfully removed'))
 			} catch (error) {
 				console.error(error)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -70,12 +70,20 @@ type GuestsCapabilities = {
 	enabled: boolean
 }
 
+// From https://github.com/nextcloud/notifications/blob/master/lib/Capabilities.php
+type NotificationsCapabilities = {
+	'ocs-endpoints': string[]
+	push: string[]
+	'admin-notifications': string[]
+}
+
 // Capabilities
 export type Capabilities = {
 	spreed: SpreedCapabilities
 	calendar?: CalendarCapabilities
 	circles?: CirclesCapabilities
 	guests?: GuestsCapabilities
+	notifications?: NotificationsCapabilities
 	password_policy?: PasswordPolicyCapabilities
 }
 
@@ -424,6 +432,26 @@ export type summarizeChatResponse = ApiResponse<operations['chat-summarize-chat'
 export type SummarizeChatTask = operations['chat-summarize-chat']['responses'][201]['content']['application/json']['ocs']['data']
 export type upcomingRemindersResponse = ApiResponse<operations['chat-get-upcoming-reminders']['responses'][200]['content']['application/json']>
 export type UpcomingReminder = components['schemas']['ChatReminderUpcoming']
+// From https://github.com/nextcloud/notifications/blob/master/lib/ResponseDefinitions.php
+export type NotificationsNotification = {
+	notification_id: number
+	app: string
+	user: string
+	datetime: string
+	object_type: string
+	object_id: string
+	subject: string
+	message: string
+	link: string
+	subjectRichParameters: ChatMessage['messageParameters'] | []
+	messageRich: string
+	messageRichParameters: ChatMessage['messageParameters'] | []
+}
+// The notifications API answers 204 without a body when no app registered a notifier
+export type getReminderNotificationsResponse = ApiResponse<{ ocs: { data: NotificationsNotification[] } } | ''>
+// A reminder shown on the dashboard. `notificationId` is only set when the reminder already
+// triggered, in which case it only exists as a notification of the user.
+export type DashboardReminder = UpcomingReminder & { notificationId: number | null }
 export type pinMessageParams = Required<operations['chat-pin-message']>['requestBody']['content']['application/json']
 export type pinMessageResponse = ApiResponse<operations['chat-pin-message']['responses'][200]['content']['application/json']>
 export type unpinMessageResponse = ApiResponse<operations['chat-unpin-message']['responses'][200]['content']['application/json']>


### PR DESCRIPTION
## ☑️ Resolves

* Requires https://github.com/nextcloud/notifications/pull/3348

### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="1695" height="993" alt="grafik" src="https://github.com/user-attachments/assets/a968e77b-022e-4fe0-b0a3-c3f4dc172bc7" />| <img width="1695" height="993" alt="grafik" src="https://github.com/user-attachments/assets/058f2ae9-17d2-448b-9b8b-54a92603e04d" />

### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [ ] Chromium (Chrome / Edge / Opera / Brave)
  - [x] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
