### PR TITLE
fix: start threads with the file upload

### DIFF
--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -2592,6 +2592,14 @@ class ChatController extends AEnvironmentAwareOCSController {
 		$threadId = isset($metaData['threadId']) ? (int)$metaData['threadId'] : 0;
 		unset($metaData['replyTo'], $metaData['threadId'], $metaData[Message::METADATA_SILENT]);
 
+		$threadTitle = '';
+		if (isset($metaData['threadTitle'])) {
+			if (is_string($metaData['threadTitle']) && trim($metaData['threadTitle']) !== '') {
+				$threadTitle = trim($metaData['threadTitle']);
+			}
+			unset($metaData['threadTitle']);
+		}
+
 		$replyToComment = null;
 		if ($replyToId !== null) {
 			try {
@@ -2601,10 +2609,12 @@ class ChatController extends AEnvironmentAwareOCSController {
 			}
 		}
 
+		$createThread = $replyToId === null && $threadId === Thread::THREAD_NONE && $threadTitle !== '';
+
 		// Create the file_shared system message referencing the file by node ID.
 		// The parameters use 'fileId' instead of 'share' so no per-file TYPE_ROOM
 		// share is needed; access is controlled by the folder-level share.
-		$this->chatManager->addSystemMessage(
+		$comment = $this->chatManager->addSystemMessage(
 			$this->room,
 			$this->participant,
 			Attendee::ACTOR_USERS,
@@ -2618,6 +2628,26 @@ class ChatController extends AEnvironmentAwareOCSController {
 			$silent,
 			$threadId,
 		);
+
+		if ($createThread) {
+			$thread = $this->threadService->createThread($this->room, (int)$comment->getId(), $threadTitle);
+			// Add to subscribed threads list
+			$this->threadService->setNotificationLevel($this->participant->getAttendee(), $thread->getId(), Participant::NOTIFY_DEFAULT);
+
+			$this->chatManager->addSystemMessage(
+				$this->room,
+				$this->participant,
+				$this->participant->getAttendee()->getActorType(),
+				$this->participant->getAttendee()->getActorId(),
+				json_encode(['message' => 'thread_created', 'parameters' => ['thread' => (int)$comment->getId(), 'title' => $thread->getName()]]),
+				$this->timeFactory->getDateTime(),
+				false,
+				null,
+				$comment,
+				true,
+				true
+			);
+		}
 
 		return new DataResponse(['renames' => [[$renameFrom => $renameTo]]], Http::STATUS_OK);
 	}

--- a/tests/integration/features/sharing-1/conversation-folder.feature
+++ b/tests/integration/features/sharing-1/conversation-folder.feature
@@ -98,6 +98,22 @@ Feature: sharing-1/conversation-folder
       | group room | users     | participant1 | participant1-displayname | Caption text | "IGNORE"          | Message 1     |
       | group room | users     | participant2 | participant2-displayname | Message 1    | []                |               |
 
+  Scenario: Post with a thread title creates a thread
+    Given user "participant1" creates room "group room" (v4)
+      | roomType | 2    |
+      | roomName | room |
+    And user "participant1" renames room "group room" to "Group room" with 200 (v4)
+    And user "participant1" adds user "participant2" to room "group room" with 200 (v4)
+    And user "participant1" uploads file "test.txt" with content "Hello!" to conversation folder for room "group room" with name "Group room"
+    When user "participant1" posts file "test.txt" from conversation folder of room "group room" with name "Group room" with 200 (v1)
+      | talkMetaData.threadTitle | Thread 1 |
+    Then user "participant1" sees the following messages in room "group room" with 200
+      | room       | actorType | actorId      | actorDisplayName         | message | messageParameters | threadTitle |
+      | group room | users     | participant1 | participant1-displayname | {file}  | "IGNORE"          | Thread 1    |
+    And user "participant1" sees the following recent threads in room "group room" with 200
+      | t.id   | t.title  | t.numReplies | t.lastMessage | a.notificationLevel | firstMessage | lastMessage |
+      | {file} | Thread 1 | 0            | 0             | 0                   | {file}       | NULL        |
+
   Scenario: Room name with a hyphen does not confuse token extraction
     Given user "participant1" creates room "group room" (v4)
       | roomType | 2        |


### PR DESCRIPTION
## ☑️ Resolves

* Fix #19345 
	- conversation-subfolders file upload path
	- code mirrors lib/Chat/SystemMessage/Listener.php#fixMimeTypeOfVoiceMessage() and lib/Controller/ChatController.php#sendMessage()

### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

### 🖼️ Screenshots / Screencasts

<img width="318" height="143" alt="image" src="https://github.com/user-attachments/assets/4a8921cd-a8b2-4fac-a140-b4dd659045d3" />


## 🛠️ API Checklist

### 🚧 Tasks

- [ ] Tests sanity check - belong here or in `threads.feature`?

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [ ] 📘 API documentation in `docs/` has been updated or is not required
- [ ] 🔖 Capability is added or not needed 
