### PR TITLE
fix: show leave call button for guests

### DIFF
--- a/src/components/TopBar/CallButton.vue
+++ b/src/components/TopBar/CallButton.vue
@@ -341,8 +341,7 @@ export default {
 		},
 
 		showLeaveCallButton() {
-			return this.conversation.readOnly === CONVERSATION.STATE.READ_WRITE
-				&& this.isInCall
+			return this.isInCall
 		},
 
 		isBreakoutRoom() {


### PR DESCRIPTION
## Resolves

Fix #18844

## What changed

The Leave Call button was only shown when the conversation was in READ_WRITE state.

Guests in voice rooms can be connected to a call while the conversation is read-only, which prevented them from seeing the Leave Call button.

This change makes the Leave Call button depend on the actual call state instead of the conversation read/write state.

## Testing

- Verified the change with `git diff --check`.
- The project build could not be completed because the local Yarn Plug'n'Play setup reports `browserslist` as an undeclared dependency.

## AI

- [x] The content of this PR was partly or fully generated using AI