### PR TITLE
Fix missing Leave call button for guests in voice rooms

### DIFF
--- a/src/components/CallView/BottomBar.vue
+++ b/src/components/CallView/BottomBar.vue
@@ -34,6 +34,7 @@ import {
 	useDocumentFullscreen,
 } from '../../composables/useDocumentFullscreen.ts'
 import { useGetToken } from '../../composables/useGetToken.ts'
+import { useIsInCall } from '../../composables/useIsInCall.js'
 import { ATTENDEE, CONVERSATION } from '../../constants.ts'
 import {
 	getTalkConfig,
@@ -52,6 +53,7 @@ const { isSidebar = false } = defineProps<{
 
 const store = useStore()
 const token = useGetToken()
+const isInCall = useIsInCall()
 const actorStore = useActorStore()
 const isFullscreen = !isSidebar && useDocumentFullscreen()
 const callViewStore = useCallViewStore()
@@ -691,7 +693,7 @@ function setCallLayout(layout: CallLayout) {
 			</NcActions>
 
 			<CallButton
-				v-show="!(isVoiceRoom && isGuestActor)"
+				v-show="!isVoiceRoom || !isGuestActor || isInCall"
 				class="call-button"
 				:hideText="isSidebar || isMobile"
 				:isScreensharing="!!localMediaModel.attributes.localScreen" />


### PR DESCRIPTION
## Problem

Guests in voice rooms can join a call, but the "Leave call" button is hidden, leaving them without a clear way to leave the call through the UI.

## Change

Updated the call button visibility logic so that:

- Guests who are not in a voice-room call do not see the call button.
- Guests who have already joined the call can see the "Leave call" button.
- Existing behavior for other users remains unchanged.

## Implementation

Updated `src/components/CallView/BottomBar.vue` to use the current call state when deciding whether to display the `CallButton`.

Addresses #18844