### PR TITLE
chore: Set E2EE version for talk-android to 25.0.0

### DIFF
--- a/lib/Middleware/CanUseTalkMiddleware.php
+++ b/lib/Middleware/CanUseTalkMiddleware.php
@@ -43,7 +43,10 @@ class CanUseTalkMiddleware extends Middleware {
 
 	public const TALK_ANDROID_MIN_VERSION = '15.0.0';
 	public const TALK_ANDROID_MIN_VERSION_RECORDING_CONSENT = '18.0.0';
-	public const TALK_ANDROID_MIN_VERSION_E2EE_CALLS = '99.0.0';
+
+	// Talk Android >= 25 handles the configuration flag for E2EE and shows a appropiate message
+	// Support for E2EE on Talk Android is still pending
+	public const TALK_ANDROID_MIN_VERSION_E2EE_CALLS = '25.0.0';
 
 	public const TALK_IOS_MIN_VERSION = '15.0.0';
 	public const TALK_IOS_MIN_VERSION_RECORDING_CONSENT = '18.0.0';


### PR DESCRIPTION
## 🛠️ API Checklist

* With https://github.com/nextcloud/talk-android/pull/6671 talk-android is aware of the end-to-end-encryption flag and can show a message to the user, instead of showing "outdated app".
* same solution was applied for iOS: https://github.com/nextcloud/talk-ios/pull/2369


### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
