### PR TITLE
fix(FilePreview): fallback to real image in case of a preview failure

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.spec.js
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.spec.js
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import { encodePath } from '@nextcloud/paths'
 import { generateRemoteUrl, imagePath } from '@nextcloud/router'
 import { getUploader } from '@nextcloud/upload'
 import { mount } from '@vue/test-utils'
@@ -205,9 +206,44 @@ describe('FilePreview.vue', () => {
 		})
 
 		test('renders default mime icon on load error', async () => {
+			OC.MimeType.getIconUrl.mockReturnValueOnce(imagePath('core', 'video/mpeg'))
+			props.file = {
+				id: '123',
+				name: 'test.mpeg',
+				path: 'path/to/test.mpeg',
+				size: '128',
+				etag: '1872ade88f3013edeb33decd74a4f947',
+				permissions: '15',
+				mimetype: 'video/mpeg',
+				'preview-available': 'yes',
+			}
+			const wrapper = mountFilePreview()
+
+			await wrapper.find('img').trigger('error')
+
+			expect(wrapper.element.tagName).toBe('A')
+			const imageUrl = wrapper.find('img').attributes('src')
+			expect(imageUrl).toBe(imagePath('core', 'video/mpeg'))
+		})
+
+		test('renders actual image on preview load error', async () => {
+			const davPath = generateRemoteUrl(`dav/files/${actorStore.userId}`) + '/' + encodePath(props.file.path)
+			const wrapper = mountFilePreview()
+
+			await wrapper.find('img').trigger('error')
+
+			expect(wrapper.element.tagName).toBe('A')
+			const imageUrl = wrapper.find('img').attributes('src')
+			expect(imageUrl).toBe(davPath)
+		})
+
+		test('renders default mime icon on image load error', async () => {
 			OC.MimeType.getIconUrl.mockReturnValueOnce(imagePath('core', 'image/jpeg'))
 			const wrapper = mountFilePreview()
 
+			// Preview fails to load
+			await wrapper.find('img').trigger('error')
+			// Actual file fails to load
 			await wrapper.find('img').trigger('error')
 
 			expect(wrapper.element.tagName).toBe('A')

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
@@ -48,7 +48,7 @@
 					class="file-preview__image"
 					:class="previewImageClass"
 					:alt="sanitizedFileName"
-					:src="failed ? defaultIconUrl : previewUrl"
+					:src="previewImageSrc"
 					@load="onLoad"
 					@error="onError">
 				<template v-if="!isLoading || fallbackLocalUrl">
@@ -227,6 +227,7 @@ export default {
 		return {
 			isLoading: true,
 			failed: false,
+			previewFailed: false,
 			uploadManager: null,
 		}
 	},
@@ -425,33 +426,40 @@ export default {
 			return PREVIEW_TYPE.PREVIEW
 		},
 
-		previewUrl() {
-			const userId = this.actorStore.userId
-
+		previewImageSrc() {
 			if (this.previewType === PREVIEW_TYPE.TEMPORARY) {
 				return this.file.localUrl
 			}
 			if (this.fallbackLocalUrl) {
 				return this.fallbackLocalUrl
 			}
-			if (this.previewType === PREVIEW_TYPE.MIME_ICON || this.rowLayout) {
-				return OC.MimeType.getIconUrl(this.file.mimetype)
+			if (this.previewType === PREVIEW_TYPE.MIME_ICON || this.rowLayout || this.failed) {
+				return this.defaultIconUrl
 			}
 			// whether to embed/render the file directly
-			if (this.previewType === PREVIEW_TYPE.DIRECT) {
-				// return direct image
-				if (userId === null) {
-					// guest mode, use public link download URL
-					return this.file.link + '/download/' + encodePath(this.file.name)
-				} else {
-					// use direct DAV URL
-					return generateRemoteUrl(`dav/files/${userId}`) + encodePath(this.internalAbsolutePath)
-				}
+			if (this.previewType === PREVIEW_TYPE.DIRECT || this.previewFailed) {
+				return this.directImageUrl
 			}
 
+			// this.previewType === PREVIEW_TYPE.PREVIEW
+			return this.previewImageUrl
+		},
+
+		directImageUrl() {
+			// return direct image
+			if (this.actorStore.userId === null) {
+				// guest mode, use public link download URL
+				return this.file.link + '/download/' + encodePath(this.file.name)
+			} else {
+				// use direct DAV URL
+				return generateRemoteUrl(`dav/files/${this.actorStore.userId}`) + encodePath(this.internalAbsolutePath)
+			}
+		},
+
+		previewImageUrl() {
 			// use preview provider URL to render a smaller preview
 			const previewSize = Math.ceil(384 * window.devicePixelRatio)
-			if (userId === null) {
+			if (this.actorStore.userId === null) {
 				// guest mode: grab token from the link URL
 				// FIXME: use a cleaner way...
 				const token = this.file.link.slice(this.file.link.lastIndexOf('/') + 1)
@@ -595,6 +603,12 @@ export default {
 		},
 
 		onError() {
+			// If preview endpoint failed, retry once with the actual image (this.directImageUrl)
+			if (!this.previewFailed && this.previewType === PREVIEW_TYPE.PREVIEW && this.file.mimetype.startsWith('image/')) {
+				this.previewFailed = true
+				return
+			}
+
 			this.isLoading = false
 			this.failed = true
 		},

--- a/src/composables/useViewer.js
+++ b/src/composables/useViewer.js
@@ -117,7 +117,7 @@ export function useViewer(fileAPI) {
 				isViewerOpen.value = false
 				callViewStore.setIsViewerOverlay(false)
 			},
-			loadMore,
+			loadMore: loadMore && (async (...args) => (await loadMore(...args)).map(generateViewerObject)),
 			canLoop: false,
 		})
 


### PR DESCRIPTION
## ☑️ Resolves

* Companion to https://github.com/nextcloud/talk-desktop/pull/1900
	* Fallback for chat images and shared items tab
		* Cons - it's a full-size image
		* Pros - we don't have another at this point
* Companion to https://github.com/nextcloud/talk-desktop/pull/1901
	* Fix normalization of `loadMore` endpoint

### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI



## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="280" height="230" alt="image" src="https://github.com/user-attachments/assets/dbacf319-a22d-42d0-80d0-fe0ccaa525e4" /> | <img width="294" height="264" alt="image" src="https://github.com/user-attachments/assets/4032949b-7520-4871-bd06-8fe6288c5fc0" />

### TODO / Follow-ups
- [ ] Other usages of core/preview endpoint (less noticeable or unrelated to chat)
	- [ ] Need to extract and reuse functions in this case, like desktop does

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox
  - [ ] Safari
  - [ ] Talk Desktop
  - [ ] Integrations with Files sidebar and other apps
  - [x] Not risky to browser differences / client
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required