### PR TITLE
fix(TopBar): move 'Search' closer to menu actions

### DIFF
--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -140,6 +140,8 @@
 					class="top-bar__calendar-events"
 					:token="token" />
 
+				<CallButton v-if="!isInCall" shrinkOnMobile />
+
 				<!-- Search messages button -->
 				<NcButton
 					v-if="!isSidebar && actorStore.isLoggedIn && !isSmallMobile"
@@ -151,8 +153,6 @@
 						<IconMagnify :size="20" />
 					</template>
 				</NcButton>
-
-				<CallButton v-if="!isInCall" shrinkOnMobile />
 
 				<!-- TopBar menu -->
 				<TopBarMenu
@@ -547,7 +547,7 @@ export default {
 	overflow-y: clip;
 	white-space: nowrap;
 	flex: 1 1 0;
-	min-width: 200px;
+	min-width: 150px;
 	cursor: pointer;
 	&__text {
 		display: flex;


### PR DESCRIPTION
## ☑️ Resolves

* Fix #19340
	* Don't put tertiary action between primary/secondary	
	* reduce TopBar wrap threshold to 150px

### AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="454" height="91" alt="2026-09-08_14h15_34" src="https://github.com/user-attachments/assets/a1c9b5d7-e51f-44cb-b8cb-59fc2a32a06e" /> | <img width="476" height="91" alt="2026-09-08_14h18_22" src="https://github.com/user-attachments/assets/f4cb4fc5-d3f1-443a-9c9f-c190c36292c6" />
<img width="406" height="116" alt="2026-09-08_14h15_50" src="https://github.com/user-attachments/assets/02cfe398-43ca-490c-98c8-8f659b2171d0" /> | <img width="415" height="93" alt="2026-09-08_14h18_05" src="https://github.com/user-attachments/assets/30cf6286-8e97-4e89-ae18-b34752c18df7" />



### 🏁 Checklist

- [x] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required