### PR TITLE
chore: remove declaration file for nextcloud/vue

### DIFF
--- a/src/types/vendor/@nextcloud/vue.d.ts
+++ b/src/types/vendor/@nextcloud/vue.d.ts
@@ -1,8 +1,0 @@
-/**
- * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
- */
-declare module '@nextcloud/vue/components/*'
-declare module '@nextcloud/vue/composables/*'
-declare module '@nextcloud/vue/directives/*'
-declare module '@nextcloud/vue/functions/*'


### PR DESCRIPTION
Assisted-by: ClaudeCode:claude-sonnet-5

## ☑️ Resolves

* Fix #14166
	* Remaining items from agent check:
		* `vue-cropperjs` + `vue-draggable-resizable` libraries - both poorly maintained and to be replaced
		* .js-only libs (hark, webrtcsupport, mockconsole) — not in the scope until related code migrated to TS

### AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI