### PR TITLE
chore(release): Changelogs for v22.0.18, v23.0.11, v24.0.5, v25.0.0-rc.3

### DIFF
--- a/docs/changelogs/changelog-22.md
+++ b/docs/changelogs/changelog-22.md
@@ -4,6 +4,16 @@
 -->
 # Changelog
 All notable changes to this project will be documented in this file.
+
+## 22.0.18 – 2026-09-10
+### Changed
+- Update dependencies
+- Update translations
+
+### Fixed
+- fix: scroll to bottom for long messages
+  [#19022](https://github.com/nextcloud/spreed/pull/19022)
+
 ## 22.0.17 – 2026-08-13
 ### Changed
 - Update dependencies

--- a/docs/changelogs/changelog-23.md
+++ b/docs/changelogs/changelog-23.md
@@ -4,6 +4,18 @@
 -->
 # Changelog
 All notable changes to this project will be documented in this file.
+
+## 23.0.11 – 2026-09-10
+### Changed
+- Update dependencies
+- Update translations
+
+### Fixed
+- fix(chat): fallback to real image in case of a preview failure
+  [#19363](https://github.com/nextcloud/spreed/pull/19363)
+- fix: scroll to bottom for long messages
+  [#19023](https://github.com/nextcloud/spreed/pull/19023)
+
 ## 23.0.10 – 2026-08-13
 ### Changed
 - Update dependencies

--- a/docs/changelogs/changelog-24.md
+++ b/docs/changelogs/changelog-24.md
@@ -4,6 +4,30 @@
 -->
 # Changelog
 All notable changes to this project will be documented in this file.
+
+## 24.0.5 – 2026-09-10
+### Changed
+- Update dependencies
+- Update translations
+
+### Fixed
+- fix(chat): fallback to real image in case of a preview failure
+  [#19362](https://github.com/nextcloud/spreed/pull/19362)
+- fix(chat): start threads with the file upload
+  [#19350](https://github.com/nextcloud/spreed/pull/19350)
+- fix(call): improve UI guard when leaving a call
+  [#19260](https://github.com/nextcloud/spreed/pull/19260)
+- fix(chat): lock scrolling in inactive session
+  [#19225](https://github.com/nextcloud/spreed/pull/19225)
+- fix(chat): Send read marker only when session is active
+  [#19220](https://github.com/nextcloud/spreed/pull/19220)
+- fix(tags): drop total unread counter
+  [#19103](https://github.com/nextcloud/spreed/pull/19103)
+- fix(conversation): adjust scroll to unread mentions
+  [#19101](https://github.com/nextcloud/spreed/pull/19101)
+- fix(chat): scroll to bottom for long messages
+  [#19024](https://github.com/nextcloud/spreed/pull/19024)
+
 ## 24.0.4 – 2026-08-13
 ### Added
 - feat(bots): Allow bots to fetch their own enabled features

--- a/docs/changelogs/changelog-25.md
+++ b/docs/changelogs/changelog-25.md
@@ -5,6 +5,18 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 25.0.0-rc.3 – 2026-09-10
+### Changed
+- Update translations
+- design: rearrange file previews in combined messages
+  [#19269](https://github.com/nextcloud/spreed/pull/19269)
+
+### Fixed
+- fix(chat): fallback to real image in case of a preview failure
+  [#19361](https://github.com/nextcloud/spreed/pull/19361)
+- fix(chat): start threads with the file upload
+  [#19351](https://github.com/nextcloud/spreed/pull/19351)
+
 ## 25.0.0-rc.2 – 2026-09-03
 ### Changed
 - Update dependencies


### PR DESCRIPTION
## 22.0.18 – 2026-09-10
### Changed
- Update dependencies
- Update translations

### Fixed
- fix: scroll to bottom for long messages
  [#19022](https://github.com/nextcloud/spreed/pull/19022)

## 23.0.11 – 2026-09-10
### Changed
- Update dependencies
- Update translations

### Fixed
- fix(chat): fallback to real image in case of a preview failure
  [#19363](https://github.com/nextcloud/spreed/pull/19363)
- fix: scroll to bottom for long messages
  [#19023](https://github.com/nextcloud/spreed/pull/19023)

## 24.0.5 – 2026-09-10
### Changed
- Update dependencies
- Update translations

### Fixed
- fix(chat): fallback to real image in case of a preview failure
  [#19362](https://github.com/nextcloud/spreed/pull/19362)
- fix(chat): start threads with the file upload
  [#19350](https://github.com/nextcloud/spreed/pull/19350)
- fix(call): improve UI guard when leaving a call
  [#19260](https://github.com/nextcloud/spreed/pull/19260)
- fix(chat): lock scrolling in inactive session
  [#19225](https://github.com/nextcloud/spreed/pull/19225)
- fix(chat): Send read marker only when session is active
  [#19220](https://github.com/nextcloud/spreed/pull/19220)
- fix(tags): drop total unread counter
  [#19103](https://github.com/nextcloud/spreed/pull/19103)
- fix(conversation): adjust scroll to unread mentions
  [#19101](https://github.com/nextcloud/spreed/pull/19101)
- fix(chat): scroll to bottom for long messages
  [#19024](https://github.com/nextcloud/spreed/pull/19024)

## 25.0.0-rc.3 – 2026-09-10
### Changed
- Update translations
- design: rearrange file previews in combined messages
  [#19269](https://github.com/nextcloud/spreed/pull/19269)

### Fixed
- fix(chat): fallback to real image in case of a preview failure
  [#19361](https://github.com/nextcloud/spreed/pull/19361)
- fix(chat): start threads with the file upload
  [#19351](https://github.com/nextcloud/spreed/pull/19351)